### PR TITLE
fix: unable to load a local resource whose path has been encoded

### DIFF
--- a/packages/core-electron-main/src/bootstrap/services/protocol.ts
+++ b/packages/core-electron-main/src/bootstrap/services/protocol.ts
@@ -25,7 +25,7 @@ export class ProtocolElectronMainContribution implements ElectronMainContributio
         const { url } = req;
         //  对于webview中vscode:/aaaa/a或者 vscode:///aaaa/a 的路径
          // 旧版electron此处会是vscode://aaaa/a, 少了个斜杠，导致路径解析出现问题
-        const uri = URI.file(url.replace(/^vscode-resource:(\/\/|)/, ''));
+        const uri = URI.file(decodeURI(url).replace(/^vscode-resource:(\/\/|)/, ''));
         const fsPath = uri.codeUri.fsPath;
         const data = await readFile(fsPath);
         callback({ mimeType: getWebviewContentMimeType(uri), data});

--- a/packages/express-file-server/src/node/express-file-server.contribution.ts
+++ b/packages/express-file-server/src/node/express-file-server.contribution.ts
@@ -21,7 +21,7 @@ export class ExpressFileServerContribution implements ServerAppContribution {
 
   initialize(app: IServerApp) {
     app.use(mount('/assets', async (ctx) => {
-      const filePath = ctx.path.replace(/^\/assets/, '');
+      const filePath = decodeURI(ctx.path.replace(/^\/assets/, ''));
       if (!filePath) {
         ctx.status = 404;
         return;


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案

When fetching local static resources, for example, if a local js is introduced into the extension's webviwe, if the path contains spaces (considering that the path in windwos will contain 'Program Files', some apps on mac will have spaces in their names, for example 'Kaitian Ide.app'), it will be encoded as '%20'. This will not be loaded when fetching local resources. Calling decodeURI to handle this.

### changelog

unable to load a local resource whose path has been encoded
