### PR TITLE
fix: theme fallback logic

### DIFF
--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -40,9 +40,16 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
     this.registerDefaultTokenType();
     this.registerDefaultTokenModifier();
 
-    const themeId = this.preferenceService.get<string>(COLOR_THEME_SETTING);
-    if (!themeId || themeId === DEFAULT_THEME_ID) {
-      this.themeService.applyTheme(DEFAULT_THEME_ID);
+    this.initializeDefaultTheme();
+  }
+
+  private initializeDefaultTheme() {
+    const globalProvider = this.preferenceService.getProvider(PreferenceScope.User);
+    if (globalProvider) {
+      const themeId = globalProvider.get<string>(COLOR_THEME_SETTING);
+      if (!themeId || themeId === DEFAULT_THEME_ID) {
+        this.themeService.applyTheme(DEFAULT_THEME_ID);
+      }
     }
   }
 


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案
之前的改动会导致工作区主题修改后刷新失效，修复方式是仅获取全局的主题设置，若没有再走 fallback 逻辑，理论上这一段只会走一次，后面有任何主题修改都不会走这里了

### changelog

- 修复没有任何主题时的 fallback 逻辑