### PR TITLE
fix: clean up the wrong usage of debug command

### DIFF
--- a/packages/core-browser/src/raw-context-key.ts
+++ b/packages/core-browser/src/raw-context-key.ts
@@ -89,7 +89,7 @@ export class RawContextKey<T> implements IRawContextKey<T> {
   /**
    * is equal to
    */
-  public equalsTo(value: string): string {
+  public equalsTo<T = string>(value: T): string {
     return this.raw + ' == ' + value;
   }
 

--- a/packages/debug/__tests__/browser/view/console/debug-console-tree.model.service.test.ts
+++ b/packages/debug/__tests__/browser/view/console/debug-console-tree.model.service.test.ts
@@ -33,6 +33,7 @@ import { WSChannelHandler } from '@opensumi/ide-connection';
 import { IVariableResolverService } from '@opensumi/ide-variable';
 import { ITaskService } from '@opensumi/ide-task';
 import { DebugConsoleFilterService } from '@opensumi/ide-debug/lib/browser/view/console/debug-console-filter.service';
+import { DebugContextKey } from '@opensumi/ide-debug/lib/browser/contextkeys/debug-contextkey.service';
 
 describe('Debug Console Tree Model', () => {
   const mockInjector = createBrowserInjector([]);
@@ -179,6 +180,14 @@ describe('Debug Console Tree Model', () => {
     mockInjector.overrideProviders({
       token: ITaskService,
       useValue: {},
+    });
+    mockInjector.overrideProviders({
+      token: DebugContextKey,
+      useValue: {
+        contextInDebugConsole: {
+          set: jest.fn(),
+        },
+      },
     });
 
     debugConsoleModelService = mockInjector.get(DebugConsoleModelService);

--- a/packages/debug/src/browser/contextkeys/debug-contextkey.service.ts
+++ b/packages/debug/src/browser/contextkeys/debug-contextkey.service.ts
@@ -2,6 +2,7 @@ import { Optional, Injectable, Autowired } from '@opensumi/di';
 import { IContextKeyService, IContextKey, IScopedContextKeyService } from '@opensumi/ide-core-browser';
 import {
   CONTEXT_IN_DEBUG_REPL,
+  CONTEXT_IN_DEBUG_CONSOLE,
   CONTEXT_IN_DEBUG_MODE,
   CONTEXT_DEBUG_STATE,
   CONTEXT_VARIABLE_EVALUATE_NAME_PRESENT,
@@ -19,6 +20,7 @@ export class DebugContextKey {
   private _contextKeyService: IScopedContextKeyService | undefined;
 
   public readonly contextInDebugRepl: IContextKey<boolean>;
+  public readonly contextInDebugConsole: IContextKey<boolean>;
   public readonly contextInDdebugMode: IContextKey<boolean>;
   public readonly contextDebugState: IContextKey<keyof typeof DebugState>;
   public readonly contextVariableEvaluateNamePresent: IContextKey<boolean>;
@@ -29,6 +31,7 @@ export class DebugContextKey {
   constructor(@Optional() dom?: HTMLElement) {
     this._contextKeyService = this.globalContextKeyService.createScoped(dom);
     this.contextInDebugRepl = CONTEXT_IN_DEBUG_REPL.bind(this.contextKeyScoped);
+    this.contextInDebugConsole = CONTEXT_IN_DEBUG_CONSOLE.bind(this.contextKeyScoped);
     this.contextInDdebugMode = CONTEXT_IN_DEBUG_MODE.bind(this.contextKeyScoped);
     this.contextDebugState = CONTEXT_DEBUG_STATE.bind(this.contextKeyScoped);
     this.contextVariableEvaluateNamePresent = CONTEXT_VARIABLE_EVALUATE_NAME_PRESENT.bind(this.contextKeyScoped);

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -77,6 +77,7 @@ import { IFileServiceClient, IShadowFileProvider } from '@opensumi/ide-file-serv
 import { FileServiceClient } from '@opensumi/ide-file-service/lib/browser/file-service-client';
 import { DebugProgressService } from './debug-progress.service';
 import { DebugRunToCursorService } from './editor/debug-run-to-cursor.service';
+import { DebugContextKey } from './contextkeys/debug-contextkey.service';
 
 const LAUNCH_JSON_REGEX = /launch\.json$/;
 
@@ -245,15 +246,14 @@ export namespace DebugBreakpointWidgetCommands {
 )
 export class DebugContribution
   implements
-    ComponentContribution,
-    TabBarToolbarContribution,
-    CommandContribution,
-    KeybindingContribution,
-    JsonSchemaContribution,
-    PreferenceContribution,
-    MenuContribution,
-    BrowserEditorContribution
-{
+  ComponentContribution,
+  TabBarToolbarContribution,
+  CommandContribution,
+  KeybindingContribution,
+  JsonSchemaContribution,
+  PreferenceContribution,
+  MenuContribution,
+  BrowserEditorContribution {
   schema: PreferenceSchema = debugPreferencesSchema;
 
   @Autowired(IMainLayoutService)
@@ -318,6 +318,9 @@ export class DebugContribution
 
   @Autowired(DebugRunToCursorService)
   protected readonly debugRunToCursorService: DebugRunToCursorService;
+
+  @Autowired(DebugContextKey)
+  protected readonly debugContextKey: DebugContextKey;
 
   private firstSessionStart = true;
 
@@ -682,11 +685,13 @@ export class DebugContribution
       execute: (uri: URI) => {
         this.debugRunToCursorService.run(uri);
       },
+      isEnabled: () => this.debugContextKey.contextDebugState.get() === 'Stopped',
     });
     commands.registerCommand(DEBUG_COMMANDS.FORCE_RUN_TO_CURSOR, {
       execute: (uri: URI) => {
         this.debugRunToCursorService.run(uri, true);
       },
+      isEnabled: () => this.debugContextKey.contextDebugState.get() === 'Stopped',
     });
   }
 

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -323,8 +323,8 @@ export class DebugSession implements IDebugSession {
     const response = await this.connection.sendRequest(
       'initialize',
       {
-        clientID: 'KatiTian',
-        clientName: 'KatiTian IDE',
+        clientID: 'OpenSumi',
+        clientName: 'OpenSumi IDE',
         adapterID: this.configuration.type,
         locale: 'en-US',
         linesStartAt1: true,
@@ -379,7 +379,7 @@ export class DebugSession implements IDebugSession {
     return this.sendRequest('setExceptionBreakpoints', args);
   }
 
-  public onStateChange(): void {
+  protected onStateChange(): void {
     const state = this.state;
     if (this.previousState !== state) {
       this.previousState = state;

--- a/packages/debug/src/browser/view/console/debug-console-tree.model.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console-tree.model.service.ts
@@ -1,3 +1,4 @@
+import { DebugContextKey } from './../../contextkeys/debug-contextkey.service';
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import {
   DecorationsManager,
@@ -72,6 +73,9 @@ export class DebugConsoleModelService {
 
   @Autowired(LinkDetector)
   private readonly linkDetector: LinkDetector;
+
+  @Autowired(DebugContextKey)
+  private readonly debugContextKey: DebugContextKey;
 
   private _activeDebugSessionModel: IDebugConsoleModel | undefined;
   private debugSessionModelMap: Map<string, IDebugConsoleModel> = new Map();
@@ -374,6 +378,7 @@ export class DebugConsoleModelService {
     ev.preventDefault();
 
     const { x, y } = ev.nativeEvent;
+    this.debugContextKey.contextInDebugConsole.set(true);
 
     if (expression) {
       this.activeNodeActivedDecoration(expression);
@@ -390,14 +395,18 @@ export class DebugConsoleModelService {
     }
     const menus = this.contextMenuService.createMenu({
       id: MenuId.DebugConsoleContext,
-      contextKeyService: this.contextMenuContextKeyService,
+      contextKeyService: this.debugContextKey.contextKeyScoped,
     });
     const menuNodes = menus.getMergedMenuNodes();
     menus.dispose();
+
     this.ctxMenuRenderer.show({
       anchor: { x, y },
       menuNodes,
       args: [node],
+      onHide: () => {
+        this.debugContextKey.contextInDebugConsole.set(false);
+      },
     });
   };
 

--- a/packages/debug/src/browser/view/console/debug-console.contribution.ts
+++ b/packages/debug/src/browser/view/console/debug-console.contribution.ts
@@ -24,6 +24,7 @@ import { DEBUG_COMMANDS } from '../../debug-contribution';
 import { DebugConsoleModelService } from './debug-console-tree.model.service';
 import { IMenuRegistry, MenuContribution, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { DebugConsoleNode } from '../../tree';
+import { DebugContextKey } from '../../contextkeys/debug-contextkey.service';
 
 export const DEBUG_CONSOLE_VIEW_ID = 'debug-console-view';
 
@@ -48,7 +49,7 @@ export class DebugConsoleContribution
   private readonly debugConsoleModelService: DebugConsoleModelService;
 
   @Autowired()
-  private debugConsoleInputDocumentProvider: DebugConsoleInputDocumentProvider;
+  private readonly debugConsoleInputDocumentProvider: DebugConsoleInputDocumentProvider;
 
   @Autowired(IContextKeyService)
   protected readonly contextKeyService: IContextKeyService;
@@ -58,6 +59,9 @@ export class DebugConsoleContribution
 
   @Autowired(DebugConsoleFilterService)
   protected readonly debugConsoleFilterService: DebugConsoleFilterService;
+
+  @Autowired(DebugContextKey)
+  protected readonly debugContextKey: DebugContextKey;
 
   registerComponent(registry: ComponentRegistry) {
     registry.register(
@@ -95,6 +99,7 @@ export class DebugConsoleContribution
       execute: () => {
         this.debugConsoleModelService.clear();
       },
+      isEnabled: () => this.debugContextKey.contextInDebugConsole.get() === true,
     });
     registry.registerCommand(DEBUG_COMMANDS.COPY_CONSOLE_ITEM, {
       execute: (node: DebugConsoleNode) => {
@@ -110,6 +115,7 @@ export class DebugConsoleContribution
       execute: () => {
         this.debugConsoleModelService.collapseAll();
       },
+      isEnabled: () => this.debugContextKey.contextInDebugConsole.get() === true,
     });
     registry.registerCommand(DEBUG_COMMANDS.CONSOLE_ENTER_EVALUATE, {
       execute: () => {

--- a/packages/debug/src/browser/view/console/debug-console.view.tsx
+++ b/packages/debug/src/browser/view/console/debug-console.view.tsx
@@ -147,7 +147,7 @@ export const DebugConsoleView = observer(({ viewState }: { viewState: ViewState 
     handleContextMenu(ev);
   };
 
-  const handleOuterClick = (ev: React.MouseEvent) => {
+  const handleConsoleClick = (ev: React.MouseEvent) => {
     // 空白区域点击，取消焦点状态
     const { enactiveNodeDecoration } = consoleModel;
     enactiveNodeDecoration();
@@ -215,7 +215,7 @@ export const DebugConsoleView = observer(({ viewState }: { viewState: ViewState 
   };
 
   return (
-    <div className={styles.debug_console} onContextMenu={handleOuterContextMenu} onClick={handleOuterClick}>
+    <div className={styles.debug_console} onContextMenu={handleOuterContextMenu} onClick={handleConsoleClick}>
       <div
         className={styles.debug_console_output}
         tabIndex={-1}

--- a/packages/debug/src/common/constants.ts
+++ b/packages/debug/src/common/constants.ts
@@ -23,6 +23,7 @@ export const CONTEXT_DEBUG_UX_KEY = 'debugUx';
 export const CONTEXT_DEBUG_UX = new RawContextKey<string>(CONTEXT_DEBUG_UX_KEY, 'default');
 export const CONTEXT_IN_DEBUG_MODE = new RawContextKey<boolean>('inDebugMode', false);
 export const CONTEXT_IN_DEBUG_REPL = new RawContextKey<boolean>('inDebugRepl', false);
+export const CONTEXT_IN_DEBUG_CONSOLE = new RawContextKey<boolean>('inDebugConsole', false);
 export const CONTEXT_BREAKPOINT_WIDGET_VISIBLE = new RawContextKey<boolean>('breakpointWidgetVisible', false);
 export const CONTEXT_IN_BREAKPOINT_WIDGET = new RawContextKey<boolean>('inBreakpointWidget', false);
 export const CONTEXT_BREAKPOINTS_FOCUSED = new RawContextKey<boolean>('breakpointsFocused', true);


### PR DESCRIPTION
### 变动类型

- [x] 日常 bug 修复

### 需求背景和解决方案

1. **运行到光标处** 和 **强制运行到光标处** 只有在开启调试的时候才 enabled
![image](https://user-images.githubusercontent.com/20262815/147216125-4436f9e5-b636-4216-8b53-04f2ea333469.png)


2. 调试控制台只有触发右键菜单的时候才开启 **清空日志** 和 **折叠全部**
![image](https://user-images.githubusercontent.com/20262815/147216093-874b4add-1c9d-4f89-89d5-2a7b28b9d998.png)


### changelog
fix: Clean up the wrong usage of debug command