### PR TITLE
fix: register default color theme before render

### DIFF
--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -24,7 +24,6 @@ import {
 import { Autowired } from '@opensumi/di';
 import { MenuContribution, IMenuRegistry, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { ISemanticTokenRegistry, ProbeScope } from '../common/semantic-tokens-registry';
-import { COLOR_THEME_SETTING } from './workbench.theme.service';
 
 export const THEME_TOGGLE_COMMAND: Command = {
   id: 'theme.toggle',
@@ -56,9 +55,14 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
   protected readonly semanticTokenRegistry: ISemanticTokenRegistry;
 
   initialize() {
+    this.registerDefaultColorTheme();
     this.registerDefaultTokenStyles();
     this.registerDefaultTokenType();
     this.registerDefaultTokenModifier();
+  }
+
+  private registerDefaultColorTheme() {
+    this.themeService.applyTheme(DEFAULT_THEME_ID);
   }
 
   private registerDefaultTokenModifier() {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<img width="1346" alt="截屏2021-12-28 下午8 56 37" src="https://user-images.githubusercontent.com/9823838/147570596-864d340e-cc3b-4042-9353-70d7db090f09.png">


### Changelog

register default color theme before render
