### PR TITLE
feat: adjust explorerResourceIsFolder behavior

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -213,8 +213,8 @@ export const FileTree = ({ viewState }: React.PropsWithChildren<{ viewState: Vie
 
   const handleOuterClick = React.useCallback(() => {
     // 空白区域点击，取消焦点状态
-    const { enactiveFileDecoration } = fileTreeModelService;
-    enactiveFileDecoration();
+    const { deactivateFileDecoration } = fileTreeModelService;
+    deactivateFileDecoration();
   }, []);
 
   const handleFocus = React.useCallback(() => {

--- a/packages/file-tree-next/src/common/file-tree-node.define.ts
+++ b/packages/file-tree-next/src/common/file-tree-node.define.ts
@@ -12,7 +12,7 @@ export class Directory extends CompositeTreeNode {
     parent: ICompositeTreeNode | undefined,
     public uri: URI = new URI(''),
     name = '',
-    public filestat: FileStat = { children: [], isDirectory: false, uri: '', lastModification: 0 },
+    public filestat: FileStat = { children: [], isDirectory: true, uri: '', lastModification: 0 },
     public tooltip: string,
     id?: number,
   ) {


### PR DESCRIPTION
follow vscode explorerResourceIsFolder behavior
right click explorer empty area still set this value to true.

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

配置了右键菜单 explorerResourceIsFolder：
然后在 vscode 下在根目录是有这个选项的：
![image](https://user-images.githubusercontent.com/13938334/148188969-4e2a55a9-1d97-4dee-989a-458a178fc380.png)


在 sumi 里根目录下右键没:

![image](https://user-images.githubusercontent.com/13938334/148189005-3dcb5a86-6eb4-47a9-84ad-8fb558793d01.png)


### Changelog

set explorerResourceIsFolder to `true` when right click in explorer root