### PR TITLE
feat: support go to test

### DIFF
--- a/packages/testing/src/browser/test-tree-view.model.ts
+++ b/packages/testing/src/browser/test-tree-view.model.ts
@@ -1,5 +1,5 @@
 import { ITestTreeData } from './../common/tree-view.model';
-import { applyTestItemUpdate, ITestItemUpdate } from './../common/testCollection';
+import { applyTestItemUpdate, IncrementalTestCollectionItem, ITestItemUpdate } from './../common/testCollection';
 import { Autowired, Injectable } from '@opensumi/di';
 import { Emitter } from '@opensumi/ide-components/lib/utils';
 import { Disposable, isDefined, filter, map } from '@opensumi/ide-core-browser';
@@ -45,7 +45,7 @@ export class TestTreeViewModelImpl extends Disposable implements ITestTreeViewMo
   @Autowired(TestServiceToken)
   private readonly testService: ITestService;
 
-  protected readonly items = new Map<string, TestTreeItem>();
+  private readonly items = new Map<string, TestTreeItem>();
 
   private readonly updateEmitter = new Emitter<void>();
   readonly onUpdate = this.updateEmitter.event;
@@ -62,7 +62,7 @@ export class TestTreeViewModelImpl extends Disposable implements ITestTreeViewMo
     return filter(rootsIt, isDefined);
   }
 
-  protected getRevealDepth(element: TestTreeItem): number | undefined {
+  private getRevealDepth(element: TestTreeItem): number | undefined {
     return element.depth === 0 ? 0 : undefined;
   }
 
@@ -132,6 +132,10 @@ export class TestTreeViewModelImpl extends Disposable implements ITestTreeViewMo
         }),
       );
     }
+  }
+
+  public getTestItem(extId: string): IncrementalTestCollectionItem | undefined {
+    return this.testService.collection.getNodeById(extId);
   }
 
   public expandElement(element: ITestTreeItem, depth: number): Promise<void> {

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -1,23 +1,37 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import {
   ClientAppContribution,
+  CommandContribution,
+  CommandRegistry,
+  CommandService,
   ComponentContribution,
   ComponentRegistry,
   Domain,
+  EDITOR_COMMANDS,
+  FileType,
   getIcon,
   localize,
   SlotLocation,
+  URI,
 } from '@opensumi/ide-core-browser';
+import { GoToTestCommand } from '../common/commands';
 
 import { TestingContainerId, TestingViewId } from '../common/testing-view';
 import { ITestTreeViewModel, TestTreeViewModelToken } from '../common/tree-view.model';
 import { TestingView } from './components/testing.view';
+import { IFileServiceClient } from '@opensumi/ide-file-service';
 
 @Injectable()
-@Domain(ClientAppContribution, ComponentContribution)
-export class TestingContribution implements ClientAppContribution, ComponentContribution {
+@Domain(ClientAppContribution, ComponentContribution, CommandContribution)
+export class TestingContribution implements ClientAppContribution, ComponentContribution, CommandContribution {
   @Autowired(TestTreeViewModelToken)
   private readonly testTreeViewModel: ITestTreeViewModel;
+
+  @Autowired(IFileServiceClient)
+  protected readonly filesystem: IFileServiceClient;
+
+  @Autowired(CommandService)
+  private readonly commandService: CommandService;
 
   initialize(): void {
     this.testTreeViewModel.initTreeModel();
@@ -37,5 +51,41 @@ export class TestingContribution implements ClientAppContribution, ComponentCont
       },
       SlotLocation.left,
     );
+  }
+
+  registerCommands(commands: CommandRegistry): void {
+    commands.registerCommand(GoToTestCommand, {
+      execute: async (extId: string) => {
+        const test = this.testTreeViewModel.getTestItem(extId);
+        if (!test) {
+          return;
+        }
+
+        const { range, uri } = test.item;
+        if (!uri) {
+          return;
+        }
+
+        const fileStat = await this.filesystem.getFileStat(uri.toString());
+
+        if (!fileStat) {
+          return;
+        }
+
+        if (fileStat.type === FileType.Directory) {
+          // ** filetree 未实现文件夹的 focus , 只能是将窗口切到资源管理器但无法选中文件夹 **
+          this.commandService.executeCommand('revealInExplorer', uri);
+          return;
+        }
+
+        if (fileStat.type === FileType.File) {
+          this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, URI.parse(uri.toString()), {
+            range,
+            focus: true,
+          });
+        }
+      },
+      isVisible: () => false,
+    });
   }
 }

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -1,7 +1,13 @@
-import { Command, getIcon } from '@opensumi/ide-core-browser';
+import { Command, getExternalIcon, getIcon } from '@opensumi/ide-core-browser';
 
 export const RuntTestCommand: Command = {
-  id: 'testing-run-test',
+  id: 'testing.run.test',
   label: 'Run Test',
   iconClass: getIcon('start'),
+};
+
+export const GoToTestCommand: Command = {
+  id: 'testing.goto.test',
+  label: 'Go To Test',
+  iconClass: getExternalIcon('go-to-file'),
 };

--- a/packages/testing/src/common/testing-view.ts
+++ b/packages/testing/src/common/testing-view.ts
@@ -1,3 +1,21 @@
+import { IBasicInlineMenu, IBasicInlineMenuPosition } from '@opensumi/ide-components';
+import { GoToTestCommand, RuntTestCommand } from './commands';
+
 export const TestingViewId = '@opensumi/ide-testing';
 
 export const TestingContainerId = 'testing';
+
+export const TestingExplorerInlineMenus: IBasicInlineMenu[] = [
+  {
+    icon: 'start',
+    title: 'Run Test',
+    command: RuntTestCommand.id,
+    position: IBasicInlineMenuPosition.TREE_CONTAINER,
+  },
+  {
+    icon: 'openfile',
+    title: 'Go To Test',
+    command: GoToTestCommand.id,
+    position: IBasicInlineMenuPosition.TREE_CONTAINER,
+  },
+];

--- a/packages/testing/src/common/tree-view.model.ts
+++ b/packages/testing/src/common/tree-view.model.ts
@@ -1,7 +1,7 @@
 import { IBasicTreeData, IRecycleTreeHandle } from '@opensumi/ide-components';
 import { Event } from '@opensumi/ide-core-browser';
 
-import { InternalTestItem, TestResultState } from './testCollection';
+import { InternalTestItem, TestResultState, IncrementalTestCollectionItem } from './testCollection';
 
 export const TestTreeViewModelToken = Symbol('TestTreeViewModel');
 
@@ -14,6 +14,8 @@ export interface ITestTreeViewModel {
   expandElement(element: ITestTreeItem, depth: number): void;
 
   setTreeHandlerApi(handle: IRecycleTreeHandle): void;
+
+  getTestItem(extId: string): IncrementalTestCollectionItem | undefined;
 }
 
 export interface ITestTreeItem {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

- [x] 支持类名和类方法的文件打开
- [ ] 对于测试类路径的文件夹定位暂不支持，只能将窗口切到文件树

![Kapture 2022-01-13 at 15 39 25](https://user-images.githubusercontent.com/20262815/149286466-986e632f-fc4f-4bf3-a2a2-2e0c46c4b9b1.gif)


### Changelog
测试资源管理器支持 Go To Test
