### PR TITLE
fix: panel.view.TitleBar render condition

### DIFF
--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -81,8 +81,7 @@ const ContainerView: React.FC<{
     <div ref={containerRef} className={styles.view_container}>
       {!CustomComponent && <div onContextMenu={handleContextMenu} className={styles.panel_titlebar}>
         {
-          // title and titleMenu both none, donot render
-          !title && !titleMenu ? null :
+          !title ? null :
           <TitleBar
             title={title!}
             menubar={<InlineActionBar menus={titleMenu} />}


### PR DESCRIPTION
### 变动类型
- [x] 日常 bug 修复

### 需求背景和解决方案
`titleMenu` 是一定不为空的，之前条件判断有问题
### changelog
