### PR TITLE
feat: support DebugSession.parentSession API

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -19,7 +19,7 @@ import { Injectable, Autowired } from '@opensumi/di';
 import { DebugSession } from './debug-session';
 import { WaitUntilEvent, Emitter, Event, URI, IContextKey, DisposableCollection, IContextKeyService, formatLocalize, Uri, IReporterService, uuid, localize, COMMON_COMMANDS, CommandService } from '@opensumi/ide-core-browser';
 import { BreakpointManager } from './breakpoint/breakpoint-manager';
-import { DebugConfiguration, DebugError, IDebugServer, DebugServer, DebugSessionOptions, InternalDebugSessionOptions, DEBUG_REPORT_NAME, IDebugSessionManager, DebugSessionExtra, DebugThreadExtra, CONTEXT_DEBUG_STOPPED_KEY, CONTEXT_IN_DEBUG_MODE_KEY, CONTEXT_DEBUG_TYPE_KEY, DebugState } from '../common';
+import { DebugConfiguration, DebugError, IDebugServer, DebugServer, DebugSessionOptions, IDebugSessionDTO, DEBUG_REPORT_NAME, IDebugSessionManager, DebugSessionExtra, DebugThreadExtra, CONTEXT_DEBUG_STOPPED_KEY, CONTEXT_IN_DEBUG_MODE_KEY, CONTEXT_DEBUG_TYPE_KEY, DebugState } from '../common';
 import { DebugStackFrame } from './model/debug-stack-frame';
 import { IMessageService } from '@opensumi/ide-overlay';
 import { IVariableResolverService } from '@opensumi/ide-variable';
@@ -294,7 +294,7 @@ export class DebugSessionManager implements IDebugSessionManager {
         }
         this.debugProgressService.onDebugServiceStateChange(DebugState.Running);
       }
