### PR TITLE
fix: repeat breakpointLocations DAP request

### DIFF
--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -427,7 +427,7 @@ export class DebugSession implements IDebugSession {
             breakpoint = this.id2Breakpoint.get(raw.id);
             if (breakpoint) {
               (breakpoint as IRuntimeBreakpoint).status.set(this.id, raw);
-              this.breakpointManager.updateBreakpoint(breakpoint);
+              this.breakpointManager.updateBreakpoint(breakpoint, true);
             }
           }
           break;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
在接收 BreakpointEvent 这个自定义事件的时候，应该只改变状态，而不应该再触发断点的任何 DAP 请求

### Changelog
修复 breakpointLocations DAP 重复请求的问题
