### PR TITLE
fix: editor tab icon style

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -181,6 +181,7 @@
       border-bottom: 1px solid var(--tab-border);
       box-sizing: border-box;
       z-index: 1;
+
       .tab_loading {
         display: block;
         position: absolute;
@@ -188,6 +189,7 @@
         left: 13.5px;
       }
       :global(.icon-label::before) {
+        font-size: calc(1.5*14px) !important;
         transition: transform 0.2s ease-in;
       }
       .small::before {
@@ -204,7 +206,6 @@
         &::before {
           background-size: 14px;
           background-position: 2px;
-          font-size: 12px;
         }
       }
       .kt_editor_close_icon {

--- a/packages/editor/src/browser/navigation.module.less
+++ b/packages/editor/src/browser/navigation.module.less
@@ -27,10 +27,16 @@
     display: flex;
     align-items: center;
     white-space: nowrap;
+
     > span:first-child {
       font-size: 14px;
       vertical-align: middle;
       padding-right: 5px;
+
+      &::before {
+        background-size: 12px;
+        font-size: calc(1.5*12px);
+      }
     }
     &:hover {
       color: var(--breadcrumb-focusForeground);


### PR DESCRIPTION
### 变动类型

- [x] 样式改进

### 需求背景和解决方案

fixes #156 
before
![image](https://user-images.githubusercontent.com/17701805/146725109-bd0f93df-1be8-4347-b4c6-99f00bc97cee.png)

after
![image](https://user-images.githubusercontent.com/17701805/146725129-b35f10fa-1aeb-4a2b-a3b0-f7150f3c00b2.png)

seti 主题下(使用 icon font)

before

![image](https://user-images.githubusercontent.com/17701805/146725499-c2c4d54f-d9e6-4b6d-ac8b-3c493be8dbbf.png)

after

![image](https://user-images.githubusercontent.com/17701805/146725404-c0efa17d-b0ce-4c94-a717-c2686da8f3ea.png)



### changelog
- 优化编辑器 Tab 栏图标样式