### PR TITLE
chore: update release condition

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,7 +18,8 @@ jobs:
     # issue 评论包含 '/pre-release'
     # issue label 包含 'pre-release'
     if: |
-      (github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER') &&
+      ((github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER') ||
+      (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')) &&
       ((contains(github.event.issue.body, 'Pre-release Summary') &&
         contains(github.event.issue.title,'OpenSumi Pre-release')) &&
         startsWith(github.event.comment.body, '/pre-release')) &&

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,9 +13,16 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # issue 正文包含 'Pre-Release'
+    # issue 标题包含 'OpenSumi Pre-Release'
+    # issue 评论包含 '/pre-release'
+    # issue label 包含 'pre-release'
     if: |
       (github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER') &&
-      ((startsWith(github.event.issue.body, '## OpenSumi next version prerelease') && github.event.issue.title == 'OpenSumi Pre-Release') || startsWith(github.event.comment.body, '/pre-release'))
+      ((contains(github.event.issue.body, 'Pre-release Summary') &&
+        contains(github.event.issue.title,'OpenSumi Pre-release')) &&
+        startsWith(github.event.comment.body, '/pre-release')) &&
+      contains(github.event.issue.labels.*.name, 'pre-release')
 
     strategy:
       matrix:
@@ -57,8 +64,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `🤖 OpenSumi PreRelease ${new Date().toDateString()}`,
-              body: `## ${new Date().toDateString()} Pre-Release Summary \r\n ${releasemd}`
+              title: `🤖 OpenSumi Pre-release ${new Date().toDateString()}`,
+              body: `## ${new Date().toDateString()} Pre-release Summary \r\n ${releasemd}`
             })
 
       # 发布 next 版本，并在 issue 中回复

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,11 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: |
-      (github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER') &&
-      ((startsWith(github.event.issue.body, '## OpenSumi release') && github.event.issue.title == 'OpenSumi Release') && startsWith(github.event.comment.body, '/release'))
+      (github.event.issue.author_association == 'OWNER') &&
+      ((contains(github.event.issue.body, 'Release Summary') &&
+        contains(github.event.issue.title,'OpenSumi Release')) &&
+        startsWith(github.event.comment.body, '/release')) &&
+      contains(github.event.issue.labels.*.name, 'release')
 
     strategy:
       matrix:
@@ -128,7 +131,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: issueBody
+              body: issueBody,
             });
 
             // 关闭 issue
@@ -137,4 +140,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'closed'
+            });
+
+            // 锁定 issue
+            github.issues.lock({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              lock_reason: 'resolved',
             });


### PR DESCRIPTION
### Types


- [x] 🧹 Chores

### Background or solution
修改了一下 pre-release 和 release 版本的发布条件

#### pre-release 版本
1. 基于 issue 模板创建标题为 `OpenSumi Pre-release`  的 issue，会自动添加 `pre-release` 标签
2. 创建后会触发一次 next 版本发布
3. 在 issue 评论 `/pre-release` 也会触发发布

同时运行判断了以下条件
1.  issue、评论人权限必须为 `OWNER` 或 `MEMBER`
2. issue 正文包含 'Pre-Release'
3. issue 标题包含 'OpenSumi Pre-Release'
4. 若有评论，issue 评论包含 '/pre-release'
5. issue label 包含 'pre-release'

#### release 版本

与 pre-release 区别在于
1. 发布前需要手动修改 `lerna.json` 为期望发布的版本号
2. 创建 issue 后不会自动发布，只有 `OWNER` 权限评论后才会发布
3. 发布后自动添加 tag ，发布 github release 以及 push 代码
4. 发布后自动添加 changelog 到 issue 正文
5. 发布后自动关闭 issue
6. 发布后自动锁定 issue

### Changelog

- 更新 workflow 运行条件