### PR TITLE
fix: repeat breakpointLocations DAP request

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-marker.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-marker.ts
@@ -1,23 +1,10 @@
 import { URI } from '@opensumi/ide-core-common';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
 import btoa = require('btoa');
+import { IRuntimeBreakpoint, ISourceBreakpoint } from '../../common';
 import { Marker } from '../markers';
 
 export const BREAKPOINT_KIND = 'breakpoint';
-
-export interface ISourceBreakpoint {
-  id: string;
-  enabled: boolean;
-  uri: string;
-  raw: DebugProtocol.SourceBreakpoint;
-  logMessage?: string;
-  message?: string;
-  status: Map<string, DebugProtocol.Breakpoint>;
-}
-
-export interface IRuntimeBreakpoint extends ISourceBreakpoint {
-  status: Map<string, DebugProtocol.Breakpoint>;
-}
 
 export type DebugBreakpoint = ISourceBreakpoint | IRuntimeBreakpoint;
 

--- a/packages/debug/src/browser/breakpoint/breakpoint-marker.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-marker.ts
@@ -31,7 +31,7 @@ export namespace DebugBreakpoint {
       id: generateId(uri.toString(), data.line, data.column),
       uri: uri.toString(),
       enabled,
-      status: new Map(),
+      status: new Map<string, DebugProtocol.Breakpoint>(),
       raw: {
         column: undefined,
         condition: undefined,

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -427,7 +427,7 @@ export class DebugSession implements IDebugSession {
             breakpoint = this.id2Breakpoint.get(raw.id);
             if (breakpoint) {
               (breakpoint as IRuntimeBreakpoint).status.set(this.id, raw);
-              this.breakpointManager.updateBreakpoint(breakpoint);
+              this.breakpointManager.updateBreakpoint(breakpoint, true);
             }
           }
           break;
@@ -1106,7 +1106,7 @@ export class DebugSession implements IDebugSession {
   }
 
   public currentEditor(): DebugEditor | undefined {
-    return this.getModel()?.editor;
+    return this.getModel()?.getEditor();
   }
 
   public getModel(): IDebugModel | undefined {

--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.ts
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.ts
@@ -3,7 +3,7 @@ import { CONTEXT_BREAKPOINT_INPUT_FOCUSED } from './../../common/constants';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import { Disposable, positionToRange } from '@opensumi/ide-core-common';
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import { DebugEditor } from '../../common';
+import { DebugEditor, IDebugBreakpointWidget } from '../../common';
 import { DebugBreakpointZoneWidget, DebugBreakpointWidgetContext } from './debug-breakpoint-zone-widget';
 import { DebugBreakpointsService } from '../view/breakpoints/debug-breakpoints.service';
 
@@ -13,7 +13,7 @@ export enum TopStackType {
 }
 
 @Injectable()
-export class DebugBreakpointWidget extends Disposable {
+export class DebugBreakpointWidget extends Disposable implements IDebugBreakpointWidget {
   @Autowired(DebugEditor)
   private readonly editor: DebugEditor;
 

--- a/packages/debug/src/browser/editor/debug-editor-contribution.ts
+++ b/packages/debug/src/browser/editor/debug-editor-contribution.ts
@@ -214,11 +214,11 @@ export class DebugEditorContribution implements IEditorFeatureContribution {
       editor.monacoEditor.onKeyDown(async (keydownEvent: monaco.IKeyboardEvent) => {
         if (keydownEvent.keyCode === monaco.KeyCode.Alt) {
           editor.monacoEditor.updateOptions({ hover: { enabled: true } });
-          this.debugModelManager.model?.debugHoverWidget.hide();
+          this.debugModelManager.model?.getDebugHoverWidget().hide();
           const listener = editor.monacoEditor.onKeyUp(async (keyupEvent: monaco.IKeyboardEvent) => {
             if (keyupEvent.keyCode === monaco.KeyCode.Alt) {
               editor.monacoEditor.updateOptions({ hover: { enabled: false } });
-              this.debugModelManager.model?.debugHoverWidget.show();
+              this.debugModelManager.model?.getDebugHoverWidget().show();
               listener.dispose();
             }
           });

--- a/packages/debug/src/browser/editor/debug-hover-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-hover-widget.tsx
@@ -11,39 +11,21 @@ import {
   IReporterService,
 } from '@opensumi/ide-core-browser';
 import { DebugSessionManager } from '../debug-session-manager';
-import { DebugEditor, IDebugSessionManager, DEBUG_REPORT_NAME } from '../../common';
+import {
+  DebugEditor,
+  IDebugSessionManager,
+  DEBUG_REPORT_NAME,
+  IDebugHoverWidget,
+  ShowDebugHoverOptions,
+  HideDebugHoverOptions,
+} from '../../common';
 import { DebugExpressionProvider } from './debug-expression-provider';
 import { DebugHoverSource } from './debug-hover-source';
 import { DebugHoverView } from './debug-hover.view';
 import debounce = require('lodash.debounce');
 
-export interface ShowDebugHoverOptions {
-  /**
-   * 选中区域
-   */
-  selection: monaco.Range;
-  /**
-   * 是否为焦点
-   * 默认值：false
-   */
-  focus?: boolean;
-  /**
-   * 是否立即调用，当为true时会清理之前的队列
-   * 默认值：true
-   */
-  immediate?: boolean;
-}
-
-export interface HideDebugHoverOptions {
-  /**
-   * 是否立即调用，当为true时会清理之前的队列
-   * 默认值：true
-   */
-  immediate?: boolean;
-}
-
 @Injectable()
-export class DebugHoverWidget implements monaco.editor.IContentWidget {
+export class DebugHoverWidget implements IDebugHoverWidget {
   static ID = 'debug-hover-widget';
 
   protected readonly toDispose = new DisposableCollection();

--- a/packages/debug/src/browser/editor/debug-model-manager.ts
+++ b/packages/debug/src/browser/editor/debug-model-manager.ts
@@ -64,6 +64,7 @@ export class DebugModelManager extends Disposable {
     this.editorCollection.onCodeEditorCreate((codeEditor: ICodeEditor) => this.push(codeEditor));
 
     this.breakpointManager.onDidChangeBreakpoints((event) => {
+      const { statusUpdated } = event;
       const { currentEditor } = this.editorService;
       const uri = currentEditor && currentEditor.currentUri;
       if (uri) {
@@ -89,13 +90,14 @@ export class DebugModelManager extends Disposable {
         return;
       }
       for (const model of models) {
-        const position = model.breakpointWidget.position;
+        const breakpointWidget = model.getBreakpointWidget();
+        const position = breakpointWidget.position;
         if (!position) {
           return;
         }
         for (const breakpoint of removed) {
           if (breakpoint.raw.line === position.lineNumber) {
-            model.breakpointWidget.dispose();
+            breakpointWidget.dispose();
           }
         }
       }
@@ -120,7 +122,7 @@ export class DebugModelManager extends Disposable {
       let isRendered = false;
       if (debugModel.length > 0) {
         for (const model of debugModel) {
-          if ((model.editor as any)._id === (monacoEditor as any)._id) {
+          if ((model.getEditor() as any)._id === (monacoEditor as any)._id) {
             model.render();
             isRendered = true;
             break;
@@ -189,12 +191,12 @@ export class DebugModelManager extends Disposable {
       return;
     }
     // 同一个uri可能对应多个打开的monacoEditor，这里只需要验证其中一个即可
-    const canSetBreakpoints = this.debugConfigurationManager.canSetBreakpointsIn(debugModel[0].editor.getModel()!);
+    const canSetBreakpoints = this.debugConfigurationManager.canSetBreakpointsIn(debugModel[0].getEditor().getModel()!);
     if (!canSetBreakpoints) {
       return;
     }
     for (const model of debugModel) {
-      if (model.editor.getId() === monacoEditor.getId()) {
+      if (model.getEditor().getId() === monacoEditor.getId()) {
         switch (type) {
           case DebugModelSupportedEventType.contextMenu:
             model.onContextMenu(event);

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -28,13 +28,13 @@ export class DebugModel implements IDebugModel {
   protected readonly toDispose = new DisposableCollection();
 
   @Autowired(DebugEditor)
-  readonly editor: DebugEditor;
+  private readonly editor: DebugEditor;
 
   @Autowired(DebugBreakpointWidget)
-  readonly breakpointWidget: DebugBreakpointWidget;
+  private readonly breakpointWidget: DebugBreakpointWidget;
 
   @Autowired(DebugHoverWidget)
-  readonly debugHoverWidget: DebugHoverWidget;
+  private readonly debugHoverWidget: DebugHoverWidget;
 
   @Autowired(IDebugSessionManager)
   private debugSessionManager: DebugSessionManager;
@@ -409,7 +409,13 @@ export class DebugModel implements IDebugModel {
     });
   }
 
-  private async getCandidateBreakpoints(breakpoints: DebugBreakpoint[]) {
+  private async getCandidateBreakpoints(breakpoints: DebugBreakpoint[]): Promise<
+    {
+      range: monaco.Range;
+      options: monaco.editor.IModelDecorationOptions;
+      breakpoint?: DebugBreakpoint | undefined;
+    }[]
+  > {
     const model = this.editor.getModel();
     const session = this.debugSessionManager.currentSession;
     if (!model || !session?.capabilities.supportsBreakpointLocationsRequest) {
@@ -659,10 +665,6 @@ export class DebugModel implements IDebugModel {
     this.deltaHintDecorations([]);
   }
 
-  public getBreakpoints(uri?: URI | undefined, filter?: Partial<monaco.IPosition> | undefined): DebugBreakpoint[] {
-    return this.breakpointManager.getBreakpoints(uri, filter);
-  }
-
   protected hintDecorations: string[] = [];
   protected hintBreakpoint(event) {
     const hintDecorations = this.createHintDecorations(event);
@@ -689,6 +691,18 @@ export class DebugModel implements IDebugModel {
       ];
     }
     return [];
+  }
+
+  public getBreakpoints(uri?: URI | undefined, filter?: Partial<monaco.IPosition> | undefined): DebugBreakpoint[] {
+    return this.breakpointManager.getBreakpoints(uri, filter);
+  }
+
+  public getEditor(): DebugEditor {
+    return this.editor;
+  }
+
+  public getBreakpointWidget(): DebugBreakpointWidget {
+    return this.breakpointWidget;
   }
 }
 

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -246,7 +246,7 @@ export class DebugModel implements IDebugModel {
    * @param {DebugStackFrame} frame
    * @memberof DebugModel
    */
-  focusStackFrame(frame: DebugStackFrame) {
+  focusStackFrame() {
     this.renderFrames();
   }
 
@@ -703,6 +703,10 @@ export class DebugModel implements IDebugModel {
 
   public getBreakpointWidget(): DebugBreakpointWidget {
     return this.breakpointWidget;
+  }
+
+  public getDebugHoverWidget(): DebugHoverWidget {
+    return this.debugHoverWidget;
   }
 }
 

--- a/packages/debug/src/browser/model/debug-source.ts
+++ b/packages/debug/src/browser/model/debug-source.ts
@@ -77,7 +77,7 @@ export class DebugSource extends DebugSourceData {
       const models = this.modelManager.resolve(this.uri);
       if (models) {
         for (const model of models) {
-          model.focusStackFrame(frame);
+          model.focusStackFrame();
         }
       }
     } else {

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -176,7 +176,6 @@ export class DebugBreakpointsService extends WithEventBus {
 
   delBreakpoint(bp: DebugBreakpoint): void {
     this.breakpoints.delBreakpoint(bp);
-    this.updateBreakpoints();
   }
 
   @action

--- a/packages/debug/src/common/debug-breakpoint.ts
+++ b/packages/debug/src/common/debug-breakpoint.ts
@@ -1,0 +1,15 @@
+import { DebugProtocol } from '@opensumi/vscode-debugprotocol';
+
+export interface ISourceBreakpoint {
+  id: string;
+  enabled: boolean;
+  uri: string;
+  raw: DebugProtocol.SourceBreakpoint;
+  logMessage?: string;
+  message?: string;
+  status: Map<string, DebugProtocol.Breakpoint>;
+}
+
+export interface IRuntimeBreakpoint extends ISourceBreakpoint {
+  status: Map<string, DebugProtocol.Breakpoint>;
+}

--- a/packages/debug/src/common/debug-hover.ts
+++ b/packages/debug/src/common/debug-hover.ts
@@ -1,0 +1,31 @@
+import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
+
+export interface IDebugHoverWidget extends monaco.editor.IContentWidget {
+  show: (options?: ShowDebugHoverOptions | undefined) => void;
+  hide: (options?: ShowDebugHoverOptions | undefined) => void;
+}
+
+export interface ShowDebugHoverOptions {
+  /**
+   * 选中区域
+   */
+  selection: monaco.Range;
+  /**
+   * 是否为焦点
+   * 默认值：false
+   */
+  focus?: boolean;
+  /**
+   * 是否立即调用，当为true时会清理之前的队列
+   * 默认值：true
+   */
+  immediate?: boolean;
+}
+
+export interface HideDebugHoverOptions {
+  /**
+   * 是否立即调用，当为true时会清理之前的队列
+   * 默认值：true
+   */
+  immediate?: boolean;
+}

--- a/packages/debug/src/common/debug-model.ts
+++ b/packages/debug/src/common/debug-model.ts
@@ -6,6 +6,10 @@ import { DebugEditor } from './debug-editor';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import { DebugBreakpoint } from '../browser';
 
+export interface IDebugBreakpointWidget extends IDisposable {
+  position: monaco.Position | undefined;
+}
+
 export const DebugAdapterSession = Symbol('DebugAdapterSession');
 
 export interface DebugAdapterSession {
@@ -117,11 +121,13 @@ export type DebugModelFactory = (editor: DebugEditor) => IDebugModel;
 
 export const IDebugModel = Symbol('IDebugModel');
 export interface IDebugModel extends IDisposable {
+  breakpoint: DebugBreakpoint | undefined;
   onContextMenu: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
   onMouseDown: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
   onMouseMove: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
   onMouseLeave: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
-  editor: DebugEditor;
   getBreakpoints(uri?: URI | undefined, filter?: Partial<monaco.IPosition> | undefined): DebugBreakpoint[];
-  [key: string]: any;
+  getEditor: () => DebugEditor;
+  getBreakpointWidget: () => IDebugBreakpointWidget;
+  render: () => void;
 }

--- a/packages/debug/src/common/debug-model.ts
+++ b/packages/debug/src/common/debug-model.ts
@@ -1,10 +1,11 @@
+import { IRuntimeBreakpoint, ISourceBreakpoint } from './debug-breakpoint';
+import { IDebugHoverWidget } from './debug-hover';
 import stream from 'stream';
 import type { editor } from '@opensumi/monaco-editor-core';
 import { DebugConfiguration } from './debug-configuration';
 import { IDisposable, MaybePromise, IJSONSchema, IJSONSchemaSnippet, URI } from '@opensumi/ide-core-common';
 import { DebugEditor } from './debug-editor';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
-import { DebugBreakpoint } from '../browser';
 
 export interface IDebugBreakpointWidget extends IDisposable {
   position: monaco.Position | undefined;
@@ -121,13 +122,18 @@ export type DebugModelFactory = (editor: DebugEditor) => IDebugModel;
 
 export const IDebugModel = Symbol('IDebugModel');
 export interface IDebugModel extends IDisposable {
-  breakpoint: DebugBreakpoint | undefined;
+  focusStackFrame: () => void;
+  breakpoint: ISourceBreakpoint | IRuntimeBreakpoint | undefined;
   onContextMenu: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
   onMouseDown: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
   onMouseMove: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
   onMouseLeave: (event: editor.IEditorMouseEvent | editor.IPartialEditorMouseEvent) => void;
-  getBreakpoints(uri?: URI | undefined, filter?: Partial<monaco.IPosition> | undefined): DebugBreakpoint[];
+  getBreakpoints(
+    uri?: URI | undefined,
+    filter?: Partial<monaco.IPosition> | undefined,
+  ): Array<ISourceBreakpoint | IRuntimeBreakpoint>;
   getEditor: () => DebugEditor;
   getBreakpointWidget: () => IDebugBreakpointWidget;
+  getDebugHoverWidget: () => IDebugHoverWidget;
   render: () => void;
 }

--- a/packages/debug/src/common/index.ts
+++ b/packages/debug/src/common/index.ts
@@ -1,5 +1,7 @@
 export * from './debug-configuration';
 export * from './debug-service';
+export * from './debug-hover';
+export * from './debug-breakpoint';
 export * from './debug-model';
 export * from './debug-session';
 export * from './debug-session-options';


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
- [x] 💄 Code Style Changes

### Background or solution

在接收 BreakpointEvent 这个自定义事件的时候，应该只改变状态，而不应该再触发断点的任何 DAP 请求

### Changelog
修复 breakpointLocations DAP 重复请求的问题
