### PR TITLE
feat: 代码导航跳转出去时，编辑器Tab自动固定

### DIFF
--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1317,6 +1317,11 @@ const customEditorSchema: PreferenceSchemaProperties = {
     default: false,
     description: '%editor.configuration.wrapTab%',
   },
+  'editor.enablePreviewFromCodeNavigation': {
+    type: 'boolean',
+    default: false,
+    description: '%editor.configuration.enablePreviewFromCodeNavigation%',
+  },
   'editor.minimap': {
     type: 'boolean',
     default: false,

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -459,6 +459,7 @@ export const localizationBundle = {
     'keymaps.tab.name': 'Keyboard Shortcuts',
 
     'preference.editor.wrapTab': 'Wrap Editor Tabs',
+    'preference.editor.enablePreviewFromCodeNavigation': 'Controls whether editors remain in preview when a code navigation is started from them. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled.',
     'preference.editor.preferredFormatter': 'Default Formatter',
     'preference.editor.previewMode': 'Preview Mode',
     'preference.editor.fontFamily': 'Font Family',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -441,6 +441,7 @@ export const localizationBundle = {
     'preference.array.additem': '添加',
 
     'editor.configuration.wrapTab': '控制当编辑器 Tab 超过可用空间时，是否使用换行来代替滚动模式。',
+    'editor.configuration.enablePreviewFromCodeNavigation': '控制当代码导航从其出发时，编辑器是否仍处于预览模式。',
     'editor.configuration.renderLineHighlight': '控制编辑器的当前行突出显示方式。',
     'editor.configuration.formatOnSaveTimeout': '控制保存时格式化的超时时间（毫秒）。仅当 `#editor.formatOnSave#` 启用时生效。',
     'editor.configuration.autoSave': '控制如何自动保存文件。',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -358,6 +358,7 @@ export const defaultSettingSections: {
       preferences: [
         // 预览模式
         { id: 'editor.previewMode', localized: 'preference.editor.previewMode' },
+        { id: 'editor.enablePreviewFromCodeNavigation', localized: 'preference.editor.enablePreviewFromCodeNavigation' },
         // 自动保存
         { id: 'editor.autoSave', localized: 'preference.editor.autoSave' },
         { id: 'editor.autoSaveDelay', localized: 'preference.editor.autoSaveDelay' },


### PR DESCRIPTION
### 变动类型

- [x] 新特性提交

### 需求背景和解决方案
目前从编辑器通过代码导航跳转到新文件时，如果当前文件为预览模式，Tab 会被替换掉，该 PR follow 了 vscode 的 `workbench.editor.enablePreviewFromCodeNavigation` 配置，支持自定义该行为，默认改为不替换

### changelog
pin editor tab where code navigation started