### PR TITLE
feat: add remote opener

### DIFF
--- a/configs/ts/references/tsconfig.remote-opener.json
+++ b/configs/ts/references/tsconfig.remote-opener.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../../../packages/remote-opener/src",
+    "outDir": "../../../packages/remote-opener/lib"
+  },
+  "include": ["../../../packages/remote-opener/src"]
+}

--- a/configs/ts/tsconfig.build.json
+++ b/configs/ts/tsconfig.build.json
@@ -58,6 +58,9 @@
       "path": "./references/tsconfig.editor.json"
     },
     {
+      "path": "./references/tsconfig.remote-opener.json"
+    },
+    {
       "path": "./references/tsconfig.monaco-enhance.json"
     },
     {

--- a/configs/ts/tsconfig.resolve.json
+++ b/configs/ts/tsconfig.resolve.json
@@ -344,6 +344,12 @@
       ],
       "@opensumi/ide-testing/lib/*": [
         "../packages/testing/src/*"
+      ],
+      "@opensumi/ide-remote-opener": [
+        "../packages/remote-opener/src/index.ts"
+      ],
+      "@opensumi/ide-remote-opener/lib/*": [
+        "../packages/remote-opener/src/*"
       ]
     }
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,8 @@ module.exports = {
     '!packages/startup/**/*.ts',
     // Test 功能暂未完成
     '!packages/testing/**/*.ts',
+    // CLI 不需要测试
+    '!packages/remote-cli/**/*.ts',
     '!packages/core-electron-main/**/*.ts',
     '!packages/*/src/electron-main/**/*.ts',
   ],

--- a/packages/core-browser/__tests__/remote-opener/remote-opener-converter.test.ts
+++ b/packages/core-browser/__tests__/remote-opener/remote-opener-converter.test.ts
@@ -1,0 +1,46 @@
+import { IRemoteHostConverter } from '@opensumi/ide-core-browser/lib/remote-opener';
+import { Disposable } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
+import { RemoteOpenerBrowserServiceImpl } from '../../../remote-opener/lib/browser';
+import { IRemoteOpenerBrowserService, RemoteOpenerBrowserServiceToken } from '../../lib/remote-opener';
+
+describe('packages/core-browser/src/remote-opener/converter.contribution.ts', () => {
+  let remoteOpenerService: IRemoteOpenerBrowserService;
+
+  beforeEach(() => {
+    const injector = createBrowserInjector([]);
+    injector.addProviders({
+      token: RemoteOpenerBrowserServiceToken,
+      useClass: RemoteOpenerBrowserServiceImpl,
+    });
+    remoteOpenerService = injector.get(RemoteOpenerBrowserServiceToken);
+  });
+
+  it('register remote host converter', () => {
+    const disposes = new Disposable();
+    const converter: IRemoteHostConverter = {
+      convert: (port) => `opensumi-${port}-ide.com`,
+    };
+    disposes.addDispose(remoteOpenerService.registerConverter(converter));
+    expect(remoteOpenerService['converter']).toBeDefined();
+    expect(remoteOpenerService['converter'].convert('3030')).toBe('opensumi-3030-ide.com');
+
+    const converter2: IRemoteHostConverter = {
+      convert: (port) => `opensumi-${port}-ide.net`,
+    };
+
+    expect(() => remoteOpenerService.registerConverter(converter2)).toThrow(
+      new Error('Only one converter is allowed.'),
+    );
+    disposes.dispose();
+  });
+
+  it('register support remote host', () => {
+    const disposes = new Disposable();
+    disposes.addDispose(remoteOpenerService.registerSupportHosts(['128.168.0.1', '0.0.0.1']));
+    expect(remoteOpenerService['supportHosts'].size).toBe(5);
+    expect(remoteOpenerService['supportHosts'].has('0.0.0.0')).toBeTruthy();
+    expect(remoteOpenerService['supportHosts'].has('255.255.255.0')).toBeFalsy();
+    disposes.dispose();
+  });
+});

--- a/packages/core-browser/src/common/common.module.ts
+++ b/packages/core-browser/src/common/common.module.ts
@@ -6,6 +6,7 @@ import { DefaultOpenerContribution, OpenerContributionClient } from '../opener/o
 import { CommonServerPath, CryptrServicePath, KeytarServicePath } from '@opensumi/ide-core-common';
 import { AuthenticationContribution } from '../authentication/authentication.contribution';
 import { HashCalculateContribution } from '../hash-calculate/hash-calculate.contribution';
