### PR TITLE
fix: optimize extension treeview init logic

### DIFF
--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -31,7 +31,10 @@ export const ExtensionTabBarTreeView = observer(
 
     const isVisible = React.useMemo(() => {
       const state = accordionService?.getViewState(treeViewId);
-      return !state?.collapsed && !state?.hidden;
+      if (!state) {
+        return false;
+      }
+      return !state.collapsed && !state.hidden;
     }, [accordionService]);
 
     React.useEffect(() => {

--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './extension-tree-view.module.less';
-import { isOSX } from '@opensumi/ide-core-browser';
+import { isOSX, useInjectable } from '@opensumi/ide-core-browser';
 import { Injector } from '@opensumi/di';
 import { observer } from 'mobx-react-lite';
 import { ViewState } from '@opensumi/ide-core-browser';
@@ -12,6 +12,7 @@ import { TREE_VIEW_NODE_HEIGHT, TreeViewNode } from './extension-tree-view-node'
 import { ExtensionCompositeTreeNode, ExtensionTreeNode } from '../vscode/api/tree-view/tree-view.node.defined';
 import { TreeViewDataProvider } from '../vscode/api/main.thread.treeview';
 import { ProgressBar } from '@opensumi/ide-core-browser/lib/components/progressbar';
+import { IMainLayoutService } from '@opensumi/ide-main-layout/lib/common/main-layout.defination';
 
 export interface ExtensionTabBarTreeViewProps {
   injector: Injector;
@@ -25,6 +26,13 @@ export const ExtensionTabBarTreeView = observer(
   ({ viewState, model, dataProvider, treeViewId }: React.PropsWithChildren<ExtensionTabBarTreeViewProps>) => {
     const [isReady, setIsReady] = React.useState<boolean>(false);
     const [isEmpty, setIsEmpty] = React.useState(dataProvider.isTreeEmpty);
+    const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
+    const accordionService = React.useMemo(() => layoutService.getViewAccordionService(treeViewId), []);
+
+    const isVisible = React.useMemo(() => {
+      const state = accordionService?.getViewState(treeViewId);
+      return !state?.collapsed && !state?.hidden;
+    }, [accordionService]);
 
     React.useEffect(() => {
       const disposable = dataProvider.onDidChangeEmpty(() => {
@@ -118,7 +126,7 @@ export const ExtensionTabBarTreeView = observer(
       let unmouted = false;
       (async () => {
         await model.whenReady;
-        if (model.treeModel) {
+        if (model.treeModel && isVisible) {
           // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
           // 这里需要重新取一下treeModel的值确保为最新的TreeModel
           await model.treeModel.root.ensureLoaded();
@@ -131,7 +139,7 @@ export const ExtensionTabBarTreeView = observer(
         unmouted = true;
         model && model.removeNodeDecoration();
       };
-    }, [model]);
+    }, [model, isVisible]);
 
     React.useEffect(() => {
       const handleBlur = () => {

--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -93,7 +93,7 @@ export class MainThreadTreeView extends WithEventBus implements IMainThreadTreeV
     });
 
     this.addDispose(
-      this.eventBus?.on(ViewCollapseChangedEvent, (e) => {
+      this.eventBus.on(ViewCollapseChangedEvent, (e) => {
         if (e.payload.viewId && this.treeModels.has(e.payload.viewId) && !e.payload.collapsed) {
           const treeModel = this.treeModels.get(e.payload.viewId);
           if (treeModel) {

--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -340,7 +340,7 @@ export class TreeViewDataProvider extends Tree {
     const icon = await this.toIconClass(item);
     const actions = this.getInlineMenuNodes(item.contextValue || '');
     const { label, description } = this.getLabelAndDescription(item);
-    console.log('createFoldNode', label);
+
     const node = new ExtensionCompositeTreeNode(
       this,
       parent,

--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -17,8 +17,9 @@ import {
   URI,
   IContextKeyService,
   CancellationTokenSource,
+  WithEventBus,
 } from '@opensumi/ide-core-browser';
-import { IMainLayoutService } from '@opensumi/ide-main-layout';
+import { IMainLayoutService, ViewCollapseChangedEvent } from '@opensumi/ide-main-layout';
 import { ExtensionTabBarTreeView } from '../../components';
 import { IIconService, IconType, IThemeService } from '@opensumi/ide-theme';
 import { ExtensionTreeViewModel } from './tree-view/tree-view.model.service';
@@ -32,9 +33,10 @@ import {
   MenuNode,
 } from '@opensumi/ide-core-browser/lib/menu/next';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
+import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
 
 @Injectable({ multiple: true })
-export class MainThreadTreeView implements IMainThreadTreeView {
+export class MainThreadTreeView extends WithEventBus implements IMainThreadTreeView {
   static TREE_VIEW_COLLAPSE_ALL_COMMAND_ID = 'TREE_VIEW_COLLAPSE_ALL';
 
   private readonly proxy: IExtHostTreeView;
@@ -53,6 +55,9 @@ export class MainThreadTreeView implements IMainThreadTreeView {
 
   @Autowired(IThemeService)
   private readonly themeService: IThemeService;
+
+  @Autowired(IProgressService)
+  private readonly progressService: IProgressService;
 
   @Autowired(LabelService)
   private readonly labelService: LabelService;
@@ -77,6 +82,7 @@ export class MainThreadTreeView implements IMainThreadTreeView {
   private disposable: DisposableStore = new DisposableStore();
 
   constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
+    super();
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostTreeView);
     this.disposable.add(toDisposable(() => this.treeModels.clear()));
     this._registerInternalCommands();
@@ -85,6 +91,17 @@ export class MainThreadTreeView implements IMainThreadTreeView {
         this.userhome = new URI(home.uri);
       }
     });
+
+    this.addDispose(
+      this.eventBus?.on(ViewCollapseChangedEvent, (e) => {
+        if (e.payload.viewId && this.treeModels.has(e.payload.viewId) && !e.payload.collapsed) {
+          const treeModel = this.treeModels.get(e.payload.viewId);
+          if (treeModel) {
+            this.progressService.withProgress({ location: e.payload.viewId }, () => treeModel.refresh());
+          }
+        }
+      }),
+    );
   }
 
   dispose() {
@@ -323,6 +340,7 @@ export class TreeViewDataProvider extends Tree {
     const icon = await this.toIconClass(item);
     const actions = this.getInlineMenuNodes(item.contextValue || '');
     const { label, description } = this.getLabelAndDescription(item);
+    console.log('createFoldNode', label);
     const node = new ExtensionCompositeTreeNode(
       this,
       parent,

--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -346,6 +346,15 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
     return options.containerId;
   }
 
+  getViewAccordionService(viewId: string) {
+    const containerId = this.viewToContainerMap.get(viewId);
+    if (!containerId) {
+      return;
+    }
+
+    return this.getAccordionService(containerId);
+  }
+
   collectViewComponent(view: View, containerId: string, props: any = {}, options?: ViewComponentOptions): string {
     this.customViews.set(view.id, view);
     this.viewToContainerMap.set(view.id, containerId);

--- a/packages/main-layout/src/common/main-layout.defination.ts
+++ b/packages/main-layout/src/common/main-layout.defination.ts
@@ -69,6 +69,7 @@ export interface IMainLayoutService {
   revealView(viewId: string): void;
   getTabbarService(location: string): TabbarService;
   getAccordionService(containerId: string, noRestore?: boolean): AccordionService;
+  getViewAccordionService(viewId: string): AccordionService | undefined;
   // 某一位置是否可见
   isVisible(location: string): boolean;
   isViewVisible(viewId: string): boolean;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
之前对于折叠或者隐藏状态下的 view 也会加载数据，例如这个场景下第一次激活插件所有的 treeview 加起来会创建 760 个 treeNode 实例

![image](https://user-images.githubusercontent.com/17701805/148169694-2a6dd214-4227-40f8-ae40-9a17d62ac944.png)

优化后，当视图展开且显示状态下，才会在第一次激活时获取数据，对于这个场景，第一次只创建 49 个 treeNode，后续视图折叠/展开时都会刷新并重新获取数据(与 VS Code 表现一致)

![image](https://user-images.githubusercontent.com/17701805/148169882-34f57e74-7135-4567-8797-a9bdbab2ee58.png)




### Changelog
- 优化插件 treeview 初始化逻辑，减少冗余的加载逻辑