### PR TITLE
feat: support TerminalLink tooltips api

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.terminal.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.terminal.ts
@@ -237,6 +237,7 @@ class ExtensionTerminalLinkProvider implements ITerminalExternalLinkProvider {
       id: dto.id,
       startIndex: dto.startIndex,
       length: dto.length,
+      label: dto.label,
       activate: () => proxy.$activateLink(instance.id, dto.id),
     }));
   }

--- a/packages/extension/src/hosted/api/vscode/ext.host.terminal.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.terminal.ts
@@ -254,6 +254,7 @@ export class ExtHostTerminal implements IExtHostTerminal {
               id: nextLinkId++,
               startIndex: providerLink.startIndex,
               length: providerLink.length,
+              label: providerLink.tooltip,
             };
             cacheLinkMap.set(link.id, {
               provider: provideResult.provider,

--- a/packages/terminal-next/__tests__/browser/links/helpers.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/helpers.test.ts
@@ -1,5 +1,5 @@
-import { IBufferLine, IBufferCell } from 'xterm';
 import { convertLinkRangeToBuffer } from '../../../src/browser/links/helpers';
+import { createBufferLineArray } from '../utils';
 
 describe('convertLinkRangeToBuffer', () => {
   test('should convert ranges for ascii characters', () => {
@@ -204,53 +204,3 @@ describe('convertLinkRangeToBuffer', () => {
     });
   });
 });
-
-const TEST_WIDE_CHAR = '文';
-const TEST_NULL_CHAR = 'C';
-
-function createBufferLineArray(lines: { text: string; width: number }[]): IBufferLine[] {
-  const result: IBufferLine[] = [];
-  lines.forEach((l, i) => {
-    result.push(new TestBufferLine(l.text, l.width, i + 1 !== lines.length));
-  });
-  return result;
-}
-
-class TestBufferLine implements IBufferLine {
-  constructor(private _text: string, public length: number, public isWrapped: boolean) {}
-  getCell(x: number): IBufferCell | undefined {
-    // Create a fake line of cells and use that to resolve the width
-    const cells: string[] = [];
-    let wideNullCellOffset = 0; // There is no null 0 width char after a wide char
-    const emojiOffset = 0; // Skip chars as emoji are multiple characters
-    for (let i = 0; i <= x - wideNullCellOffset + emojiOffset; i++) {
-      let char = this._text.charAt(i);
-      if (char === '\ud83d') {
-        // Make "🙂"
-        char += '\ude42';
-      }
-      cells.push(char);
-      if (this._text.charAt(i) === TEST_WIDE_CHAR) {
-        // Skip the next character as it's width is 0
-        cells.push(TEST_NULL_CHAR);
-        wideNullCellOffset++;
-      }
-    }
-    return {
-      getChars: () => (x >= cells.length ? '' : cells[x]),
-      getWidth: () => {
-        switch (cells[x]) {
-          case TEST_WIDE_CHAR:
-            return 2;
-          case TEST_NULL_CHAR:
-            return 0;
-          default:
-            return 1;
-        }
-      },
-    } as any;
-  }
-  translateToString(): string {
-    throw new Error('Method not implemented.');
-  }
-}

--- a/packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
@@ -1,14 +1,19 @@
 import { Terminal, ILink } from 'xterm';
 import { TerminalProtocolLinkProvider } from '../../../src/browser/links/protocol-link-provider';
+import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 
 describe('Workbench - TerminalWebLinkProvider', () => {
+  const injector = createBrowserInjector([]);
+
   async function assertLink(text: string, expected: { text: string; range: [number, number][] }[]) {
     const xterm = new Terminal();
-    const provider = new TerminalProtocolLinkProvider(
+    const provider = injector.get(TerminalProtocolLinkProvider, [
       xterm,
       () => {},
-      () => {},
-    );
+      () => ({
+        dispose: () => {},
+      }),
+    ]);
 
     // Write the text and wait for the parser to finish
     await new Promise<void>((r) => xterm.write(text, r));

--- a/packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
@@ -4,7 +4,11 @@ import { TerminalProtocolLinkProvider } from '../../../src/browser/links/protoco
 describe('Workbench - TerminalWebLinkProvider', () => {
   async function assertLink(text: string, expected: { text: string; range: [number, number][] }[]) {
     const xterm = new Terminal();
-    const provider = new TerminalProtocolLinkProvider(xterm, () => {});
+    const provider = new TerminalProtocolLinkProvider(
+      xterm,
+      () => {},
+      () => {},
+    );
 
     // Write the text and wait for the parser to finish
     await new Promise<void>((r) => xterm.write(text, r));

--- a/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
@@ -66,6 +66,7 @@ describe('Workbench - TerminalValidatedLocalLinkProvider', () => {
       client,
       () => {},
       (() => {}) as any,
+      () => {},
       (_: string, cb: (result: { uri: URI; isDirectory: boolean } | undefined) => void) => {
         cb({ uri: URI.file('/'), isDirectory: false });
       },

--- a/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
@@ -1,6 +1,7 @@
 import { Terminal, ILink } from 'xterm';
 import { URI } from '@opensumi/ide-core-common';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
+import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { TerminalValidatedLocalLinkProvider } from '../../../src/browser/links/validated-local-link-provider';
 
 const unixLinks = ['/foo', '~/foo', './foo', '../foo', '/foo/bar', '/foo/bar+more', 'foo/bar', 'foo/bar+more'];
@@ -58,19 +59,23 @@ function format(pattern: string, ...args: any[]) {
 }
 
 describe('Workbench - TerminalValidatedLocalLinkProvider', () => {
+  const injector = createBrowserInjector([]);
+
   async function assertLink(text: string, isWindows: boolean, expected: { text: string; range: [number, number][] }[]) {
     const xterm = new Terminal();
     const client = { os: isWindows ? OperatingSystem.Windows : OperatingSystem.Linux } as any;
-    const provider = new TerminalValidatedLocalLinkProvider(
+    const provider = injector.get(TerminalValidatedLocalLinkProvider, [
       xterm,
       client,
       () => {},
       (() => {}) as any,
-      () => {},
+      () => ({
+        dispose: () => {},
+      }),
       (_: string, cb: (result: { uri: URI; isDirectory: boolean } | undefined) => void) => {
         cb({ uri: URI.file('/'), isDirectory: false });
       },
-    );
+    ]);
 
     // Write the text and wait for the parser to finish
     await new Promise<void>((r) => xterm.write(text, r));

--- a/packages/terminal-next/__tests__/browser/terminal.hover.manager.test.ts
+++ b/packages/terminal-next/__tests__/browser/terminal.hover.manager.test.ts
@@ -1,0 +1,163 @@
+import { Injector } from '@opensumi/di';
+import { LayoutState } from '@opensumi/ide-core-browser/lib/layout/layout-state';
+import { MockLogger } from '@opensumi/ide-core-browser/__mocks__/logger';
+import { CommandService, CommandServiceImpl } from '@opensumi/ide-core-common/lib/command';
+import { mockService } from '@opensumi/ide-dev-tool/src/mock-injector';
+import { ILogger } from '@opensumi/ide-logs/lib/common';
+import { IDialogService } from '@opensumi/ide-overlay/lib/common';
+import { IStatusBarService } from '@opensumi/ide-status-bar';
+import { StatusBarService } from '@opensumi/ide-status-bar/lib/browser/status-bar.service';
+import { ITerminalProcessPath } from '@opensumi/ide-terminal-next';
+import { IWorkspaceStorageService } from '@opensumi/ide-workspace/lib/common';
+import { TerminalHoverManagerService } from '../../src/browser/terminal.hover.manager';
+import { ITerminalHoverManagerService } from '../../lib/common';
+import { IViewportRange, Terminal } from 'xterm';
+import { TerminalLink } from '../../lib/browser/links/link';
+import { convertBufferRangeToViewport, convertLinkRangeToBuffer } from '../../src/browser/links/helpers';
+import { createBufferLineArray } from './utils';
+import { Disposable } from '@opensumi/ide-core-common';
+
+const mockData = [
+  {
+    extensionIdentifier: 'vscode-samples.vscode-terminal-api-example',
+    collection: [['FOO', { value: 'BAR', type: 1 }]],
+  },
+];
+
+describe('terminal.environment.service', () => {
+  const injector = new Injector();
+  let terminalHoverManagerService: TerminalHoverManagerService;
+  const modifierDownCallback = () => {};
+  const modifierUpCallback = () => {};
+
+  beforeAll(() => {
+    injector.addProviders(
+      {
+        token: IStatusBarService,
+        useClass: StatusBarService,
+      },
+      {
+        token: IDialogService,
+        useValue: {},
+      },
+      {
+        token: CommandService,
+        useClass: CommandServiceImpl,
+      },
+      {
+        token: ILogger,
+        useClass: MockLogger,
+      },
+      {
+        token: ITerminalHoverManagerService,
+        useClass: TerminalHoverManagerService,
+      },
+      {
+        token: ITerminalProcessPath,
+        useValue: {
+          getEnv: () => ({}),
+        },
+      },
+      {
+        token: IWorkspaceStorageService,
+        useValue: {
+          getData: () => JSON.stringify(mockData),
+          setData: () => {},
+        },
+      },
+      {
+        token: LayoutState,
+        useValue: mockService({
+          getState: () => ({}),
+        }),
+      },
+    );
+
+    terminalHoverManagerService = injector.get(ITerminalHoverManagerService);
+  });
+
+  it('TerminalHoverManagerService#init', async (done) => {
+    const _xterm = new Terminal();
+    const lines = createBufferLineArray([
+      { text: 'AA http://t', width: 11 },
+      { text: '.com/f/', width: 8 },
+    ]);
+
+    const startLine = 0;
+    const bufferRange = convertLinkRangeToBuffer(
+      lines,
+      _xterm.cols,
+      {
+        startColumn: 0,
+        startLineNumber: 1,
+        endColumn: 1,
+        endLineNumber: 1,
+      },
+      startLine,
+    );
+
+    const matchingText = 'test';
+    const handler = (_: Event, text: string) => console.log(text);
+    const activateLink = (handler) => (event: Event | undefined, text: string) => {
+      handler(event, text);
+    };
+    const _tooltipCallback = (
+      link: TerminalLink,
+      viewportRange: IViewportRange,
+      modifierDownCallback?: () => void,
+      modifierUpCallback?: () => void,
+    ) => {
+      console.log('test', link, viewportRange, modifierDownCallback, modifierUpCallback);
+      return Disposable.create(() => {
+        console.log('dispose');
+      });
+    };
+
+    const link: TerminalLink = injector.get(TerminalLink, [
+      _xterm,
+      bufferRange,
+      matchingText,
+      _xterm.buffer.active.viewportY,
+      activateLink(handler),
+      _tooltipCallback,
+      true,
+      'text label',
+    ]);
+
+    const _viewportY = 10; // random value
+    const viewportRange: IViewportRange = convertBufferRangeToViewport(bufferRange, _viewportY);
+    const cellDimensions = {
+      width: 2,
+      height: 2,
+    };
+    const terminalDimensions = {
+      width: _xterm.cols,
+      height: _xterm.rows,
+    };
+    const boundingClientRect = {
+      bottom: 1375,
+      height: 1375,
+      left: 0,
+      right: 2560,
+      top: 0,
+      width: 2560,
+      x: 0,
+      y: 0,
+    };
+
+    terminalHoverManagerService.setHoverOverlay(document.createElement('div'));
+    terminalHoverManagerService.showHover(
+      {
+        viewportRange,
+        cellDimensions,
+        terminalDimensions,
+        boundingClientRect,
+        modifierDownCallback,
+        modifierUpCallback,
+      },
+      'test',
+      (text) => link.activate(undefined, text),
+    );
+    done();
+  });
+});

--- a/packages/terminal-next/__tests__/browser/utils.ts
+++ b/packages/terminal-next/__tests__/browser/utils.ts
@@ -1,4 +1,5 @@
 import * as puppeteer from 'puppeteer';
+import { IBufferCell, IBufferLine } from 'xterm';
 
 const reaction = 200;
 
@@ -65,4 +66,54 @@ export async function delay(ms: number) {
       resolve();
     }, ms);
   });
+}
+
+const TEST_WIDE_CHAR = '文';
+const TEST_NULL_CHAR = 'C';
+
+export function createBufferLineArray(lines: { text: string; width: number }[]): IBufferLine[] {
+  const result: IBufferLine[] = [];
+  lines.forEach((l, i) => {
+    result.push(new TestBufferLine(l.text, l.width, i + 1 !== lines.length));
+  });
+  return result;
+}
+
+class TestBufferLine implements IBufferLine {
+  constructor(private _text: string, public length: number, public isWrapped: boolean) {}
+  getCell(x: number): IBufferCell | undefined {
+    // Create a fake line of cells and use that to resolve the width
+    const cells: string[] = [];
+    let wideNullCellOffset = 0; // There is no null 0 width char after a wide char
+    const emojiOffset = 0; // Skip chars as emoji are multiple characters
+    for (let i = 0; i <= x - wideNullCellOffset + emojiOffset; i++) {
+      let char = this._text.charAt(i);
+      if (char === '\ud83d') {
+        // Make "🙂"
+        char += '\ude42';
+      }
+      cells.push(char);
+      if (this._text.charAt(i) === TEST_WIDE_CHAR) {
+        // Skip the next character as it's width is 0
+        cells.push(TEST_NULL_CHAR);
+        wideNullCellOffset++;
+      }
+    }
+    return {
+      getChars: () => (x >= cells.length ? '' : cells[x]),
+      getWidth: () => {
+        switch (cells[x]) {
+          case TEST_WIDE_CHAR:
+            return 2;
+          case TEST_NULL_CHAR:
+            return 0;
+          default:
+            return 1;
+        }
+      },
+    } as any;
+  }
+  translateToString(): string {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/packages/terminal-next/src/browser/index.ts
+++ b/packages/terminal-next/src/browser/index.ts
@@ -17,6 +17,7 @@ import {
   IWidget,
   ITerminalRenderProvider,
   ITerminalNetwork,
+  ITerminalHoverManagerService,
 } from '../common';
 import { ITerminalPreference } from '../common/preference';
 import {
@@ -34,6 +35,7 @@ import { TerminalRestore } from './terminal.restore';
 import { TerminalClientFactory } from './terminal.client';
 import { TerminalApiService } from './terminal.api';
 import { TerminalSearchService } from './terminal.search';
+import { TerminalHoverManagerService } from './terminal.hover.manager';
 import { TerminalGroupViewService } from './terminal.view';
 import { TerminalErrorService } from './terminal.error';
 import { TerminalPreference } from './terminal.preference';
@@ -66,6 +68,10 @@ export class TerminalNextModule extends BrowserModule {
     {
       token: ITerminalSearchService,
       useClass: TerminalSearchService,
+    },
+    {
+      token: ITerminalHoverManagerService,
+      useClass: TerminalHoverManagerService,
     },
     {
       token: ITerminalGroupViewService,

--- a/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
+++ b/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
@@ -1,9 +1,10 @@
-import type { Terminal, IBufferLine } from 'xterm';
+import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
 import { getXtermLineContent, convertLinkRangeToBuffer } from './helpers';
 import { TerminalLink } from './link';
 import { TerminalBaseLinkProvider } from './base';
 import { ITerminalExternalLinkProvider, ITerminalClient } from '../../common';
 import { XtermLinkMatcherHandler } from './link-manager';
+import { IDisposable } from '@opensumi/ide-core-common';
 
 /**
  * An adapter to convert a simple external link provider into an internal link provider that
@@ -17,6 +18,12 @@ export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvide
     private readonly _wrapLinkHandler: (
       handler: (event: MouseEvent | undefined, link: string) => void,
     ) => XtermLinkMatcherHandler,
+    private readonly _tooltipCallback: (
+      link: TerminalLink,
+      viewportRange: IViewportRange,
+      modifierDownCallback?: () => void,
+      modifierUpCallback?: () => void,
+    ) => IDisposable,
   ) {
     super();
   }
@@ -67,7 +74,9 @@ export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvide
         matchingText,
         this._xterm.buffer.active.viewportY,
         activateLink,
+        this._tooltipCallback,
         true,
+        link.label,
       );
     });
   }

--- a/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
+++ b/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
@@ -1,16 +1,21 @@
 import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { IDisposable } from '@opensumi/ide-core-common';
 import { getXtermLineContent, convertLinkRangeToBuffer } from './helpers';
 import { TerminalLink } from './link';
 import { TerminalBaseLinkProvider } from './base';
 import { ITerminalExternalLinkProvider, ITerminalClient } from '../../common';
 import { XtermLinkMatcherHandler } from './link-manager';
-import { IDisposable } from '@opensumi/ide-core-common';
 
 /**
  * An adapter to convert a simple external link provider into an internal link provider that
  * manages link lifecycle, hovers, etc. and gets registered in xterm.js.
  */
+@Injectable({ multiple: true })
 export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvider {
+  @Autowired(INJECTOR_TOKEN)
+  private readonly injector: Injector;
+
   constructor(
     private readonly _xterm: Terminal,
     private readonly _instance: ITerminalClient,
@@ -68,7 +73,8 @@ export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvide
       );
       const matchingText = lineContent.substr(link.startIndex, link.length) || '';
       const activateLink = this._wrapLinkHandler((_, text) => link.activate(text));
-      return new TerminalLink(
+
+      return this.injector.get(TerminalLink, [
         this._xterm,
         bufferRange,
         matchingText,
@@ -77,7 +83,7 @@ export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvide
         this._tooltipCallback,
         true,
         link.label,
-      );
+      ]);
     });
   }
 }

--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -177,9 +177,7 @@ export class TerminalLinkManager extends Disposable {
     const attached = this._hoverManager.showHover(targetOptions, text, linkHandler);
     link?.onInvalidated(() => attached.dispose());
 
-    return {
-      dispose: () => attached.dispose(),
-    };
+    return Disposable.create(() => attached.dispose());
   }
 
   public registerExternalLinkProvider(

--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -1,9 +1,17 @@
-import { Terminal, ILinkProvider } from 'xterm';
+import { Terminal, ILinkProvider, IViewportRange } from 'xterm';
 import { Injectable, Autowired } from '@opensumi/di';
-import { URI, Disposable, IDisposable, DisposableCollection, isOSX, FileUri } from '@opensumi/ide-core-common';
-import { OperatingSystem, isWindows } from '@opensumi/ide-core-common/lib/platform';
+import {
+  URI,
+  Disposable,
+  IDisposable,
+  DisposableCollection,
+  isOSX,
+  FileUri,
+  localize,
+} from '@opensumi/ide-core-common';
+import { OperatingSystem, isWindows, isMacintosh } from '@opensumi/ide-core-common/lib/platform';
 import { posix, win32, IPath } from '@opensumi/ide-core-common/lib/path';
-import { IOpenerService } from '@opensumi/ide-core-browser';
+import { IOpenerService, PreferenceService } from '@opensumi/ide-core-browser';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/common';
 import { TerminalProtocolLinkProvider } from './protocol-link-provider';
@@ -18,8 +26,10 @@ import {
   lineAndColumnClauseGroupCount,
 } from './validated-local-link-provider';
 import { TerminalExternalLinkProviderAdapter } from './external-link-provider-adapter';
-import { ITerminalClient, ITerminalExternalLinkProvider } from '../../common';
+import { TerminalLink } from './link';
+import { ITerminalClient, ITerminalExternalLinkProvider, ITerminalHoverManagerService } from '../../common';
 import { TerminalClient } from '../terminal.client';
+import { XTermCore } from '../../common/xterm-private';
 
 export type XtermLinkMatcherHandler = (event: MouseEvent | undefined, link: string) => Promise<void>;
 
@@ -28,6 +38,30 @@ export interface ITextEditorSelection {
   readonly startColumn: number;
   readonly endLineNumber?: number;
   readonly endColumn?: number;
+}
+
+export interface ILinkHoverTargetOptions {
+  readonly viewportRange: IViewportRange;
+  readonly cellDimensions: {
+    width: number;
+    height: number;
+  };
+  readonly terminalDimensions: {
+    width: number;
+    height: number;
+  };
+  readonly boundingClientRect: {
+    bottom: number;
+    height: number;
+    left: number;
+    right: number;
+    top: number;
+    width: number;
+    x: number;
+    y: number;
+  };
+  readonly modifierDownCallback?: () => void;
+  readonly modifierUpCallback?: () => void;
 }
 
 /**
@@ -40,16 +74,22 @@ export class TerminalLinkManager extends Disposable {
   private _standardLinkProvidersDisposables = new DisposableCollection();
 
   @Autowired()
-  private _editorService: WorkbenchEditorService;
+  private readonly _editorService: WorkbenchEditorService;
 
   @Autowired(IOpenerService)
-  private _openerService: IOpenerService;
+  private readonly _openerService: IOpenerService;
 
   @Autowired(IFileServiceClient)
-  private _fileService: IFileServiceClient;
+  private readonly _fileService: IFileServiceClient;
 
   @Autowired(IFileServiceClient)
   private readonly _fileSystem: IFileServiceClient;
+
+  @Autowired(PreferenceService)
+  private readonly preferenceService: PreferenceService;
+
+  @Autowired(ITerminalHoverManagerService)
+  private readonly _hoverManager: ITerminalHoverManagerService;
 
   private _getHomeDirPromise: Promise<string>;
 
@@ -58,7 +98,11 @@ export class TerminalLinkManager extends Disposable {
 
     // Protocol links
     const wrappedActivateCallback = this._wrapLinkHandler((_, link) => this._handleProtocolLink(link));
-    const protocolProvider = new TerminalProtocolLinkProvider(this._xterm, wrappedActivateCallback);
+    const protocolProvider = new TerminalProtocolLinkProvider(
+      this._xterm,
+      wrappedActivateCallback,
+      this._tooltipCallback.bind(this),
+    );
     this._standardLinkProviders.push(protocolProvider);
 
     // Validated local links
@@ -68,6 +112,7 @@ export class TerminalLinkManager extends Disposable {
       this._client,
       wrappedTextLinkActivateCallback,
       this._wrapLinkHandler.bind(this),
+      this._tooltipCallback.bind(this),
       async (link, cb) => cb(await this._resolvePath(link)),
     );
     this._standardLinkProviders.push(validatedProvider);
@@ -87,6 +132,53 @@ export class TerminalLinkManager extends Disposable {
     }
   }
 
+  private _tooltipCallback(
+    link: TerminalLink,
+    viewportRange: IViewportRange,
+    modifierDownCallback?: () => void,
+    modifierUpCallback?: () => void,
+  ) {
+    const core = (this._xterm as any)._core as XTermCore;
+    const cellDimensions = {
+      width: core._renderService.dimensions.actualCellWidth,
+      height: core._renderService.dimensions.actualCellHeight,
+    };
+    const terminalDimensions = {
+      width: this._xterm.cols,
+      height: this._xterm.rows,
+    };
+    const boundingClientRect = core.element.getBoundingClientRect();
+
+    // Don't pass the mouse event as this avoids the modifier check
+    return this._showHover(
+      {
+        viewportRange,
+        cellDimensions,
+        terminalDimensions,
+        boundingClientRect,
+        modifierDownCallback,
+        modifierUpCallback,
+      },
+      this._getLinkHoverString(link.text, link.label),
+      (text) => link.activate(undefined, text),
+      link,
+    );
+  }
+
+  private _showHover(
+    targetOptions: ILinkHoverTargetOptions,
+    text: string,
+    linkHandler: (url: string) => void,
+    link?: TerminalLink,
+  ) {
+    const attached = this._hoverManager.showHover(targetOptions, text, linkHandler);
+    link?.onInvalidated(() => attached.dispose());
+
+    return {
+      dispose: () => attached.dispose(),
+    };
+  }
+
   public registerExternalLinkProvider(
     instance: ITerminalClient,
     linkProvider: ITerminalExternalLinkProvider,
@@ -96,6 +188,7 @@ export class TerminalLinkManager extends Disposable {
       instance,
       linkProvider,
       this._wrapLinkHandler.bind(this),
+      this._tooltipCallback.bind(this),
     );
     const newLinkProvider = this._xterm.registerLinkProvider(wrappedLinkProvider);
     // Re-register the standard link providers so they are a lower priority that the new one
@@ -172,6 +265,30 @@ export class TerminalLinkManager extends Disposable {
       return win32;
     }
     return posix;
+  }
+
+  private _getLinkHoverString(uri: string, label: string | undefined): string {
+    const multiCursorModifier = this.preferenceService.get<'ctrlCmd' | 'alt'>('editor.multiCursorModifier');
+
+    let clickLabel = '';
+    if (multiCursorModifier === 'ctrlCmd') {
+      if (isMacintosh) {
+        clickLabel = localize('terminalLinkHandler.followLinkAlt.mac', 'option + click');
+      } else {
+        clickLabel = localize('terminalLinkHandler.followLinkAlt', 'alt + click');
+      }
+    } else {
+      if (isMacintosh) {
+        clickLabel = localize('terminalLinkHandler.followLinkCmd', 'cmd + click');
+      } else {
+        clickLabel = localize('terminalLinkHandler.followLinkCtrl', 'ctrl + click');
+      }
+    }
+
+    const fallbackLabel = localize('followLink', 'Follow link');
+    label = label || fallbackLabel;
+
+    return `${label} (${clickLabel})`;
   }
 
   /**

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -1,10 +1,21 @@
-import type { IBufferRange, ILink, ILinkDecorations, Terminal } from 'xterm';
-import { Disposable, DisposableCollection, Emitter, Event, isOSX } from '@opensumi/ide-core-common';
+import type { IBufferRange, ILink, ILinkDecorations, IViewportRange, Terminal } from 'xterm';
+import {
+  Disposable,
+  IDisposable,
+  DisposableCollection,
+  Emitter,
+  Event,
+  isOSX,
+  RunOnceScheduler,
+} from '@opensumi/ide-core-common';
+import { convertBufferRangeToViewport } from './helpers';
 
 export class TerminalLink extends Disposable implements ILink {
   decorations: ILinkDecorations;
 
+  private _tooltipScheduler: RunOnceScheduler | undefined;
   private _hoverListeners: DisposableCollection | undefined;
+  private _tooltipDisposable: Disposable | undefined;
 
   private readonly _onInvalidated = new Emitter<void>();
   public get onInvalidated(): Event<void> {
@@ -17,7 +28,14 @@ export class TerminalLink extends Disposable implements ILink {
     public readonly text: string,
     private readonly _viewportY: number,
     private readonly _activateCallback: (event: MouseEvent | undefined, uri: string) => void,
+    private readonly _tooltipCallback: (
+      link: TerminalLink,
+      viewportRange: IViewportRange,
+      modifierDownCallback?: () => void,
+      modifierUpCallback?: () => void,
+    ) => IDisposable,
     private readonly _isHighConfidenceLink: boolean,
+    readonly label: string | undefined,
   ) {
     super();
     this.decorations = {
@@ -30,6 +48,10 @@ export class TerminalLink extends Disposable implements ILink {
     super.dispose();
     this._hoverListeners?.dispose();
     this._hoverListeners = undefined;
+    this._tooltipScheduler?.dispose();
+    this._tooltipScheduler = undefined;
+    this._tooltipDisposable?.dispose();
+    this._tooltipDisposable = undefined;
   }
 
   activate(event: MouseEvent | undefined, text: string): void {
@@ -71,6 +93,24 @@ export class TerminalLink extends Disposable implements ILink {
       }),
     );
 
+    // Only show the tooltip and highlight for high confidence links (not word/search workspace
+    // links). Feedback was that this makes using the terminal overly noisy.
+    if (this._isHighConfidenceLink) {
+      this._tooltipScheduler = new RunOnceScheduler(() => {
+        this._tooltipDisposable = this._tooltipCallback(
+          this,
+          convertBufferRangeToViewport(this.range, this._viewportY),
+          this._isHighConfidenceLink ? () => this._enableDecorations() : undefined,
+          this._isHighConfidenceLink ? () => this._disableDecorations() : undefined,
+        );
+        // Clear out scheduler until next hover event
+        this._tooltipScheduler?.dispose();
+        this._tooltipScheduler = undefined;
+      }, 1000);
+      this._tooltipScheduler.schedule();
+    }
+
+    const origin = { x: event.pageX, y: event.pageY };
     this._hoverListeners.push(
       this._addDisposableListener(document, 'mousemove', (e) => {
         // Update decorations
@@ -79,6 +119,16 @@ export class TerminalLink extends Disposable implements ILink {
         } else {
           this._disableDecorations();
         }
+
+        // Reset the scheduler if the mouse moves too much
+        if (
+          Math.abs(e.pageX - origin.x) > window.devicePixelRatio * 2 ||
+          Math.abs(e.pageY - origin.y) > window.devicePixelRatio * 2
+        ) {
+          origin.x = e.pageX;
+          origin.y = e.pageY;
+          this._tooltipScheduler?.schedule();
+        }
       }),
     );
   }
@@ -86,6 +136,10 @@ export class TerminalLink extends Disposable implements ILink {
   leave(): void {
     this._hoverListeners?.dispose();
     this._hoverListeners = undefined;
+    this._tooltipScheduler?.dispose();
+    this._tooltipScheduler = undefined;
+    this._tooltipDisposable?.dispose();
+    this._tooltipDisposable = undefined;
   }
 
   private _enableDecorations(): void {

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -12,7 +12,7 @@ import {
 import { PreferenceService } from '@opensumi/ide-core-browser';
 import { convertBufferRangeToViewport } from './helpers';
 
-// 默认鼠标放在 link 上面，会显示 tooltip 的延迟时间 (ms)
+// default delay time (ms) for showing tooltip when mouse is over a link
 const DEFAULT_HOVER_DELAY = 500;
 
 @Injectable({ multiple: true })

--- a/packages/terminal-next/src/browser/links/protocol-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/protocol-link-provider.ts
@@ -1,12 +1,17 @@
 import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import { IDisposable } from '@opensumi/ide-core-common';
 import { ILinkComputerTarget, LinkComputer } from '../../common';
 import { getXtermLineContent, convertLinkRangeToBuffer } from './helpers';
 import { TerminalLink } from './link';
 import { TerminalBaseLinkProvider } from './base';
 
+@Injectable({ multiple: true })
 export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
   private _linkComputerTarget: ILinkComputerTarget | undefined;
+
+  @Autowired(INJECTOR_TOKEN)
+  private readonly injector: Injector;
 
   constructor(
     private readonly _xterm: Terminal,
@@ -44,7 +49,7 @@ export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
       const range = convertLinkRangeToBuffer(lines, this._xterm.cols, link.range, startLine);
 
       // Check if the link if within the mouse position
-      return new TerminalLink(
+      return this.injector.get(TerminalLink, [
         this._xterm,
         range,
         link.url?.toString() || '',
@@ -53,7 +58,7 @@ export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
         this._tooltipCallback,
         true,
         undefined,
-      );
+      ]);
     });
   }
 }

--- a/packages/terminal-next/src/browser/links/protocol-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/protocol-link-provider.ts
@@ -1,4 +1,5 @@
-import type { Terminal, IBufferLine } from 'xterm';
+import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
+import { IDisposable } from '@opensumi/ide-core-common';
 import { ILinkComputerTarget, LinkComputer } from '../../common';
 import { getXtermLineContent, convertLinkRangeToBuffer } from './helpers';
 import { TerminalLink } from './link';
@@ -10,6 +11,12 @@ export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
   constructor(
     private readonly _xterm: Terminal,
     private readonly _activateCallback: (event: MouseEvent | undefined, uri: string) => void,
+    private readonly _tooltipCallback: (
+      link: TerminalLink,
+      viewportRange: IViewportRange,
+      modifierDownCallback?: () => void,
+      modifierUpCallback?: () => void,
+    ) => IDisposable,
   ) {
     super();
   }
@@ -43,7 +50,9 @@ export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
         link.url?.toString() || '',
         this._xterm.buffer.active.viewportY,
         this._activateCallback,
+        this._tooltipCallback,
         true,
+        undefined,
       );
     });
   }

--- a/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 // Some code copied and modified from https://github.com/microsoft/vscode/blob/1.44.0/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
 
-import type { Terminal, IBufferLine } from 'xterm';
-import { URI } from '@opensumi/ide-core-common';
+import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
+import { IDisposable, URI } from '@opensumi/ide-core-common';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
 import type { TerminalClient } from '../terminal.client';
 import { TerminalLink } from './link';
@@ -76,6 +76,12 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
     private readonly _wrapLinkHandler: (
       handler: (event: MouseEvent | undefined, link: string) => void,
     ) => XtermLinkMatcherHandler,
+    private readonly _tooltipCallback: (
+      link: TerminalLink,
+      viewportRange: IViewportRange,
+      modifierDownCallback?: () => void,
+      modifierUpCallback?: () => void,
+    ) => IDisposable,
     private readonly _validationCallback: (
       link: string,
       callback: (result: { uri: URI; isDirectory: boolean } | undefined) => void,
@@ -169,7 +175,9 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
                 link,
                 this._xterm.buffer.active.viewportY,
                 activateCallback,
+                this._tooltipCallback,
                 true,
+                undefined,
               ),
             );
           } else {

--- a/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
@@ -5,6 +5,7 @@
 // Some code copied and modified from https://github.com/microsoft/vscode/blob/1.44.0/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
 
 import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import { IDisposable, URI } from '@opensumi/ide-core-common';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
 import type { TerminalClient } from '../terminal.client';
@@ -68,7 +69,11 @@ export const lineAndColumnClauseGroupCount = 6;
 
 const MAX_LENGTH = 2000;
 
+@Injectable({ multiple: true })
 export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider {
+  @Autowired(INJECTOR_TOKEN)
+  private readonly injector: Injector;
+
   constructor(
     private readonly _xterm: Terminal,
     private readonly _client: TerminalClient,
@@ -169,7 +174,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
               this._activateFileCallback(event, text);
             });
             r(
-              new TerminalLink(
+              this.injector.get(TerminalLink, [
                 this._xterm,
                 bufferRange,
                 link,
@@ -178,7 +183,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
                 this._tooltipCallback,
                 true,
                 undefined,
-              ),
+              ]),
             );
           } else {
             r(undefined);

--- a/packages/terminal-next/src/browser/terminal.hover.manager.ts
+++ b/packages/terminal-next/src/browser/terminal.hover.manager.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@opensumi/di';
-import { ITerminalHoverManagerService, ITerminalGroupViewService, ITerminalController } from '../common';
+import { Disposable, IDisposable } from '@opensumi/ide-core-common';
+import { ITerminalHoverManagerService } from '../common';
 import { ILinkHoverTargetOptions } from './links/link-manager';
 
 const TIPS_OFFSET_Y = 20;
@@ -76,11 +77,7 @@ export class TerminalHoverManagerService implements ITerminalHoverManagerService
       }
     });
 
-    return {
-      dispose: () => {
-        this.dispose();
-      },
-    };
+    return Disposable.create(() => this.dispose());
   }
 
   hideHover() {

--- a/packages/terminal-next/src/browser/terminal.hover.manager.ts
+++ b/packages/terminal-next/src/browser/terminal.hover.manager.ts
@@ -1,5 +1,4 @@
-import { Injectable, Autowired } from '@opensumi/di';
-import { Disposable } from '@opensumi/ide-core-common';
+import { Injectable } from '@opensumi/di';
 import { ITerminalHoverManagerService, ITerminalGroupViewService, ITerminalController } from '../common';
 import { ILinkHoverTargetOptions } from './links/link-manager';
 
@@ -9,28 +8,6 @@ const TIPS_OFFSET_X = 5;
 @Injectable()
 export class TerminalHoverManagerService implements ITerminalHoverManagerService {
   hoverWidget: HTMLElement | undefined;
-
-  @Autowired(ITerminalController)
-  private readonly controller: ITerminalController;
-
-  @Autowired(ITerminalGroupViewService)
-  private readonly terminalView: ITerminalGroupViewService;
-
-  constructor() {
-    this.controller.onDidCloseTerminal(() => {
-      this.hideHover();
-    });
-    this.controller.onDidChangeActiveTerminal(() => {
-      this.hideHover();
-    });
-  }
-
-  private _addDisposableListener(node: Node, type: string, handler: EventListener) {
-    node.addEventListener(type, handler);
-    return Disposable.create(() => {
-      node.removeEventListener(type, handler);
-    });
-  }
 
   private appendTerminalHoverContainer() {
     const overlayContainer = document.querySelector('#ide-overlay');

--- a/packages/terminal-next/src/browser/terminal.hover.manager.ts
+++ b/packages/terminal-next/src/browser/terminal.hover.manager.ts
@@ -1,0 +1,98 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { Disposable } from '@opensumi/ide-core-common';
+import { ITerminalHoverManagerService, ITerminalGroupViewService, ITerminalController } from '../common';
+import { ILinkHoverTargetOptions } from './links/link-manager';
+
+const TIPS_OFFSET_Y = 20;
+const TIPS_OFFSET_X = 5;
+
+@Injectable()
+export class TerminalHoverManagerService implements ITerminalHoverManagerService {
+  hoverWidget: HTMLElement | undefined;
+
+  @Autowired(ITerminalController)
+  private readonly controller: ITerminalController;
+
+  @Autowired(ITerminalGroupViewService)
+  private readonly terminalView: ITerminalGroupViewService;
+
+  constructor() {
+    this.controller.onDidCloseTerminal(() => {
+      this.hideHover();
+    });
+    this.controller.onDidChangeActiveTerminal(() => {
+      this.hideHover();
+    });
+  }
+
+  private _addDisposableListener(node: Node, type: string, handler: EventListener) {
+    node.addEventListener(type, handler);
+    return Disposable.create(() => {
+      node.removeEventListener(type, handler);
+    });
+  }
+
+  private appendTerminalHoverContainer() {
+    const overlayContainer = document.querySelector('#ide-overlay');
+
+    if (!overlayContainer) {
+      throw new Error('ide-overlay is requried');
+    }
+
+    const overlay = document.createElement('div');
+    overlay.classList.add('terminal-hover-overlay');
+    overlayContainer.appendChild(overlay);
+
+    this.hoverWidget = document.createElement('div');
+    this.hoverWidget.style.display = 'none';
+    this.hoverWidget.style.position = 'fixed';
+    this.hoverWidget.style.color = 'var(--editorWidget-foreground)';
+    this.hoverWidget.style.backgroundColor = 'var(--editorWidget-background)';
+    this.hoverWidget.style.borderColor = 'var(--editorWidget-border)';
+    this.hoverWidget.style.borderWidth = '0.5px';
+    this.hoverWidget.style.borderStyle = 'solid';
+    this.hoverWidget.style.padding = '5px';
+    this.hoverWidget.style.zIndex = '10';
+
+    this.hoverWidget.classList.add('hover-container');
+    overlay.appendChild(this.hoverWidget);
+  }
+
+  showHover(targetOptions: ILinkHoverTargetOptions, text: string, linkHandler: (url: string) => void) {
+    if (!this.hoverWidget) {
+      this.appendTerminalHoverContainer();
+    }
+
+    const viewportRange = targetOptions.viewportRange;
+    const cellDimensions = targetOptions.cellDimensions;
+    const boundingClientRect = targetOptions.boundingClientRect;
+
+    if (this.hoverWidget) {
+      this.hoverWidget.style.top = `${
+        (viewportRange.start.y - 1) * cellDimensions.height + boundingClientRect.y - TIPS_OFFSET_Y
+      }px`;
+      this.hoverWidget.style.left = `${
+        viewportRange.start.x * cellDimensions.width + boundingClientRect.x + TIPS_OFFSET_X
+      }px`;
+      this.hoverWidget.style.display = 'inline';
+      this.hoverWidget.textContent = text;
+    }
+
+    return {
+      dispose: () => {
+        this.dispose();
+      },
+    };
+  }
+
+  hideHover() {
+    if (this.hoverWidget) {
+      this.hoverWidget.style.display = 'none';
+    }
+  }
+
+  dispose() {
+    this.hoverWidget?.remove();
+    this.hoverWidget = undefined;
+  }
+}

--- a/packages/terminal-next/src/browser/terminal.hover.manager.ts
+++ b/packages/terminal-next/src/browser/terminal.hover.manager.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@opensumi/di';
-import { Disposable, IDisposable } from '@opensumi/ide-core-common';
+import { Disposable } from '@opensumi/ide-core-common';
 import { ITerminalHoverManagerService } from '../common';
 import { ILinkHoverTargetOptions } from './links/link-manager';
 
@@ -44,6 +44,10 @@ export class TerminalHoverManagerService implements ITerminalHoverManagerService
     }
 
     this.hoverOverlay?.appendChild(this.hoverWidget);
+  }
+
+  setHoverOverlay(overlay: HTMLElement) {
+    this.hoverOverlay = overlay;
   }
 
   showHover(targetOptions: ILinkHoverTargetOptions, text: string, linkHandler: (url: string) => void) {

--- a/packages/terminal-next/src/common/controller.ts
+++ b/packages/terminal-next/src/common/controller.ts
@@ -4,6 +4,7 @@ import { IWidgetGroup, IWidget } from './resize';
 import { ITerminalClient, ITerminalExitEvent, ITerminalExternalLinkProvider } from './client';
 import { TerminalOptions, ITerminalInfo } from './pty';
 import { IContextKeyService } from '@opensumi/ide-core-browser';
+import type { ILinkHoverTargetOptions } from '../browser/links/link-manager';
 
 export interface ITerminalExternalClient {
   readonly id: string;
@@ -97,4 +98,16 @@ export interface ITerminalGroupViewService {
 export interface ITerminalBrowserHistory {
   current: string | undefined;
   groups: (string[] | { clientId: string }[])[];
+}
+
+export const ITerminalHoverManagerService = Symbol('ITerminalHoverManagerService');
+export interface ITerminalHoverManagerService {
+  showHover(
+    targetOptions: ILinkHoverTargetOptions,
+    text: string,
+    linkHandler: (url: string) => void,
+  ): {
+    dispose(): void;
+  };
+  dispose(): void;
 }

--- a/packages/terminal-next/src/common/controller.ts
+++ b/packages/terminal-next/src/common/controller.ts
@@ -101,13 +101,6 @@ export interface ITerminalBrowserHistory {
 }
 
 export const ITerminalHoverManagerService = Symbol('ITerminalHoverManagerService');
-export interface ITerminalHoverManagerService {
-  showHover(
-    targetOptions: ILinkHoverTargetOptions,
-    text: string,
-    linkHandler: (url: string) => void,
-  ): {
-    dispose(): void;
-  };
-  dispose(): void;
+export interface ITerminalHoverManagerService extends IDisposable {
+  showHover(targetOptions: ILinkHoverTargetOptions, text: string, linkHandler: (url: string) => void): IDisposable;
 }

--- a/packages/terminal-next/src/common/extension.ts
+++ b/packages/terminal-next/src/common/extension.ts
@@ -95,8 +95,8 @@ export interface ITerminalLinkDto {
   startIndex: number;
   /** The length of the link in the line. */
   length: number;
-  /** TODO: The descriptive label for what the link does when activated. */
-  // label?: string;
+  /** The descriptive label for what the link does when activated. */
+  label?: string;
 }
 
 export interface ITerminalLaunchError {

--- a/packages/terminal-next/src/common/xterm-private.d.ts
+++ b/packages/terminal-next/src/common/xterm-private.d.ts
@@ -1,0 +1,40 @@
+import { IBufferCell } from 'xterm';
+
+export type XTermAttributes = Omit<IBufferCell, 'getWidth' | 'getChars' | 'getCode'> & { clone?(): XTermAttributes };
+
+export interface XTermCore {
+  viewport?: {
+    _innerRefresh(): void;
+  };
+  _onKey: IEventEmitter<{ key: string }>;
+
+  _charSizeService: {
+    width: number;
+    height: number;
+  };
+
+  element: HTMLElement;
+
+  _coreService: {
+    triggerDataEvent(data: string, wasUserInput?: boolean): void;
+  };
+
+  _inputHandler: {
+    _curAttrData: XTermAttributes;
+  };
+
+  _renderService: {
+    dimensions: {
+      actualCellWidth: number;
+      actualCellHeight: number;
+    };
+    _renderer: {
+      _renderLayers: any[];
+    };
+    _onIntersectionChange: any;
+  };
+}
+
+export interface IEventEmitter<T> {
+  fire(e: T): void;
+}

--- a/packages/types/vscode/typings/vscode.d.ts
+++ b/packages/types/vscode/typings/vscode.d.ts
@@ -291,23 +291,23 @@ declare module 'vscode' {
     isExtensionTerminal?: boolean;
 
     /**
-		 * A message to write to the terminal on first launch, note that this is not sent to the
-		 * process but, rather written directly to the terminal. This supports escape sequences such
-		 * a setting text style.
-		 */
-		message?: string;
+     * A message to write to the terminal on first launch, note that this is not sent to the
+     * process but, rather written directly to the terminal. This supports escape sequences such
+     * a setting text style.
+     */
+    message?: string;
 
-		/**
-		 * The icon path or {@link ThemeIcon} for the terminal.
-		 */
-		iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+    /**
+     * The icon path or {@link ThemeIcon} for the terminal.
+     */
+    iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
 
-		/**
-		 * The icon {@link ThemeColor} for the terminal.
-		 * The `terminal.ansi*` theme keys are
-		 * recommended for the best contrast and consistency across themes.
-		 */
-		color?: ThemeColor;
+    /**
+     * The icon {@link ThemeColor} for the terminal.
+     * The `terminal.ansi*` theme keys are
+     * recommended for the best contrast and consistency across themes.
+     */
+    color?: ThemeColor;
   }
 
   /**
@@ -361,13 +361,13 @@ declare module 'vscode' {
     length: number;
 
     /**
-     * TODO: The tooltip text when you hover over this link.
+     * The tooltip text when you hover over this link.
      *
      * If a tooltip is provided, is will be displayed in a string that includes instructions on
      * how to trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary
      * depending on OS, user settings, and localization.
      */
-    // tooltip?: string;
+    tooltip?: string;
   }
 
   /**
@@ -402,16 +402,16 @@ declare module 'vscode' {
     pty: Pseudoterminal;
 
     /**
-		 * The icon path or {@link ThemeIcon} for the terminal.
-		 */
-		iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+     * The icon path or {@link ThemeIcon} for the terminal.
+     */
+    iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
 
-		/**
-		 * The icon {@link ThemeColor} for the terminal.
-		 * The standard `terminal.ansi*` theme keys are
-		 * recommended for the best contrast and consistency across themes.
-		 */
-		color?: ThemeColor;
+    /**
+     * The icon {@link ThemeColor} for the terminal.
+     * The standard `terminal.ansi*` theme keys are
+     * recommended for the best contrast and consistency across themes.
+     */
+    color?: ThemeColor;
   }
 
   /**
@@ -501,22 +501,22 @@ declare module 'vscode' {
     onDidClose?: Event<void | number>;
 
     /**
-		 * An event that when fired allows changing the name of the terminal.
-		 *
-		 * **Example:** Change the terminal name to "My new terminal".
-		 * ```typescript
-		 * const writeEmitter = new vscode.EventEmitter<string>();
-		 * const changeNameEmitter = new vscode.EventEmitter<string>();
-		 * const pty: vscode.Pseudoterminal = {
-		 *   onDidWrite: writeEmitter.event,
-		 *   onDidChangeName: changeNameEmitter.event,
-		 *   open: () => changeNameEmitter.fire('My new terminal'),
-		 *   close: () => {}
-		 * };
-		 * vscode.window.createTerminal({ name: 'My terminal', pty });
-		 * ```
-		 */
-		onDidChangeName?: Event<string>;
+     * An event that when fired allows changing the name of the terminal.
+     *
+     * **Example:** Change the terminal name to "My new terminal".
+     * ```typescript
+     * const writeEmitter = new vscode.EventEmitter<string>();
+     * const changeNameEmitter = new vscode.EventEmitter<string>();
+     * const pty: vscode.Pseudoterminal = {
+     *   onDidWrite: writeEmitter.event,
+     *   onDidChangeName: changeNameEmitter.event,
+     *   open: () => changeNameEmitter.fire('My new terminal'),
+     *   close: () => {}
+     * };
+     * vscode.window.createTerminal({ name: 'My terminal', pty });
+     * ```
+     */
+    onDidChangeName?: Event<string>;
 
     /**
      * Implement to handle when the pty is open and ready to start firing events.
@@ -1672,19 +1672,19 @@ declare module 'vscode' {
      * Generally, a TreeItem has no need to set the `role` of the accessibilityInformation;
      * however, there are cases where a TreeItem is not displayed in a tree-like way where setting the `role` may make sense.
      */
-     accessibilityInformation?: AccessibilityInformation;
+    accessibilityInformation?: AccessibilityInformation;
 
-     /**
-      * @param label A human-readable string describing this item
-      * @param collapsibleState {@link TreeItemCollapsibleState} of the tree item. Default is {@link TreeItemCollapsibleState.None}
-      */
-     constructor(label: string | TreeItemLabel, collapsibleState?: TreeItemCollapsibleState);
+    /**
+     * @param label A human-readable string describing this item
+     * @param collapsibleState {@link TreeItemCollapsibleState} of the tree item. Default is {@link TreeItemCollapsibleState.None}
+     */
+    constructor(label: string | TreeItemLabel, collapsibleState?: TreeItemCollapsibleState);
 
-     /**
-      * @param resourceUri The {@link Uri} of the resource representing this item.
-      * @param collapsibleState {@link TreeItemCollapsibleState} of the tree item. Default is {@link TreeItemCollapsibleState.None}
-      */
-     constructor(resourceUri: Uri, collapsibleState?: TreeItemCollapsibleState);
+    /**
+     * @param resourceUri The {@link Uri} of the resource representing this item.
+     * @param collapsibleState {@link TreeItemCollapsibleState} of the tree item. Default is {@link TreeItemCollapsibleState.None}
+     */
+    constructor(resourceUri: Uri, collapsibleState?: TreeItemCollapsibleState);
   }
   /**
    * Represents a line of text, such as a line of source code.
@@ -2001,7 +2001,7 @@ declare module 'vscode' {
      * @param pathSegments One more more path fragments
      * @returns A new uri which path is joined with the given fragments
      */
-     static joinPath(base: Uri, ...pathSegments: string[]): Uri;
+    static joinPath(base: Uri, ...pathSegments: string[]): Uri;
 
     /**
      * Use the `file` and `parse` factory functions to create new `Uri` objects.
@@ -2203,7 +2203,7 @@ declare module 'vscode' {
 
     /** The text change is caused by an redo operation. */
     Redo = 2,
-	}
+  }
 
   /**
    * An event describing a transactional [document](#TextDocument) change.
@@ -2492,9 +2492,9 @@ declare module 'vscode' {
     readonly keys: readonly string[];
   }
 
-    /**
-   * The event data that is fired when a secret is added or removed.
-   */
+  /**
+ * The event data that is fired when a secret is added or removed.
+ */
   export interface SecretStorageChangeEvent {
     /**
      * The key of the secret that has changed.
@@ -2777,7 +2777,7 @@ declare module 'vscode' {
     /**
      * The uri of the directory containing the extension.
      */
-     readonly extensionUri: Uri;
+    readonly extensionUri: Uri;
 
     /**
      * Gets the extension's environment variable collection for this workspace, enabling changes


### PR DESCRIPTION
### 变动类型

<!-- 请将这段及下面未选中的项一起删除，保持 PR 描述的简洁性 -->

- [x] 新特性提交

### 需求背景和解决方案
close #77 

支持 VSCode 1.60 API。

- 支持链接跳转提示
- 支持非链接声明的 tooltips，并且执行 command [TerminalLink API](https://code.visualstudio.com/api/references/vscode-api#TerminalLink)

![screenshort_20211222-201058](https://user-images.githubusercontent.com/2226423/147090963-fb5c1d2b-2b99-4866-812e-e2cc8e2b6a1f.gif)


### changelog
- 支持 TerminalLink 的 tooltips API