### PR TITLE
fix: align VS Code debug configuration processing logic

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -259,6 +259,10 @@ export namespace COMMON_COMMANDS {
     id: 'core.keymaps.open',
     label: '%common.keymaps.open%',
   };
+
+  export const OPEN_LAUNCH_CONFIGURATION: Command = {
+    id: 'core.launchConfiguration.open',
+  };
 }
 
 export namespace EDITOR_COMMANDS {

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -1,6 +1,6 @@
 import { CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_IN_DEBUG_MODE, CONTEXT_BREAKPOINT_INPUT_FOCUSED } from './../common/constants';
 import { URI } from '@ide-framework/ide-core-common';
-import { Domain, ClientAppContribution, localize, CommandContribution, CommandRegistry, KeybindingContribution, JsonSchemaContribution, IJSONSchemaRegistry, PreferenceSchema, PreferenceContribution, CommandService, IReporterService, formatLocalize, CoreConfiguration, ComponentContribution, ComponentRegistry, KeybindingRegistry, getIcon, PreferenceService, IPreferenceSettingsService } from '@ide-framework/ide-core-browser';
+import { Domain, ClientAppContribution, localize, CommandContribution, CommandRegistry, KeybindingContribution, JsonSchemaContribution, IJSONSchemaRegistry, PreferenceSchema, PreferenceContribution, CommandService, IReporterService, formatLocalize, CoreConfiguration, ComponentContribution, ComponentRegistry, KeybindingRegistry, getIcon, PreferenceService, IPreferenceSettingsService, COMMON_COMMANDS } from '@ide-framework/ide-core-browser';
 import * as monaco from '@ide-framework/monaco-editor-core/esm/vs/editor/editor.api';
 import { DebugBreakpointView } from './view/breakpoints/debug-breakpoints.view';
 import { DebugVariableView } from './view/variables/debug-variables.view';
@@ -397,53 +397,58 @@ export class DebugContribution implements ComponentContribution, TabBarToolbarCo
   }
 
   registerCommands(commands: CommandRegistry) {
+    commands.registerCommand(COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION, {
+      execute: () => {
+        this.debugConfigurationService.openConfiguration();
+      },
+    });
     commands.registerCommand(DEBUG_COMMANDS.REMOVE_ALL_BREAKPOINTS, {
-      execute: (data) => {
+      execute: () => {
         this.debugBreakpointsService.removeAllBreakpoints();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.START, {
-      execute: (data) => {
+      execute: () => {
         this.debugConfigurationService.start();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.STOP, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doStop();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.NEXT, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doStepIn();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.PREV, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doStepOut();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.CONTINUE, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doContinue();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.PAUSE, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doPause();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.OVER, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doStepOver();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.RESTART, {
-      execute: (data) => {
+      execute: () => {
         this.debugToolbarService.doRestart();
       },
     });
     commands.registerCommand(DEBUG_COMMANDS.TOGGLE_BREAKPOINTS, {
-      execute: (data) => {
+      execute: () => {
         this.debugBreakpointsService.toggleBreakpoints();
       },
     });

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -46,7 +46,7 @@ export interface DebugServer extends IDisposable {
    * @param config 需要处理的配置
    * @param workspaceFolderUri 工作区目录路径
    */
-  resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
+  resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null>;
 
   /**
    * 进一步处理调试配置，通过补全缺省值的方式
@@ -54,7 +54,7 @@ export interface DebugServer extends IDisposable {
    * @param {DebugConfiguration} 处理的配置
    * @param {(string | undefined)} 工作区路径
    */
-  resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
+  resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null>;
   /**
    * 创建一个新的DebugAdapterSession进程
    * @param config 传入配置

--- a/packages/debug/src/common/debug-session.ts
+++ b/packages/debug/src/common/debug-session.ts
@@ -25,8 +25,8 @@ export const IDebugSession = Symbol('DebugSession');
 export const IDebugSessionManager = Symbol('DebugSessionManager');
 export interface IDebugSessionManager {
   fireWillStartDebugSession(): Promise<void>;
-  resolveConfiguration(options: Readonly<DebugSessionOptions>): Promise<InternalDebugSessionOptions>;
-  resolveDebugConfiguration(configuration: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
+  resolveConfiguration(options: Readonly<DebugSessionOptions>): Promise<InternalDebugSessionOptions | undefined>;
+  resolveDebugConfiguration(configuration: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null>;
   fireWillResolveDebugConfiguration(debugType: string): Promise<void>;
   report(name: string, msg: string | undefined, extra?: any): void;
   reportTime(name: string, defaults?: any): (msg: string | undefined, extra?: any) => number;

--- a/packages/extension/src/browser/vscode/api/debug/extension-debug-adapter-contribution.ts
+++ b/packages/extension/src/browser/vscode/api/debug/extension-debug-adapter-contribution.ts
@@ -22,31 +22,31 @@ export class ExtensionDebugAdapterContribution {
   }
 
   async getSchemaAttributes(): Promise<IJSONSchema[]> {
-    return this.extDebug.$getSchemaAttributes(this.type);
+    return await this.extDebug.$getSchemaAttributes(this.type);
   }
 
   async getConfigurationSnippets(): Promise<IJSONSchemaSnippet[]> {
-    return this.extDebug.$getConfigurationSnippets(this.type);
+    return await this.extDebug.$getConfigurationSnippets(this.type);
   }
 
   async provideDebugConfigurations(workspaceFolderUri: string | undefined): Promise<DebugConfiguration[]> {
-    return this.extDebug.$provideDebugConfigurations(this.type, workspaceFolderUri);
+    return await this.extDebug.$provideDebugConfigurations(this.type, workspaceFolderUri);
   }
 
-  async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
-    return this.extDebug.$resolveDebugConfigurations(config, workspaceFolderUri);
+  async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null> {
+    return await this.extDebug.$resolveDebugConfigurations(config, workspaceFolderUri);
   }
 
-  async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
-    return this.extDebug.$resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
+  async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null> {
+    return await this.extDebug.$resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
   }
 
   async createDebugSession(config: DebugConfiguration): Promise<string> {
     await this.activationEventService.fireEvent('onDebugAdapterProtocolTracker', config.type);
-    return this.extDebug.$createDebugSession(config);
+    return await this.extDebug.$createDebugSession(config);
   }
 
   async terminateDebugSession(sessionId: string): Promise<void> {
-    this.extDebug.$terminateDebugSession(sessionId);
+    await this.extDebug.$terminateDebugSession(sessionId);
   }
 }

--- a/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
+++ b/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
@@ -116,44 +116,28 @@ export class ExtensionDebugService implements DebugServer, ExtensionDebugAdapter
     }
   }
 
-  async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration> {
-    let resolved = config;
-    // 处理请求类型为 `*` 的情况
-    for (const contributor of this.contributors.values()) {
-      if (contributor) {
-        try {
-          const next = await contributor.resolveDebugConfiguration(resolved, workspaceFolderUri);
-          if (next) {
-            resolved = next;
-          } else {
-            return resolved;
-          }
-        } catch (e) {
-          this.logger.error(e);
-        }
+  async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null> {
+    const contributor = this.contributors.get(config.type);
+    if (contributor) {
+      try {
+        const next = await contributor.resolveDebugConfiguration(config, workspaceFolderUri);
+        return next;
+      } catch (e) {
+        this.logger.error(e);
       }
     }
-    return resolved;
   }
 
-  async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration> {
-    let resolved = config;
-    // 处理请求类型为 `*` 的情况
-    for (const contributor of this.contributors.values()) {
-      if (contributor) {
-        try {
-          const next = await contributor.resolveDebugConfigurationWithSubstitutedVariables(resolved, workspaceFolderUri);
-          if (next) {
-            resolved = next;
-          } else {
-            return resolved;
-          }
-        } catch (e) {
-          this.logger.error(e);
-        }
+  async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null> {
+    const contributor = this.contributors.get(config.type);
+    if (contributor) {
+      try {
+        const next = await contributor.resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
+        return next;
+      } catch (e) {
+        this.logger.error(e);
       }
     }
-    return resolved;
   }
 
   async getDebuggersForLanguage(language: string): Promise<DebuggerDescription[]> {

--- a/packages/extension/src/common/vscode/debug.ts
+++ b/packages/extension/src/common/vscode/debug.ts
@@ -33,8 +33,8 @@ export interface IExtHostDebug {
   $sessionDidDestroy(sessionId: string): void;
   $sessionDidChange(sessionId: string | undefined): void;
   $provideDebugConfigurations(debugType: string, workspaceFolder: string | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]>;
-  $resolveDebugConfigurations(debugConfiguration: vscode.DebugConfiguration, workspaceFolder: string | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined>;
-  $resolveDebugConfigurationWithSubstitutedVariables(debugConfiguration: vscode.DebugConfiguration, workspaceFolder: string | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined>;
+  $resolveDebugConfigurations(debugConfiguration: vscode.DebugConfiguration, workspaceFolder: string | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined | null>;
+  $resolveDebugConfigurationWithSubstitutedVariables(debugConfiguration: vscode.DebugConfiguration, workspaceFolder: string | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined | null>;
   $getSupportedLanguages(debugType: string): Promise<string[]>;
   $getSchemaAttributes(debugType: string): Promise<IJSONSchema[]>;
   $getConfigurationSnippets(debugType: string): Promise<IJSONSchemaSnippet[]>;

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -334,6 +334,8 @@ export const localizationBundle = {
     'debug.launch.configurations.debugWindowsConfiguration': 'Windows specific launch configuration attributes.',
     'debug.launch.configurations.debugOSXConfiguration': 'OS X specific launch configuration attributes.',
     'debug.launch.configurations.debugLinuxConfiguration': 'Linux specific launch configuration attributes.',
+    'debug.launch.typeNotSupported': 'The debug session type "{0}" is not supported.',
+    'debug.launch.catchError': 'There was an error starting the debug session, check the logs for more details.',
 
     'output.tabbar.title': 'OUTPUT',
     'output.channel.none': '<no output yet>',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -320,6 +320,8 @@ export const localizationBundle = {
     'debug.launch.configurations.debugWindowsConfiguration': '特定于 Windows 的启动配置属性。',
     'debug.launch.configurations.debugOSXConfiguration': '特定于 OS X 的启动配置属性。',
     'debug.launch.configurations.debugLinuxConfiguration': '特定于 Linux 的启动配置属性。',
+    'debug.launch.typeNotSupported': '调试类型 "{0}" 不支持',
+    'debug.launch.catchError': '启动调试进程时遇到了错误, 请检查调试控制台',
 
     'workspace.openDirectory': '打开文件夹',
     'workspace.addFolderToWorkspace': '将文件夹添加到工作区...',


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案

参考 VS Code debug 文档：https://code.visualstudio.com/api/references/vscode-api#DebugConfigurationProvider

分别处理 `resolveDebugConfigurations`  和 `resolveDebugConfigurationWithSubstitutedVariables`

### changelog

对齐 VS Code 调试配置处理逻辑
