### PR TITLE
feat: remove archived api

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.api.progress.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.progress.ts
@@ -1,6 +1,6 @@
 import { IMainThreadProgress, IExtHostProgress } from '../../../common/vscode/progress';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Autowired, Injectable, Optinal } from '@opensumi/di';
+import { Autowired, Injectable, Optional } from '@opensumi/di';
 import { ExtHostAPIIdentifier } from '../../../common/vscode';
 import { IProgressOptions, IProgressStep, IProgress, ProgressLocation, IProgressNotificationOptions } from '@opensumi/ide-core-common';
 import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
@@ -14,7 +14,7 @@ export class MainThreadProgress implements IMainThreadProgress {
   @Autowired(IProgressService)
   private readonly progressService: IProgressService;
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostProgress);
   }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.api.webview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.webview.ts
@@ -1,5 +1,5 @@
 import { IMainThreadWebview, WebviewPanelShowOptions, IWebviewPanelOptions, IWebviewOptions, ExtHostAPIIdentifier, IExtHostWebview, IWebviewPanelViewState, IMainThreadWebviewView, IWebviewExtensionDescription, IExtHostWebviewView, WebviewViewResolverRegistrationEvent, WebviewViewResolverRegistrationRemovalEvent, WebviewViewOptions } from '../../../common/vscode';
-import { Injectable, Autowired, Optinal } from '@opensumi/di';
+import { Injectable, Autowired, Optional } from '@opensumi/di';
 import { IWebviewService, IEditorWebviewComponent, IWebview, IPlainWebview, IPlainWebviewComponentHandle } from '@opensumi/ide-webview';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { WorkbenchEditorService, IResource } from '@opensumi/ide-editor';
@@ -69,7 +69,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
 
   private extWebviewStorage: Promise<IStorage>;
 
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
     super();
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostWebview);
     this.sumiProxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.SumiExtHostWebview);

--- a/packages/extension/src/browser/vscode/api/main.thread.commands.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.commands.ts
@@ -1,6 +1,6 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { ExtHostAPIIdentifier, IMainThreadCommands, IExtHostCommands, ArgumentProcessor } from '../../../common/vscode';
-import { Injectable, Autowired, Optinal } from '@opensumi/di';
+import { Injectable, Autowired, Optional } from '@opensumi/di';
 import { CommandRegistry, ILogger, IContextKeyService, IDisposable } from '@opensumi/ide-core-browser';
 import { URI, isNonEmptyArray, Disposable, IExtensionInfo } from '@opensumi/ide-core-common';
 import { ICommandServiceToken, IMonacoCommandService } from '@opensumi/ide-monaco/lib/browser/contrib/command';
@@ -30,7 +30,7 @@ export class MainThreadCommands implements IMainThreadCommands {
 
   private disposable = new Disposable();
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol, fromWorker?: boolean) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol, fromWorker?: boolean) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostCommands);
     if (!fromWorker) {
       this.proxy.$registerBuiltInCommands();

--- a/packages/extension/src/browser/vscode/api/main.thread.connection.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.connection.ts
@@ -1,6 +1,6 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { Disposable, DisposableCollection } from '@opensumi/ide-core-common';
-import { Injectable, Optinal, Autowired } from '@opensumi/di';
+import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { ILoggerManagerClient, ILogServiceClient, SupportLogNamespace, Deferred } from '@opensumi/ide-core-browser';
 
 import { IMainThreadConnectionService, ExtensionConnection, IExtHostConnection, ExtHostAPIIdentifier, ExtensionMessageReader, ExtensionMessageWriter } from '../../../common/vscode';
@@ -16,7 +16,7 @@ export class MainThreadConnection implements IMainThreadConnectionService {
   protected readonly LoggerManager: ILoggerManagerClient;
   protected readonly logger: ILogServiceClient;
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostConnection);
     this.logger = this.LoggerManager.getLogger(SupportLogNamespace.ExtensionHost);
   }

