### PR TITLE
refactor: optimize terminal create process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,33 +9,27 @@
       "request": "attach",
       "name": "Attach to BackEnd",
       "port": 9999,
-      "restart": true,
+      "restart": true
     },
     {
       "type": "node",
       "request": "attach",
       "name": "Attach to Electron Main",
       "port": 9229,
-      "restart": true,
+      "restart": true
     },
     {
       "type": "node",
       "request": "launch",
       "name": "Launch BackEnd",
-      "args": [
-        "./entry/web/server.ts"
-      ],
-      "runtimeArgs": [
-        "--nolazy",
-        "-r",
-        "ts-node/register"
-      ],
+      "args": ["./entry/web/server.ts"],
+      "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
       "sourceMaps": true,
       "cwd": "${workspaceRoot}/packages/startup",
       "protocol": "inspector",
       "console": "internalConsole",
       "env": {
-        "IS_DEV" : "1",
+        "IS_DEV": "1",
         "KTLOG_SHOW_DEBUG": "1"
       }
     },
@@ -44,10 +38,7 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/webpack-dev-server",
-      "args": [
-        "--config",
-        "${workspaceRoot}/packages/startup/webpack.config.js"
-      ],
+      "args": ["--config", "${workspaceRoot}/packages/startup/webpack.config.js"],
       "cwd": "${workspaceRoot}/packages/startup",
       "console": "internalConsole"
     },
@@ -58,9 +49,7 @@
       "port": 9889,
       "restart": true,
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/tools/extension/**/*.js"
-      ],
+      "outFiles": ["${workspaceRoot}/tools/extension/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///./~/*": "${workspaceRoot}/node_modules/*",
         "webpack:///./*": "${workspaceRoot}/*",
@@ -72,7 +61,7 @@
       "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["${relativeFile}"],
+      "args": ["${relativeFile}", "--detectOpenHandles"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },
@@ -80,18 +69,12 @@
       "type": "node",
       "request": "launch",
       "name": "Publish test",
-      "args": [
-        "./scripts/publish.ts"
-      ],
-      "runtimeArgs": [
-        "--nolazy",
-        "-r",
-        "ts-node/register"
-      ],
+      "args": ["./scripts/publish.ts"],
+      "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
       "sourceMaps": true,
       "cwd": "${workspaceRoot}",
       "protocol": "inspector",
-      "console": "internalConsole",
+      "console": "internalConsole"
     },
     {
       "type": "node",

--- a/CONTRIBUTING-zh_CN.md
+++ b/CONTRIBUTING-zh_CN.md
@@ -49,11 +49,11 @@ $ npm install --canvas_binary_host_mirror=https://npmmirror.com/mirrors/node-can
 
 ## 构建和运行
 
-如果你想了解如何运行 OpenSuni 或者想调试一个 Issue，你需要在本地获取代码，构建，然后运行它
+如果你想了解如何运行 OpenSumi 或者想调试一个 Issue，你需要在本地获取代码，构建，然后运行它
 
 ### 获取代码
 
-第一步，你需要先 Fork 一份 `OpenSuni` 仓库副本，然后再将其克隆到本地：
+第一步，你需要先 Fork 一份 `OpenSumi` 仓库副本，然后再将其克隆到本地：
 
 ```bash
 $ git clone https://github.com/<<<your-github-account>>>/core.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,11 @@ In the actual development process, you may encounter issues such as `node-gyp` a
 
 ## Build and run
 
-If you want to learn how to run OpenSuni or want to debug an issue, you need to get the code locally, build it, and then run it
+If you want to learn how to run OpenSumi or want to debug an issue, you need to get the code locally, build it, and then run it
 
 ### Getting the sources
 
-In the first step, you need to fork a copy of the `OpenSuni` repository, and then clone it locally:
+In the first step, you need to fork a copy of the `OpenSumi` repository, and then clone it locally:
 
 ```bash
 $ git clone https://github.com/<<<your-github-account>>>/core.git

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepublishOnly": "npm run build && npm run build:dist",
     "build": "tsc --build ../../configs/ts/references/tsconfig.components.json",
-    "build:dist": "webpack --config ./webpack.config.js --progress --color",
+    "build:dist": "webpack --config ./webpack.config.js --color",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -2,9 +2,11 @@ const path = require('path');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { ProgressPlugin } = require('webpack');
 
 const tsConfigPath = path.join(__dirname, '../../configs/ts/references/tsconfig.components.json');
 
+/** @type { import('webpack').Configuration } */
 module.exports = {
   entry: path.join(__dirname, './src/index.ts'),
   output: {
@@ -18,7 +20,8 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: 'index.css',
     }),
-  ],
+    !process.env.CI && new ProgressPlugin(),
+  ].filter(Boolean),
   node: {
     net: 'empty',
     child_process: 'empty',
@@ -105,4 +108,5 @@ module.exports = {
       },
     ],
   },
