### PR TITLE
style: keep editor component scrollbar and remove tabs scrollbar

### DIFF
--- a/packages/editor/src/browser/component/scroll/scroll.module.less
+++ b/packages/editor/src/browser/component/scroll/scroll.module.less
@@ -18,7 +18,7 @@
 .thumb-vertical {
   position: absolute;
   width:5px;
-  opacity: 0;
+  opacity: 0.8;
   top:0;
   transition: opacity 200ms ease-out;
   background: var(--scrollbarSlider-background);
@@ -66,8 +66,7 @@
     background: rgb(50, 50, 50);
   }
   >*:first-child{
-    overflow-x: auto;
-    overflow-y: hidden;
+    overflow: auto;
     height:100%;
     width:100%;
   }

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -99,6 +99,13 @@
   .kt_editor_tabs_scroll_wrapper {
     flex-grow:1;
     width:10px;
+    div {
+      &:first-child {
+        >*:first-child{
+          overflow-y: hidden;
+        }
+      }
+    }
   }
 
   .kt_editor_tabs_scroll {


### PR DESCRIPTION
### 变动类型

- [x] 样式改进

### 需求背景和解决方案

阻止编辑器 tab 的纵向滚动，同时保留编辑器视图的滚动条

### changelog

keep editor component scrollbar and remove tabs scrollbar