--- a/packages/extension/src/browser/vscode/api/main.thread.debug.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.debug.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optinal, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
+import { Injectable, Optional, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
 import { IMainThreadDebug, ExtHostAPIIdentifier, IExtHostDebug, ExtensionWSChannel, IMainThreadConnectionService, IStartDebuggingOptions } from '../../../common/vscode';
 import { DisposableCollection, Uri, ILoggerManagerClient, ILogServiceClient, SupportLogNamespace, URI } from '@opensumi/ide-core-browser';
 import { DebuggerDescription, IDebugService, DebugConfiguration, IDebugServer, IDebuggerContribution, IDebugServiceContributionPoint } from '@opensumi/ide-debug';
@@ -83,8 +83,8 @@ export class MainThreadDebug implements IMainThreadDebug {
   private readonly injector: Injector;
 
   constructor(
-    @Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol,
-    @Optinal(IMainThreadConnectionService) private mainThreadConnection: IMainThreadConnectionService,
+    @Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol,
+    @Optional(IMainThreadConnectionService) private mainThreadConnection: IMainThreadConnectionService,
   ) {
     this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionHost);
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostDebug);

--- a/packages/extension/src/browser/vscode/api/main.thread.doc.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.doc.ts
@@ -1,7 +1,7 @@
 import { WithEventBus, OnEvent, Event, URI, IDisposable, Disposable, isUndefinedOrNull, Emitter, LRUMap } from '@opensumi/ide-core-common';
 import { ExtHostAPIIdentifier, IMainThreadDocumentsShape, IExtensionHostDocService } from '../../../common/vscode';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Injectable, Optinal, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { Injectable, Optional, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import { Schemas } from '../../../common/vscode/ext-types';
 import { ResourceService } from '@opensumi/ide-editor';
 import { EditorComponentRegistry, IEditorDocumentModelService, IEditorDocumentModelContentRegistry, IEditorDocumentModelRef, EditorDocumentModelContentChangedEvent, EditorDocumentModelCreationEvent, EditorDocumentModelRemovalEvent, EditorDocumentModelSavedEvent, IEditorDocumentModelContentProvider, EditorDocumentModelOptionChangedEvent, EditorDocumentModelWillSaveEvent } from '@opensumi/ide-editor/lib/browser';
@@ -99,7 +99,7 @@ export class MainThreadExtensionDocumentData extends WithEventBus implements IMa
     return this.docSyncEnabled.get(uriString)!;
   }
 
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
     super();
 
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostDocuments);

--- a/packages/extension/src/browser/vscode/api/main.thread.editor.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor.ts
@@ -2,7 +2,7 @@ import type { ICodeEditor as IMonacoCodeEditor, ITextModel } from '@opensumi/ide
 import { RenderLineNumbersType } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 import { StaticServices } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
-import { Injectable, Autowired, Optinal } from '@opensumi/di';
+import { Injectable, Autowired, Optional } from '@opensumi/di';
 import { IMainThreadEditorsService, IExtensionHostEditorService, ExtHostAPIIdentifier, IEditorChangeDTO, IResolvedTextEditorConfiguration, TextEditorRevealType, ITextEditorUpdateConfiguration, TextEditorCursorStyle } from '../../../common/vscode';
 import { WorkbenchEditorService, IEditorGroup, IResource, IUndoStopOptions, ISingleEditOperation, IDecorationApplyOptions, IEditorOpenType, IResourceOpenOptions, EditorCollectionService, IDecorationRenderOptions, IThemeDecorationRenderOptions } from '@opensumi/ide-editor';
 import { WorkbenchEditorServiceImpl } from '@opensumi/ide-editor/lib/browser/workbench-editor.service';