+import { RemoteOpenerConverterContributionClient } from '../remote-opener/converter.contribution';
 
 @Injectable()
 export class ClientCommonModule extends BrowserModule {
@@ -16,6 +17,7 @@ export class ClientCommonModule extends BrowserModule {
     OpenerContributionClient,
     AuthenticationContribution,
     HashCalculateContribution,
+    RemoteOpenerConverterContributionClient,
   ];
   backServices = [
     {

--- a/packages/core-browser/src/remote-opener/converter.contribution.ts
+++ b/packages/core-browser/src/remote-opener/converter.contribution.ts
@@ -1,0 +1,21 @@
+import { Autowired } from '@opensumi/di';
+import { Domain, ContributionProvider } from '@opensumi/ide-core-common';
+
+import { ClientAppContribution } from '../common/common.define';
+import { IRemoteOpenerBrowserService, RemoteOpenerBrowserServiceToken, RemoteOpenerConverterContribution } from '.';
+
+@Domain(ClientAppContribution)
+export class RemoteOpenerConverterContributionClient implements ClientAppContribution {
+  @Autowired(RemoteOpenerConverterContribution)
+  private readonly contributionProvider: ContributionProvider<RemoteOpenerConverterContribution>;
+
+  @Autowired(RemoteOpenerBrowserServiceToken)
+  private readonly remoteOpenerService: IRemoteOpenerBrowserService;
+
+  onStart() {
+    const contributions = this.contributionProvider.getContributions();
+    for (const contribution of contributions) {
+      contribution.registerConverter(this.remoteOpenerService);
+    }
+  }
+}

--- a/packages/core-browser/src/remote-opener/index.ts
+++ b/packages/core-browser/src/remote-opener/index.ts
@@ -1,0 +1,35 @@
+import { IDisposable, Uri } from '..';
+
+export const RemoteOpenerConverterContribution = Symbol('RemoteOpenerConverterContribution');
+
+export interface RemoteOpenerConverterContribution {
+  registerConverter(registry: IRemoteOpenerBrowserService): void;
+}
+
+export interface IRemoteHostConverter {
+  /**
+   * Convert a port to a host name for cloud IDE.
+   * @example
+   * ```typescript
+   * // port: 3030
+   * const host = converter.convert('3030');
+   * // host: 'cloud-ide.opensumi-3030.com'
+   * ```
+   */
+  convert(port: string): string;
+}
+
+export const RemoteOpenerBrowserServiceToken = Symbol('RemoteOpenerBrowserServiceToken');
+
+export interface IRemoteOpenerBrowserService {
+  $openExternal(type: 'file' | 'url', uri: Uri): Promise<void>;
+
+  /**
+   * Register a converter.
+   * @see IRemoteHostConverter
+   * @param converter is a converter to convert port to host name.
+   */
+  registerConverter(converter: IRemoteHostConverter): IDisposable;
+
+  registerSupportHosts(hosts: string[]): IDisposable;
+}

--- a/packages/remote-cli/bin/open
+++ b/packages/remote-cli/bin/open
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../dist/cli');

--- a/packages/remote-cli/package.json
+++ b/packages/remote-cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@opensumi/remote-cli",
+  "version": "1.0.0",
+  "files": [
+    "lib"
+  ],
+  "preview": true,
+  "license": "MIT",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "prepublishOnly": "npm run build",
+    "build": "webpack --config=webpack.config.js --progress"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:opensumi/core.git"
+  },
+  "dependencies": {
+    "commander": "^8.1.0",
+    "got": "^11.8.2",
+    "chalk": "^4.1.2"
+  },
+  "devDependencies": {
+    "webpack": "^4.30.0",
+    "webpack-cli": "^3.3.1",
+    "ts-loader": "^6.0.1"
+  }
+}

--- a/packages/remote-cli/src/index.ts
+++ b/packages/remote-cli/src/index.ts
@@ -1,0 +1,87 @@
+import { join } from 'path';
+import got from 'got';
+import { statSync, existsSync } from 'fs';
+import { Command } from 'commander';
+import { green, yellow, red } from 'chalk';
+
+const CLI_NAME = process.env.CLI_NAME || 'sumi';
+const PRODUCTION_NAME = process.env.PRODUCTION_NAME || 'OpenSumi';
+const CLIENT_ID = process.env.CLIENT_ID;
+const SUMI_SERVER_HOST = process.env.SUMI_SERVER_HOST || 'http://127.0.0.1:8000';
+const OPENER_ROUTE = process.env.OPENER_ROUTE || 'open';
+
+const program = new Command(CLI_NAME);
+
+enum OpenType {
+  url = 'url',
+  file = 'file',
+}
+
+program.addHelpText(
+  'beforeAll',
+  `Help: Open files or website from a shell.
+By default, opens each file using the ${PRODUCTION_NAME} for that file.
+If the file is in the form of a URL, will be opened the website use internal browser.
+
+Examples:
+    1. ${green('open https://www.hostname.com')}  Will open the website use internal browser.
+    2. ${green('open ./package.json')} Will open the file use ${PRODUCTION_NAME}.
+    3. ${green('open /path/to/file')} Will open the file use ${PRODUCTION_NAME}.
+`,
+);
+
+program
+  .argument('<URL or FilePath>')
+  .description('file path or url')
+  .action((pathOrUrl) => {
+    if (!CLIENT_ID) {
+      console.error(red(`${PRODUCTION_NAME} Client id is undefined!`));
+      process.exit(0);
+    }
+
+    let type: OpenType = OpenType.file;
+    let fullPathOrUrl = pathOrUrl;
+    if (isHttpProtocol(pathOrUrl)) {
+      type = OpenType.url;
+    } else if (isRelativePath(pathOrUrl)) {
+      fullPathOrUrl = join(process.cwd(), pathOrUrl);
+    }
+
+    if (type === OpenType.file) {
+      if (!existsSync(fullPathOrUrl)) {
+        console.error(red(`The file path ${fullPathOrUrl} is not exist!`));
+        process.exit(0);
+      }
+
+      if (statSync(fullPathOrUrl).isDirectory()) {
+        console.error(red('Directory is unsupported'));
+        process.exit(0);
+      }
+    }
+
+    const query = `?type=${type}&${type}=${encodeURIComponent(fullPathOrUrl)}&clientId=${CLIENT_ID}`;
+    got(`${SUMI_SERVER_HOST}/${OPENER_ROUTE}${query}`).catch((err) => {
+      console.error(red(`Open ${type} ${fullPathOrUrl} error: \n ${err.message}`));
+      process.exit(1);
+    });
+  });
+
+program.configureOutput({
+  outputError: (str, write) => write(yellow(str)),
+});
+
+program.exitOverride();
+
+try {
+  program.parse(process.argv);
+} catch (err) {
+  process.exit(0);
+}
+
+function isRelativePath(path: string): boolean {
+  return path.startsWith('./') || !path.startsWith('/');
+}
+
+function isHttpProtocol(url: string): boolean {
+  return !!url && (url.startsWith('http://') || url.startsWith('https://'));
+}

--- a/packages/remote-cli/tsconfig.json
+++ b/packages/remote-cli/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "importHelpers": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "downlevelIteration": true,
+    "noEmitOnError": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "strictFunctionTypes": false
+  },
+  "include": ["./src"]
+}

