### PR TITLE
chore: add missing type of ext props

### DIFF
--- a/packages/types/kaitian-browser.d.ts
+++ b/packages/types/kaitian-browser.d.ts
@@ -10,7 +10,7 @@ interface IComponentProps<N, W = any> {
     node: N;
     worker: W;
   };
-  viewState: {
+  viewState?: {
     width: number;
     height: number;
   };


### PR DESCRIPTION
### 变动类型

- [x] TypeScript 定义更新

### 需求背景和解决方案
扩展研发的时候，`IComponentProps` 类型跟实际 `props` 不一致，缺少了 `viewState`
![image](https://user-images.githubusercontent.com/37991688/143018059-6acae105-f6e1-4a07-93d4-cfe8051f40d9.png)

### changelog
