### PR TITLE
fix: 修正 kaitian-browser URI 导出异常

### DIFF
--- a/packages/types/kaitian-browser.d.ts
+++ b/packages/types/kaitian-browser.d.ts
@@ -20,7 +20,7 @@ declare module 'kaitian-browser' {
 
   import { ROTATE_TYPE, ANIM_TYPE } from '@ide-framework/ide-components';
 
-  export type { URI } from '@ide-framework/ide-core-browser';
+  export { URI } from '@ide-framework/ide-core-browser';
 
   export interface ScrollAreaProps {
     className?: string;


### PR DESCRIPTION
### 变动类型

- [x] TypeScript 定义更新

### 需求背景和解决方案
扩展研发时，`kaitian-browser` 中的 `URI` 被 `export type`，导致使用的地方报类型错误。
![image](https://user-images.githubusercontent.com/37991688/143025312-2f904179-59f4-4ddf-9e16-1fe96e30d153.png)

### changelog