--- a/packages/remote-cli/webpack.config.js
+++ b/packages/remote-cli/webpack.config.js
@@ -1,0 +1,44 @@
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const path = require('path');
+
+const tsConfigPath = path.join(__dirname, './tsconfig.json');
+const srcDir = path.join(__dirname, './src');
+const distDir = path.join(__dirname, './dist');
+
+module.exports = {
+  entry: path.join(srcDir, './index.ts'),
+  target: 'node',
+  output: {
+    filename: 'cli.js',
+    path: distDir,
+  },
+  devtool: 'null',
+  mode: 'production',
+  node: false,
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json', '.less'],
+    plugins: [
+      new TsconfigPathsPlugin({
+        configFile: tsConfigPath,
+      }),
+    ],
+  },
+  module: {
+    exprContextCritical: false,
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        options: {
+          configFile: tsConfigPath,
+        },
+      },
+    ],
+  },
+  resolveLoader: {
+    modules: [path.join(__dirname, './node_modules')],
+    extensions: ['.ts', '.tsx', '.js', '.json', '.less'],
+    mainFields: ['loader', 'main'],
+    moduleExtensions: ['-loader'],
+  },
+};

--- a/packages/remote-opener/__tests__/browser/remote.opener.service.test.ts
+++ b/packages/remote-opener/__tests__/browser/remote.opener.service.test.ts
@@ -1,0 +1,83 @@
+import { IOpenerService } from '@opensumi/ide-core-browser/lib/opener';
+import {
+  IRemoteHostConverter,
+  IRemoteOpenerBrowserService,
+  RemoteOpenerBrowserServiceToken,
+} from '@opensumi/ide-core-browser/lib/remote-opener';
+import { Disposable } from '@opensumi/ide-core-common';
+import { URI, Uri } from '@opensumi/ide-core-common/lib/uri';
+import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/common/editor';
+import { RemoteOpenerBrowserServiceImpl } from '@opensumi/ide-remote-opener/lib/browser';
+import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
+
+describe('packages/remote-opener/src/browser/remote.opener.service.ts', () => {
+  let remoteOpenerService: IRemoteOpenerBrowserService;
+  let workbenchEditorService: WorkbenchEditorService;
+  let openerService: IOpenerService;
+
+  beforeEach(() => {
+    const injector = createBrowserInjector([]);
+    injector.addProviders({
+      token: RemoteOpenerBrowserServiceToken,
+      useClass: RemoteOpenerBrowserServiceImpl,
+    });
+    injector.overrideProviders(
+      {
+        token: IOpenerService,
+        useValue: {
+          open: jest.fn(),
+        },
+      },
+      {
+        token: WorkbenchEditorService,
+        useValue: {
+          open: jest.fn(),
+        },
+      },
+    );
+
+    remoteOpenerService = injector.get(RemoteOpenerBrowserServiceToken);
+    workbenchEditorService = injector.get(WorkbenchEditorService);
+    openerService = injector.get(IOpenerService);
+  });
+
+  it('$openExternal open file should be work', async () => {
+    const spyOnOpen = jest.spyOn(workbenchEditorService, 'open');
+    const spyOnOpenExternal = jest.spyOn(remoteOpenerService, '$openExternal');
+
+    const mockFileUri = Uri.file('/path/to/file.js');
+    await remoteOpenerService.$openExternal('file', mockFileUri);
+
+    expect(spyOnOpenExternal).toBeCalledWith('file', mockFileUri);
+    expect(spyOnOpen).toBeCalledWith(URI.parse(mockFileUri.toString()), { preview: false, focus: true });
+  });
+
+  it('$openExternal open url should be work', async () => {
+    const disposes = new Disposable();
+    const converter: IRemoteHostConverter = {
+      convert: (port) => `opensumi-${port}-ide.com`,
+    };
+    const spyOnConverter = jest.spyOn(converter, 'convert');
+
+    disposes.addDispose(remoteOpenerService.registerConverter(converter));
+
+    const spyOnOpen = jest.spyOn(openerService, 'open');
+    const spyOnOpenExternal = jest.spyOn(remoteOpenerService, '$openExternal');
+
+    const mockUrl = Uri.parse('https://opensumi-ide.com');
+    await remoteOpenerService.$openExternal('url', mockUrl);
+
+    expect(spyOnOpenExternal).toBeCalledWith('url', mockUrl);
+    expect(spyOnOpen).toBeCalledWith(mockUrl.toString());
+
+    spyOnOpen.mockClear();
+
+    const mockLocalUrl = Uri.parse('http://127.0.0.1:3030');
+    await remoteOpenerService.$openExternal('url', mockLocalUrl);
+
+    expect(spyOnOpenExternal).toBeCalledWith('url', mockLocalUrl);
+    expect(spyOnOpen).toBeCalledWith('https://opensumi-3030-ide.com/');
+
+    expect(spyOnConverter).toBeCalledWith('3030');
+  });
+});

