### PR TITLE
chore: split github workflows to check and ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,36 @@
+name: CHECK
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Init
+      run: |
+        npm i
+        npm run init
+
+    - name: Lint
+      run: |
+        npm run lint
+
+    - name: Build
+      run: |
+        npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Lint
-      run: |
-        npm i
-        npm run lint
-
     - name: Build
       run: |
         npm i


### PR DESCRIPTION
### 变动类型

- [x] Workflows

### 需求背景和解决方案

将 GitHub Action 的工作流程分离成两部，pull request 和 main push 只进行 build 以及 lint 验证

### changelog

split github workflows to check and ci