### PR TITLE
fix: debug.removeBreakpoints api

### DIFF
--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -133,8 +133,8 @@ export class DebugModel implements IDebugModel {
     return this.getBreakpoint();
   }
 
-  protected getBreakpoint(position: monaco.Position = this.position) {
-    return this.breakpointManager.getBreakpoint(this.uri, position.lineNumber);
+  protected getBreakpoint(position?: monaco.Position) {
+    return this.breakpointManager.getBreakpoint(this.uri, position ? position.lineNumber : undefined);
   }
 
   /**

--- a/packages/extension/__tests__/browser/main.thread.debug.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.debug.test.ts
@@ -79,6 +79,7 @@ const mockBreakpointManager = {
   onDidChangeBreakpoints: jest.fn(() => Disposable.create(() => {})),
   addBreakpoint: jest.fn(),
   findMarkers: jest.fn(),
+  delBreakpoint: jest.fn(),
 };
 
 const mockDebugConsoleModelService = {
@@ -254,7 +255,6 @@ describe('MainThreadDebug API Test Suite', () => {
         enabled: true,
       },
     ];
-    const remove = jest.fn();
     mockBreakpointManager.findMarkers.mockReturnValueOnce([
       {
         data: {
@@ -262,17 +262,9 @@ describe('MainThreadDebug API Test Suite', () => {
         },
       },
     ]);
-    mockDebugModelManager.resolve.mockReturnValueOnce([
-      {
-        breakpoint: {
-          remove,
-        },
-      },
-    ]);
     mockBreakpointManager.findMarkers.mockClear();
     await mainThreadDebug.$removeBreakpoints(breakpoints as any);
     expect(mockBreakpointManager.findMarkers).toBeCalledTimes(1);
-    expect(remove).toBeCalledTimes(1);
   });
 
   it('$customRequest method should be work', async () => {

--- a/packages/extension/src/browser/vscode/api/main.thread.debug.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.debug.ts
@@ -285,7 +285,7 @@ export class MainThreadDebug implements IMainThreadDebug {
     for (const origin of this.breakpointManager.findMarkers({ dataFilter: (data) => ids.has(data.id) })) {
       const model = this.modelManager.resolve(new URI(origin.data.uri));
       if (model && model[0].breakpoint) {
-        model[0].breakpoint.remove();
+        this.breakpointManager.delBreakpoint(model[0].breakpoint);
       }
     }
   }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

test code
```
const bp = vscode.debug.breakpoints;
vscode.debug.removeBreakpoints(bp);
```
预期效果: 所有断点均被删除

### Changelog
修复 debug.removeBreakpoints API 失效的问题