### PR TITLE
feat: support testing result refresh

### DIFF
--- a/packages/core-browser/src/contextkey/testing.ts
+++ b/packages/core-browser/src/contextkey/testing.ts
@@ -2,3 +2,5 @@ import { RawContextKey } from '../raw-context-key';
 
 export const TestingServiceProviderCount = new RawContextKey('service.testing.providerCount', 0);
 export const TestingServiceHasDebuggableContextKey = new RawContextKey('service.testing.hasDebuggableContext', false);
+export const TestingHasAnyResults = new RawContextKey('testing.hasAnyResults', false);
+export const TestingIsRunning = new RawContextKey('testing.isRunning', false);

--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -23,7 +23,7 @@ export const debugPreferencesSchema: PreferenceSchema = {
     },
     'debug.openDebug': {
       enum: ['neverOpen', 'openOnSessionStart', 'openOnFirstSessionStart', 'openOnDebugBreak'],
-      default: 'openOnSessionStart',
+      default: 'openOnDebugBreak',
       description: localize('preference.debug.openDebug'),
     },
     'debug.internalConsoleOptions': {

--- a/packages/extension/src/browser/vscode/api/main.thread.tests.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tests.ts
@@ -143,7 +143,6 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
     state: TestResultState,
     duration?: number,
   ): void {
-    console.log('$updateTestStateInRun', runId, taskId, testId, state, duration);
     this.withTestResult(runId, (r) => r.updateState(testId, taskId, state, duration));
   }
 
@@ -165,12 +164,10 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
   }
 
   $startedTestRunTask(runId: string, task: ITestRunTask): void {
-    console.log('$startedTestRunTask', runId, task);
     this.withTestResult(runId, (r) => r.addTask(task));
   }
 
   $finishedTestRunTask(runId: string, taskId: string): void {
-    console.log('$finishedTestRunTask', runId, taskId);
     this.withTestResult(runId, (r) => r.markTaskComplete(taskId));
   }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.tests.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tests.ts
@@ -151,8 +151,13 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
     console.log('$appendTestMessagesInRun', runId, taskId, testId, messages);
   }
 
