### PR TITLE
fix: add ExtensionDidContributes event for themes

### DIFF
--- a/packages/core-common/src/types/extension.ts
+++ b/packages/core-common/src/types/extension.ts
@@ -83,3 +83,5 @@ export interface IExtensionActivateEventPayload {
 }
 
 export class ExtensionActivateEvent extends BasicEvent<IExtensionActivateEventPayload> {}
+
+export class ExtensionDidContributes extends BasicEvent<void> {}

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -3,7 +3,7 @@ import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
 import { IExtensionStorageService } from '@opensumi/ide-extension-storage';
-import { localize, OnEvent, WithEventBus, ProgressLocation } from '@opensumi/ide-core-common';
+import { localize, OnEvent, WithEventBus, ProgressLocation, ExtensionDidContributes } from '@opensumi/ide-core-common';
 import { FileSearchServicePath, IFileSearchService } from '@opensumi/ide-file-search/lib/common';
 import {
   AppConfig,
@@ -474,6 +474,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
       await this.activationEventService.fireEvent('onCommand', command);
       return args;
     });
+    this.eventBus.fire(new ExtensionDidContributes());
   }
 
   /**


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
1. 添加 ExtensionDidContributes 事件
2. 注册主题时若是已设置的自动应用
3. 主题全部注册完成后，如果已设置的主题没有安装，fallback 到默认主题

[默认主题相关修改](https://github.com/opensumi/Default-Themes/commit/6050a0a1b70b42140269aee837827570cdabda6f)
1. 合并所有定义到 plus.json, 原因是之前定义了三层的继承关系(include), 但实际是不必要的，需要分别读取三个文件，导致加载主题时较慢

### Changelog
- 修正主题 fallback 逻辑