### PR TITLE
feat: support simple testing outputpeek view widget

### DIFF
--- a/packages/debug/src/browser/editor/debug-breakpoint-zone-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-zone-widget.tsx
@@ -19,6 +19,8 @@ import { ICSSStyleService } from '@opensumi/ide-theme';
 
 @Injectable({ multiple: true })
 export class DebugBreakpointZoneWidget extends ZoneWidget {
+  protected _fillContainer(container: HTMLElement): void {}
+
   static INPUT_PLACEHOLDER_AFTER = styles.input_placeholder + '::after';
 
   @Autowired(DebugBreakpointsService)

--- a/packages/extension/src/browser/vscode/api/main.thread.tests.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tests.ts
@@ -147,7 +147,17 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
   }
 
   $appendTestMessagesInRun(runId: string, taskId: string, testId: string, messages: SerializedTestMessage[]): void {
-    console.log('$appendTestMessagesInRun', runId, taskId, testId, messages);
+    const r = this.resultService.getResult(runId);
+    if (r && r instanceof TestResultImpl) {
+      for (const message of messages) {
+        if (message.location) {
+          message.location.uri = URI.revive(message.location.uri);
+          message.location.range = Range.lift(message.location.range);
+        }
+
+        r.appendMessage(testId, taskId, message);
+      }
+    }
   }
 
   $appendOutputToRun(runId: string, taskId: string, output: string, locationDto?: ILocationDto, testId?: string): void {

--- a/packages/monaco-enhance/src/browser/folded-code-widget.ts
+++ b/packages/monaco-enhance/src/browser/folded-code-widget.ts
@@ -6,6 +6,7 @@ import { ZoneWidget } from './zone-widget';
 import { IFoldedCodeWidgetContentProvider } from '../common';
 
 export class FoldedCodeWidget extends ZoneWidget {
+  protected _fillContainer(container: HTMLElement): void {}
   protected applyClass() {}
 
   protected applyStyle() {}

--- a/packages/monaco-enhance/src/browser/peek-view.ts
+++ b/packages/monaco-enhance/src/browser/peek-view.ts
@@ -46,7 +46,9 @@ export abstract class PeekViewWidget extends ZoneWidget {
   }
 
   protected _fillHead(container: HTMLElement, noCloseAction?: boolean): void {
-    const titleElement = document.createElement('.peekview-title');
+    const titleElement = document.createElement('div');
+    titleElement.classList.add('peekview-title');
+
     if ((this.options as IPeekViewOptions).supportOnTitleClick) {
       titleElement.classList.add('clickable');
       // handle click event
@@ -54,12 +56,21 @@ export abstract class PeekViewWidget extends ZoneWidget {
     this._headElement!.append(titleElement);
 
     this._fillTitleIcon(titleElement);
-    this._primaryHeading = document.createElement('span.filename');
-    this._secondaryHeading = document.createElement('span.dirname');
-    this._metaHeading = document.createElement('span.meta');
+
+    this._primaryHeading = document.createElement('span');
+    this._primaryHeading.classList.add('filename');
+
+    this._secondaryHeading = document.createElement('span');
+    this._secondaryHeading.classList.add('dirname');
+
+    this._metaHeading = document.createElement('span');
+    this._metaHeading.classList.add('meta');
+
     titleElement.append(this._primaryHeading, this._secondaryHeading, this._metaHeading);
 
-    const actionsContainer = document.createElement('.peekview-actions');
+    const actionsContainer = document.createElement('div');
+    actionsContainer.classList.add('peekview-actions');
+
     this._headElement!.append(actionsContainer);
   }
 

--- a/packages/monaco-enhance/src/browser/peek-view.ts
+++ b/packages/monaco-enhance/src/browser/peek-view.ts
@@ -1,0 +1,99 @@
+import { Emitter } from '@opensumi/ide-core-common';
+import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
+import { ZoneWidget } from './zone-widget';
+
+export interface IPeekViewOptions {
+  supportOnTitleClick?: boolean;
+}
+
+export abstract class PeekViewWidget extends ZoneWidget {
+  private readonly _onDidClose = new Emitter<PeekViewWidget>();
+  readonly onDidClose = this._onDidClose.event;
+
+  protected _headElement?: HTMLDivElement;
+  protected _primaryHeading?: HTMLElement;
+  protected _secondaryHeading?: HTMLElement;
+  protected _metaHeading?: HTMLElement;
+  // 👇待定
+  // protected _actionbarWidget?: IMenuAction;
+  protected _bodyElement?: HTMLDivElement;
+
+  constructor(protected readonly editor: ICodeEditor, protected readonly options: IPeekViewOptions = {}) {
+    super(editor);
+  }
+
+  public override dispose(): void {
+    if (!this.disposed) {
+      super.dispose();
+      this._onDidClose.fire(this);
+    }
+  }
+
+  protected _fillContainer(container: HTMLElement): void {
+    this.setCssClass('peekview-widget');
+
+    this._headElement = document.createElement('div');
+    this._headElement.classList.add('head');
+
+    this._bodyElement = document.createElement('div');
+    this._bodyElement.classList.add('body');
+
+    this._fillHead(this._headElement);
+    this._fillBody(this._bodyElement);
+
+    container.appendChild(this._headElement);
+    container.appendChild(this._bodyElement);
+  }
+
+  protected _fillHead(container: HTMLElement, noCloseAction?: boolean): void {
+    const titleElement = document.createElement('.peekview-title');
+    if ((this.options as IPeekViewOptions).supportOnTitleClick) {
+      titleElement.classList.add('clickable');
+      // handle click event
+    }
+    this._headElement!.append(titleElement);
+
+    this._fillTitleIcon(titleElement);
+    this._primaryHeading = document.createElement('span.filename');
+    this._secondaryHeading = document.createElement('span.dirname');
+    this._metaHeading = document.createElement('span.meta');
+    titleElement.append(this._primaryHeading, this._secondaryHeading, this._metaHeading);
+
+    const actionsContainer = document.createElement('.peekview-actions');
+    this._headElement!.append(actionsContainer);
+  }
+
+  protected _fillTitleIcon(container: HTMLElement): void {}
+
+  protected abstract _fillBody(container: HTMLElement): void;
+
+  /**
+   * 如果 supportOnTitleClick 为 true，则需要覆写该方法
+   */
+  protected _onTitleClick(event: MouseEvent): void {}
+
+  public setTitle(primaryHeading: string, secondaryHeading?: string): void {
+    if (this._primaryHeading && this._secondaryHeading) {
+      this._primaryHeading.innerText = primaryHeading;
+      this._primaryHeading.setAttribute('title', primaryHeading);
+      if (secondaryHeading) {
+        this._secondaryHeading.innerText = secondaryHeading;
+      } else {
+        while (this._secondaryHeading.firstChild) {
+          this._secondaryHeading.firstChild.remove();
+        }
+      }
+    }
+  }
+
+  public setMetaTitle(value: string): void {
+    if (this._metaHeading) {
+      if (value) {
+        this._metaHeading.innerText = value;
+        this._metaHeading.style.display = '';
+      } else {
+        this._metaHeading.style.display = 'none';
+      }
+    }
+  }
+}

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -158,6 +158,18 @@ export abstract class ZoneWidget extends Disposable {
     this._container.style.height = `${height}px`;
   }
 
+  protected setCssClass(className: string, classToReplace?: string): void {
+    if (!this._container) {
+      return;
+    }
+
+    if (classToReplace) {
+      this._container.classList.remove(classToReplace);
+    }
+
+    this._container.classList.add(className);
+  }
+
   layout(layoutInfo: monaco.editor.EditorLayoutInfo) {
     this.left = this._getLeft(layoutInfo);
     this.width = this._getWidth(layoutInfo);

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -87,6 +87,7 @@ export abstract class ZoneWidget extends Disposable {
 
   protected abstract applyClass(): void;
   protected abstract applyStyle(): void;
+  protected abstract _fillContainer(container: HTMLElement): void;
 
   private _showImpl(where: monaco.IRange, heightInLines: number) {
     const { startLineNumber: lineNumber, startColumn: column } = where;
@@ -179,6 +180,8 @@ export abstract class ZoneWidget extends Disposable {
   render() {
     this._container.style.width = `${this.width}px`;
     this._container.style.left = `${this.left}px`;
+
+    this._fillContainer(this._container);
     this.applyStyle();
   }
 

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -15,6 +15,7 @@ export enum DirtyDiffWidgetActionType {
 }
 
 export class DirtyDiffWidget extends ZoneWidget {
+  protected _fillContainer(container: HTMLElement): void {}
   private _wrapper: HTMLDivElement;
   private _head: HTMLDivElement;
   private _content: HTMLDivElement;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -23,6 +23,7 @@
     "@opensumi/ide-editor": "2.13.9",
     "@opensumi/ide-monaco": "2.13.9",
     "@opensumi/ide-file-service": "2.13.9",
+    "@opensumi/ide-monaco-enhance": "2.13.9",
     "@opensumi/ide-main-layout": "2.13.9"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -21,6 +21,8 @@
     "@opensumi/ide-components": "2.13.9",
     "@opensumi/ide-dev-tool": "^1.1.0",
     "@opensumi/ide-editor": "2.13.9",
+    "@opensumi/ide-monaco": "2.13.9",
+    "@opensumi/ide-file-service": "2.13.9",
     "@opensumi/ide-main-layout": "2.13.9"
   }
 }

--- a/packages/testing/src/browser/index.ts
+++ b/packages/testing/src/browser/index.ts
@@ -10,8 +10,10 @@ import { TestResultServiceImpl } from './test.result.service';
 import { TestServiceImpl } from './test.service';
 import { TestingContribution } from './testing.contribution';
 import { TestServiceToken } from '../common';
+import { TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
 
 import './icons/icons.less';
+import { TestingPeekOpenerServiceImpl } from './outputPeek/test-peek-opener.service';
 @Injectable()
 export class TestingModule extends BrowserModule {
   providers: Provider[] = [
@@ -31,6 +33,10 @@ export class TestingModule extends BrowserModule {
     {
       token: TestResultServiceToken,
       useClass: TestResultServiceImpl,
+    },
+    {
+      token: TestingPeekOpenerServiceToken,
+      useClass: TestingPeekOpenerServiceImpl,
     },
   ];
 }

--- a/packages/testing/src/browser/index.ts
+++ b/packages/testing/src/browser/index.ts
@@ -13,6 +13,8 @@ import { TestServiceToken } from '../common';
 import { TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
 
 import './icons/icons.less';
+import './outputPeek/test-peek-widget.less';
+
 import { TestingPeekOpenerServiceImpl } from './outputPeek/test-peek-opener.service';
 @Injectable()
 export class TestingModule extends BrowserModule {

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -1,0 +1,14 @@
+import { Injectable, Optional } from '@opensumi/di';
+import { Disposable, IDisposable } from '@opensumi/ide-core-common';
+import { IEditor, IEditorFeatureContribution } from '@opensumi/ide-editor/lib/browser';
+
+@Injectable({ multiple: true })
+export class TestOutputPeekContribution implements IEditorFeatureContribution {
+  private readonly disposer: Disposable = new Disposable();
+
+  constructor(@Optional() private readonly editor: IEditor) {}
+
+  public contribute(): IDisposable {
+    return this.disposer;
+  }
+}

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -14,6 +14,7 @@ import {
 import { TestingOutputPeek } from './test-peek-widget';
 import { TestResultServiceImpl } from '../test.result.service';
 import { TestResultServiceToken } from '../../common/test-result';
+import { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
 const isDiffable = (
   message: ITestErrorMessage,
@@ -65,6 +66,11 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   private readonly disposer: Disposable = new Disposable();
 
   private readonly peekView = new MutableDisposable<TestingOutputPeek>();
+
+  public static get(editor: ICodeEditor): TestOutputPeekContribution | undefined {
+    console.log('ICodeEditor', editor);
+    return;
+  }
 
   constructor(@Optional() private readonly editor: IEditor) {}
 

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -1,14 +1,102 @@
-import { Injectable, Optional } from '@opensumi/di';
-import { Disposable, IDisposable } from '@opensumi/ide-core-common';
+import { buildTestUri, parseTestUri, TestUriType } from './../../common/testingUri';
+import { Injectable, Optional, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { Disposable, IDisposable, MutableDisposable, URI } from '@opensumi/ide-core-common';
 import { IEditor, IEditorFeatureContribution } from '@opensumi/ide-editor/lib/browser';
+import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
+import {
+  IRichLocation,
+  ITestErrorMessage,
+  ITestItem,
+  ITestMessage,
+  TestMessageType,
+  TestResultItem,
+} from '../../common/testCollection';
+import { TestingOutputPeek } from './test-peek-widget';
+import { TestResultServiceImpl } from '../test.result.service';
+import { TestResultServiceToken } from '../../common/test-result';
+
+const isDiffable = (
+  message: ITestErrorMessage,
+): message is ITestErrorMessage & { actualOutput: string; expectedOutput: string } =>
+  message.actual !== undefined && message.expected !== undefined;
+class TestDto {
+  public readonly test: ITestItem;
+  public readonly messages: ITestMessage[];
+  public readonly expectedUri: URI;
+  public readonly actualUri: URI;
+  public readonly messageUri: URI;
+  public readonly revealLocation: IRichLocation | undefined;
+
+  public get isDiffable() {
+    const message = this.messages[this.messageIndex];
+    return message.type === TestMessageType.Error && isDiffable(message);
+  }
+
+  constructor(
+    public readonly resultId: string,
+    test: TestResultItem,
+    public readonly taskIndex: number,
+    public readonly messageIndex: number,
+  ) {
+    this.test = test.item;
+    this.messages = test.tasks[taskIndex].messages;
+    this.messageIndex = messageIndex;
+
+    const parts = { messageIndex, resultId, taskIndex, testExtId: test.item.extId };
+    this.expectedUri = buildTestUri({ ...parts, type: TestUriType.ResultExpectedOutput });
+    this.actualUri = buildTestUri({ ...parts, type: TestUriType.ResultActualOutput });
+    this.messageUri = buildTestUri({ ...parts, type: TestUriType.ResultMessage });
+
+    const message = this.messages[this.messageIndex];
+    this.revealLocation =
+      message.location ??
+      (test.item.uri && test.item.range ? { uri: test.item.uri, range: Range.lift(test.item.range) } : undefined);
+  }
+}
 
 @Injectable({ multiple: true })
 export class TestOutputPeekContribution implements IEditorFeatureContribution {
+  @Autowired(INJECTOR_TOKEN)
+  private readonly injector: Injector;
+
+  @Autowired(TestResultServiceToken)
+  private readonly testResultService: TestResultServiceImpl;
+
   private readonly disposer: Disposable = new Disposable();
+
+  private readonly peekView = new MutableDisposable<TestingOutputPeek>();
 
   constructor(@Optional() private readonly editor: IEditor) {}
 
+  private retrieveTest(uri: URI): TestDto | undefined {
+    const parts = parseTestUri(uri);
+    if (!parts) {
+      return undefined;
+    }
+
+    const { resultId, testExtId, taskIndex, messageIndex } = parts;
+    const test = this.testResultService.getResult(parts.resultId)?.getStateById(testExtId);
+    if (!test || !test.tasks[parts.taskIndex]) {
+      return;
+    }
+
+    return new TestDto(resultId, test, taskIndex, messageIndex);
+  }
+
   public contribute(): IDisposable {
     return this.disposer;
+  }
+
+  public async show(uri: URI): Promise<void> {
+    const dto = this.retrieveTest(uri);
+    if (!dto) {
+      return;
+    }
+
+    if (!this.peekView.value) {
+      this.peekView.value = this.injector.get(TestingOutputPeek, [this.editor.monacoEditor]);
+    }
+
+    this.peekView.value.show(dto.revealLocation?.range!, 28);
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
+++ b/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@opensumi/di';
+import { Disposable } from '@opensumi/ide-core-common';
+import { ITextEditorOptions } from '@opensumi/monaco-editor-core/esm/vs/platform/editor/common/editor';
+import { ITestResult } from '../../common/test-result';
+import { TestResultItem } from '../../common/testCollection';
+import { ITestingPeekOpenerService } from '../../common/testingPeekOpener';
+
+@Injectable()
+export class TestingPeekOpenerServiceImpl extends Disposable implements ITestingPeekOpenerService {
+  _serviceBrand: undefined;
+  tryPeekFirstError(result: ITestResult, test: TestResultItem, options?: Partial<ITextEditorOptions>): boolean {
+    throw new Error('Method not implemented.');
+  }
+  open(): void {
+    throw new Error('Method not implemented.');
+  }
+  closeAllPeeks(): void {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
+++ b/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
@@ -1,20 +1,103 @@
-import { Injectable } from '@opensumi/di';
-import { Disposable } from '@opensumi/ide-core-common';
+import { WorkbenchEditorService } from '@opensumi/ide-editor';
+import { Injectable, Autowired } from '@opensumi/di';
+import { Disposable, URI } from '@opensumi/ide-core-common';
 import { ITextEditorOptions } from '@opensumi/monaco-editor-core/esm/vs/platform/editor/common/editor';
-import { ITestResult } from '../../common/test-result';
-import { TestResultItem } from '../../common/testCollection';
+import { ITestResult, TestResultServiceToken } from '../../common/test-result';
+import { ITestMessage, ITestTaskState, TestResultItem } from '../../common/testCollection';
 import { ITestingPeekOpenerService } from '../../common/testingPeekOpener';
+import { buildTestUri, ParsedTestUri, TestUriType } from '../../common/testingUri';
+import { TestOutputPeekContribution } from './test-output-peek';
+import { TestResultServiceImpl } from '../test.result.service';
+
+type TestUriWithDocument = ParsedTestUri & { documentUri: URI };
+
+const mapFindTestMessage = <T>(
+  test: TestResultItem,
+  fn: (task: ITestTaskState, message: ITestMessage, messageIndex: number, taskIndex: number) => T | undefined,
+) => {
+  for (let taskIndex = 0; taskIndex < test.tasks.length; taskIndex++) {
+    const task = test.tasks[taskIndex];
+    for (let messageIndex = 0; messageIndex < task.messages.length; messageIndex++) {
+      const r = fn(task, task.messages[messageIndex], messageIndex, taskIndex);
+      if (r !== undefined) {
+        return r;
+      }
+    }
+  }
+
+  return undefined;
+};
 
 @Injectable()
 export class TestingPeekOpenerServiceImpl extends Disposable implements ITestingPeekOpenerService {
-  _serviceBrand: undefined;
-  tryPeekFirstError(result: ITestResult, test: TestResultItem, options?: Partial<ITextEditorOptions>): boolean {
+  @Autowired(WorkbenchEditorService)
+  private editorService: WorkbenchEditorService;
+
+  @Autowired(TestResultServiceToken)
+  private readonly testResultService: TestResultServiceImpl;
+
+  declare _serviceBrand: undefined;
+
+  private lastUri?: TestUriWithDocument;
+
+  private async showPeekFromUri(uri: TestUriWithDocument, options?: ITextEditorOptions) {
+    const editor = this.editorService.currentEditor;
+
+    this.lastUri = uri;
+    TestOutputPeekContribution.get(editor?.monacoEditor!)!.show(buildTestUri(this.lastUri));
+    return true;
+  }
+
+  private getAnyCandidateMessage() {
+    const seen = new Set<string>();
+    for (const result of this.testResultService.results) {
+      for (const test of result.tests) {
+        if (seen.has(test.item.extId)) {
+          continue;
+        }
+
+        seen.add(test.item.extId);
+        const found = mapFindTestMessage(
+          test,
+          (task, message, messageIndex, taskIndex) =>
+            message.location && {
+              type: TestUriType.ResultMessage,
+              testExtId: test.item.extId,
+              resultId: result.id,
+              taskIndex,
+              messageIndex,
+              documentUri: message.location.uri,
+            },
+        );
+
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  public tryPeekFirstError(result: ITestResult, test: TestResultItem, options?: Partial<ITextEditorOptions>): boolean {
     throw new Error('Method not implemented.');
   }
-  open(): void {
-    throw new Error('Method not implemented.');
+
+  public async open(): Promise<boolean> {
+    let uri: any;
+
+    if (!uri) {
+      uri = this.getAnyCandidateMessage();
+    }
+
+    if (!uri) {
+      return false;
+    }
+
+    return this.showPeekFromUri(uri);
   }
-  closeAllPeeks(): void {
+
+  public closeAllPeeks(): void {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
+++ b/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
@@ -40,11 +40,17 @@ export class TestingPeekOpenerServiceImpl extends Disposable implements ITesting
 
   private lastUri?: TestUriWithDocument;
 
-  private async showPeekFromUri(uri: TestUriWithDocument, options?: ITextEditorOptions) {
+  private peekControllerMap: Map<string, TestOutputPeekContribution> = new Map();
+
+  private async showPeekFromUri(testUri: TestUriWithDocument, options?: ITextEditorOptions) {
     const editor = this.editorService.currentEditor;
 
-    this.lastUri = uri;
-    TestOutputPeekContribution.get(editor?.monacoEditor!)!.show(buildTestUri(this.lastUri));
+    this.lastUri = testUri;
+
+    const uri = buildTestUri(this.lastUri);
+    const ctor = this.peekControllerMap.get(editor?.currentUri!.toString()!);
+    ctor?.show(uri);
+
     return true;
   }
 
@@ -77,6 +83,14 @@ export class TestingPeekOpenerServiceImpl extends Disposable implements ITesting
     }
 
     return undefined;
+  }
+
+  public setPeekContrib(uri: URI, contrib: TestOutputPeekContribution): this {
+    const uriStr = uri.toString();
+    if (!this.peekControllerMap.has(uriStr)) {
+      this.peekControllerMap.set(uriStr, contrib);
+    }
+    return this;
   }
 
   public tryPeekFirstError(result: ITestResult, test: TestResultItem, options?: Partial<ITextEditorOptions>): boolean {

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -1,0 +1,88 @@
+// @import '~@opensumi/ide-monaco-enhance/lib/browser/styles.module.less';
+
+.peekview-widget .head {
+  box-sizing: border-box;
+  display: flex;
+}
+
+.peekview-widget .head .peekview-title {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  margin-left: 20px;
+  min-width: 0;
+}
+
+.peekview-widget .head .peekview-title.clickable {
+  cursor: pointer;
+}
+
+.peekview-widget .head .peekview-title .dirname:not(:empty) {
+  font-size: 0.9em;
+  margin-left: 0.5em;
+}
+
+.peekview-widget .head .peekview-title .meta {
+  white-space: nowrap;
+}
+
+.peekview-widget .head .peekview-title .dirname {
+  white-space: nowrap;
+}
+
+.peekview-widget .head .peekview-title .filename {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.peekview-widget .head .peekview-title .meta:not(:empty)::before {
+  content: '-';
+  padding: 0 0.3em;
+}
+
+.peekview-widget .head .peekview-actions {
+  flex: 1;
+  text-align: right;
+  padding-right: 2px;
+}
+
+.peekview-widget .head .peekview-actions > .monaco-action-bar {
+  display: inline-block;
+}
+
+.peekview-widget .head .peekview-actions > .monaco-action-bar,
+.peekview-widget .head .peekview-actions > .monaco-action-bar > .actions-container {
+  height: 100%;
+}
+
+.peekview-widget > .body {
+  border-top: 1px solid;
+  position: relative;
+}
+
+.peekview-widget .head .peekview-title .codicon {
+  margin-right: 4px;
+}
+
+.testing-output-peek-container {
+  border-top-color: rgb(241, 76, 76);
+  border-bottom-color: rgb(241, 76, 76);
+  height: 416px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-top-style: solid;
+  border-bottom-style: solid;
+  top: 6px;
+  overflow: hidden;
+
+  .head {
+    background-color: rgba(241, 76, 76, 0.1);
+    height: 22px;
+    line-height: 22px;
+  }
+
+  .body {
+    border-color: rgb(241, 76, 76);
+  }
+}

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -1,17 +1,57 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { PeekViewWidget } from '@opensumi/ide-monaco-enhance/lib/browser/peek-view';
-import { Injectable, Autowired } from '@opensumi/di';
+import { Injectable } from '@opensumi/di';
+import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
+import { TestDto } from './test-output-peek';
+import { TestMessageType } from '../../common/testCollection';
+import './test-peek-widget.less';
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {
+  public current?: TestDto;
+  private _wrapper: HTMLDivElement;
+
+  constructor(public readonly editor: ICodeEditor) {
+    super(editor);
+
+    this._wrapper = document.createElement('div');
+  }
+
   protected _fillBody(container: HTMLElement): void {
-    throw new Error('Method not implemented.');
+    container.appendChild(this._wrapper);
+
+    this.setTitle('testing peekview widget title', this.current?.test.label);
+    this.setCssClass('testing-output-peek-container');
   }
+
   protected applyClass(): void {
-    throw new Error('Method not implemented.');
+    console.log('applyClass Method not implemented.');
   }
+
   protected applyStyle(): void {
-    throw new Error('Method not implemented.');
+    const message = this.current!.messages[this.current!.messageIndex];
+
+    ReactDOM.render(<div>{message.message.toString()}</div>, this._wrapper);
+  }
+
+  public setModel(dto: TestDto): Promise<void> {
+    const message = dto.messages[dto.messageIndex];
+    const previous = this.current;
+
+    if (message.type !== TestMessageType.Error) {
+      return Promise.resolve();
+    }
+
+    if (!dto.revealLocation && !previous) {
+      return Promise.resolve();
+    }
+
+    this.current = dto;
+
+    this.show(dto.revealLocation!.range, message.location?.range.startLineNumber!);
+    this.editor.focus();
+
+    return Promise.resolve();
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -4,7 +4,7 @@ import { PeekViewWidget } from '@opensumi/ide-monaco-enhance/lib/browser/peek-vi
 import { Injectable, Autowired } from '@opensumi/di';
 
 @Injectable({ multiple: true })
-export class DebugBreakpointZoneWidget extends PeekViewWidget {
+export class TestingOutputPeek extends PeekViewWidget {
   protected _fillBody(container: HTMLElement): void {
     throw new Error('Method not implemented.');
   }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { PeekViewWidget } from '@opensumi/ide-monaco-enhance/lib/browser/peek-view';
+import { Injectable, Autowired } from '@opensumi/di';
+
+@Injectable({ multiple: true })
+export class DebugBreakpointZoneWidget extends PeekViewWidget {
+  protected _fillBody(container: HTMLElement): void {
+    throw new Error('Method not implemented.');
+  }
+  protected applyClass(): void {
+    throw new Error('Method not implemented.');
+  }
+  protected applyStyle(): void {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -24,8 +24,8 @@ import { TestingView } from './components/testing.view';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { TestDecorationsContribution } from './test-decorations';
 import { TestOutputPeekContribution } from './outputPeek/test-output-peek';
-import { ITestingPeekOpenerService, TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
-
+import { TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
+import { TestingPeekOpenerServiceImpl } from './outputPeek/test-peek-opener.service';
 @Injectable()
 @Domain(ClientAppContribution, ComponentContribution, CommandContribution, BrowserEditorContribution)
 export class TestingContribution
@@ -44,7 +44,7 @@ export class TestingContribution
   private readonly injector: Injector;
 
   @Autowired(TestingPeekOpenerServiceToken)
-  private readonly testingPeekOpenerService: ITestingPeekOpenerService;
+  private readonly testingPeekOpenerService: TestingPeekOpenerServiceImpl;
 
   initialize(): void {
     this.testTreeViewModel.initTreeModel();
@@ -105,7 +105,6 @@ export class TestingContribution
       execute: async (extId: string) => {
         this.testingPeekOpenerService.open();
       },
-      isVisible: () => false,
     });
   }
 

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -16,7 +16,7 @@ import {
   SlotLocation,
   URI,
 } from '@opensumi/ide-core-browser';
-import { GoToTestCommand } from '../common/commands';
+import { GoToTestCommand, PeekTestError } from '../common/commands';
 
 import { TestingContainerId, TestingViewId } from '../common/testing-view';
 import { ITestTreeViewModel, TestTreeViewModelToken } from '../common/tree-view.model';
@@ -24,6 +24,7 @@ import { TestingView } from './components/testing.view';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { TestDecorationsContribution } from './test-decorations';
 import { TestOutputPeekContribution } from './outputPeek/test-output-peek';
+import { ITestingPeekOpenerService, TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
 
 @Injectable()
 @Domain(ClientAppContribution, ComponentContribution, CommandContribution, BrowserEditorContribution)
@@ -41,6 +42,9 @@ export class TestingContribution
 
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
+
+  @Autowired(TestingPeekOpenerServiceToken)
+  private readonly testingPeekOpenerService: ITestingPeekOpenerService;
 
   initialize(): void {
     this.testTreeViewModel.initTreeModel();
@@ -93,6 +97,13 @@ export class TestingContribution
             focus: true,
           });
         }
+      },
+      isVisible: () => false,
+    });
+
+    commands.registerCommand(PeekTestError, {
+      execute: async (extId: string) => {
+        this.testingPeekOpenerService.open();
       },
       isVisible: () => false,
     });

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -23,6 +23,7 @@ import { ITestTreeViewModel, TestTreeViewModelToken } from '../common/tree-view.
 import { TestingView } from './components/testing.view';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { TestDecorationsContribution } from './test-decorations';
+import { TestOutputPeekContribution } from './outputPeek/test-output-peek';
 
 @Injectable()
 @Domain(ClientAppContribution, ComponentContribution, CommandContribution, BrowserEditorContribution)
@@ -100,6 +101,9 @@ export class TestingContribution
   registerEditorFeature(registry: IEditorFeatureRegistry) {
     registry.registerEditorFeatureContribution({
       contribute: (editor: IEditor) => this.injector.get(TestDecorationsContribution, [editor]).contribute(),
+    });
+    registry.registerEditorFeatureContribution({
+      contribute: (editor: IEditor) => this.injector.get(TestOutputPeekContribution, [editor]).contribute(),
     });
   }
 }

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -14,4 +14,5 @@ export const GoToTestCommand: Command = {
 
 export const PeekTestError: Command = {
   id: 'testing.peek.test.error',
+  label: 'Peek Output',
 };

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -11,3 +11,7 @@ export const GoToTestCommand: Command = {
   label: 'Go To Test',
   iconClass: getExternalIcon('go-to-file'),
 };
+
+export const PeekTestError: Command = {
+  id: 'testing.peek.test.error',
+};

--- a/packages/testing/src/common/test-result.ts
+++ b/packages/testing/src/common/test-result.ts
@@ -5,10 +5,12 @@ import {
   IRichLocation,
   ISerializedTestResults,
   ITestItem,
+  ITestMessage,
   ITestOutputMessage,
   ITestRunTask,
   ITestTaskState,
   ResolvedTestRunRequest,
+  SerializedTestMessage,
   TestItemExpandState,
   TestResultItem,
   TestResultState,
@@ -239,6 +241,20 @@ export class TestResultImpl implements ITestResult {
     }
 
     this.fireUpdateAndRefresh(entry, index, state);
+  }
+  appendMessage(testId: string, taskId: string, message: ITestMessage | SerializedTestMessage) {
+    const entry = this.testById.get(testId);
+    if (!entry) {
+      return;
+    }
+
+    entry.tasks[this.mustGetTaskIndex(taskId)].messages.push(message as ITestMessage);
+    this.changeEmitter.fire({
+      item: entry,
+      result: this,
+      reason: TestResultItemChangeReason.OwnStateChange,
+      previous: entry.ownComputedState,
+    });
   }
   appendOutput(output: string, taskId: string, location?: IRichLocation, testId?: string): void {
     console.error('##TestResult## appendOutput: >> ', output, taskId, location, testId);

--- a/packages/testing/src/common/testingPeekOpener.ts
+++ b/packages/testing/src/common/testingPeekOpener.ts
@@ -1,0 +1,30 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ITextEditorOptions } from '@opensumi/monaco-editor-core/esm/vs/platform/editor/common/editor';
+import { ITestResult } from './test-result';
+import { TestResultItem } from './testCollection';
+
+export const TestingPeekOpenerServiceToken = Symbol('TestingPeekOpenerService');
+
+export interface ITestingPeekOpenerService {
+  _serviceBrand: undefined;
+
+  /**
+   * Tries to peek the first test error, if the item is in a failed state.
+   * @returns a boolean indicating whether a peek was opened
+   */
+  tryPeekFirstError(result: ITestResult, test: TestResultItem, options?: Partial<ITextEditorOptions>): boolean;
+
+  /**
+   * Opens the peek. Shows any available message.
+   */
+  open(): void;
+
+  /**
+   * Closes peeks for all visible editors.
+   */
+  closeAllPeeks(): void;
+}

--- a/packages/testing/src/common/testingUri.ts
+++ b/packages/testing/src/common/testingUri.ts
@@ -1,0 +1,101 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '@opensumi/ide-core-common';
+
+export const TEST_DATA_SCHEME = 'opensumi-test-data';
+
+export const enum TestUriType {
+  ResultMessage,
+  ResultActualOutput,
+  ResultExpectedOutput,
+}
+
+interface IResultTestUri {
+  resultId: string;
+  taskIndex: number;
+  testExtId: string;
+}
+
+interface IResultTestMessageReference extends IResultTestUri {
+  type: TestUriType.ResultMessage;
+  messageIndex: number;
+}
+
+interface IResultTestOutputReference extends IResultTestUri {
+  type: TestUriType.ResultActualOutput | TestUriType.ResultExpectedOutput;
+  messageIndex: number;
+}
+
+export type ParsedTestUri = IResultTestMessageReference | IResultTestOutputReference;
+
+const enum TestUriParts {
+  Results = 'results',
+
+  Messages = 'message',
+  Text = 'TestFailureMessage',
+  ActualOutput = 'ActualOutput',
+  ExpectedOutput = 'ExpectedOutput',
+}
+
+export const parseTestUri = (uri: URI): ParsedTestUri | undefined => {
+  const type = uri.authority;
+  const [locationId, ...request] = uri.path.toString().slice(1).split('/');
+
+  if (request[0] === TestUriParts.Messages) {
+    const taskIndex = Number(request[1]);
+    const index = Number(request[2]);
+    const part = request[3];
+    const testExtId = uri.query;
+    if (type === TestUriParts.Results) {
+      switch (part) {
+        case TestUriParts.Text:
+          return { resultId: locationId, taskIndex, testExtId, messageIndex: index, type: TestUriType.ResultMessage };
+        case TestUriParts.ActualOutput:
+          return {
+            resultId: locationId,
+            taskIndex,
+            testExtId,
+            messageIndex: index,
+            type: TestUriType.ResultActualOutput,
+          };
+        case TestUriParts.ExpectedOutput:
+          return {
+            resultId: locationId,
+            taskIndex,
+            testExtId,
+            messageIndex: index,
+            type: TestUriType.ResultExpectedOutput,
+          };
+      }
+    }
+  }
+
+  return undefined;
+};
+
+export const buildTestUri = (parsed: ParsedTestUri): URI => {
+  const uriParts = {
+    scheme: TEST_DATA_SCHEME,
+    authority: TestUriParts.Results,
+  };
+  const msgRef = (locationId: string, ...remaining: (string | number)[]) =>
+    URI.from({
+      ...uriParts,
+      query: parsed.testExtId,
+      path: ['', locationId, TestUriParts.Messages, ...remaining].join('/'),
+    });
+
+  switch (parsed.type) {
+    case TestUriType.ResultActualOutput:
+      return msgRef(parsed.resultId, parsed.taskIndex, parsed.messageIndex, TestUriParts.ActualOutput);
+    case TestUriType.ResultExpectedOutput:
+      return msgRef(parsed.resultId, parsed.taskIndex, parsed.messageIndex, TestUriParts.ExpectedOutput);
+    case TestUriType.ResultMessage:
+      return msgRef(parsed.resultId, parsed.taskIndex, parsed.messageIndex, TestUriParts.Text);
+    default:
+      throw new Error('Invalid test uri');
+  }
+};


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![Kapture 2022-01-19 at 20 44 07](https://user-images.githubusercontent.com/20262815/150133186-ee112bff-16b2-4c57-b9de-033250517cee.gif)


基于 ZoneWidget 拓展了 PeekView 组件，Testing Output Peek 组件继承于它，但还未实现 body 里左侧 markdown 右侧树组件的效果，相当于目前只有个壳

### Changelog
实现简单的 Testing Output Peek Widget 组件
