### PR TITLE
feat: support testing decorations run test

### DIFF
--- a/packages/debug/src/browser/editor/debug-model-manager.ts
+++ b/packages/debug/src/browser/editor/debug-model-manager.ts
@@ -64,7 +64,6 @@ export class DebugModelManager extends Disposable {
     this.editorCollection.onCodeEditorCreate((codeEditor: ICodeEditor) => this.push(codeEditor));
 
     this.breakpointManager.onDidChangeBreakpoints((event) => {
-      const { statusUpdated } = event;
       const { currentEditor } = this.editorService;
       const uri = currentEditor && currentEditor.currentUri;
       if (uri) {

--- a/packages/extension/src/browser/vscode/api/main.thread.tests.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tests.ts
@@ -119,11 +119,11 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
     console.log('Method not implemented.');
   }
   $removeTestProfile(controllerId: string, configId: number): void {
-    console.log('Method not implemented.');
+    this.testProfiles.removeProfile(controllerId, configId);
   }
-  $runTests(req: ResolvedTestRunRequest, token: CancellationToken): Promise<string> {
-    console.log('Method not implemented.');
-    return Promise.resolve('');
+  async $runTests(req: ResolvedTestRunRequest, token: CancellationToken): Promise<string> {
+    const result = await this.testService.runResolvedTests(req, token);
+    return result.id;
   }
 
   $addTestsToRun(controllerId: string, runId: string, tests: ITestItem[]): void {
@@ -172,11 +172,11 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
   }
 
   $startedExtensionTestRun(req: ExtensionRunTestsRequest): void {
-    console.log('Method not implemented.');
+    this.resultService.createTestResult(req);
   }
 
   $finishedExtensionTestRun(runId: string): void {
-    console.log('Method not implemented.');
+    this.withTestResult(runId, (r) => r.markComplete());
   }
 
   private withTestResult<T>(runId: string, fn: (run: ITestResult) => T): T | undefined {

--- a/packages/testing/src/browser/icons/icons.less
+++ b/packages/testing/src/browser/icons/icons.less
@@ -21,3 +21,11 @@
 .testing_icon_iconUnset {
   color: var(--testing-iconUnset);
 }
+
+.monaco-editor .testing-run-glyph {
+  cursor: pointer;
+}
+
+.monaco-editor .testing-inline-message-content {
+  cursor: pointer;
+}

--- a/packages/theme/src/common/color-tokens/index.ts
+++ b/packages/theme/src/common/color-tokens/index.ts
@@ -31,5 +31,6 @@ export * from './debug';
 export * from './debugToolbar';
 export * from './charts';
 export * from './minimap';
+export * from './testing';
 
 export * from './custom';


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![Kapture 2022-01-18 at 19 15 19](https://user-images.githubusercontent.com/20262815/149927586-4f5e1829-933d-4b76-8962-17de9f1ff43f.gif)

1. 在测试资源管理器里运行测试状态也会同步到编辑器，反之亦然
2. 如果当前 line 存在 testing decoration 则不会走到 debug 的断点逻辑

### Changelog
实现在 Testing Decoration 里运行测试用例