@@ -32,7 +32,7 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
 
   private readonly proxy: IExtensionHostEditorService;
 
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol, private documents: MainThreadExtensionDocumentData) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol, private documents: MainThreadExtensionDocumentData) {
     super();
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostEditors);
     this.$getInitialState().then((change) => {

--- a/packages/extension/src/browser/vscode/api/main.thread.env.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.env.ts
@@ -1,5 +1,5 @@
 import type vscode from 'vscode';
-import { Injectable, Optinal, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { Injectable, Optional, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import { IRPCProtocol, WSChannelHandler } from '@opensumi/ide-connection';
 import { ILoggerManagerClient } from '@opensumi/ide-logs/lib/browser';
 import { IMainThreadEnv, IExtHostEnv, ExtHostAPIIdentifier } from '../../../common/vscode';
@@ -38,7 +38,7 @@ export class MainThreadEnv implements IMainThreadEnv {
     return HttpOpener.standardSupportedLinkSchemes.has(uri.scheme) || uri.scheme === this.appConfig.uriScheme;
   }
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol, private storage: MainThreadStorage) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol, private storage: MainThreadStorage) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostEnv);
 
     this.eventDispose = this.loggerManger.onDidChangeLogLevel((level) => {

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -2,7 +2,7 @@ import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import * as modes from '@opensumi/monaco-editor-core/esm/vs/editor/common/modes';
 import { StaticServices } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import type { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
-import { Autowired, Injectable, Optinal } from '@opensumi/di';
+import { Autowired, Injectable, Optional } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { IReporterService, PreferenceService } from '@opensumi/ide-core-browser';
 import { DisposableCollection, Emitter, IMarkerData, IRange, LRUMap, MarkerManager, REPORT_NAME, URI } from '@opensumi/ide-core-common';
@@ -59,7 +59,7 @@ export class MainThreadLanguages implements IMainThreadLanguages {
     return data as modes.CodeAction[];
   }
 
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy<IExtHostLanguages>(ExtHostAPIIdentifier.ExtHostLanguages);
   }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.message.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.message.ts
@@ -1,7 +1,7 @@
 import type vscode from 'vscode';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 import { IMainThreadMessage, IExtHostMessage, ExtHostAPIIdentifier } from '../../../common/vscode';
-import { Injectable, Optinal, Autowired } from '@opensumi/di';
+import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { MessageType } from '@opensumi/ide-core-common';
 
@@ -16,7 +16,7 @@ export class MainThreadMessage implements IMainThreadMessage {
   @Autowired(IMessageService)
   protected readonly messageService: IMessageService;
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostMessage);
   }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.preference.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.preference.ts
@@ -1,6 +1,6 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { ExtHostAPIIdentifier, IMainThreadPreference, PreferenceData, PreferenceChangeExt } from '../../../common/vscode';
-import { Injectable, Optinal, Autowired } from '@opensumi/di';
+import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { ConfigurationTarget } from '../../../common/vscode';
 import { PreferenceService, PreferenceProviderProvider, PreferenceScope, DisposableCollection, PreferenceSchemaProvider } from '@opensumi/ide-core-browser';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
@@ -47,7 +47,7 @@ export class MainThreadPreference implements IMainThreadPreference {
   protected readonly toDispose = new DisposableCollection();
 
   private readonly proxy: any;
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostPreference);
     this.toDispose.push(this.preferenceService.onPreferencesChanged((changes) => {
       const roots = this.workspaceService.tryGetRoots();

--- a/packages/extension/src/browser/vscode/api/main.thread.storage.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.storage.ts
@@ -1,6 +1,6 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { ExtHostAPIIdentifier, IMainThreadStorage, KeysToAnyValues, IExtHostStorage } from '../../../common/vscode';
-import { Injectable, Autowired, Optinal } from '@opensumi/di';
+import { Injectable, Autowired, Optional } from '@opensumi/di';
 import { IExtensionStorageService } from '@opensumi/ide-extension-storage';
 
 @Injectable({multiple: true})
@@ -10,7 +10,7 @@ export class MainThreadStorage implements IMainThreadStorage {
   @Autowired(IExtensionStorageService)
   extensionStorageService: IExtensionStorageService;
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostStorage);
     this.init();
   }

--- a/packages/extension/src/browser/vscode/api/main.thread.terminal.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.terminal.ts
@@ -1,5 +1,5 @@
 import type vscode from 'vscode';
-import { Injectable, Optinal, Autowired } from '@opensumi/di';
+import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { ILogger, Disposable, PreferenceService, IDisposable } from '@opensumi/ide-core-browser';
 import { ITerminalApiService, ITerminalGroupViewService, ITerminalController, ITerminalInfo, ITerminalProcessExtHostProxy, IStartExtensionTerminalRequest, ITerminalDimensions, ITerminalDimensionsDto, ITerminalExternalLinkProvider, ITerminalClient, ITerminalLink } from '@opensumi/ide-terminal-next';
@@ -40,7 +40,7 @@ export class MainThreadTerminal implements IMainThreadTerminal {
   @Autowired(ILogger)
   logger: ILogger;
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostTerminal);
     this.initData();
     this.bindEvent();

--- a/packages/extension/src/browser/vscode/api/main.thread.theming.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.theming.ts
@@ -1,6 +1,6 @@
 import { IMainThreadTheming, IExtHostTheming } from '../../../common/vscode';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Autowired, Injectable, Optinal } from '@opensumi/di';
+import { Autowired, Injectable, Optional } from '@opensumi/di';
 import { ExtHostAPIIdentifier } from '../../../common/vscode';
 import { IThemeService } from '@opensumi/ide-theme';
 import { IDisposable } from '@opensumi/ide-core-common';
@@ -14,7 +14,7 @@ export class MainThreadTheming implements IMainThreadTheming {
 
   private readonly _themeChangeListener: IDisposable;
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostTheming);
     this._themeChangeListener = this._themeService.onThemeChange((e) => {
       this.proxy.$onColorThemeChange(e.type);

--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -1,5 +1,5 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optinal } from '@opensumi/di';
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { TreeViewItem, TreeViewBaseOptions, ITreeViewRevealOptions } from '../../../common/vscode';
 import { TreeItemCollapsibleState } from '../../../common/vscode/ext-types';
 import { IMainThreadTreeView, IExtHostTreeView, ExtHostAPIIdentifier } from '../../../common/vscode';
@@ -56,7 +56,7 @@ export class MainThreadTreeView implements IMainThreadTreeView {
   private disposableCollection: Map<string, DisposableStore> = new Map();
   private disposable: DisposableStore = new DisposableStore();
 
-  constructor(@Optinal(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostTreeView);
     this.disposable.add(toDisposable(() => this.treeModels.clear()));
     this._registerInternalCommands();

--- a/packages/extension/src/browser/vscode/api/main.thread.urls.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.urls.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optinal, Autowired } from '@opensumi/di';
+import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { IMainThreadUrls, IExtHostUrls, ExtHostAPIIdentifier } from '../../../common/vscode';
 import { IOpenerService, IDisposable, IOpener, URI, MaybePromise, ILogger, AppConfig } from '@opensumi/ide-core-browser';
@@ -83,7 +83,7 @@ export class MainThreadUrls implements IMainThreadUrls {
 
   private handlers = new Map<number, IDisposable>();
 
-  constructor(@Optinal(IRPCProtocol) rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(IRPCProtocol) rpcProtocol: IRPCProtocol) {
     this.proxy = rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostUrls);
     this.openerService.registerOpener(this.extensionOpener);
   }

--- a/packages/extension/src/browser/vscode/api/main.thread.window-state.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.window-state.ts
@@ -1,6 +1,6 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { ExtHostAPIIdentifier, IExtHostWindowState } from '../../../common/vscode';
-import { Optinal, Injectable } from '@opensumi/di';
+import { Optional, Injectable } from '@opensumi/di';
 
 @Injectable({multiple: true})
 export class MainThreadWindowState {
@@ -8,7 +8,7 @@ export class MainThreadWindowState {
   private readonly proxy: IExtHostWindowState;
   private blurHandler;
   private focusHandler;
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostWindowState);
 
     this.blurHandler = () => {

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -1,6 +1,6 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { ExtHostAPIIdentifier, IMainThreadWorkspace, IExtHostStorage, IExtHostWorkspace, reviveWorkspaceEditDto } from '../../../common/vscode';
-import { Injectable, Optinal, Autowired } from '@opensumi/di';
+import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { FileStat } from '@opensumi/ide-file-service';
 import { URI, ILogger, WithEventBus, OnEvent, CancellationToken } from '@opensumi/ide-core-browser';
@@ -38,7 +38,7 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
 
   private workspaceChangeEvent;
 
-  constructor(@Optinal(Symbol()) private rpcProtocol: IRPCProtocol) {
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
     super();
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostWorkspace);
 

--- a/packages/file-tree-next/src/browser/symlink-file-decoration.ts
+++ b/packages/file-tree-next/src/browser/symlink-file-decoration.ts
@@ -1,4 +1,4 @@
-import { Optinal } from '@opensumi/di';
+import { Optional } from '@opensumi/di';
 import { IDecorationsProvider, IDecorationData } from '@opensumi/ide-decoration';
 import { Uri, Emitter, localize } from '@opensumi/ide-core-browser';
 import { FileTreeService } from './file-tree.service';
@@ -8,7 +8,7 @@ export class SymlinkDecorationsProvider implements IDecorationsProvider {
 
   readonly onDidChangeEmitter: Emitter<Uri[]> = new Emitter();
 
-  constructor(@Optinal() private readonly fileTreeService: FileTreeService) {}
+  constructor(@Optional() private readonly fileTreeService: FileTreeService) {}
 
   get onDidChange() {
     return this.onDidChangeEmitter.event;


### PR DESCRIPTION
### 变动类型

- [x] 其他改动（删除废弃API）

### 需求背景和解决方案
引用的@openSumi/di库中的Optinal已被废弃

### changelog
将对Optinal的引用全换成Optional