--- a/packages/remote-opener/__tests__/node/opener.client.test.ts
+++ b/packages/remote-opener/__tests__/node/opener.client.test.ts
@@ -1,0 +1,57 @@
+import { createNodeInjector } from '../../../../tools/dev-tool/src/injector-helper';
+import {
+  IRemoteOpenerClient,
+  IRemoteOpenerService,
+  RemoteOpenerClientToken,
+} from '@opensumi/ide-remote-opener/lib/common';
+import { RemoteOpenerClientImpl } from '@opensumi/ide-remote-opener/lib/node/opener.client';
+
+describe('packages/remote-opener/src/node/opener.client.ts', () => {
+  let remoteOpenerClient: IRemoteOpenerClient;
+
+  beforeEach(() => {
+    const injector = createNodeInjector([]);
+    injector.addProviders({
+      token: RemoteOpenerClientToken,
+      useClass: RemoteOpenerClientImpl,
+    });
+    remoteOpenerClient = injector.get(RemoteOpenerClientToken);
+  });
+
+  it('setRemoteOpenerServiceInstance should be work', () => {
+    const service: IRemoteOpenerService = {
+      openExternal: jest.fn(),
+    };
+    remoteOpenerClient.setRemoteOpenerServiceInstance('mock_clientId', service);
+    expect(remoteOpenerClient['remoteOpenerServices'].has('mock_clientId')).toBeTruthy();
+    expect(remoteOpenerClient['remoteOpenerServices'].get('mock_clientId')).toBe(service);
+    expect(() => remoteOpenerClient.setRemoteOpenerServiceInstance('mock_clientId', service)).toThrow(
+      new Error('Remote opener service instance for client mock_clientId already set.'),
+    );
+  });
+
+  it('openExternal should be work', async (done) => {
+    const service: IRemoteOpenerService = {
+      openExternal: jest.fn(),
+    };
+
+    remoteOpenerClient.setRemoteOpenerServiceInstance('mock_clientId_2', service);
+
+    await remoteOpenerClient.openExternal(
+      {
+        file: 'mock_file',
+        type: 'file',
+        clientId: 'mock_clientId_2',
+      },
+      'mock_clientId_2',
+    );
+
+    expect(service.openExternal).toBeCalledWith({
+      file: 'mock_file',
+      type: 'file',
+      clientId: 'mock_clientId_2',
+    });
+
+    done();
+  });
+});

