### PR TITLE
fix: fix ext-host editors error on closing diff editors

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.editor.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor.ts
@@ -263,7 +263,7 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
             change.removed = [getTextEditorId(payload.group, payload.oldResource!.uri)];
             if (payload.oldOpenType.type === 'diff') {
               change.removed.push(
-                getTextEditorId(payload.group, (payload.oldResource as IDiffResource).metadata!.original),
+                getTextEditorId(payload.group, (payload.oldResource as IDiffResource).metadata!.original, true),
               );
             }
           }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

![image](https://user-images.githubusercontent.com/1378130/147655192-61a358fd-181c-4973-8124-8081096db731.png)

### Background or solution

Wrong `removed` changes were push to extension host after closing diffEditors, causing `TextEditor` without `TextDocument` kept in `workspace.textEditors`.  

### Changelog
- fixes editor features failing after closing diffEditors.
