### PR TITLE
feat: 🚀🚀🚀 add message batcher for pty

### DIFF
--- a/packages/terminal-next/src/node/terminal.service.ts
+++ b/packages/terminal-next/src/node/terminal.service.ts
@@ -1,9 +1,15 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import { PtyService, IPtyService } from './pty';
-import { IPty, TerminalOptions } from '../common/pty';
+import { IPty } from '../common/pty';
 import { IShellLaunchConfig } from '../common/pty';
 import { ITerminalNodeService, ITerminalServiceClient } from '../common';
 import { INodeLogger, AppConfig, isDevelopment } from '@opensumi/ide-core-node';
+
+// ref: https://github.com/vercel/hyper/blob/4c90d7555c79fb6dc438fa9549f1d0ef7c7a5aa7/app/session.ts#L27-L32
+// 批处理字符最大长度
+const BATCH_MAX_SIZE = 200 * 1024;
+// 批处理延时
+const BATCH_DURATION_MS = 16;
 
 /**
  * terminal service 的具体实现
@@ -27,6 +33,9 @@ export class TerminalServiceImpl implements ITerminalNodeService {
 
   @Autowired(AppConfig)
   private appConfig: AppConfig;
+
+  private batchedPtyDataMap: Map<string, string> = new Map();
+  private batchedPtyDataTimer: Map<string, NodeJS.Timeout> = new Map();
 
   public setClient(clientId: string, client: ITerminalServiceClient) {
     this.serviceClientMap.set(clientId, client);
@@ -67,6 +76,15 @@ export class TerminalServiceImpl implements ITerminalNodeService {
     }
   }
 
+  private flushPtyData(clientId: string, sessionId: string) {
+    const ptyData = this.batchedPtyDataMap.get(sessionId);
+    this.batchedPtyDataMap.delete(sessionId);
+    this.batchedPtyDataTimer.delete(sessionId);
+
+    const serviceClient = this.serviceClientMap.get(clientId) as ITerminalServiceClient;
+    serviceClient.clientMessage(sessionId, ptyData);
+  }
+
   public async create2(id: string, options: IShellLaunchConfig) {
     const clientId = id.split('|')[0];
     let terminal: IPty | undefined;
@@ -75,10 +93,36 @@ export class TerminalServiceImpl implements ITerminalNodeService {
       terminal = (await this.ptyService.create2(options)) as IPty;
       this.terminalMap.set(id, terminal);
 
-      terminal.onData((data) => {
+      // ref: https://hyper.is/blog
+      // 合并 pty 输出的数据，16ms 后发送给客户端，如
+      // 果在 16ms 内没有收到新的数据，或短时间内数据
+      // 超过 BATCH_MAX_SIZE 限定的长度，则立即发送缓
+      // 存的数据，避免因为输出较多时阻塞 RPC 通信
+      terminal.onData((chunk: string) => {
         if (this.serviceClientMap.has(clientId)) {
-          const serviceClient = this.serviceClientMap.get(clientId) as ITerminalServiceClient;
-          serviceClient.clientMessage(id, data);
+          if (!this.batchedPtyDataMap.has(id)) {
+            this.batchedPtyDataMap.set(id, '');
+          }
+
+          this.batchedPtyDataMap.set(id, this.batchedPtyDataMap.get(id) + chunk);
+
+          const ptyData = this.batchedPtyDataMap.get(id) || '';
+
+          if (ptyData?.length + chunk.length >= BATCH_MAX_SIZE) {
+            if (this.batchedPtyDataTimer.has(id)) {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              global.clearTimeout(this.batchedPtyDataTimer.get(id)!);
+              this.batchedPtyDataTimer.delete(id);
+            }
+            this.flushPtyData(clientId, id);
+          }
+
+          if (!this.batchedPtyDataTimer.has(id)) {
+            this.batchedPtyDataTimer.set(
+              id,
+              global.setTimeout(() => this.flushPtyData(clientId, id), BATCH_DURATION_MS),
+            );
+          }
         } else {
           this.logger.warn(`terminal: pty ${clientId} on data not found`);
         }
@@ -100,7 +144,7 @@ export class TerminalServiceImpl implements ITerminalNodeService {
       if (!this.clientTerminalMap.has(clientId)) {
         this.clientTerminalMap.set(clientId, new Map());
       }
-      this.clientTerminalMap.get(clientId)!.set(id, terminal);
+      this.clientTerminalMap.get(clientId)?.set(id, terminal);
     } catch (error) {
       this.logger.error(`${id} create terminal error: ${error}, options: ${JSON.stringify(options)}`);
       if (this.serviceClientMap.has(clientId)) {


### PR DESCRIPTION
### Types

- [x] 🚀 Performance Improvements

### Background or solution

参考自 [hyper 3](https://hyper.is/blog) 的一篇博客，原理是批处理终端 pty 的输出，将 16ms 内的输出内容合并到一起批量发送到前端，避免在终端执行输出很多的命令时阻塞 RPC 通信

before

在终端执行 `find ~` 命令后，文件树打开等操作明显变慢，同时按快捷键 `ctrl+c` 也无法终止命令，原因是 terminal 消息挤占了 RPC 通信

![terminal-before](https://user-images.githubusercontent.com/17701805/148632970-d39bd251-7387-4a00-aa69-c6c96d299d47.gif)

after

优化后同样在执行 `find ~` 命令时，文件打开等操作不受影响，且终端 `ctrl+c` 交互正常 

![terminal-after](https://user-images.githubusercontent.com/17701805/148633037-9b878aaf-735d-4ea1-ae24-6e37f753adc1.gif)



### Changelog
- 提升终端性能