### PR TITLE
fix: (wip) optimize file-tree perf

### DIFF
--- a/packages/components/src/recycle-tree/RecycleTree.tsx
+++ b/packages/components/src/recycle-tree/RecycleTree.tsx
@@ -281,7 +281,7 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
 
   // 批量更新Tree节点
   private batchUpdate = (() => {
-    let timer: number;
+    let lastFrame: number | null;
     const commitUpdate = () => {
       // 已经在 componentWillUnMount 中 disposed 了
       if (this.disposables.disposed) {
@@ -339,9 +339,13 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
           this.onDidUpdateEmitter.fire();
         });
       }
+
       // 更新批量更新返回的promise对象
-      clearTimeout(timer);
-      timer = setTimeout(commitUpdate, RecycleTree.BATCHED_UPDATE_MAX_DEBOUNCE_MS) as any;
+      if (lastFrame) {
+        window.cancelAnimationFrame(lastFrame);
+      }
+
+      lastFrame = requestAnimationFrame(commitUpdate);
       return this.batchUpdatePromise;
     };
   })();

--- a/packages/file-tree-next/src/browser/file-tree-model.ts
+++ b/packages/file-tree-next/src/browser/file-tree-model.ts
@@ -12,7 +12,7 @@ export interface IFileTreeMetaData extends IOptionalMetaData {
 
 @Injectable({ multiple: true })
 export class FileTreeModel extends TreeModel {
-  static DEFAULT_FLUSH_DELAY = 100;
+  static DEFAULT_FLUSH_DELAY = 16;
 
   @Autowired(FileTreeDecorationService)
   public readonly decorationService: FileTreeDecorationService;

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -450,7 +450,7 @@ export class FileTreeModelService {
       this.onDidSelectedFileChangeEmitter.fire([target.uri]);
       // 通知视图更新
       if (dispatchChange) {
-        this.treeModel.dispatchChange();
+        this.treeModel.doDispatchChange();
       }
     }
   };
@@ -481,7 +481,7 @@ export class FileTreeModelService {
       this.onDidSelectedFileChangeEmitter.fire([target.uri]);
       // 通知视图更新
       if (dispatchChange) {
-        this.treeModel.dispatchChange();
+        this.treeModel.doDispatchChange();
       }
     }
   };
@@ -497,7 +497,7 @@ export class FileTreeModelService {
     }
     this.contextMenuDecoration.addTarget(target);
     this._contextMenuFile = target;
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
   };
 
   // 清空其他焦点态节点，更新当前焦点节点，
@@ -532,7 +532,7 @@ export class FileTreeModelService {
       }
     }
     // 通知视图更新
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
   };
 
   // 判断节点是否选中，进行状态反转
@@ -555,7 +555,7 @@ export class FileTreeModelService {
       this.focusedDecoration.addTarget(target);
     }
     // 通知视图更新
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
   };
 
   // 选中范围内的所有节点
@@ -572,7 +572,7 @@ export class FileTreeModelService {
     // 选中状态变化
     this.onDidSelectedFileChangeEmitter.fire(this._selectedFiles.map((file) => file.uri));
     // 通知视图更新
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
   };
 
   // 取消选中节点焦点
@@ -935,7 +935,7 @@ export class FileTreeModelService {
       this.loadingDecoration.addTarget(effectNode!);
     }
     // 通知视图更新
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
     // 移除文件
     for (const uri of uris) {
       if (!!preUri! && preUri!.isEqualOrParent(uri)) {
@@ -1140,7 +1140,7 @@ export class FileTreeModelService {
             uri: to.toString(),
           });
           target.updateToolTip(this.fileTreeAPI.getReadableTooltip(to));
-          this.treeModel.dispatchChange();
+          this.treeModel.doDispatchChange();
           if ((target.parent as Directory).children?.find((child) => target.path.indexOf(child.path) >= 0)) {
             // 当重命名后的压缩节点在父节点中存在子集节点时，刷新父节点
             // 如：
@@ -1462,7 +1462,7 @@ export class FileTreeModelService {
       this.contextKey?.explorerResourceCut.set(false);
     }
     // 通知视图更新
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
     const files: (File | Directory)[] = [];
     for (const uri of from) {
       const file = this.fileTreeService.getNodeByPathOrUri(uri);
@@ -1511,7 +1511,7 @@ export class FileTreeModelService {
       }
       this.contextKey?.explorerResourceCut.set(false);
       // 更新视图
-      this.treeModel.dispatchChange();
+      this.treeModel.doDispatchChange();
       this._pasteStore = {
         files: [],
         type: PasteTypes.NONE,
@@ -1569,7 +1569,7 @@ export class FileTreeModelService {
       }
     }
     // 通知视图更新
-    this.treeModel.dispatchChange();
+    this.treeModel.doDispatchChange();
   };
 
   public location = async (pathOrUri: URI | string) => {


### PR DESCRIPTION
### Types

- [x] 🚀 Performance Improvements

### Background or solution

fileTreeModelService 本身对 model 的更新做了 debounce，而 RecycleTree 内部也做了延时处理(100ms)，导致同样的更新频率下，文件树交互看起来卡卡的

![100ms-delay-tree](https://user-images.githubusercontent.com/17701805/148715161-90b000a1-63ac-4959-bdcb-7f2bf146375b.gif)

将外部的 debounce 延时修改为 16，取消 RecycleTree 内部的延时处理，对于文件树来说，目前的效果是

![16ms-delay-tree](https://user-images.githubusercontent.com/17701805/148715221-e59b1ac7-f50e-4a73-8d0b-075a43cc3834.gif)

### Changelog

- 优化文件树更新机制