--- a/packages/remote-opener/__tests__/node/opener.service.test.ts
+++ b/packages/remote-opener/__tests__/node/opener.service.test.ts
@@ -1,0 +1,52 @@
+import { RemoteOpenerServiceImpl } from '@opensumi/ide-remote-opener/lib/node/opener.service';
+import { RemoteOpenerClientImpl } from '@opensumi/ide-remote-opener/lib/node/opener.client';
+import {
+  IRemoteOpenerClient,
+  IRemoteOpenerService,
+  RemoteOpenerClientToken,
+  RemoteOpenerServiceToken,
+} from '@opensumi/ide-remote-opener/lib/common';
+
+import { createNodeInjector } from '../../../../tools/dev-tool/src/injector-helper';
+
+describe('packages/remote-opener/src/node/opener.service.ts', () => {
+  let remoteOpenerService: IRemoteOpenerService;
+  let remoteOpenerClient: IRemoteOpenerClient;
+
+  beforeEach(() => {
+    const injector = createNodeInjector([]);
+    injector.addProviders(
+      {
+        token: RemoteOpenerServiceToken,
+        useClass: RemoteOpenerServiceImpl,
+      },
+      {
+        token: RemoteOpenerClientToken,
+        useClass: RemoteOpenerClientImpl,
+      },
+    );
+
+    remoteOpenerService = injector.get(RemoteOpenerServiceToken);
+    remoteOpenerClient = injector.get(RemoteOpenerClientToken);
+  });
+
+  it('openExternal should be work', async () => {
+    const spyOnSetInstance = jest.spyOn(remoteOpenerClient, 'setRemoteOpenerServiceInstance');
+    remoteOpenerService['setConnectionClientId']('mock_client_id');
+    expect(spyOnSetInstance).toBeCalledWith('mock_client_id', remoteOpenerService);
+
+    const spyOnOpenExternal = jest.spyOn(remoteOpenerService, 'openExternal');
+    expect(remoteOpenerService['clientId']).toBe('mock_client_id');
+
+    await remoteOpenerService.openExternal({
+      file: 'mock_file',
+      type: 'file',
+      clientId: 'mock_client_id',
+    });
+    expect(spyOnOpenExternal).toBeCalledWith({
+      file: 'mock_file',
+      type: 'file',
+      clientId: 'mock_client_id',
+    });
+  });
+});

--- a/packages/remote-opener/package.json
+++ b/packages/remote-opener/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@opensumi/ide-remote-opener",
+  "version": "2.13.9",
+  "files": [
+    "lib"
+  ],
+  "license": "MIT",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "prepublishOnly": "npm run build",
+    "build": "tsc --build ../../configs/ts/references/tsconfig.remote-opener.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:opensumi/core.git"
+  },
+  "dependencies": {
+    "@opensumi/ide-core-browser": "2.13.9",
+    "@opensumi/ide-core-node": "2.13.9",
+    "@opensumi/ide-core-common": "2.13.9",
+    "@opensumi/ide-connection": "2.13.9",
+    "@opensumi/ide-editor": "2.13.9"
+  },
+  "devDependencies": {}
+}

