### PR TITLE
fix: tabsize minimum should be >= 1

### DIFF
--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1714,6 +1714,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.tabSize': {
     type: 'number',
     default: EDITOR_FONT_DEFAULTS.tabSize,
+    minimum: 1,
     description: '%editor.configuration.tabSize%',
   },
   'editor.formatOnPaste': {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
tabsize 配置最小值限制为 1