### PR TITLE
chore: improve menu item divider style

### DIFF
--- a/packages/components/src/menu/style.less
+++ b/packages/components/src/menu/style.less
@@ -37,12 +37,6 @@
     transition: all 0.3s;
   }
 
-  &-submenu,
-  &-submenu-inline {
-    transition: border-color 0.3s @ease-in-out, background 0.3s @ease-in-out,
-      padding 0.15s @ease-in-out;
-  }
-
   &-submenu-selected {
     color: @menu-highlight-color;
   }

--- a/packages/core-browser/src/style/override.less
+++ b/packages/core-browser/src/style/override.less
@@ -65,7 +65,6 @@
       border-radius: 0 !important;
       min-width: 120px;
       background-color: var(--menu-background) !important;
-      transition: none !important;
     }
   }
 


### PR DESCRIPTION
### 变动类型

- [x] 样式改进

### 需求背景和解决方案
之前的样式有点扎眼

![image](https://user-images.githubusercontent.com/17701805/145529444-2bba8ee4-dd07-43eb-b69f-04e68480c58f.png)
![image](https://user-images.githubusercontent.com/17701805/145529454-df6e1984-bc56-4ddd-adbb-67dc67e0ec8b.png)

after

![image](https://user-images.githubusercontent.com/17701805/145529504-abcda934-af09-4d5d-bfe8-a74676bb21ea.png)
![image](https://user-images.githubusercontent.com/17701805/145529534-51019398-1baa-49f8-91fe-c62c7494a34d.png)


去掉了 transition
![context-menu-transition](https://user-images.githubusercontent.com/17701805/145540618-3b54ae06-6281-4942-addc-b116b952bb76.gif)


### changelog
- 更新右键菜单样式