--- a/packages/remote-opener/src/browser/index.ts
+++ b/packages/remote-opener/src/browser/index.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@opensumi/di';
+import { BrowserModule } from '@opensumi/ide-core-browser';
+import { RemoteOpenerBrowserServiceToken } from '@opensumi/ide-core-browser/lib/remote-opener';
+
+import { RemoteOpenerServicePath } from '../common';
+import { RemoteOpenerBrowserServiceImpl } from './remote.opener.service';
+
+export * from './remote.opener.service';
+
+@Injectable()
+export class RemoteOpenerModule extends BrowserModule {
+  providers = [
+    {
+      token: RemoteOpenerBrowserServiceToken,
+      useClass: RemoteOpenerBrowserServiceImpl,
+    },
+  ];
+  backServices = [
+    {
+      servicePath: RemoteOpenerServicePath,
+      clientToken: RemoteOpenerBrowserServiceToken,
+    },
+  ];
+}

--- a/packages/remote-opener/src/browser/remote.opener.service.ts
+++ b/packages/remote-opener/src/browser/remote.opener.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { WorkbenchEditorService } from '@opensumi/ide-editor';
+import { CommandService, Disposable, IDisposable, Uri, URI } from '@opensumi/ide-core-common';
+import { RPCService } from '@opensumi/ide-connection/lib/common/proxy';
+
+import { PreferenceService } from '@opensumi/ide-core-browser/lib/preferences';
+import { IOpenerService } from '@opensumi/ide-core-browser/lib/opener';
+import { IRemoteHostConverter, IRemoteOpenerBrowserService } from '@opensumi/ide-core-browser/lib/remote-opener';
+
+const SUPPORT_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0'];
+
+@Injectable()
+export class RemoteOpenerBrowserServiceImpl extends RPCService implements IRemoteOpenerBrowserService {
+  @Autowired(WorkbenchEditorService)
+  private readonly workbenchEditorService: WorkbenchEditorService;
+
+  @Autowired(CommandService)
+  protected commandService: CommandService;
+
+  @Autowired(PreferenceService)
+  private readonly preferenceService: PreferenceService;
+
+  @Autowired(IOpenerService)
+  private readonly openerService: IOpenerService;
+
+  private supportHosts: Set<string> = new Set(SUPPORT_HOSTS);
+
+  private converter: IRemoteHostConverter | null = null;
+
+  registerSupportHosts(hosts: string[]) {
+    for (const host of hosts) {
+      this.supportHosts.add(host);
+    }
+    return Disposable.create(() => {
+      for (const host of hosts) {
+        this.supportHosts.delete(host);
+      }
+    });
+  }
+
+  registerConverter(converter: IRemoteHostConverter): IDisposable {
+    if (this.converter) {
+      throw new Error('Only one converter is allowed.');
+    }
+
+    this.converter = converter;
+    return Disposable.create(() => {
+      this.converter = null;
+    });
+  }
+
+  get isRemoteOpenerEnabled(): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.preferenceService.get('remote.opener.enable', true)!;
+  }
+
+  async $openExternal(type: 'file' | 'url', uri: Uri): Promise<void> {
+    if (!this.isRemoteOpenerEnabled) {
+      return;
+    }
+
+    const revivedUri = Uri.revive(uri);
+    switch (type) {
+      case 'url': {
+        const url = new URL(decodeURIComponent(revivedUri.toString()));
+        if (this.supportHosts.has(url.hostname)) {
+          if (!this.converter) {
+            throw new Error('Converter is not registered.');
+          }
+
+          const { port } = url;
+          const hostname = this.converter.convert(port);
+          // Default use https protocol
+          url.protocol = 'https';
+          // remove port
+          url.port = '';
+          url.hostname = hostname;
+        }
+
+        this.openerService.open(url.toString());
+        break;
+      }
+      case 'file':
+        this.workbenchEditorService.open(URI.parse(revivedUri.toString()), { preview: false, focus: true });
+        break;
+      default:
+        console.warn(`Unsupported ${type}.`);
+        break;
+    }
+  }
+}

--- a/packages/remote-opener/src/common/index.ts
+++ b/packages/remote-opener/src/common/index.ts
@@ -1,0 +1,26 @@
+export const RemoteOpenerServicePath = 'RemoteOpenerService';
+
+export interface IExternalFileArgs {
+  type: 'file';
+  clientId: string;
+  file: string;
+}
+
+export interface IExternalUrlArgs {
+  type: 'url';
+  clientId: string;
+  url: string;
+}
+
+export const RemoteOpenerServiceToken = Symbol('RemoteOpenerServiceToken');
+
+export interface IRemoteOpenerService {
+  openExternal(args: IExternalFileArgs | IExternalUrlArgs): Promise<void>;
+}
+
+export const RemoteOpenerClientToken = Symbol('RemoteOpenerClientToken');
+
+export interface IRemoteOpenerClient {
+  setRemoteOpenerServiceInstance(clientId: string, service: IRemoteOpenerService): void;
+  openExternal(args: IExternalFileArgs | IExternalUrlArgs, clientId: string): Promise<void>;
+}

