### PR TITLE
fix: the min-width property name of the toolbar button

### DIFF
--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -167,7 +167,7 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
     } else {
       // BtnStyle == inline 或 btnTitleStyle === 'vertical' (类似小程序IDE工具栏） 的模式
       if (btnTitleStyle === BUTTON_TITLE_STYLE.VERTICAL) {
-        backgroundBindings.style['min-width'] = '42px';
+        backgroundBindings.style['minWidth'] = '42px';
       }
       buttonElement = (
         <div


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案
使用 toolbar 的 button 会报下面的错误：
![image](https://user-images.githubusercontent.com/2226423/146709698-51d4ac13-7ff0-4068-853e-649e607a7c6c.png)


### changelog
- 修复 Toolbar 按钮的 min-width 属性名