### PR TITLE
fix: make editor tabs and actions display as expected

### DIFF
--- a/packages/editor/src/browser/component/scroll/scroll.module.less
+++ b/packages/editor/src/browser/component/scroll/scroll.module.less
@@ -15,19 +15,6 @@
   width:10px;
   z-index: 2;
 }
-.thumb-vertical {
-  position: absolute;
-  width:5px;
-  opacity: 0.8;
-  top:0;
-  transition: opacity 200ms ease-out;
-  background: var(--scrollbarSlider-background);
-  box-shadow: 1px 0 0 var(--scrollbar-shadow);
-
-  &:hover {
-    background: var(--scrollbarSlider-hoverBackground);
-  }
-}
 
 .track-horizontal{
   position: absolute;
@@ -44,10 +31,27 @@
   height:5px;
   z-index: 2;
 }
-.thumb-horizontal {
+
+:global(.thumb-vertical) {
+  position: absolute;
+  width:5px;
+  opacity: 0.8;
+  top:0;
+  right: 0;
+  transition: opacity 200ms ease-out;
+  background: var(--scrollbarSlider-background);
+  box-shadow: 1px 0 0 var(--scrollbar-shadow);
+
+  &:hover {
+    background: var(--scrollbarSlider-hoverBackground);
+  }
+}
+
+:global(.thumb-horizontal) {
   position: absolute;
   height:5px;
   left:0;
+  bottom: 0;
   opacity: 0.8;
   transition: opacity 200ms ease-out 200ms;
   background: var(--scrollbarSlider-background);
@@ -73,10 +77,10 @@
 }
 
 .hide-thumb {
-  .thumb-horizontal {
+  :global(.thumb-horizontal) {
     opacity: 0 !important;
   }
-  .thumb-vertical {
+  :global(.thumb-vertical) {
     opacity: 0 !important;
   }
 }

--- a/packages/editor/src/browser/component/scroll/scroll.tsx
+++ b/packages/editor/src/browser/component/scroll/scroll.tsx
@@ -341,7 +341,7 @@ export class Scroll extends React.Component<ScrollAreaProps, any> {
             onMouseDown={this.onMouseDownHorizontal.bind(this)}
           />
           <div
-            className={styles['thumb-horizontal']}
+            className={'thumb-horizontal'}
             onMouseDown={this.onMouseDownHorizontal.bind(this)}
             ref={(e) => e && (this.thumbH = e)}
           />
@@ -353,7 +353,7 @@ export class Scroll extends React.Component<ScrollAreaProps, any> {
             onMouseDown={this.onMouseDownVertical.bind(this)}
           />
           <div
-            className={styles['thumb-vertical']}
+            className={'thumb-vertical'}
             onMouseDown={this.onMouseDownVertical.bind(this)}
             ref={(e) => e && (this.thumbV = e)}
           />

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -99,16 +99,13 @@
   .kt_editor_tabs_scroll_wrapper {
     flex-grow:1;
     width:10px;
-    div {
-      &:first-child {
-        >*:first-child{
-          overflow-y: hidden;
-        }
-      }
+    :global(.thumb-vertical) {
+      opacity: 0 !important;
     }
   }
 
   .kt_editor_tabs_scroll {
+    overflow-y: hidden;
     display: flex;
     background: var(--editorGroupHeader-tabsBackground);
     &::before {

--- a/packages/search/src/browser/search-tree.view.tsx
+++ b/packages/search/src/browser/search-tree.view.tsx
@@ -85,11 +85,12 @@ const ResultTotalContent = observer<{
   return null;
 });
 
-export const SearchTree = React.forwardRef((
+export const SearchTree = (
   {
     searchPanelLayout,
     viewState,
   }: ISearchTreeProp,
+  ref,
 ) => {
   const configContext = React.useContext(ConfigContext);
   const [scrollContainerStyle, setScrollContainerStyle] = React.useState<ISearchLayoutProp>({
@@ -166,4 +167,4 @@ export const SearchTree = React.forwardRef((
       }
     </div>
   );
-});
+};

--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -23,7 +23,6 @@ export const Search = React.memo(observer(({
   const { injector } = configContext;
   const searchBrowserService = injector.get(ContentSearchClientService);
   const [searchPanelLayout, setSearchPanelLayout] = React.useState({ height: 0, width: 0 });
-  const searchTreeRef = React.useRef();
 
   const searchResults = searchBrowserService.searchResults;
   const resultTotal = searchBrowserService.resultTotal;
@@ -135,7 +134,6 @@ export const Search = React.memo(observer(({
         (searchResults && searchResults.size > 0 && !searchError ) ? <SearchTree
           searchPanelLayout={searchPanelLayout}
           viewState={viewState}
-          ref={searchTreeRef}
         /> : <div
               className={cls(
                 { [styles.result_describe]: searchState === SEARCH_STATE.done },


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案

存在两个问题：

1. 非折行 Tab 下的滚动条不展示，展示就会有纵向滚动条

2. Editor 的工具栏展示不全，被遮挡
<img width="360" alt="截屏2021-12-13 下午10 35 15" src="https://user-images.githubusercontent.com/9823838/145963102-3ac999d3-5acd-4398-8ee1-823b8646e7bf.png">

修复后：

![Kapture 2021-12-14 at 16 30 15](https://user-images.githubusercontent.com/9823838/145963228-df73492e-de9c-4f00-979a-dbdb5f2add81.gif)


### changelog

make editor tabs and actions display as expected