--- a/packages/remote-opener/src/node/index.ts
+++ b/packages/remote-opener/src/node/index.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@opensumi/di';
+import { BackService, NodeModule } from '@opensumi/ide-core-node';
+
+import { RemoteOpenerClientToken, RemoteOpenerServicePath, RemoteOpenerServiceToken } from '../common';
+import { RemoteOpenerClientImpl } from './opener.client';
+import { RemoteOpenerServiceImpl } from './opener.service';
+
+export * from './opener.service';
+
+@Injectable()
+export class OpenerModule extends NodeModule {
+  providers = [
+    {
+      token: RemoteOpenerServiceToken,
+      useClass: RemoteOpenerServiceImpl,
+    },
+    {
+      token: RemoteOpenerClientToken,
+      useClass: RemoteOpenerClientImpl,
+    },
+  ];
+  backServices: BackService[] = [
+    {
+      servicePath: RemoteOpenerServicePath,
+      token: RemoteOpenerServiceToken,
+    },
+  ];
+}

--- a/packages/remote-opener/src/node/opener.client.ts
+++ b/packages/remote-opener/src/node/opener.client.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@opensumi/di';
+
+import { IExternalFileArgs, IExternalUrlArgs, IRemoteOpenerClient, IRemoteOpenerService } from '../common';
+
+@Injectable()
+export class RemoteOpenerClientImpl implements IRemoteOpenerClient {
+  private remoteOpenerServices: Map<string, IRemoteOpenerService> = new Map();
+
+  setRemoteOpenerServiceInstance(clientId: string, service: IRemoteOpenerService): void {
+    if (this.remoteOpenerServices.has(clientId)) {
+      throw new Error(`Remote opener service instance for client ${clientId} already set.`);
+    }
+    this.remoteOpenerServices.set(clientId, service);
+  }
+
+  async openExternal(args: IExternalFileArgs | IExternalUrlArgs, clientId: string): Promise<void> {
+    const service = this.remoteOpenerServices.get(clientId);
+    if (!service) {
+      throw new Error(`Remote opener service instance for client ${clientId} not set.`);
+    }
+
+    service.openExternal(args);
+  }
+}

--- a/packages/remote-opener/src/node/opener.service.ts
+++ b/packages/remote-opener/src/node/opener.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { Uri } from '@opensumi/ide-core-common/lib/uri';
+import { RPCService } from '@opensumi/ide-connection';
+
+import {
+  IExternalFileArgs,
+  IExternalUrlArgs,
+  IRemoteOpenerClient,
+  IRemoteOpenerService,
+  RemoteOpenerClientToken,
+} from '../common';
+
+@Injectable()
+export class RemoteOpenerServiceImpl extends RPCService implements IRemoteOpenerService {
+  private clientId: string | undefined;
+
+  @Autowired(RemoteOpenerClientToken)
+  private readonly remoteOpenerClient: IRemoteOpenerClient;
+
+  setConnectionClientId(clientId: string): void {
+    this.clientId = clientId;
+    this.remoteOpenerClient.setRemoteOpenerServiceInstance(clientId, this);
+  }
+
+  async openExternal(args: IExternalFileArgs | IExternalUrlArgs): Promise<void> {
+    if (args.clientId !== this.clientId) {
+      throw new Error(`Unknown client id ${args.clientId}`);
+    }
+
+    try {
+      await this.client.$openExternal(args.type, args.type === 'file' ? Uri.file(args.file) : Uri.parse(args.url));
+    } catch (err) {
+      console.log(`Error opening external error: ${err.message || err}`);
+    }
+  }
+}

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -7,6 +7,7 @@ import '@opensumi/ide-core-browser/lib/style/index.less';
 import { ExpressFileServerModule } from '@opensumi/ide-express-file-server/lib/browser';
 import { SlotLocation } from '@opensumi/ide-core-browser';
 import { defaultConfig } from '@opensumi/ide-main-layout/lib/browser/default-config';
