### PR TITLE
feat: support testing message inline content

### DIFF
--- a/packages/testing/src/browser/index.ts
+++ b/packages/testing/src/browser/index.ts
@@ -14,6 +14,7 @@ import { TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
 
 import './icons/icons.less';
 import './outputPeek/test-peek-widget.less';
+import './theme.less';
 
 import { TestingPeekOpenerServiceImpl } from './outputPeek/test-peek-opener.service';
 @Injectable()

--- a/packages/testing/src/browser/theme.less
+++ b/packages/testing/src/browser/theme.less
@@ -1,0 +1,6 @@
+.monaco-editor {
+  // error message
+  .testing-inline-message-severity-0 {
+    background: rgba(255, 0, 0, 0.2);
+  }
+}

--- a/packages/testing/src/common/constants.ts
+++ b/packages/testing/src/common/constants.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '@opensumi/ide-core-common';
-import { TestResultState, TestRunProfileBitset } from './testCollection';
+import { TestMessageType, TestResultState, TestRunProfileBitset } from './testCollection';
 
 export const enum Testing {
   // marked as "extension" so that any existing test extensions are assigned to it.
@@ -41,10 +41,16 @@ export const testStateNames: { [K in TestResultState]: string } = {
   [TestResultState.Unset]: localize('testState.unset', 'Not yet run'),
 };
 
-export const labelForTestInState = (label: string, state: TestResultState) => 'label then the unit tests state, for example "Addition Tests (Running)"';
+export const labelForTestInState = (label: string, state: TestResultState) =>
+  'label then the unit tests state, for example "Addition Tests (Running)"';
 
 export const testConfigurationGroupNames: { [K in TestRunProfileBitset]: string } = {
   [TestRunProfileBitset.Debug]: localize('testGroup.debug', 'Debug'),
   [TestRunProfileBitset.Run]: localize('testGroup.run', 'Run'),
   [TestRunProfileBitset.Coverage]: localize('testGroup.coverage', 'Coverage'),
+};
+
+export const testMessageSeverityColors = {
+  [TestMessageType.Error]: '#F14C4C',
+  [TestMessageType.Info]: '#33333380', // --> #333333 透明度 0.5 的结果
 };


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

当测试结果为 error 时在对应测试函数右侧显示测试结果

![Kapture 2022-01-20 at 14 08 05](https://user-images.githubusercontent.com/20262815/150283188-0ac7f02c-2bd7-4484-b5ab-b38637ed0d50.gif)


### Changelog
实现 Test Message 的内敛显示
