### PR TITLE
feat: auto release by new tag with prefix v*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: RELEASE
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node_version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: npm install
+      - run: npm run init
+
+      - run: |
+          cd tools/electron
+          npm i
+          npm run rebuild-native
+          npm run link-local
+          npm run pack
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          files: |
+            LICENSE
+            tools/electron/dist/*.dmg
+
+      - name: Release ✅
+        if: ${{ success() }}
+        run: |
+          echo 执行成功
+
+      - name: Release 🚨
+        if: ${{ failure() }}
+        run: |
+          echo 执行失败


### PR DESCRIPTION
### 变动类型

- [x] 新特性提交

### 需求背景和解决方案
主动推版本号能自动打包成 dmg。
- tag 前缀要求是 v 开头，比如 v2.13.0
- 默认打的是 pre release 信息，需要手动修改再开放为 release（这样比较保险）
- 提供一个 release 页面的 change log 信息列表：
![image](https://user-images.githubusercontent.com/2226423/144377048-cd1640c8-4357-4fde-b9f5-8b6017de605d.png)

related #83 

### changelog
- 根据 tag 主动打包 Sumi 桌面版本