### PR TITLE
fix: quickopen hide don't exec dispose

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -316,7 +316,6 @@ class QuickPickExt<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
 
   hide(): void {
     this.quickOpen.hideQuickPick();
-    this.dispose();
   }
 
   show(): void {
@@ -437,7 +436,6 @@ class QuickInputExt implements vscode.InputBox {
   }
   hide(): void {
     this.quickOpen.hideInputBox();
-    this.dispose();
   }
 
   dispose(): void {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

demo:

```js
const vscode = require('vscode')

exports.activate = () => {
  const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
  const quickPick = vscode.window.createQuickPick();


  quickPick.items = [
    {
      label: 'Create Project',
      command: 'test.createProject'
    },
    {
      label: 'Run dev node',
      command: 'test.runDevNode'
    },
    {
      label: 'hide',
      command: 'test.hide'
    },
  ]

  vscode.commands.registerCommand('test.createProject', () => {
    vscode.window.showInformationMessage('createProject');
  });

  vscode.commands.registerCommand('test.runDevNode', () => {
    vscode.window.showInformationMessage('runDevNode');
  });

  vscode.commands.registerCommand('test.hide', () => {
    quickPick.hide();
  });

  vscode.commands.registerCommand('test.openQuickPick', () => {
    quickPick.show();
  });

  quickPick.onDidChangeSelection((items) => {
    vscode.commands.executeCommand(items[0].command, items[0].arg).catch(console.error);
  });

  statusBar.text = 'test';
  statusBar.command = 'test.openQuickPick';
  statusBar.show();
}
```

If it disposed, we can't execute selection event after

### Changelog
QuickOpen hide do not dispose