+  stats: process.env.CI ? 'errors-only' : 'normal',
 };

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -124,7 +124,11 @@ describe('connection', () => {
     const clientCenter = new RPCServiceCenter();
     clientCenter.setConnection(createWebSocketConnection(clientConnection) as RPCMessageConnection);
 
-    const { getRPCService } = initRPCService(clientCenter);
+    const { getRPCService } = initRPCService<
+      MockFileService & {
+        onFileChange: (k: any) => void;
+      }
+    >(clientCenter);
 
     const remoteService = getRPCService('MockFileServicePath');
     const remoteResult = await remoteService.getContent('1');

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -248,6 +248,14 @@ export const corePreferenceSchema: PreferenceSchema = {
       default: [],
       description: '%preference.terminal.integrated.shellArgs.linuxDesc%',
     },
+    'terminal.integrated.shellArgs.osx': {
+      type: 'array',
+      default: [],
+    },
+    'terminal.integrated.shellArgs.windows': {
+      type: 'array',
+      default: [],
+    },
     'output.maxChannelLine': {
       type: 'number',
       default: 50000,
@@ -323,6 +331,8 @@ export interface CoreConfiguration {
   'general.language': string;
   'general.theme': string;
   'terminal.integrated.shellArgs.linux': string[];
+  'terminal.integrated.shellArgs.osx': string[];
+  'terminal.integrated.shellArgs.windows': string[];
   'view.saveLayoutWithWorkspace': boolean;
 }
 

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -215,7 +215,7 @@ export const corePreferenceSchema: PreferenceSchema = {
       enum:
         isElectronRenderer() && isWindows
           ? ['powershell', 'cmd', 'git-bash', 'default']
-          : ['bash', 'zsh', 'sh', 'default'],
+          : ['zsh', 'bash', 'sh', 'default'],
       default: isElectronRenderer() && isWindows ? 'git-bash' : '',
       description: '%preference.terminal.typeDesc%',
     },

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import net from 'net';
 import { NodeModule } from './node-module';
 import { WebSocketServerRoute, WebSocketHandler, WSChannel } from '@opensumi/ide-connection';
-import { Injector, ClassCreator, FactoryCreator } from '@opensumi/di';
+import { Injector, InstanceCreator, ClassCreator, FactoryCreator } from '@opensumi/di';
 import ws from 'ws';
 
 import {
@@ -101,12 +101,13 @@ export function bindModuleBackService(
           logger.log('back service', service.token);
           const serviceToken = service.token;
 
-          if (!injector.creatorMap.get(serviceToken)) {
+          if (!injector.creatorMap.has(serviceToken)) {
             continue;
           }
-          const creator = injector.creatorMap.get(serviceToken)!;
-          // @ts-ignore
-          if (creator.useFactory) {
+
+          const creator = injector.creatorMap.get(serviceToken) as InstanceCreator;
+
+          if ((creator as FactoryCreator).useFactory) {
             const serviceFactory = (creator as FactoryCreator).useFactory;
             childInjector.addProviders({
               token: serviceToken,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -12,9 +12,9 @@
     "prepublishOnly": "npm run build",
     "build": "npm run build:pkg && npm run build:ext-host && npm run compile:worker",
     "build:pkg": "tsc --build ../../configs/ts/references/tsconfig.extension.json",
-    "compile:worker": "webpack --config webpack.config.worker.js --progress",
+    "compile:worker": "webpack --config webpack.config.worker.js",
     "compile:worker:slient": "webpack --config webpack.config.worker.js",
-    "watch:worker": "webpack -w --config webpack.config.worker.js --progress",
+    "watch:worker": "webpack -w --config webpack.config.worker.js",
     "build:ext-host": "tsc -p ../../configs/ts/references/tsconfig.extension.json",
     "watch:ext-host": "tsc --watch -p ../../configs/ts/references/tsconfig.extension.json"
   },

--- a/packages/extension/src/browser/extension-node.service.ts
+++ b/packages/extension/src/browser/extension-node.service.ts
@@ -173,7 +173,9 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
       mainThreadCenter.setConnection(createWebSocketConnection(channel));
     }
 
-    const { getRPCService } = initRPCService(mainThreadCenter);
+    const { getRPCService } = initRPCService<{
+      onMessage: (msg: string) => void;
+    }>(mainThreadCenter);
 
     const service = getRPCService('ExtProtocol');
     const onMessageEmitter = new Emitter<string>();

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -68,16 +68,21 @@ export interface ExtProcessConfig {
 
 async function initRPCProtocol(extInjector): Promise<any> {
   const extCenter = new RPCServiceCenter();
-  const { getRPCService } = initRPCService(extCenter);
+  const { getRPCService } = initRPCService<{
+    onMessage(msg: string): void;
+  }>(extCenter);
+
   const extConnection = net.createConnection(JSON.parse(argv[KT_PROCESS_SOCK_OPTION_KEY] || '{}'));
 
   extCenter.setConnection(createSocketConnection(extConnection));
 
   const service = getRPCService('ExtProtocol');
+
   const onMessageEmitter = new Emitter<string>();
-  service.on('onMessage', (msg) => {
+  service.on('onMessage', (msg: string) => {
     onMessageEmitter.fire(msg);
   });
+
   const onMessage = onMessageEmitter.event;
   const send = service.onMessage;
 

--- a/packages/extension/webpack.config.worker.js
+++ b/packages/extension/webpack.config.worker.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const fs = require('fs');
+const { ProgressPlugin } = require('webpack');
 
 const tsconfigPath = path.join(__dirname, '../../configs/ts/references/tsconfig.extension.json');
 
 const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, './package.json'), 'utf-8'));
 
+/** @type { import('webpack').Configuration } */
 module.exports = {
   entry: path.join(__dirname, './src/hosted/worker.host-preload.ts'),
   node: {
@@ -33,4 +35,5 @@ module.exports = {
       { test: /\.css$/, loader: 'null-loader' },
     ],
   },
+  plugins: [!process.env.CI && new ProgressPlugin()].filter(Boolean),
 };

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -584,6 +584,10 @@ export const localizationBundle = {
     'terminal.environment.relaunch': 'Relaunch Terminal',
     'terminal.environment.changes': "Extensions want to make the following changes to the terminal's environment:",
     'terminal.environment.removal': "Extensions want to remove these existing changes from the terminal's environment:",
+    'terminal.launchFail.cwdNotDirectory': 'Starting directory (cwd) "{0}" is not a directory',
+    'terminal.launchFail.cwdDoesNotExist': 'Starting directory (cwd) "{0}" does not exist',
+    'terminal.launchFail.executableIsNotFileOrSymlink': 'Path to shell executable "{0}" is not a file or a symlink',
+    'terminal.launchFail.executableDoesNotExist': 'Path to shell executable "{0}" does not exist',
 
     'deugger.menu.setValue': 'Set Value',
     'deugger.menu.setValue.param': 'Please input the value of this variable',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -628,6 +628,10 @@ export const localizationBundle = {
     'terminal.environment.changed': '终端环境变量已经被部分插件修改',
     'terminal.environment.changes': '扩展期望对终端的环境变量做以下更改：',
     'terminal.environment.removal': '扩展期望从现有的终端环境变量中删除以下值：',
+    'terminal.launchFail.cwdNotDirectory': '终端启动目录 (cwd) "{0}" 不是一个文件夹',
+    'terminal.launchFail.cwdDoesNotExist': '终端启动目录 (cwd) "{0}" 不存在',
+    'terminal.launchFail.executableIsNotFileOrSymlink': '终端启动的可执行文件 "{0}" 的路径非文件或符号链接',
+    'terminal.launchFail.executableDoesNotExist': '终端启动的可执行文件 "{0}" 的路径不存在',
 
     'deugger.menu.setValue': '设置变量',
     'deugger.menu.setValue.param': '请输入你要改变变量的值',

--- a/packages/overlay/src/browser/message.service.tsx
+++ b/packages/overlay/src/browser/message.service.tsx
@@ -42,6 +42,9 @@ export class MessageService extends AbstractMessageService implements IMessageSe
     closable = true,
     from?: string,
   ): Promise<T | undefined> {
+    if (!rawMessage) {
+      return Promise.resolve(undefined);
+    }
     let message = rawMessage;
     // 如果两秒内提示信息相同，则直接返回上一个提示
     if (

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -25,7 +25,7 @@
     "bundle:standard": "cross-env NODE_ENV=production webpack --config webpack.standard.config.js",
     "bundle:standard:analysis": "cross-env analysis=1 npm run bundle:standard",
     "bundle:lite": "cross-env NODE_ENV=production webpack --config webpack.lite.config.js",
-    "bundle:lite:stats": "cross-env NODE_ENV=production webpack --progress --profile --config webpack.lite.config.js --json > stats.json",
+    "bundle:lite:stats": "cross-env NODE_ENV=production webpack --profile --config webpack.lite.config.js --json > stats.json",
     "bundle:lite:analysis": "cross-env analysis=1 npm run bundle:lite",
     "prod": "node prod-server.js",
     "prod:lite": "npm run bundle:lite && npm run prod"

--- a/packages/startup/src/node/common-modules.ts
+++ b/packages/startup/src/node/common-modules.ts
@@ -21,10 +21,8 @@ export const CommonNodeModules: ConstructorOf<NodeModule>[] = [
   FileSearchModule,
   SearchModule,
   TerminalNodePtyModule,
-
   ExtensionModule,
   OpenVsxExtensionManagerModule,
   FileSchemeNodeModule,
-
   AddonsModule,
 ];

--- a/packages/startup/webpack.lite.config.js
+++ b/packages/startup/webpack.lite.config.js
@@ -34,6 +34,7 @@ module.exports = createWebpackConfig(__dirname, require('path').join(__dirname, 
     new ServiceWorkerWebpackPlugin({
       entry: path.join(__dirname, 'entry/web-lite/sw.js'),
     }),
+    !process.env.CI && new ProgressPlugin(),
   ]
     .concat(process.env.analysis ? new BundleAnalyzerPlugin() : null)
     .filter(Boolean),

--- a/packages/terminal-next/__tests__/browser/inject.ts
+++ b/packages/terminal-next/__tests__/browser/inject.ts
@@ -42,6 +42,8 @@ import {
 } from './mock.service';
 import { MockWorkspaceService } from '@opensumi/ide-workspace/lib/common/mocks';
 import { EnvironmentVariableServiceToken } from '@opensumi/ide-terminal-next/lib/common/environmentVariable';
+import { MockLogger } from '@opensumi/ide-core-browser/__mocks__/logger';
+import { IMessageService } from '@opensumi/ide-overlay';
 
 const mockPreferences = new Map();
 mockPreferences.set('terminal.integrated.shellArgs.linux', []);
@@ -124,7 +126,13 @@ export const injector = new Injector([
   },
   {
     token: ILogger,
-    useValue: {},
+    useClass: MockLogger,
+  },
+  {
+    token: IMessageService,
+    useValue: {
+      error: jest.fn(),
+    },
   },
   {
     token: ITerminalNetwork,

--- a/packages/terminal-next/__tests__/node/pty.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.test.ts
@@ -1,0 +1,39 @@
+import { Injector } from '@opensumi/di';
+import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { TerminalNodePtyModule } from '../../src/node';
+import { IPtyService, PtyService } from '../../src/node/pty';
+import os from 'os';
+
+describe('PtyService function should be valid', () => {
+  let ptyService: PtyService;
+  let injector: Injector;
+  let shellPath = '';
+
+  if (os.platform() === 'win32') {
+    shellPath = 'powershell';
+  } else if (os.platform() === 'linux' || os.platform() === 'darwin') {
+    shellPath = 'sh';
+  }
+
+  beforeEach(() => {
+    injector = createNodeInjector([TerminalNodePtyModule], new Injector([]));
+    ptyService = injector.get(IPtyService);
+  });
+
+  it('cannot create a invalid shell', async () => {
+    await expect(ptyService.create2({ cols: 200, rows: 200, shellPath: '' })).rejects.toThrowError(
+      'IShellLaunchConfig.shellPath not set',
+    );
+    await expect(ptyService.create2({ cols: 200, rows: 200, shellPath: './index.ts' })).rejects.toThrowError();
+    await expect(
+      ptyService.create2({ cols: 200, rows: 200, shellPath, cwd: '/this/path/not/exists' }),
+    ).rejects.toThrowError();
+  });
+
+  it('can create a valid pty instance', async () => {
+    const instance = await ptyService.create2({ cols: 200, rows: 200, shellPath });
+    expect(instance).toBeDefined();
+    expect(instance.pid).toBeDefined();
+    expect(instance.launchConfig).toBeDefined();
+  });
+});

--- a/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
+++ b/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
@@ -2,7 +2,7 @@ import { Injector } from '@opensumi/di';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { ITerminalServiceClient, ITerminalNodeService } from '../../src/common';
 import { TerminalNodePtyModule } from '../../src/node';
-import { IPty } from '../../src/node/pty';
+import { IPty } from '../../src/common/pty';
 
 describe('TerminalServiceClientImpl', () => {
   let terminalServiceClient: ITerminalServiceClient;

--- a/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
+++ b/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
@@ -3,12 +3,20 @@ import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { ITerminalServiceClient, ITerminalNodeService } from '../../src/common';
 import { TerminalNodePtyModule } from '../../src/node';
 import { IPty } from '../../src/common/pty';
+import os from 'os';
 
 describe('TerminalServiceClientImpl', () => {
   let terminalServiceClient: ITerminalServiceClient;
   let terminalService: ITerminalNodeService;
   let injector: Injector;
   const mockClientId = 'a';
+  let shellPath = '';
+
+  if (os.platform() === 'win32') {
+    shellPath = 'powershell';
+  } else if (os.platform() === 'linux' || os.platform() === 'darwin') {
+    shellPath = 'sh';
+  }
 
   beforeEach(() => {
     injector = createNodeInjector([TerminalNodePtyModule], new Injector([]));
@@ -21,9 +29,32 @@ describe('TerminalServiceClientImpl', () => {
     expect((terminalService as any).serviceClientMap.get(mockClientId)).not.toBeUndefined();
   });
 
+  it('can not create pty because of invalid IShellLaunchConfig', async () => {
+    const mockId = '0';
+    let closeClientData;
+    let closeClientId;
+    terminalServiceClient.closeClient = (id: string, data: any) => {
+      closeClientId = id;
+      closeClientData = data;
+    };
+
+    terminalServiceClient.setConnectionClientId(mockId);
+    const pty = await terminalServiceClient.create(mockId, { name: 'test', cols: 200, rows: 200 });
+    expect(pty).toBeUndefined();
+    expect(closeClientId).toEqual(mockId);
+    expect(closeClientData).not.toBeUndefined();
+  });
+
   it('Should be create pty, and other operations.', async () => {
     const mockId = '1';
-    await terminalServiceClient.create(mockId, { name: 'test', cols: 200, rows: 200 });
+    terminalServiceClient.setConnectionClientId(mockId);
+
+    await terminalServiceClient.create(mockId, {
+      name: 'test',
+      shellPath,
+      cols: 200,
+      rows: 200,
+    });
     const terminal: IPty = (terminalService as any).getTerminal(mockId);
     let receiveData = '';
 
@@ -48,10 +79,15 @@ describe('TerminalServiceClientImpl', () => {
     expect(terminal.cols).toEqual(400);
   });
 
-  it('Should be  disposed.', async () => {
+  it.only('Should be disposed.', async () => {
     (process as any).env.IS_DEV = 0;
     const mockId = '2';
-    await terminalServiceClient.create(mockId, { name: 'test', cols: 200, rows: 200 });
+    await terminalServiceClient.create(mockId, {
+      name: 'test',
+      shellPath,
+      cols: 200,
+      rows: 200,
+    });
 
     terminalServiceClient.disposeById(mockId);
     terminalServiceClient.dispose();

--- a/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
+++ b/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
@@ -23,7 +23,7 @@ describe('TerminalServiceClientImpl', () => {
 
   it('Should be create pty, and other operations.', async () => {
     const mockId = '1';
-    await terminalServiceClient.create(mockId, 200, 200, { name: 'test' });
+    await terminalServiceClient.create(mockId, { name: 'test', cols: 200, rows: 200 });
     const terminal: IPty = (terminalService as any).getTerminal(mockId);
     let receiveData = '';
 
@@ -51,7 +51,7 @@ describe('TerminalServiceClientImpl', () => {
   it('Should be  disposed.', async () => {
     (process as any).env.IS_DEV = 0;
     const mockId = '2';
-    await terminalServiceClient.create(mockId, 200, 200, { name: 'test' });
+    await terminalServiceClient.create(mockId, { name: 'test', cols: 200, rows: 200 });
 
     terminalServiceClient.disposeById(mockId);
     terminalServiceClient.dispose();

--- a/packages/terminal-next/src/browser/component/terminal.widget.tsx
+++ b/packages/terminal-next/src/browser/component/terminal.widget.tsx
@@ -19,6 +19,8 @@ function renderError(error: ITerminalError, eService: ITerminalErrorService, vie
     eService.fix(error.id);
   };
 
+  // TODO: 展示要打开的地址不存在等错误情况 + Terminal 之前的最后几行信息
+  // 比如说 TerminalError 有几个已知的错误 code
   return error.stopped ? (
     <div className={styles.terminalCover}>
       <div>{localize('terminal.disconnected')}</div>

--- a/packages/terminal-next/src/browser/terminal.addon.ts
+++ b/packages/terminal-next/src/browser/terminal.addon.ts
@@ -121,7 +121,7 @@ export class FilePathAddon extends Disposable implements ITerminalAddon {
 }
 
 export class AttachAddon extends Disposable implements ITerminalAddon {
-  private _connection: ITerminalConnection | undefined;
+  connection: ITerminalConnection | undefined;
   private _disposeConnection: Disposable | null;
   private _terminal: Terminal;
 
@@ -130,9 +130,6 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
 
   private _onExit = new Emitter<number | undefined>();
   onExit = this._onExit.event;
-
-  private _onError = new Emitter<{ code?: number; name?: string; bin?: string }>();
-  onError = this._onError.event;
 
   private _onTime = new Emitter<number>();
   onTime = this._onTime.event;
@@ -144,7 +141,7 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
       this._disposeConnection.dispose();
       this._disposeConnection = null;
     }
-    this._connection = connection;
+    this.connection = connection;
     if (connection) {
       this._disposeConnection = new Disposable(
         connection.onData((data: string | ArrayBuffer) => {
@@ -161,14 +158,6 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
         this._disposeConnection.addDispose(
           connection.onExit((code) => {
             this._onExit.fire(code);
-
-            if (code !== 0) {
-              this._onError.fire({
-                code,
-                name: connection.name,
-                bin: connection.launchConfig?.shellPath,
-              });
-            }
           }),
         );
       }
@@ -183,15 +172,15 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
   }
 
   private _sendData(data: string): void {
-    if (!this._connection || this._connection.readonly) {
+    if (!this.connection || this.connection.readonly) {
       return;
     }
     this._timeResponse();
-    this._connection.sendData(data);
+    this.connection.sendData(data);
   }
 
   private _sendBinary(data: string): void {
-    if (!this._connection || this._connection.readonly) {
+    if (!this.connection || this.connection.readonly) {
       return;
     }
     const buffer = new Uint8Array(data.length);
@@ -199,7 +188,7 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
       buffer[i] = data.charCodeAt(i) & 255;
     }
     this._timeResponse();
-    this._connection.sendData(buffer);
+    this.connection.sendData(buffer);
   }
 
   private _timeResponse() {

--- a/packages/terminal-next/src/browser/terminal.addon.ts
+++ b/packages/terminal-next/src/browser/terminal.addon.ts
@@ -126,11 +126,16 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
   private _terminal: Terminal;
 
   private _onData = new Emitter<string | ArrayBuffer>();
-  onData: Event<string | ArrayBuffer> = this._onData.event;
+  onData = this._onData.event;
+
   private _onExit = new Emitter<number | undefined>();
-  onExit: Event<number | undefined> = this._onExit.event;
+  onExit = this._onExit.event;
+
+  private _onError = new Emitter<{ code?: number; name?: string; bin?: string }>();
+  onError = this._onError.event;
+
   private _onTime = new Emitter<number>();
-  onTime: Event<number> = this._onTime.event;
+  onTime = this._onTime.event;
 
   private _lastInputTime = 0;
 
@@ -156,6 +161,14 @@ export class AttachAddon extends Disposable implements ITerminalAddon {
         this._disposeConnection.addDispose(
           connection.onExit((code) => {
             this._onExit.fire(code);
+
+            if (code !== 0) {
+              this._onError.fire({
+                code,
+                name: connection.name,
+                bin: connection.launchConfig?.shellPath,
+              });
+            }
           }),
         );
       }

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -234,6 +234,12 @@ export class TerminalClient extends Disposable implements ITerminalClient {
       }),
     );
 
+    this.addDispose(
+      this.internalService.onError((error) => {
+        this.messageService.error(error.message);
+      }),
+    );
+
     this._apply(widget);
     if (await this._checkWorkspace()) {
       this._attachXterm();
@@ -307,9 +313,7 @@ export class TerminalClient extends Disposable implements ITerminalClient {
         this.logger.warn(`${this.id} ${this.name} exit with ${code}`);
         this._onExit.fire({ id: this.id, code });
       }),
-      this._attachAddon.onError((e) => {
-        this.messageService.error(`terminal ${this.name}(${e.bin}) exited with code ${e.code}`);
-      }),
+
       this._attachAddon.onTime((delta) => {
         this._onResponseTime.fire(delta);
         this.reporter.performance(REPORT_NAME.TERMINAL_MEASURE, {

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -396,10 +396,7 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     try {
       connection = await this.internalService.attach(sessionId, this._term, launchConfig);
     } catch (e) {
-      // TODO emit error
-      console.error(`attach ${sessionId} terminal failed`, connection, JSON.stringify(launchConfig), e);
-      this.messageService.error(`${e.message}`);
-      this._onExit.fire({ id: this.id, code: -1 });
+      this.logger.error(`attach ${sessionId} terminal failed`, connection, JSON.stringify(launchConfig), e);
     }
 
     this._attachAddon.setConnection(connection);

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -308,9 +308,8 @@ export class TerminalClient extends Disposable implements ITerminalClient {
         this._onExit.fire({ id: this.id, code });
       }),
       this._attachAddon.onError((e) => {
-        this.messageService.error(`Terminal ${this.name}(${e.bin}) exited with code ${e.code}`);
+        this.messageService.error(`terminal ${this.name}(${e.bin}) exited with code ${e.code}`);
       }),
-
       this._attachAddon.onTime((delta) => {
         this._onResponseTime.fire(delta);
         this.reporter.performance(REPORT_NAME.TERMINAL_MEASURE, {
@@ -390,6 +389,8 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     } catch (e) {
       // TODO emit error
       console.error(`attach ${sessionId} terminal failed`, connection, JSON.stringify(launchConfig), e);
+      this.messageService.error(`${e.message}`);
+      this._onExit.fire({ id: this.id, code: -1 });
     }
 
     this._attachAddon.setConnection(connection);

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -311,6 +311,11 @@ export class TerminalClient extends Disposable implements ITerminalClient {
       }),
       this._attachAddon.onExit((code) => {
         this.logger.warn(`${this.id} ${this.name} exit with ${code}`);
+        if (code !== 0) {
+          this.messageService.error(
+            `terminal ${this.name}(${this._attachAddon.connection?.launchConfig?.shellPath}) exited with non-zero code ${code}`,
+          );
+        }
         this._onExit.fire({ id: this.id, code });
       }),
 

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -116,7 +116,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
     return this._createClient(widget, options);
   }
 
-  private _createClient(widget: IWidget, options = {}) {
+  private _createClient(widget: IWidget, options: TerminalOptions = {}) {
     const client = this.clientFactory(widget, options);
     this._clients.set(client.id, client);
 

--- a/packages/terminal-next/src/browser/terminal.service.ts
+++ b/packages/terminal-next/src/browser/terminal.service.ts
@@ -190,11 +190,10 @@ export class NodePtyTerminalService implements ITerminalService {
       if (isWindows) {
         options.shellPath = await this.serviceClientRPC.$resolveWindowsShellPath(options.shellType as WindowsShellType);
       } else {
-        options.shellPath = `/bin/${options.shellType}`;
+        options.shellPath = await this.serviceClientRPC.$resolveLinuxShellPath(options.shellType);
       }
-    } else if (options.shellType === 'default') {
+    } else if (!options.shellType || options.shellType === 'default') {
       // default 的情况交给系统环境来决定使用的终端类型
-      // TODO: feat: 优化 default 逻辑
       if (options.os === OperatingSystem.Windows) {
         options.shellPath = 'powershell.exe';
         options.shellType = WindowsShellType.powershell;

--- a/packages/terminal-next/src/common/client.ts
+++ b/packages/terminal-next/src/common/client.ts
@@ -1,7 +1,8 @@
 import { Terminal } from 'xterm';
 import { IDisposable, Disposable, Event, Deferred } from '@opensumi/ide-core-common';
-import { TerminalOptions } from './pty';
+import { INodePtyInstance, TerminalOptions } from './pty';
 import { IWidget } from './resize';
+import { IShellLaunchConfig } from '.';
 
 export interface ITerminalDataEvent {
   id: string;
@@ -171,6 +172,7 @@ export interface ITerminalConnection {
   sendData(data: string | ArrayBuffer): void;
   onData: Event<string | ArrayBuffer>;
   onExit?: Event<number | undefined>;
+  launchConfig?: IShellLaunchConfig;
 }
 
 /**

--- a/packages/terminal-next/src/common/error.ts
+++ b/packages/terminal-next/src/common/error.ts
@@ -23,6 +23,10 @@ export interface ITerminalError {
   reconnected?: boolean;
 }
 
+export function isTerminalError(data: any): data is ITerminalError {
+  return data.message !== undefined;
+}
+
 export const ITerminalErrorService = Symbol('ITerminalErrorService');
 export interface ITerminalErrorService {
   errors: Map<string, ITerminalError>;

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -205,6 +205,7 @@ export interface ITerminalServiceClient {
   getShellName(id: string): string;
   ensureTerminal(terminalIdArr: string[]): boolean;
   $resolveWindowsShellPath(type: WindowsShellType): Promise<string | undefined>;
+  $resolveLinuxShellPath(type: string): Promise<string | undefined>;
 }
 
 export interface ITerminalInfo {

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -206,6 +206,8 @@ export interface ITerminalServiceClient {
   ensureTerminal(terminalIdArr: string[]): boolean;
   $resolveWindowsShellPath(type: WindowsShellType): Promise<string | undefined>;
   $resolveLinuxShellPath(type: string): Promise<string | undefined>;
+  $resolvePotentialLinuxShellPath(): Promise<string | undefined>;
+  $resolveShellPath(paths: string[]): Promise<string | undefined>;
 }
 
 export interface ITerminalInfo {

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -4,6 +4,7 @@ import { Uri } from '@opensumi/ide-core-common';
 import { ShellType, WindowsShellType } from './shell';
 import { IPty } from 'node-pty';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
+import { ITerminalError } from './error';
 
 export const ITerminalServicePath = 'ITerminalServicePath';
 export const ITerminalProcessPath = 'ITerminalProcessPath';
@@ -181,7 +182,15 @@ export interface ITerminalServiceClient {
   disposeById(id: string): void;
   getProcessId(id: string): number;
   clientMessage(id: string, data): void;
-  closeClient(id: string, code?: number, signal?: number): void;
+  closeClient(
+    sessionId: string,
+    data:
+      | ITerminalError
+      | {
+          code?: number;
+          signal?: number;
+        },
+  ): void;
   setConnectionClientId(clientId: string): void;
   dispose(): void;
   getShellName(id: string): string;

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -2,9 +2,18 @@ import type vscode from 'vscode';
 import { Terminal as XTerm } from 'xterm';
 import { Uri } from '@opensumi/ide-core-common';
 import { ShellType, WindowsShellType } from './shell';
-import { IPty } from 'node-pty';
+import { IPty as INodePty } from 'node-pty';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
 import { ITerminalError } from './error';
+
+export interface IPty extends INodePty {
+  /**
+   * @deprecated 请使用 `IPty.launchConfig` 的 shellPath 字段
+   */
+  bin: string;
+  launchConfig: IShellLaunchConfig;
+  parsedName: string;
+}
 
 export const ITerminalServicePath = 'ITerminalServicePath';
 export const ITerminalProcessPath = 'ITerminalProcessPath';
@@ -149,7 +158,7 @@ export interface TerminalOptions {
 
 export const ITerminalNodeService = Symbol('ITerminalNodeService');
 export interface ITerminalNodeService {
-  create(id: string, options: IShellLaunchConfig): Promise<IPty>;
+  create(id: string, options: IShellLaunchConfig): Promise<IPty | undefined>;
   onMessage(id: string, msg: string): void;
   resize(id: string, rows: number, cols: number);
   getShellName(id: string): string;
@@ -176,7 +185,7 @@ export interface INodePtyInstance {
 
 export const ITerminalServiceClient = Symbol('ITerminalServiceClient');
 export interface ITerminalServiceClient {
-  create(id: string, options: IShellLaunchConfig): Promise<INodePtyInstance>;
+  create(id: string, options: IShellLaunchConfig): Promise<INodePtyInstance | undefined>;
   onMessage(id: string, msg: string): void;
   resize(id: string, rows: number, cols: number): void;
   disposeById(id: string): void;

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -165,20 +165,17 @@ export interface ITerminalProcessService {
   getEnv(): Promise<{ [key in string]: string | undefined }>;
 }
 
+export interface INodePtyInstance {
+  id: string;
+  name: string;
+  pid: number;
+  proess: string;
+  shellPath?: string;
+}
+
 export const ITerminalServiceClient = Symbol('ITerminalServiceClient');
 export interface ITerminalServiceClient {
-  create(
-    id: string,
-    options: IShellLaunchConfig,
-  ):
-    | Promise<{
-        pid: number;
-        name: string;
-      }>
-    | {
-        pid: number;
-        name: string;
-      };
+  create(id: string, options: IShellLaunchConfig): Promise<INodePtyInstance>;
   onMessage(id: string, msg: string): void;
   resize(id: string, rows: number, cols: number): void;
   disposeById(id: string): void;
@@ -246,14 +243,12 @@ export interface IExternlTerminalService {
 }
 
 export interface IShellLaunchConfig {
-  shellPath: string;
-  args: string[];
+  shellPath?: string;
+  args?: string[];
 
   isExtensionTerminal?: boolean;
-
   shellType?: ShellType;
-
-  os: OperatingSystem;
+  os?: OperatingSystem;
 
   /**
    * Whether the terminal process environment should be exactly as provided in

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -207,6 +207,7 @@ export interface ITerminalServiceClient {
   $resolveWindowsShellPath(type: WindowsShellType): Promise<string | undefined>;
   $resolveLinuxShellPath(type: string): Promise<string | undefined>;
   $resolvePotentialLinuxShellPath(): Promise<string | undefined>;
+  $resolvePotentialWindowsShellPath(): Promise<{ path: string; type: WindowsShellType }>;
   $resolveShellPath(paths: string[]): Promise<string | undefined>;
 }
 

--- a/packages/terminal-next/src/common/service.ts
+++ b/packages/terminal-next/src/common/service.ts
@@ -2,7 +2,7 @@ import { IDisposable } from '@opensumi/ide-core-common';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
 import { ITerminalOptions, Terminal } from 'xterm';
 import { ITerminalError } from './error';
-import { IShellLaunchConfig, TerminalOptions } from './pty';
+import { IShellLaunchConfig } from './pty';
 import { ITerminalConnection } from './client';
 
 export interface IPtyExitEvent {
@@ -33,9 +33,13 @@ export interface ITerminalService {
    *
    * @param sessionId 会话唯一标识
    * @param xterm 返回的 xTerm 终端实例
-   * @param options 创建一个新终端的进程选项
+   * @param launchConfig 创建一个新终端的进程选项
    */
-  attach(sessionId: string, xterm: Terminal, options?: IShellLaunchConfig): Promise<ITerminalConnection | undefined>;
+  attach(
+    sessionId: string,
+    xterm: Terminal,
+    launchConfig?: IShellLaunchConfig,
+  ): Promise<ITerminalConnection | undefined>;
   /**
    *
    * @param id 会话唯一标识

--- a/packages/terminal-next/src/common/service.ts
+++ b/packages/terminal-next/src/common/service.ts
@@ -2,7 +2,7 @@ import { IDisposable } from '@opensumi/ide-core-common';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
 import { ITerminalOptions, Terminal } from 'xterm';
 import { ITerminalError } from './error';
-import { TerminalOptions } from './pty';
+import { IShellLaunchConfig, TerminalOptions } from './pty';
 import { ITerminalConnection } from './client';
 
 export interface IPtyExitEvent {
@@ -32,20 +32,10 @@ export interface ITerminalService {
   /**
    *
    * @param sessionId 会话唯一标识
-   * @param xterm 返回的 Xterm 终端实例
-   * @param rows 终端初始化使用的列数
-   * @param cols 终端初始化使用的行数
+   * @param xterm 返回的 xTerm 终端实例
    * @param options 创建一个新终端的进程选项
-   * @param shellType 终端类型
    */
-  attach(
-    sessionId: string,
-    xterm: Terminal,
-    rows: number,
-    cols: number,
-    options?: TerminalOptions,
-    shellType?: string,
-  ): Promise<ITerminalConnection | undefined>;
+  attach(sessionId: string, xterm: Terminal, options?: IShellLaunchConfig): Promise<ITerminalConnection | undefined>;
   /**
    *
    * @param id 会话唯一标识
@@ -82,7 +72,7 @@ export interface ITerminalService {
    *
    * @param sessionid
    */
-  onExit(handler: (sessionid: IPtyExitEvent) => void): IDisposable;
+  onExit(handler: (event: IPtyExitEvent) => void): IDisposable;
   /**
    * 返回终端环境的 OS
    */

--- a/packages/terminal-next/src/common/shell.ts
+++ b/packages/terminal-next/src/common/shell.ts
@@ -1,6 +1,6 @@
 export const WINDOWS_DEFAULT_SHELL_PATH_MAPS = {
-  ['powershell']: 'powershell.exe',
-  ['cmd']: 'cmd.exe',
+  powershell: 'powershell.exe',
+  cmd: 'cmd.exe',
 };
 
 export enum WindowsShellType {

--- a/packages/terminal-next/src/common/shell.ts
+++ b/packages/terminal-next/src/common/shell.ts
@@ -8,3 +8,5 @@ export enum WindowsShellType {
   'powershell' = 'powershell',
   'git-bash' = 'git-bash',
 }
+
+export type ShellType = WindowsShellType | string;

--- a/packages/terminal-next/src/common/utils.ts
+++ b/packages/terminal-next/src/common/utils.ts
@@ -9,4 +9,4 @@ export const userActionViewUuid = () => `UI_View_${uuid()}${count()}`;
 
 export const apiActionViewUuid = () => `API_View_${uuid()}${count()}`;
 
-export const generate = () => uuid();
+export const generateSessionId = () => uuid();

--- a/packages/terminal-next/src/node/index.ts
+++ b/packages/terminal-next/src/node/index.ts
@@ -10,6 +10,7 @@ import {
   ITerminalServicePath,
 } from '../common';
 import { TerminalProcessServiceImpl } from './terminal-process.service';
+import { PtyService, IPtyService } from './pty';
 
 @Injectable()
 export class TerminalNodePtyModule extends NodeModule {
@@ -25,6 +26,10 @@ export class TerminalNodePtyModule extends NodeModule {
     {
       token: ITerminalProcessService,
       useClass: TerminalProcessServiceImpl,
+    },
+    {
+      token: IPtyService,
+      useClass: PtyService,
     },
   ];
 

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -25,6 +25,10 @@ export class PtyService {
   private readonly logger: INodeLogger;
 
   async create2(options: IShellLaunchConfig) {
+    if (!options.shellPath) {
+      throw new Error('cannot start shell because: empty shellPath');
+    }
+
     const locale = osLocale.sync();
     let ptyEnv: { [key: string]: string };
 
@@ -55,10 +59,6 @@ export class PtyService {
         },
         options.env,
       ) as { [key: string]: string };
-    }
-
-    if (!options.shellPath) {
-      throw new Error('Shell config has empty shellPath');
     }
 
     const ptyProcess = pty.spawn(options.shellPath, options.args || [], {

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -9,8 +9,11 @@ import { Injectable, Autowired } from '@opensumi/di';
 export { pty };
 
 export interface IPty extends pty.IPty {
+  /**
+   * @deprecated 请使用 `IPty.launchConfig` 的 shellPath 字段
+   */
   bin: string;
-  options: IShellLaunchConfig;
+  launchConfig: IShellLaunchConfig;
   parsedName: string;
 }
 
@@ -54,6 +57,10 @@ export class PtyService {
       ) as { [key: string]: string };
     }
 
+    if (!options.shellPath) {
+      throw new Error('Shell config has empty shellPath');
+    }
+
     const ptyProcess = pty.spawn(options.shellPath, options.args || [], {
       name: options.name || 'xterm-256color',
       cols: options.cols || 100,
@@ -62,7 +69,7 @@ export class PtyService {
       env: ptyEnv,
     });
     (ptyProcess as IPty).bin = options.shellPath;
-    (ptyProcess as IPty).options = options;
+    (ptyProcess as IPty).launchConfig = options;
     const match = options.shellPath.match(/[\w|.]+$/);
     (ptyProcess as IPty).parsedName = match ? match[0] : 'sh';
     return ptyProcess as IPty;

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -3,6 +3,7 @@ import * as osLocale from 'os-locale';
 import omit from 'lodash.omit';
 import { IShellLaunchConfig } from '../common';
 import { IPty } from '../common/pty';
+import { exists } from './shell';
 import { getShellPath } from '@opensumi/ide-core-node/lib/bootstrap/shell-path';
 import { INodeLogger, isWindows } from '@opensumi/ide-core-node';
 import { Injectable, Autowired } from '@opensumi/di';
@@ -13,15 +14,6 @@ export { pty };
 export const IPtyService = Symbol('IPtyService');
 export interface IProcessEnvironment {
   [key: string]: string | undefined;
-}
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await promises.access(path);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export function getCaseInsensitive(target: Record<string, any>, key: string): any {

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -95,7 +95,7 @@ export class PtyService {
 
   async create2(options: IShellLaunchConfig) {
     if (!options.shellPath) {
-      throw new Error('cannot start shell because: empty shellPath');
+      throw new Error('options.shellPath not set');
     }
 
     const locale = osLocale.sync();

--- a/packages/terminal-next/src/node/shell.ts
+++ b/packages/terminal-next/src/node/shell.ts
@@ -11,6 +11,28 @@ export const WINDOWS_GIT_BASH_PATHS = [
   `${process.env['AllUsersProfile']}\\scoop\\apps\\git-with-openssh\\current\\bin\\bash.exe`,
 ];
 
+export const exists = async (p: string) => {
+  try {
+    p = normalize(p);
+    await fs.promises.access(p);
+    return p;
+  } catch (error) {}
+};
+
+export async function findShellExecutableAsync(candidate: string[]): Promise<string | undefined> {
+  if (candidate.length === 0) {
+    return undefined;
+  }
+  const toPromise = candidate.map(exists);
+  return Promise.all(toPromise).then((lists) => {
+    for (const v of lists) {
+      if (v) {
+        return v;
+      }
+    }
+  });
+}
+
 export function findShellExecutable(candidate: string[]): string | undefined {
   if (candidate.length === 0) {
     return undefined;

--- a/packages/terminal-next/src/node/shell.ts
+++ b/packages/terminal-next/src/node/shell.ts
@@ -1,4 +1,15 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Some code copied and modified from https://github.com/microsoft/vscode/blob/1.63.0/src/vs/platform/terminal/node/terminalEnvironment.ts
+
 import { normalize } from '@opensumi/ide-core-common';
+import { IProcessEnvironment } from '@opensumi/ide-core-common/lib/platform';
+import * as path from '@opensumi/ide-core-common/lib/path';
+import { isWindows } from '@opensumi/ide-core-node';
+
 import fs from 'fs';
 
 // TODO: 用户装在 D 盘的不就识别不对了
@@ -44,4 +55,68 @@ export function findShellExecutable(candidate: string[]): string | undefined {
     }
     continue;
   }
+}
+
+export function getCaseInsensitive(target: Record<string, any>, key: string): any {
+  const lowercaseKey = key.toLowerCase();
+  const equivalentKey = Object.keys(target).find((k) => k.toLowerCase() === lowercaseKey);
+  return equivalentKey ? target[equivalentKey] : target[key];
+}
+
+export async function findExecutable(
+  command: string,
+  cwd?: string,
+  paths?: string[],
+  env: IProcessEnvironment = process.env as IProcessEnvironment,
+): Promise<string | undefined> {
+  // If we have an absolute path then we take it.
+  if (path.isAbsolute(command)) {
+    return (await exists(command)) ? command : undefined;
+  }
+  if (cwd === undefined) {
+    cwd = process.cwd();
+  }
+  const dir = path.dirname(command);
+  if (dir !== '.') {
+    // We have a directory and the directory is relative (see above). Make the path absolute
+    // to the current working directory.
+    const fullPath = path.join(cwd, command);
+    return (await exists(fullPath)) ? fullPath : undefined;
+  }
+  const envPath = getCaseInsensitive(env, 'PATH');
+  if (paths === undefined && typeof envPath === 'string') {
+    paths = envPath.split(path.delimiter);
+  }
+  // No PATH environment. Make path absolute to the cwd.
+  if (paths === undefined || paths.length === 0) {
+    const fullPath = path.join(cwd, command);
+    return (await exists(fullPath)) ? fullPath : undefined;
+  }
+  // We have a simple file name. We get the path variable from the env
+  // and try to find the executable on the path.
+  for (let pathEntry of paths) {
+    // The path entry is absolute.
+    let fullPath: string;
+    if (path.isAbsolute(pathEntry)) {
+      fullPath = path.join(pathEntry, command);
+    } else {
+      fullPath = path.join(cwd, pathEntry, command);
+    }
+
+    if (await exists(fullPath)) {
+      return fullPath;
+    }
+    if (isWindows) {
+      let withExtension = fullPath + '.com';
+      if (await exists(withExtension)) {
+        return withExtension;
+      }
+      withExtension = fullPath + '.exe';
+      if (await exists(withExtension)) {
+        return withExtension;
+      }
+    }
+  }
+  const fullPath = path.join(cwd, command);
+  return (await exists(fullPath)) ? fullPath : undefined;
 }

--- a/packages/terminal-next/src/node/shell.ts
+++ b/packages/terminal-next/src/node/shell.ts
@@ -1,6 +1,7 @@
 import { normalize } from '@opensumi/ide-core-common';
 import fs from 'fs';
 
+// TODO: 用户装在 D 盘的不就识别不对了
 export const WINDOWS_GIT_BASH_PATHS = [
   `${process.env['ProgramW6432']}\\Git\\bin\\bash.exe`,
   `${process.env['ProgramW6432']}\\Git\\usr\\bin\\bash.exe`,
@@ -16,21 +17,17 @@ export const exists = async (p: string) => {
     p = normalize(p);
     await fs.promises.access(p);
     return p;
-  } catch (error) {}
+  } catch {
+    return;
+  }
 };
 
 export async function findShellExecutableAsync(candidate: string[]): Promise<string | undefined> {
   if (candidate.length === 0) {
     return undefined;
   }
-  const toPromise = candidate.map(exists);
-  return Promise.all(toPromise).then((lists) => {
-    for (const v of lists) {
-      if (v) {
-        return v;
-      }
-    }
-  });
+  // 找到第一个存在的路径
+  return Promise.all(candidate.map(exists)).then((v) => v.find(Boolean));
 }
 
 export function findShellExecutable(candidate: string[]): string | undefined {

--- a/packages/terminal-next/src/node/shell.ts
+++ b/packages/terminal-next/src/node/shell.ts
@@ -26,10 +26,13 @@ export async function findShellExecutableAsync(candidate: string[]): Promise<str
   if (candidate.length === 0) {
     return undefined;
   }
-  // 找到第一个存在的路径
+  // return the first exists one
   return Promise.all(candidate.map(exists)).then((v) => v.find(Boolean));
 }
 
+/**
+ * @deprecated use findShellExecutableAsync
+ */
 export function findShellExecutable(candidate: string[]): string | undefined {
   if (candidate.length === 0) {
     return undefined;

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -116,6 +116,34 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
     }
   }
 
+  async $resolvePotentialWindowsShellPath(): Promise<{ path: string; type: WindowsShellType }> {
+    const candidates = [
+      WINDOWS_DEFAULT_SHELL_PATH_MAPS.powershell,
+      ...WINDOWS_GIT_BASH_PATHS,
+      WINDOWS_DEFAULT_SHELL_PATH_MAPS.cmd,
+    ];
+
+    // at least one of the candidates should be valid
+    // because all windows has cmd
+    let type: WindowsShellType;
+    const path = (await findShellExecutableAsync(candidates)) as string;
+
+    // if path is not undefined, then it is a known shell path in the candidate list
+    // so we compare the path to the known shell paths to determine the type
+    if (path === WINDOWS_DEFAULT_SHELL_PATH_MAPS.powershell) {
+      type = WindowsShellType.powershell;
+    } else if (path === WINDOWS_DEFAULT_SHELL_PATH_MAPS.cmd) {
+      type = WindowsShellType.cmd;
+    } else {
+      type = WindowsShellType['git-bash'];
+    }
+
+    return {
+      path,
+      type,
+    };
+  }
+
   onMessage(id: string, msg: string): void {
     const { data, params, method } = JSON.parse(msg);
 

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -85,7 +85,7 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
       case WindowsShellType.cmd:
         return WINDOWS_DEFAULT_SHELL_PATH_MAPS.cmd;
       case WindowsShellType['git-bash']: {
-        const shell = findShellExecutable(WINDOWS_GIT_BASH_PATHS);
+        const shell = await findShellExecutableAsync(WINDOWS_GIT_BASH_PATHS);
         return shell;
       }
       default:
@@ -93,10 +93,27 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
         return undefined;
     }
   }
-
   async $resolveLinuxShellPath(type: string): Promise<string | undefined> {
     const candidates = [type, `/bin/${type}`, `/usr/bin/${type}`];
-    return findShellExecutableAsync(candidates);
+    return await findShellExecutableAsync(candidates);
+  }
+
+  async $resolveShellPath(paths: string[]): Promise<string | undefined> {
+    return await findShellExecutableAsync(paths);
+  }
+
+  async $resolvePotentialLinuxShellPath(): Promise<string | undefined> {
+    if (process.env.SHELL) {
+      return process.env.SHELL;
+    }
+
+    const candidates = ['zsh', 'bash', 'sh'];
+    for (const candidate of candidates) {
+      const path = await this.$resolveLinuxShellPath(candidate);
+      if (path) {
+        return path;
+      }
+    }
   }
 
   onMessage(id: string, msg: string): void {

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -10,7 +10,7 @@ import {
 import { IPty } from '../common/pty';
 import { INodeLogger } from '@opensumi/ide-core-node';
 import { WindowsShellType, WINDOWS_DEFAULT_SHELL_PATH_MAPS } from '../common/shell';
-import { findShellExecutable, findShellExecutableAsync, WINDOWS_GIT_BASH_PATHS } from './shell';
+import { findShellExecutableAsync, WINDOWS_GIT_BASH_PATHS } from './shell';
 
 /**
  * NodePtyTerminalService

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -1,6 +1,6 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import { RPCService } from '@opensumi/ide-connection';
-import { IShellLaunchConfig, ITerminalNodeService, ITerminalServiceClient, TerminalOptions } from '../common';
+import { IShellLaunchConfig, ITerminalNodeService, ITerminalServiceClient, INodePtyInstance } from '../common';
 import { IPty } from './pty';
 import { INodeLogger } from '@opensumi/ide-core-node';
 import { WindowsShellType, WINDOWS_DEFAULT_SHELL_PATH_MAPS } from '../common/shell';
@@ -54,7 +54,7 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
     return this.terminalService.ensureClientTerminal(this.clientId, terminalIdArr);
   }
 
-  async create(id: string, options: IShellLaunchConfig) {
+  async create(id: string, options: IShellLaunchConfig): Promise<INodePtyInstance> {
     this.terminalService.setClient(this.clientId, this);
     const pty = (await this.terminalService.create(id, options)) as IPty;
     this.logger.log(`client ${id} create ${pty} with options ${JSON.stringify(options)}`);
@@ -62,7 +62,9 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
     return {
       id,
       pid: pty.pid,
+      proess: pty.process,
       name: pty.parsedName,
+      shellPath: pty.launchConfig.shellPath,
     };
   }
 

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -10,7 +10,7 @@ import {
 import { IPty } from '../common/pty';
 import { INodeLogger } from '@opensumi/ide-core-node';
 import { WindowsShellType, WINDOWS_DEFAULT_SHELL_PATH_MAPS } from '../common/shell';
-import { findShellExecutable, WINDOWS_GIT_BASH_PATHS } from './shell';
+import { findShellExecutable, findShellExecutableAsync, WINDOWS_GIT_BASH_PATHS } from './shell';
 
 /**
  * NodePtyTerminalService
@@ -92,6 +92,11 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
         // 未知的 shell，返回 undefined，后续会使用系统默认值处理
         return undefined;
     }
+  }
+
+  async $resolveLinuxShellPath(type: string): Promise<string | undefined> {
+    const candidates = [type, `/bin/${type}`, `/usr/bin/${type}`];
+    return findShellExecutableAsync(candidates);
   }
 
   onMessage(id: string, msg: string): void {

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -13,7 +13,7 @@ import { WindowsShellType, WINDOWS_DEFAULT_SHELL_PATH_MAPS } from '../common/she
 import { findShellExecutableAsync, WINDOWS_GIT_BASH_PATHS } from './shell';
 
 /**
- * NodePtyTerminalService
+ * this RPC target: NodePtyTerminalService
  */
 interface IRPCTerminalService {
   closeClient(id: string, data: ITerminalError | { code?: number; signal?: number }): void;

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -7,7 +7,7 @@ import {
   INodePtyInstance,
   ITerminalError,
 } from '../common';
-import { IPty } from './pty';
+import { IPty } from '../common/pty';
 import { INodeLogger } from '@opensumi/ide-core-node';
 import { WindowsShellType, WINDOWS_DEFAULT_SHELL_PATH_MAPS } from '../common/shell';
 import { findShellExecutable, WINDOWS_GIT_BASH_PATHS } from './shell';
@@ -62,9 +62,9 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
     return this.terminalService.ensureClientTerminal(this.clientId, terminalIdArr);
   }
 
-  async create(id: string, options: IShellLaunchConfig): Promise<INodePtyInstance> {
-    try {
-      const pty = (await this.terminalService.create(id, options)) as IPty;
+  async create(id: string, options: IShellLaunchConfig): Promise<INodePtyInstance | undefined> {
+    const pty = await this.terminalService.create(id, options);
+    if (pty) {
       this.terminalService.setClient(this.clientId, this);
       this.logger.log(`client ${id} create ${pty} with options ${JSON.stringify(options)}`);
       this.terminalMap.set(id, pty);
@@ -75,13 +75,6 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
         name: pty.parsedName,
         shellPath: pty.launchConfig.shellPath,
       };
-    } catch (error) {
-      this.closeClient(id, {
-        id,
-        message: error.message,
-        stopped: true,
-      });
-      throw error;
     }
   }
 

--- a/packages/terminal-next/src/node/terminal.service.ts
+++ b/packages/terminal-next/src/node/terminal.service.ts
@@ -101,12 +101,15 @@ export class TerminalServiceImpl implements ITerminalNodeService {
       }
       this.clientTerminalMap.get(clientId)!.set(id, terminal);
     } catch (error) {
-      const serviceClient = this.serviceClientMap.get(clientId) as ITerminalServiceClient;
-      serviceClient.closeClient(id, {
-        id,
-        message: error.message,
-        stopped: true,
-      });
+      this.logger.error(`${id} create terminal error: ${error}, options: ${JSON.stringify(options)}`);
+      if (this.serviceClientMap.has(clientId)) {
+        const serviceClient = this.serviceClientMap.get(clientId) as ITerminalServiceClient;
+        serviceClient.closeClient(id, {
+          id,
+          message: error.message,
+          stopped: true,
+        });
+      }
     }
 
     return terminal;

--- a/packages/terminal-next/src/node/terminal.service.ts
+++ b/packages/terminal-next/src/node/terminal.service.ts
@@ -85,14 +85,16 @@ export class TerminalServiceImpl implements ITerminalNodeService {
       this.logger.debug(`Terminal process exit (instanceId: ${id}) with code ${exitCode}`);
       if (this.serviceClientMap.has(clientId)) {
         const serviceClient = this.serviceClientMap.get(clientId) as ITerminalServiceClient;
-        serviceClient.closeClient(id, exitCode, signal);
+        serviceClient.closeClient(id, {
+          code: exitCode,
+          signal,
+        });
       } else {
         this.logger.warn(`terminal: pty ${clientId} on data not found`);
       }
     });
 
-    const clientMap = this.clientTerminalMap.get(clientId);
-    if (!clientMap) {
+    if (!this.clientTerminalMap.has(clientId)) {
       this.clientTerminalMap.set(clientId, new Map());
     }
     this.clientTerminalMap.get(clientId)!.set(id, terminal);


### PR DESCRIPTION
### 变动类型

<!-- 请将这段及下面未选中的项一起删除，保持 PR 描述的简洁性 -->

- [x] 重构


### 需求背景和解决方案

this close: #159 close: #160

原来的逻辑是从启动到最后都使用一份 TerminalOption 的对象，现在在内部实现了一个 IShellLaunchConfig，内部都使用这个来加载 Shell，这样以后内部实现可以随意更新了。

### changelog

optimize terminal create process:
1. show error message when terminal create failed
2. show error message when terminal terminates abnormally
3. find the shell executable in user path