-      const sessionId = await this.debug.createDebugSession(resolved.configuration);
+      const sessionId = await this.debug.createDebugSession(resolved);
       timeStart(resolved.configuration.type, {
         adapterID: resolved.configuration.type,
         request: resolved.configuration.request,
@@ -321,8 +321,8 @@ export class DebugSessionManager implements IDebugSessionManager {
   }
 
   protected configurationIds = new Map<string, number>();
-  async resolveConfiguration(options: Readonly<DebugSessionOptions>): Promise<InternalDebugSessionOptions | undefined> {
-    if (InternalDebugSessionOptions.is(options)) {
+  async resolveConfiguration(options: Readonly<DebugSessionOptions>): Promise<IDebugSessionDTO | undefined> {
+    if (IDebugSessionDTO.is(options)) {
       return options;
     }
     const { workspaceFolderUri, index, noDebug, parentSession, repl, compact, lifecycleManagedByParent } = options;

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -12,7 +12,7 @@ import {
 } from '@opensumi/ide-core-browser';
 import debounce = require('lodash.debounce');
 import { DebugSessionConnection } from './debug-session-connection';
-import { DebugSessionOptions, InternalDebugSessionOptions, IDebugSession, IDebugSessionManager, DEBUG_REPORT_NAME, DebugState, DebugEventTypes, DebugExitEvent, DebugRequestTypes } from '../common';
+import { DebugSessionOptions, IDebugSessionDTO, IDebugSession, IDebugSessionManager, DEBUG_REPORT_NAME, DebugState, DebugEventTypes, DebugRequestTypes, DebugExitEvent } from '../common';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol';
@@ -573,7 +573,7 @@ export class DebugSession implements IDebugSession {
   }
 
   get label(): string {
-    if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
+    if (IDebugSessionDTO.is(this.options) && this.options.id) {
       return this.configuration.name + ' (' + (this.options.id + 1) + ')';
     }
     return this.configuration.name;

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -1,5 +1,6 @@
 import { IDisposable, IJSONSchema,  IJSONSchemaSnippet, ApplicationError, Event } from '@opensumi/ide-core-common';
 import { DebugConfiguration } from './debug-configuration';
+import { IDebugSessionDTO } from './debug-session-options';
 
 export interface DebuggerDescription {
     type: string;
@@ -60,7 +61,7 @@ export interface DebugServer extends IDisposable {
    * @param config 传入配置
    * @returns DebugAdapterSession对应sessionId.
    */
-  createDebugSession(config: DebugConfiguration): Promise<string | void>;
+  createDebugSession(config: IDebugSessionDTO): Promise<string | void>;
 
   /**
    * 终止一个调试进程

--- a/packages/debug/src/common/debug-session-options.ts
+++ b/packages/debug/src/common/debug-session-options.ts
@@ -7,12 +7,13 @@ export interface DebugSessionOptions extends IDebugSessionOptions {
   index: number;
 }
 
-export interface InternalDebugSessionOptions extends DebugSessionOptions {
+export interface IDebugSessionDTO extends DebugSessionOptions {
   id: number;
+  parent?: string;
 }
 
-export namespace InternalDebugSessionOptions {
-  export function is(options: DebugSessionOptions): options is InternalDebugSessionOptions {
+export namespace IDebugSessionDTO {
+  export function is(options: DebugSessionOptions): options is IDebugSessionDTO {
       return ('id' in options);
   }
 }

--- a/packages/debug/src/common/debug-session.ts
+++ b/packages/debug/src/common/debug-session.ts
@@ -1,6 +1,6 @@
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol';
 import { IDisposable } from '@opensumi/ide-core-browser';
-import { DebugSessionOptions, InternalDebugSessionOptions } from './debug-session-options';
+import { DebugSessionOptions, IDebugSessionDTO } from './debug-session-options';
 import { DebugConfiguration } from './debug-configuration';
 import { CancellationToken } from '@opensumi/ide-core-common';
 
@@ -26,7 +26,7 @@ export const IDebugSession = Symbol('DebugSession');
 export const IDebugSessionManager = Symbol('DebugSessionManager');
 export interface IDebugSessionManager {
   fireWillStartDebugSession(): Promise<void>;
-  resolveConfiguration(options: Readonly<DebugSessionOptions>): Promise<InternalDebugSessionOptions | undefined>;
+  resolveConfiguration(options: Readonly<DebugSessionOptions>): Promise<IDebugSessionDTO | undefined>;
   resolveDebugConfiguration(configuration: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined | null>;
   fireWillResolveDebugConfiguration(debugType: string): Promise<void>;
   report(name: string, msg: string | undefined, extra?: any): void;

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.debug.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.debug.test.ts
@@ -159,9 +159,13 @@ describe('packages/extension/__tests__/hosted/api/vscode/ext.host.debug.test.ts'
 
   it('RPC methods all should be work', async (done) => {
     const sessionId = await extHostDebug.$createDebugSession({
-      type: 'node',
-      name: 'test',
-      request: '',
+      configuration: {
+        type: 'node',
+        name: 'test',
+        request: '',
+      },
+      id: 1000,
+      index: 1,
     });
     expect(mockMainThreadConnection.$createConnection).toBeCalledTimes(1);
     await extHostDebug.$onSessionCustomEvent(sessionId, 'event');

--- a/packages/extension/src/browser/vscode/api/debug/extension-debug-adapter-contribution.ts
+++ b/packages/extension/src/browser/vscode/api/debug/extension-debug-adapter-contribution.ts
@@ -1,4 +1,4 @@
-import { DebuggerDescription, DebugConfiguration } from '@opensumi/ide-debug';
+import { DebuggerDescription, DebugConfiguration, IDebugSessionDTO } from '@opensumi/ide-debug';
 import { MaybePromise, IJSONSchema, IJSONSchemaSnippet } from '@opensumi/ide-core-browser';
 import { IExtHostDebug } from '../../../../common/vscode';
 import { IActivationEventService } from '../../../types';
@@ -41,9 +41,14 @@ export class ExtensionDebugAdapterContribution {
     return await this.extDebug.$resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
   }
 
-  async createDebugSession(config: DebugConfiguration): Promise<string> {
-    await this.activationEventService.fireEvent('onDebugAdapterProtocolTracker', config.type);
-    return await this.extDebug.$createDebugSession(config);
+  async createDebugSession(dto: IDebugSessionDTO): Promise<string> {
+    const { configuration } = dto;
+    await this.activationEventService.fireEvent('onDebugAdapterProtocolTracker', configuration.type);
+    return await this.extDebug.$createDebugSession({
+      ...dto,
+      parentSession: undefined,
+      parent: dto.parentSession ? dto.parentSession.id : undefined,
+    });
   }
 
   async terminateDebugSession(sessionId: string): Promise<void> {

--- a/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
+++ b/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Autowired } from '@opensumi/di';
-import { DebugServer, DebuggerDescription, IDebugSessionManager } from '@opensumi/ide-debug';
+import { DebugServer, DebuggerDescription, IDebugSessionManager, IDebugSessionDTO } from '@opensumi/ide-debug';
 import { ExtensionDebugAdapterContribution } from './extension-debug-adapter-contribution';
 import { Disposable, IDisposable, DisposableCollection, IJSONSchema, IJSONSchemaSnippet, WaitUntilEvent } from '@opensumi/ide-core-browser';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
@@ -175,10 +175,11 @@ export class ExtensionDebugService implements DebugServer, ExtensionDebugAdapter
     return snippets;
   }
 
-  async createDebugSession(config: DebugConfiguration): Promise<string | void> {
-    const contributor = this.contributors.get(config.type);
+  async createDebugSession(dto: IDebugSessionDTO): Promise<string | void> {
+    const { configuration } = dto;
+    const contributor = this.contributors.get(configuration.type);
     if (contributor) {
-      const sessionId = await contributor.createDebugSession(config);
+      const sessionId = await contributor.createDebugSession(dto);
       this.sessionId2contrib.set(sessionId, contributor);
       return sessionId;
     }

--- a/packages/extension/src/common/vscode/debug.ts
+++ b/packages/extension/src/common/vscode/debug.ts
@@ -2,7 +2,7 @@ import { IJSONSchema, IJSONSchemaSnippet, Event } from '@opensumi/ide-core-commo
 import { Breakpoint } from './models';
 import type vscode from 'vscode';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol';
-import { DebuggerDescription, DebugConfiguration, IDebuggerContribution } from '@opensumi/ide-debug';
+import { DebuggerDescription, DebugConfiguration, IDebuggerContribution, IDebugSessionDTO } from '@opensumi/ide-debug';
 import { WorkspaceFolder } from './models';
 
 export type DebugSessionUUID = string;
@@ -39,7 +39,7 @@ export interface IExtHostDebug {
   $getSupportedLanguages(debugType: string): Promise<string[]>;
   $getSchemaAttributes(debugType: string): Promise<IJSONSchema[]>;
   $getConfigurationSnippets(debugType: string): Promise<IJSONSchemaSnippet[]>;
-  $createDebugSession(debugConfiguration: vscode.DebugConfiguration): Promise<string>;
+  $createDebugSession(debugSessionDTO: Exclude<IDebugSessionDTO, 'parentSession'>): Promise<string>;
   $terminateDebugSession(sessionId: string): Promise<void>;
   $getTerminalCreationOptions(debugType: string): Promise<any>;
   $registerDebuggerContributions(extensionFolder: string, contributions: IDebuggerContribution[]);

--- a/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-session.ts
+++ b/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-session.ts
@@ -22,6 +22,10 @@ export class ExtensionDebugAdapterSession extends StreamDebugAdapter implements 
     this.configuration = debugSession.configuration;
   }
 
+  public get parentSession(): vscode.DebugSession | undefined {
+    return this.debugSession.parentSession;
+  }
+
   async start(channel: IWebSocket): Promise<void> {
     if (this.tracker.onWillStartSession) {
       this.tracker.onWillStartSession();

--- a/packages/types/vscode/typings/vscode.debug.d.ts
+++ b/packages/types/vscode/typings/vscode.debug.d.ts
@@ -39,6 +39,12 @@ declare module 'vscode' {
     readonly type: string;
 
     /**
+     * The parent session of this debug session, if it was created as a child.
+     * @see DebugSessionOptions.parentSession
+     */
+    readonly parentSession?: DebugSession;
+
+    /**
      * The debug session's name from the [debug configuration](#DebugConfiguration).
      */
     readonly name: string;


### PR DESCRIPTION
### 变动类型

- [x] 新特性提交

### 需求背景和解决方案

例如可以在插件里通过 vscode.debug.activeDebugSession 获取到 parentSession

![image](https://user-images.githubusercontent.com/20262815/143840820-08af3731-1f6d-4ecb-b191-b03cbd13ad7f.png)


### changelog
DebugSession API 支持 parentSession 参数