### PR TITLE
fix: ext-host editors error on closing diff editors

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.editor.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor.ts
@@ -263,7 +263,7 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
             change.removed = [getTextEditorId(payload.group, payload.oldResource!.uri)];
             if (payload.oldOpenType.type === 'diff') {
               change.removed.push(
-                getTextEditorId(payload.group, (payload.oldResource as IDiffResource).metadata!.original),
+                getTextEditorId(payload.group, (payload.oldResource as IDiffResource).metadata!.original, true),
               );
             }
           }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog

fix ext-host editors error on closing diff editors