### PR TITLE
refactor: deprecated ongiWasmPath uses ongiWasmUri

### DIFF
--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -174,9 +174,14 @@ export interface AppConfig {
    */
   didRendered?: () => void;
   /**
-   * vscode-oniguruma-wasm 资源地址
+   * @deprecated
+   * vscode-oniguruma-wasm 资源地址，在 Windows 版本中很容易传送错误的地址，请使用 onigWasmUri 参数
    */
   onigWasmPath?: string;
+  /**
+   * vscode-oniguruma-wasm 资源 Uri 地址
+   */
+  onigWasmUri?: string;
   /**
    * 工作区文件后缀，默认后缀为 `sumi-workspace`
    */

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -672,11 +672,17 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
     if (wasmLoaded) {
       return new OnigasmLib();
     }
+
     let wasmUri: string;
     if (isElectronEnv() && electronEnv.onigWasmPath) {
       wasmUri = URI.file(electronEnv.onigWasmPath).codeUri.toString();
+    } else if (isElectronEnv() && electronEnv.onigWasmUri) {
+      wasmUri = electronEnv.onigWasmUri;
     } else {
-      wasmUri = this.appConfig.onigWasmPath || 'https://g.alicdn.com/kaitian/vscode-oniguruma-wasm/1.5.1/onig.wasm';
+      wasmUri =
+        this.appConfig.onigWasmUri ||
+        this.appConfig.onigWasmPath ||
+        'https://g.alicdn.com/kaitian/vscode-oniguruma-wasm/1.5.1/onig.wasm';
     }
 
     const response = await fetch(wasmUri);


### PR DESCRIPTION
### 变动类型

<!-- 请将这段及下面未选中的项一起删除，保持 PR 描述的简洁性 -->

- [x] 重构

### 需求背景和解决方案
Windows 上面使用 Path 字符串传递会出现一些明显的路径问题，而且对于集成方会出现一些难以预知的问题

### changelog
- 弃用 ongiWasmPath 使用 ongiWasmUri
