### PR TITLE
chore: use type as a fallback in changelog script

### DIFF
--- a/scripts/changelog/run.ts
+++ b/scripts/changelog/run.ts
@@ -51,7 +51,7 @@ function convertToEnglishType(type: string) {
     return prTypeMap[type];
   }
   // 没有或匹配不到默认都是 🧹 Chores
-  return '🧹 Chores';
+  return type;
 }
 
 function convertToMarkdown(logs: ICommitLogFields[]) {


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

### Changelog

use type as a fallback in changelog script
