### PR TITLE
chore: optimize icon service append style perf

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -366,7 +366,7 @@ export class TreeViewDataProvider extends Tree {
 
   async toIconClass(item: TreeViewItem): Promise<string | undefined> {
     if (item.iconUrl || item.icon) {
-      return this.iconService.fromIcon('', item.iconUrl || item.icon, IconType.Background);
+      return this.iconService.fromIcon('', item.iconUrl || item.icon, IconType.Background, undefined, true);
     } else if (item.themeIcon) {
       let themeIconClass = getExternalIcon(item.themeIcon.id);
       if (item.resourceUri) {

--- a/packages/theme/src/browser/icon.service.ts
+++ b/packages/theme/src/browser/icon.service.ts
@@ -92,7 +92,7 @@ export class IconService implements IIconService {
 
   private styleSheetCollection = '';
 
-  private appendStylesTimer: NodeJS.Timeout | undefined;
+  private appendStylesTimer: number | undefined;
   private appendStyleCounter = 0;
 
   private doAppend(targetElement: HTMLElement | null) {
@@ -122,7 +122,7 @@ export class IconService implements IIconService {
 
     if (!this.appendStylesTimer) {
       // 超过 100 毫秒
-      this.appendStylesTimer = setTimeout(() => {
+      this.appendStylesTimer = window.setTimeout(() => {
         this.doAppend(iconStyleNode);
       }, 100);
     }

--- a/packages/theme/src/browser/icon.service.ts
+++ b/packages/theme/src/browser/icon.service.ts
@@ -90,6 +90,19 @@ export class IconService implements IIconService {
     });
   }
 
+  private styleSheetCollection = '';
+
+  private appendStylesTimer: NodeJS.Timeout | undefined;
+  private appendStyleCounter = 0;
+
+  private doAppend(targetElement: HTMLElement | null) {
+    targetElement?.append(this.styleSheetCollection);
+    this.styleSheetCollection = '';
+    this.appendStylesTimer = undefined;
+    this.appendStyleCounter = 0;
+    clearTimeout(this.appendStylesTimer);
+  }
+
   protected appendStyleSheet(styleSheet: string) {
     let iconStyleNode = document.getElementById('plugin-icons');
     if (!iconStyleNode) {
@@ -97,7 +110,22 @@ export class IconService implements IIconService {
       iconStyleNode.id = 'plugin-icons';
       document.getElementsByTagName('head')[0].appendChild(iconStyleNode);
     }
-    iconStyleNode.append(styleSheet);
+
+    this.styleSheetCollection += '\r\n' + styleSheet;
+    this.appendStyleCounter += 1;
+
+    // 超过 100 个样式
+    if (this.appendStyleCounter >= 100 && this.appendStylesTimer) {
+      clearTimeout(this.appendStylesTimer);
+      this.doAppend(iconStyleNode);
+    }
+
+    if (!this.appendStylesTimer) {
+      // 超过 100 毫秒
+      this.appendStylesTimer = setTimeout(() => {
+        this.doAppend(iconStyleNode);
+      }, 100);
+    }
   }
 
   protected getRandomIconClass() {

--- a/packages/theme/src/common/theme.service.ts
+++ b/packages/theme/src/common/theme.service.ts
@@ -57,6 +57,7 @@ export interface IIconService {
     icon?: { [index in ThemeType]: string } | string,
     type?: IconType,
     shape?: IconShape,
+    fromExtension?: boolean,
   ): string | undefined;
   registerIconThemes(iconThemesContribution: ThemeContribution[], extPath: URI): void;
   getAvailableThemeInfos(): IconThemeInfo[];


### PR DESCRIPTION
### 变动类型
- [x] 代码风格优化

### 需求背景和解决方案
初始化过程中存在插件注册大量 icon 的情况，icon 注册会分别为其生成 classname 并 append 到文档中，导致界面频繁重绘，甚至卡住

![image](https://user-images.githubusercontent.com/17701805/146901913-0c4f5e9c-f0f0-4d00-9da6-63a13a4a3c0d.png)

![image](https://user-images.githubusercontent.com/17701805/146901934-f43fd5b3-e2e6-4897-b3a0-526b556ac0fb.png)

导致例如图中这种 gitlens 的 commit 面板卡住 2 秒以上

> 注意看 COMMIT 面板下的 ProgressBar，此时会插入 900+条 css 样式

![icon-append-before](https://user-images.githubusercontent.com/17701805/146907955-fcd9c4d1-2b4f-4bbe-911f-37820d9fb266.gif)


优化后

> 仅插入十几次样式

![icon-append-after](https://user-images.githubusercontent.com/17701805/146902156-516f0621-6fea-4fc4-ab1a-bb51d0b84ae1.gif)

### changelog
- 优化图标注册性能，增加延时逻辑
