### PR TITLE
fix: locating setting id while clicking edit in settings.json

### DIFF
--- a/packages/preferences/src/browser/preference-contribution.ts
+++ b/packages/preferences/src/browser/preference-contribution.ts
@@ -341,11 +341,17 @@ export class PreferenceContribution
           lines = text.split('\n');
           preferenceLine = lines[numReturns - 1];
         }
-        const regStr = `\\s+\\"${preferenceId.replace('/./g', '\\.')}\\":\\s?\\"`;
+        const regStr = `\\s+\\"${preferenceId.replace(/\./g, '\\.')}\\":\\s?\[\"|{|t|f|\[]`;
         const match = new RegExp(regStr, 'g').exec(preferenceLine);
         if (match) {
-          editor.monacoEditor.setPosition({ lineNumber: numReturns, column: match[0].length + 1 });
-          await commandService.executeCommand('editor.action.triggerSuggest');
+          const isStringExpr = match[0].slice(-1) === '"';
+          if (!isStringExpr) {
+            editor.monacoEditor.setPosition({ lineNumber: numReturns, column: match[0].length });
+          } else {
+            editor.monacoEditor.setPosition({ lineNumber: numReturns, column: match[0].length + 1 });
+            // 只对 String 类型配置展示提示，包括不存在配置项时追加的情况
+            await commandService.executeCommand('editor.action.triggerSuggest');
+          }
         }
       }
     }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fixed #363

当不存在配置时，会根据设置ID自动填充内容并提示补全：

![image](https://user-images.githubusercontent.com/9823838/150353795-f86f7f9e-3029-48bc-8046-81996d728bf4.png)

当存在非 `String` 类型配置时，如 `Array`,  `Object` 会定为到配置位置，但不会提示补全信息：

![image](https://user-images.githubusercontent.com/9823838/150353930-27428361-5a38-4fb6-b1ff-e6bd90ca5eca.png)

### Changelog

locating setting id while clicking edit in settings.json