+import { RemoteOpenerModule } from '@opensumi/ide-remote-opener/lib/browser';
 
 import { renderApp } from './render-app';
 import { CommonBrowserModules } from '../../src/browser/common-modules';
@@ -15,7 +16,7 @@ import { SampleModule } from '../sample-modules';
 import '../styles.less';
 
 renderApp({
-  modules: [...CommonBrowserModules, ExpressFileServerModule, SampleModule],
+  modules: [...CommonBrowserModules, ExpressFileServerModule, SampleModule, RemoteOpenerModule],
   layoutConfig: {
     ...defaultConfig,
     ...{

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -3,7 +3,9 @@ console.time('Render');
 import { Injector } from '@opensumi/di';
 import { ClientApp, IClientAppOpts } from '@opensumi/ide-core-browser';
 import { ToolbarActionBasedLayout } from '@opensumi/ide-core-browser/lib/components';
+import { generate } from 'shortid';
 
+const CLIENT_ID = 'W_' + generate();
 export async function renderApp(opts: IClientAppOpts) {
   const injector = new Injector();
   opts.workspaceDir = opts.workspaceDir || process.env.WORKSPACE_DIR;
@@ -19,7 +21,7 @@ export async function renderApp(opts: IClientAppOpts) {
   opts.editorBackgroundImage =
     'https://img.alicdn.com/imgextra/i2/O1CN01NR0L1l1M3AUVVdKhq_!!6000000001378-2-tps-152-150.png';
   opts.layoutComponent = ToolbarActionBasedLayout;
-
+  opts.clientId = CLIENT_ID;
   opts.didRendered = () => {
     // tslint:disable no-console
     console.timeEnd('Render');

--- a/packages/startup/entry/web/server.ts
+++ b/packages/startup/entry/web/server.ts
@@ -1,7 +1,8 @@
 import { startServer } from '@opensumi/ide-dev-tool/src/server';
 import { ExpressFileServerModule } from '@opensumi/ide-express-file-server';
+import { OpenerModule } from '@opensumi/ide-remote-opener/lib/node';
 import { CommonNodeModules } from '../../src/node/common-modules';
 
 startServer({
-  modules: [...CommonNodeModules, ExpressFileServerModule],
+  modules: [...CommonNodeModules, ExpressFileServerModule, OpenerModule],
 });

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -81,7 +81,8 @@
     "@opensumi/ide-outline": "2.13.9",
     "@opensumi/ide-comments": "2.13.9",
     "@opensumi/ide-task": "2.13.9",
-    "@opensumi/ide-testing": "2.13.9"
+    "@opensumi/ide-testing": "2.13.9",
+    "@opensumi/ide-remote-opener": "2.13.9"
   },
   "devDependencies": {
     "@opensumi/ide-dev-tool": "^1.3.1",

--- a/tools/dev-tool/package.json
+++ b/tools/dev-tool/package.json
@@ -9,6 +9,7 @@
   "private": true,
   "dependencies": {
     "@types/koa": "^2.0.48",
+    "@types/koa-router": "^7.4.2",
     "@types/koa-bodyparser": "^4.2.2",
     "cache-loader": "^4.1.0",
     "copy-webpack-plugin": "^5.0.3",
@@ -19,6 +20,7 @@
     "html-webpack-plugin": "^3.2.0",
     "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",
+    "koa-router": "^10.1.1",
     "less": "^3.9.0",
     "less-loader": "^6.0.0",
     "mini-css-extract-plugin": "^0.6.0",
@@ -35,9 +37,9 @@
     "ts-node": "8.0.2",
     "tsconfig-paths": "^3.8.0",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
+    "typescript": "^4.4.2",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.1",
-    "typescript": "^4.4.2",
     "webpack-merge": "^4.2.2"
   }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![remote-cli](https://user-images.githubusercontent.com/17701805/148768453-341d5c8f-fb48-459a-9407-24c0ac558ab8.gif)

close #266 

### 集成&使用

1. 自行构建 `packages/remote-cli`, 将其内置在 CloudIDE 运行环境，若需要支持类似自动打开的能力，需要注入 `BROWSER` 环境变量，指向 cli 路径
2. 参考 `packages/startup/entry/web/render-app.tsx` 中的实现，自定义 `CLIENT_ID` 并注入到终端环境变量
3. 注册 RemoteOpenerConverterContribution，提供默认的 `converter`
4. server 端实现一个 /open 接口，逻辑参考 tools/dev-tool/src/server.ts

### Changelog
- Add remote opener 