-  $appendOutputToRun(runId: string, taskId: string, output: string, location?: ILocationDto, testId?: string): void {
-    console.log('$appendOutputToRun', runId, taskId, output, location);
+  $appendOutputToRun(runId: string, taskId: string, output: string, locationDto?: ILocationDto, testId?: string): void {
+    console.log('$appendOutputToRun', runId, taskId, output, locationDto);
+    const location = locationDto && {
+      uri: URI.revive(locationDto.uri),
+      range: Range.lift(locationDto.range),
+    };
+    this.withTestResult(runId, (r) => r.appendOutput(output, taskId, location, testId));
   }
 
   $signalCoverageAvailable(runId: string, taskId: string): void {
@@ -161,10 +166,12 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
 
   $startedTestRunTask(runId: string, task: ITestRunTask): void {
     console.log('$startedTestRunTask', runId, task);
+    this.withTestResult(runId, (r) => r.addTask(task));
   }
 
   $finishedTestRunTask(runId: string, taskId: string): void {
     console.log('$finishedTestRunTask', runId, taskId);
+    this.withTestResult(runId, (r) => r.markTaskComplete(taskId));
   }
 
   $startedExtensionTestRun(req: ExtensionRunTestsRequest): void {

--- a/packages/testing/src/browser/components/testing.explorer.tree.tsx
+++ b/packages/testing/src/browser/components/testing.explorer.tree.tsx
@@ -4,7 +4,7 @@ import { CommandService, Event, map, useInjectable } from '@opensumi/ide-core-br
 import { BasicRecycleTree, IRecycleTreeHandle } from '@opensumi/ide-components/lib/recycle-tree';
 
 import { ITestTreeData, ITestTreeItem, ITestTreeViewModel, TestTreeViewModelToken } from '../../common/tree-view.model';
-import { TestItemExpandState, TestRunProfileBitset } from '../../common/testCollection';
+import { TestItemExpandState, TestResultState, TestRunProfileBitset } from '../../common/testCollection';
 import { GoToTestCommand, RuntTestCommand } from '../../common/commands';
 import { ITestService, TestServiceToken } from '../../common';
 import { testingStatesToIcons } from '../icons';
@@ -13,6 +13,15 @@ import { TestingExplorerInlineMenus } from '../../common/testing-view';
 
 import styles from './testing.module.less';
 
+const testStatesToIconColors: { [K in TestResultState]?: string } = {
+  [TestResultState.Errored]: styles.testing_iconFailed,
+  [TestResultState.Failed]: styles.testing_iconErrored,
+  [TestResultState.Passed]: styles.testing_iconPassed,
+  [TestResultState.Queued]: styles.testing_runAction,
+  [TestResultState.Unset]: styles.testing_iconQueued,
+  [TestResultState.Skipped]: styles.testing_iconUnset,
+};
+
 export const TestingExplorerTree: React.FC<{}> = observer(() => {
   const testViewModel = useInjectable<ITestTreeViewModel>(TestTreeViewModelToken);
   const testService = useInjectable<ITestService>(TestServiceToken);
@@ -20,12 +29,14 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
 
   const [treeData, setTreeData] = useState<ITestTreeData[]>([]);
 
-  const getItemIcon = React.useCallback((item: ITestTreeItem) => testingStatesToIcons.get(item.state) || '', []);
+  const getItemIcon = React.useCallback((item: ITestTreeItem) => `${testingStatesToIcons.get(item.state)} ${testStatesToIconColors[item.state]}` || '', []);
 
   const asTreeData = React.useCallback(
     (item: ITestTreeItem): ITestTreeData => ({
       label: item.label,
-      icon: getItemIcon(item),
+      get icon() {
+        return getItemIcon(item);
+      },
       notExpandable: item.test.expand === TestItemExpandState.NotExpandable,
       rawItem: item,
       get children() {

--- a/packages/testing/src/browser/components/testing.module.less
+++ b/packages/testing/src/browser/components/testing.module.less
@@ -6,4 +6,24 @@
       padding-left: 5px;
     }
   }
+
+  .testing_iconFailed {
+    color: #f14c4c;
+  }
+
+  .testing_iconErrored {
+    color: #f14c4c;
+  }
+  .testing_iconPassed {
+    color: #73c991;
+  }
+  .testing_runAction {
+    color: #73c991;
+  }
+  .testing_iconQueued {
+    color: #cca700;
+  }
+  .testing_iconUnset {
+    color: #848484;
+  }
 }

--- a/packages/testing/src/browser/test.result.service.ts
+++ b/packages/testing/src/browser/test.result.service.ts
@@ -10,7 +10,13 @@ import {
   TestResultItemChange,
   TestResultItemChangeReason,
 } from '../common/test-result';
-import { ResolvedTestRunRequest, ExtensionRunTestsRequest, ITestRunProfile } from '../common/testCollection';
+import {
+  ResolvedTestRunRequest,
+  ExtensionRunTestsRequest,
+  ITestRunProfile,
+  TestResultItem,
+  TestResultState,
+} from '../common/testCollection';
 
 export type ResultChangeEvent =
   | { completed: ITestResult }
@@ -64,7 +70,7 @@ export class TestResultServiceImpl implements ITestResultService {
     this.isRunning.set(isRunningTests(this));
   }
 
-  createTestResult(req: ResolvedTestRunRequest | ExtensionRunTestsRequest): ITestResult {
+  public createTestResult(req: ResolvedTestRunRequest | ExtensionRunTestsRequest): ITestResult {
     if ('targets' in req) {
       const id = uuid();
       const testResult = new TestResultImpl(id, req);
@@ -98,11 +104,11 @@ export class TestResultServiceImpl implements ITestResultService {
     return result;
   }
 
-  getResult(resultId: string): ITestResult | undefined {
+  public getResult(resultId: string): ITestResult | undefined {
     return this.results.find((r) => r.id === resultId);
   }
 
-  addTestResult(result: ITestResult): ITestResult {
+  public addTestResult(result: ITestResult): ITestResult {
     if (result.completedAt === undefined) {
       this.results.unshift(result);
     } else {
@@ -135,5 +141,15 @@ export class TestResultServiceImpl implements ITestResultService {
     }
 
     return result;
+  }
+
+  public getStateById(extId: string): [results: ITestResult, item: TestResultItem] | undefined {
+    for (const result of this.results) {
+      const lookup = result.getStateById(extId);
+      if (lookup && lookup.computedState !== TestResultState.Unset) {
+        return [result, lookup];
+      }
+    }
+    return undefined;
   }
 }

--- a/packages/testing/src/browser/test.result.service.ts
+++ b/packages/testing/src/browser/test.result.service.ts
@@ -32,7 +32,7 @@ export class TestResultServiceImpl implements ITestResultService {
   private changeResultEmitter = new Emitter<ResultChangeEvent>();
   private testChangeEmitter = new Emitter<TestResultItemChange>();
 
-  private _results: ITestResult[];
+  private _results: ITestResult[] = [];
   private readonly hasAnyResults: IContextKey<boolean>;
   private readonly isRunning: IContextKey<boolean>;
 

--- a/packages/testing/src/browser/test.service.ts
+++ b/packages/testing/src/browser/test.service.ts
@@ -1,3 +1,4 @@
+import { ITestResult } from './../common/test-result';
 import { Injectable, Autowired } from '@opensumi/di';
 import { IContextKey, IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
 import { TestingServiceProviderCount } from '@opensumi/ide-core-browser/lib/contextkey/testing';
@@ -86,7 +87,7 @@ export class TestServiceImpl extends Disposable implements ITestService {
     return this.runResolvedTests(resolved, token);
   }
 
-  async runResolvedTests(req: ResolvedTestRunRequest, token?: CancellationToken): Promise<any> {
+  async runResolvedTests(req: ResolvedTestRunRequest, token?: CancellationToken): Promise<ITestResult> {
     if (!req.exclude) {
       // default exclude
       req.exclude = [];
@@ -113,6 +114,7 @@ export class TestServiceImpl extends Disposable implements ITestService {
           }),
       );
       await Promise.all(requests);
+      return result;
     } finally {
       result.markComplete();
     }

--- a/packages/testing/src/common/getComputedState.ts
+++ b/packages/testing/src/common/getComputedState.ts
@@ -1,0 +1,135 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Iterable } from '@opensumi/monaco-editor-core/esm/vs/base/common/iterator';
+import { TestResultState } from './testCollection';
+import { maxPriority, statePriority } from './testingStates';
+
+/**
+ * Accessor for nodes in get and refresh computed state.
+ */
+export interface IComputedStateAccessor<T> {
+  getOwnState(item: T): TestResultState | undefined;
+  getCurrentComputedState(item: T): TestResultState;
+  setComputedState(item: T, state: TestResultState): void;
+  getChildren(item: T): Iterable<T>;
+  getParents(item: T): Iterable<T>;
+}
+
+export interface IComputedStateAndDurationAccessor<T> extends IComputedStateAccessor<T> {
+  getOwnDuration(item: T): number | undefined;
+  getCurrentComputedDuration(item: T): number | undefined;
+  setComputedDuration(item: T, duration: number | undefined): void;
+}
+
+export const isDurationAccessor = <T>(
+  accessor: IComputedStateAccessor<T>,
+): accessor is IComputedStateAndDurationAccessor<T> => 'getOwnDuration' in accessor;
+
+/**
+ * Gets the computed state for the node.
+ * @param force whether to refresh the computed state for this node, even
+ * if it was previously set.
+ */
+
+export const getComputedState = <T>(accessor: IComputedStateAccessor<T>, node: T, force = false) => {
+  let computed = accessor.getCurrentComputedState(node);
+  if (computed === undefined || force) {
+    computed = accessor.getOwnState(node) ?? TestResultState.Unset;
+    for (const child of accessor.getChildren(node)) {
+      computed = maxPriority(computed, getComputedState(accessor, child));
+    }
+
+    accessor.setComputedState(node, computed);
+  }
+
+  return computed;
+};
+
+export const getComputedDuration = <T>(
+  accessor: IComputedStateAndDurationAccessor<T>,
+  node: T,
+  force = false,
+): number | undefined => {
+  let computed = accessor.getCurrentComputedDuration(node);
+  if (computed === undefined || force) {
+    const own = accessor.getOwnDuration(node);
+    if (own !== undefined) {
+      computed = own;
+    } else {
+      computed = undefined;
+      for (const child of accessor.getChildren(node)) {
+        const d = getComputedDuration(accessor, child);
+        if (d !== undefined) {
+          computed = (computed || 0) + d;
+        }
+      }
+    }
+
+    accessor.setComputedDuration(node, computed);
+  }
+
+  return computed;
+};
+
+/**
+ * Refreshes the computed state for the node and its parents. Any changes
+ * elements cause `addUpdated` to be called.
+ */
+export const refreshComputedState = <T>(
+  accessor: IComputedStateAccessor<T>,
+  node: T,
+  explicitNewComputedState?: TestResultState,
+) => {
+  const oldState = accessor.getCurrentComputedState(node);
+  const oldPriority = statePriority[oldState];
+  const newState = explicitNewComputedState ?? getComputedState(accessor, node, true);
+  const newPriority = statePriority[newState];
+  const toUpdate = new Set<T>();
+
+  if (newPriority !== oldPriority) {
+    accessor.setComputedState(node, newState);
+    toUpdate.add(node);
+
+    if (newPriority > oldPriority) {
+      // Update all parents to ensure they're at least this priority.
+      for (const parent of accessor.getParents(node)) {
+        const prev = accessor.getCurrentComputedState(parent);
+        if (prev !== undefined && statePriority[prev] >= newPriority) {
+          break;
+        }
+
+        accessor.setComputedState(parent, newState);
+        toUpdate.add(parent);
+      }
+    } else if (newPriority < oldPriority) {
+      // Re-render all parents of this node whose computed priority might have come from this node
+      for (const parent of accessor.getParents(node)) {
+        const prev = accessor.getCurrentComputedState(parent);
+        if (prev === undefined || statePriority[prev] > oldPriority) {
+          break;
+        }
+
+        accessor.setComputedState(parent, getComputedState(accessor, parent, true));
+        toUpdate.add(parent);
+      }
+    }
+  }
+
+  if (isDurationAccessor(accessor)) {
+    for (const parent of Iterable.concat(Iterable.single(node), accessor.getParents(node))) {
+      const oldDuration = accessor.getCurrentComputedDuration(parent);
+      const newDuration = getComputedDuration(accessor, parent, true);
+      if (oldDuration === newDuration) {
+        break;
+      }
+
+      accessor.setComputedDuration(parent, newDuration);
+      toUpdate.add(parent);
+    }
+  }
+
+  return toUpdate;
+};

--- a/packages/testing/src/common/test-result.ts
+++ b/packages/testing/src/common/test-result.ts
@@ -215,9 +215,9 @@ export class TestResultImpl implements ITestResult {
   }
 
   getStateById(testExtId: string): TestResultItem | undefined {
-    console.error('##TestResult## getStateById: >> ', testExtId);
-    throw new Error('Method not implemented.');
+    return this.testById.get(testExtId);
   }
+
   getOutput(): Promise<string> {
     console.error('##TestResult## getOutput: >> ');
     throw new Error('Method not implemented.');

--- a/packages/testing/src/common/testingStates.ts
+++ b/packages/testing/src/common/testingStates.ts
@@ -1,0 +1,61 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TestResultState } from './testCollection';
+
+export interface TreeStateNode { statusNode: true; state: TestResultState; priority: number }
+
+/**
+ * List of display priorities for different run states. When tests update,
+ * the highest-priority state from any of their children will be the state
+ * reflected in the parent node.
+ */
+export const statePriority: { [K in TestResultState]: number } = {
+  [TestResultState.Running]: 6,
+  [TestResultState.Errored]: 5,
+  [TestResultState.Failed]: 4,
+  [TestResultState.Queued]: 3,
+  [TestResultState.Passed]: 2,
+  [TestResultState.Unset]: 1,
+  [TestResultState.Skipped]: 0,
+};
+
+export const isFailedState = (s: TestResultState) => s === TestResultState.Errored || s === TestResultState.Failed;
+export const isStateWithResult = (s: TestResultState) =>
+  s === TestResultState.Errored || s === TestResultState.Failed || s === TestResultState.Passed;
+
+export const stateNodes = Object.entries(statePriority).reduce((acc, [stateStr, priority]) => {
+  const state = Number(stateStr) as TestResultState;
+  acc[state] = { statusNode: true, state, priority };
+  return acc;
+}, {} as { [K in TestResultState]: TreeStateNode });
+
+export const cmpPriority = (a: TestResultState, b: TestResultState) => statePriority[b] - statePriority[a];
+
+export const maxPriority = (...states: TestResultState[]) => {
+  switch (states.length) {
+    case 0:
+      return TestResultState.Unset;
+    case 1:
+      return states[0];
+    case 2:
+      return statePriority[states[0]] > statePriority[states[1]] ? states[0] : states[1];
+    default: {
+      let max = states[0];
+      for (let i = 1; i < states.length; i++) {
+        if (statePriority[max] < statePriority[states[i]]) {
+          max = states[i];
+        }
+      }
+      return max;
+    }
+  }
+};
+
+export const statesInOrder = Object.keys(statePriority)
+  .map((s) => Number(s) as TestResultState)
+  .sort(cmpPriority);
+
+export const isRunningState = (s: TestResultState) => s === TestResultState.Queued || s === TestResultState.Running;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

- [x] 运行测试时会动态更新树组件状态
- [x] 运行类会更新该类下的所有测试方法的状态

![Kapture 2022-01-15 at 17 10 00](https://user-images.githubusercontent.com/20262815/149616450-31170f9e-12d5-48a1-894e-6dfa5007de68.gif)


### Changelog
测试资源管理器支持运行中的测试状态更新