### PR TITLE
feat: title and titleMenu both none, donot render TitleBar of PanelView

### DIFF
--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -80,10 +80,14 @@ const ContainerView: React.FC<{
   return (
     <div ref={containerRef} className={styles.view_container}>
       {!CustomComponent && <div onContextMenu={handleContextMenu} className={styles.panel_titlebar}>
-        <TitleBar
-          title={title!}
-          menubar={<InlineActionBar menus={titleMenu} />}
-        />
+        {
+          // title and titleMenu both none, donot render
+          !title && !titleMenu ? null :
+          <TitleBar
+            title={title!}
+            menubar={<InlineActionBar menus={titleMenu} />}
+          />
+        }
         {titleComponent && <div className={styles.panel_component}>
           <ConfigProvider value={configContext} >
             <ComponentRenderer Component={titleComponent} initialProps={component.options?.titleProps} />


### PR DESCRIPTION
### 变动类型

- [x] 新特性提交

### 需求背景和解决方案
现在插件注册 `PanelView` 的时候，如果已经指定了 `titleComponentId`，但是没有指定 `title`，会导致 `panel` 面板多出一个空白高度的 `TitleBar`，因此在没有 `title` 以及没有 `titleMenu` 的时候，就不渲染 `TitleBar` 组件了
### changelog
feat: title and titleMenu both none, donot render TitleBar of PanelView