### PR TITLE
fix: extHostPreferences parse error

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.preference.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.preference.ts
@@ -110,24 +110,23 @@ export class ExtHostPreference implements IExtHostPreference {
   private parseConfigurationData(data: { [key: string]: any }): { [key: string]: any } {
     return Object.keys(data).reduce((result: any, key: string) => {
       const parts = key.split('.');
-      let branch = result;
 
       for (let i = 0; i < parts.length; i++) {
         if (i === parts.length - 1) {
-          branch[parts[i]] = data[key];
+          result[parts[i]] = data[key];
           continue;
         }
-        if (!branch[parts[i]]) {
-          branch[parts[i]] = {};
+        if (!result[parts[i]]) {
+          result[parts[i]] = {};
         }
-        branch = branch[parts[i]];
+        result = result[parts[i]];
 
         // overridden 的属性，如languages的 [typescript].editor.tabsize 转换为
         // "[typescript]" : {
         //    "editor.tabsize" : "2"
         //  }
         if (i === 0 && this.OVERRIDE_PROPERTY_PATTERN.test(parts[i])) {
-          branch[key.substring(parts[0].length + 1)] = data[key];
+          result[key.substring(parts[0].length + 1)] = data[key];
           break;
         }
       }


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案
对于 `clangd-format.executable.windows` 这类值，初始化时报错

![image](https://user-images.githubusercontent.com/17701805/144351491-daead863-27df-4a2b-a351-783878caf1d1.png)



### changelog
- 修复插件进程中对于  `a.b.c` 值解析错误的问题