### PR TITLE
chore: remove useless asar code from download extension scripts

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -133,13 +133,6 @@ function unzipFile (dist, targetDirName, tmpZipFile) {
           return;
         }
 
-        let originalFileName;
-        // 在Electron中，如果解包的文件中存在.asar文件，会由于Electron本身的bug导致无法对.asar创建writeStream
-        // 此处先把.asar文件写到另外一个目标文件中，完成后再进行重命名
-        if (fileName.endsWith('.asar') && this.options.isElectronEnv) {
-          originalFileName = fileName;
-          fileName += '_prevent_bug';
-        }
         const readStream = openZipStream(zipFile, entry);
         const mode = modeFromEntry(entry);
         readStream.then((stream) => {
@@ -153,10 +146,6 @@ function unzipFile (dist, targetDirName, tmpZipFile) {
           fs.mkdirp(targetDirName).then(() => {
             const writerStream = fs.createWriteStream(targetFileName, { mode });
             writerStream.on('close', () => {
-              if (originalFileName) {
-                // rename .asar, if filename has been modified
-                fs.renameSync(targetFileName, path.join(extensionDir, originalFileName));
-              }
               zipFile.readEntry();
             });
             stream.on('error', (err) => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🧹 Chores

### Background or solution
下载插件的脚本中，关于 asar 和 electron 的判断现在看起来没有必要。因为这个是执行在 Node.js 环境中的。

### Changelog
- 清理下载插件脚本中无用的代码