### PR TITLE
fix: completion item documentation

### DIFF
--- a/packages/extension/src/hosted/api/vscode/language/completion.ts
+++ b/packages/extension/src/hosted/api/vscode/language/completion.ts
@@ -100,6 +100,7 @@ export class CompletionAdapter {
         } else {
           dto[ISuggestDataDtoField.insertText] = typeof item.label === 'string' ? item.label : item.label.label;
         }
+        dto[ISuggestDataDtoField.documentation] = item.documentation;
       }
 
       const range = this.convertRange(item, inserting, replacing);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复在没有 resolveCompletionItem 的情况下补全列表的 documentation 丢失的问题