### PR TITLE
fix use focus instead preserveFocus on vscode.open command

### DIFF
--- a/packages/kaitian-extension/src/browser/extension.contribution.ts
+++ b/packages/kaitian-extension/src/browser/extension.contribution.ts
@@ -267,7 +267,7 @@ export class KaitianExtensionCommandContribution implements CommandContribution 
             options.groupIndex = columnOrOptions;
           } else {
             options.groupIndex = columnOrOptions.viewColumn;
-            options.preserveFocus = columnOrOptions.preserveFocus;
+            options.focus = options.preserveFocus = columnOrOptions.preserveFocus;
             // 这个range 可能是 vscode.range， 因为不会经过args转换
             if (columnOrOptions.selection && isLikelyVscodeRange(columnOrOptions.selection)) {
               columnOrOptions.selection = fromRange(columnOrOptions.selection);

--- a/packages/startup/entry/web-lite/modules/common-commands/index.contribution.ts
+++ b/packages/startup/entry/web-lite/modules/common-commands/index.contribution.ts
@@ -26,7 +26,7 @@ export class CommonCommandsContribution implements CommandContribution {
             options.groupIndex = columnOrOptions;
           } else {
             options.groupIndex = columnOrOptions.viewColumn;
-            options.preserveFocus = columnOrOptions.preserveFocus;
+            options.focus = options.preserveFocus = columnOrOptions.preserveFocus;
             // 这个range 可能是 vscode.range， 因为不会经过args转换
             if (columnOrOptions.selection && isLikelyVscodeRange(columnOrOptions.selection)) {
               columnOrOptions.selection = fromRange(columnOrOptions.selection);


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案
插件中调用 vscode.open command 的时候，看了下 ide-fw 这里有点问题，做下兼容
![image](https://user-images.githubusercontent.com/37991688/142364530-c5206f65-383c-4c67-8129-892440780ede.png)

### changelog
