### PR TITLE
feat: support testing message output peek view

### DIFF
--- a/packages/comments/src/browser/comments-zone.view.tsx
+++ b/packages/comments/src/browser/comments-zone.view.tsx
@@ -132,6 +132,7 @@ const CommentsZone: React.FC<ICommentProps> = observer(({ thread, widget }) => {
 
 @Injectable({ multiple: true })
 export class CommentsZoneWidget extends ResizeZoneWidget implements ICommentsZoneWidget {
+  protected _fillContainer(container: HTMLElement): void {}
   @Autowired(AppConfig)
   appConfig: AppConfig;
 

--- a/packages/core-browser/src/contextkey/testing.ts
+++ b/packages/core-browser/src/contextkey/testing.ts
@@ -4,3 +4,5 @@ export const TestingServiceProviderCount = new RawContextKey('service.testing.pr
 export const TestingServiceHasDebuggableContextKey = new RawContextKey('service.testing.hasDebuggableContext', false);
 export const TestingHasAnyResults = new RawContextKey('testing.hasAnyResults', false);
 export const TestingIsRunning = new RawContextKey('testing.isRunning', false);
+export const TestingIsInPeek = new RawContextKey('testing.isInPeek', true);
+export const TestingIsPeekVisible = new RawContextKey('testing.isPeekVisible', false);

--- a/packages/markdown/src/browser/markdown-widget.tsx
+++ b/packages/markdown/src/browser/markdown-widget.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
-import { useInjectable, Disposable, CancellationTokenSource } from '@opensumi/ide-core-browser';
+import { useInjectable, Disposable, CancellationTokenSource, URI } from '@opensumi/ide-core-browser';
 import { IMarkdownService } from '../common';
 
-export const Markdown = ({ content, onLoaded }: { content: string; onLoaded?: () => void }) => {
+export const Markdown = ({
+  content,
+  onLoaded,
+  onLinkClick,
+}: {
+  content: string;
+  onLoaded?: () => void;
+  onLinkClick?: (uri: URI) => void;
+}) => {
   let container: HTMLElement | null = null;
   const markdownService: IMarkdownService = useInjectable(IMarkdownService);
 
@@ -15,12 +23,14 @@ export const Markdown = ({ content, onLoaded }: { content: string; onLoaded?: ()
           cancellation.cancel();
         },
       });
-      markdownService.previewMarkdownInContainer(content, container!, cancellation.token).then((r) => {
-        disposer.addDispose(r);
-        if (onLoaded) {
-          onLoaded();
-        }
-      });
+      markdownService
+        .previewMarkdownInContainer(content, container!, cancellation.token, undefined, onLinkClick)
+        .then((r) => {
+          disposer.addDispose(r);
+          if (onLoaded) {
+            onLoaded();
+          }
+        });
 
       return () => {
         disposer.dispose();

--- a/packages/markdown/src/browser/markdown.service.ts
+++ b/packages/markdown/src/browser/markdown.service.ts
@@ -24,6 +24,7 @@ export class MarkdownServiceImpl implements IMarkdownService {
     container: HTMLElement,
     cancellationToken: CancellationToken,
     onUpdate?: Event<string>,
+    onLinkClick?: (uri: URI) => void,
   ): Promise<IDisposable> {
     const body = await this.getBody(content);
     if (cancellationToken.isCancellationRequested) {
@@ -46,6 +47,9 @@ export class MarkdownServiceImpl implements IMarkdownService {
         // Whitelist supported schemes for links
         if (this.isSupportedLink(link)) {
           this.openerService.open(link);
+        }
+        if (onLinkClick) {
+          onLinkClick(link);
         }
       }),
     );

--- a/packages/markdown/src/common/index.ts
+++ b/packages/markdown/src/common/index.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, IDisposable, Event } from '@opensumi/ide-core-common';
+import { CancellationToken, IDisposable, Event, URI } from '@opensumi/ide-core-common';
 
 export interface IMarkdownService {
   previewMarkdownInContainer(
@@ -6,6 +6,7 @@ export interface IMarkdownService {
     container: HTMLElement,
     cancellationToken: CancellationToken,
     onUpdate?: Event<string>,
+    onLinkClick?: (uri: URI) => void,
   ): Promise<IDisposable>;
 }
 

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -138,6 +138,10 @@ export abstract class ZoneWidget extends Disposable {
 
   hide() {}
 
+  create(): void {
+    this._fillContainer(this._container);
+  }
+
   private _getLeft(info: monaco.editor.EditorLayoutInfo): number {
     if (info.minimap && info.minimap.minimapWidth > 0 && info.minimap.minimapLeft === 0) {
       return info.minimap.minimapWidth;
@@ -181,7 +185,6 @@ export abstract class ZoneWidget extends Disposable {
     this._container.style.width = `${this.width}px`;
     this._container.style.left = `${this.left}px`;
 
-    this._fillContainer(this._container);
     this.applyStyle();
   }
 

--- a/packages/testing/src/browser/index.ts
+++ b/packages/testing/src/browser/index.ts
@@ -9,7 +9,7 @@ import { TestTreeViewModelImpl } from './test-tree-view.model';
 import { TestResultServiceImpl } from './test.result.service';
 import { TestServiceImpl } from './test.service';
 import { TestingContribution } from './testing.contribution';
-import { TestServiceToken } from '../common';
+import { TestPeekMessageToken, TestServiceToken } from '../common';
 import { TestingPeekOpenerServiceToken } from '../common/testingPeekOpener';
 
 import './icons/icons.less';
@@ -17,6 +17,7 @@ import './outputPeek/test-peek-widget.less';
 import './theme.less';
 
 import { TestingPeekOpenerServiceImpl } from './outputPeek/test-peek-opener.service';
+import { TestingPeekMessageServiceImpl } from './outputPeek/test-peek-message.service';
 @Injectable()
 export class TestingModule extends BrowserModule {
   providers: Provider[] = [
@@ -40,6 +41,10 @@ export class TestingModule extends BrowserModule {
     {
       token: TestingPeekOpenerServiceToken,
       useClass: TestingPeekOpenerServiceImpl,
+    },
+    {
+      token: TestPeekMessageToken,
+      useClass: TestingPeekMessageServiceImpl,
     },
   ];
 }

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -1,0 +1,115 @@
+import { useInjectable } from '@opensumi/ide-core-browser';
+import { Disposable } from '@opensumi/ide-core-common';
+import {
+  EditorCollectionService,
+  getSimpleEditorOptions,
+  IEditorDocumentModelService,
+} from '@opensumi/ide-editor/lib/browser';
+import { IDiffEditorOptions, IEditorOptions } from '@opensumi/ide-monaco/lib/browser/monaco-api/editor';
+import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { TestPeekMessageToken } from '../../common';
+import { ITestErrorMessage, ITestMessage } from '../../common/testCollection';
+import { TestDto } from './test-output-peek';
+import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
+
+enum EContainerType {
+  DIFF,
+  PLANTTEXT,
+  MARKDOWN,
+}
+
+const commonEditorOptions: IEditorOptions = {
+  scrollBeyondLastLine: false,
+  scrollbar: {
+    verticalScrollbarSize: 14,
+    horizontal: 'auto',
+    useShadows: true,
+    verticalHasArrows: false,
+    horizontalHasArrows: false,
+    alwaysConsumeMouseWheel: false,
+  },
+  fixedOverflowWidgets: true,
+  readOnly: true,
+  minimap: {
+    enabled: false,
+  },
+};
+
+const diffEditorOptions: IDiffEditorOptions = {
+  ...commonEditorOptions,
+  enableSplitViewResizing: true,
+  renderOverviewRuler: false,
+  ignoreTrimWhitespace: false,
+  renderSideBySide: true,
+};
+
+const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
+  const { dto } = props;
+  const documentModelService: IEditorDocumentModelService = useInjectable(IEditorDocumentModelService);
+  const editorCollectionService: EditorCollectionService = useInjectable(EditorCollectionService);
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!dto) {
+      return;
+    }
+
+    const { expectedUri, actualUri } = dto;
+    Promise.all([
+      documentModelService.createModelReference(expectedUri),
+      documentModelService.createModelReference(actualUri),
+    ]).then((data) => {
+      const [original, modified] = data;
+      // const []
+      const diffEditor = editorCollectionService.createDiffEditor(editorRef.current!, {
+        ...getSimpleEditorOptions(),
+        ...diffEditorOptions,
+      });
+
+      const originalModel = original.instance.getMonacoModel();
+      const modifiedModel = modified.instance.getMonacoModel();
+
+      diffEditor.compare(original, modified);
+
+      diffEditor.originalEditor.monacoEditor.setModel(originalModel);
+      diffEditor.modifiedEditor.monacoEditor.setModel(modifiedModel);
+    });
+  }, []);
+
+  return <div ref={editorRef} style={{ height: '2000px' }}></div>;
+};
+
+export const TestMessageContainer = () => {
+  const disposer: Disposable = new Disposable();
+  const testingPeekMessageService: TestingPeekMessageServiceImpl = useInjectable(TestPeekMessageToken);
+
+  const [type, setType] = useState<EContainerType>();
+  const [dto, setDto] = useState<TestDto>();
+
+  const getMessage = (dto?: TestDto) => (dto ? dto.messages[dto.messageIndex] : { message: '' });
+
+  useEffect(() => {
+    disposer.addDispose(
+      testingPeekMessageService.onDidReveal(async (dto: TestDto) => {
+        setDto(dto);
+        const message = getMessage(dto);
+
+        if (dto.isDiffable) {
+          setType(EContainerType.DIFF);
+        } else if (!(dto.isDiffable || typeof message.message === 'string')) {
+          setType(EContainerType.MARKDOWN);
+        } else {
+          setType(EContainerType.PLANTTEXT);
+        }
+      }),
+    );
+
+    return () => {
+      disposer.dispose();
+    };
+  }, []);
+
+  return <div>{type === EContainerType.DIFF ? <DiffContentProvider dto={dto} /> : ''}</div>;
+};

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -45,6 +45,9 @@ const diffEditorOptions: IDiffEditorOptions = {
   renderSideBySide: true,
 };
 
+const getMessage = (dto?: TestDto) =>
+  dto ? dto.messages[dto.messageIndex] : { message: '', actual: '', expected: '' };
+
 const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
   const { dto } = props;
   const documentModelService: IEditorDocumentModelService = useInjectable(IEditorDocumentModelService);
@@ -62,7 +65,8 @@ const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
       documentModelService.createModelReference(actualUri),
     ]).then((data) => {
       const [original, modified] = data;
-      // const []
+      const { actual, expected } = getMessage(dto) as ITestErrorMessage;
+
       const diffEditor = editorCollectionService.createDiffEditor(editorRef.current!, {
         ...getSimpleEditorOptions(),
         ...diffEditorOptions,
@@ -71,6 +75,9 @@ const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
       const originalModel = original.instance.getMonacoModel();
       const modifiedModel = modified.instance.getMonacoModel();
 
+      originalModel.setValue(expected!);
+      modifiedModel.setValue(actual!);
+
       diffEditor.compare(original, modified);
 
       diffEditor.originalEditor.monacoEditor.setModel(originalModel);
@@ -78,7 +85,7 @@ const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
     });
   }, []);
 
-  return <div ref={editorRef} style={{ height: '2000px' }}></div>;
+  return <div ref={editorRef} style={{ height: 'inherit' }}></div>;
 };
 
 export const TestMessageContainer = () => {
@@ -87,8 +94,6 @@ export const TestMessageContainer = () => {
 
   const [type, setType] = useState<EContainerType>();
   const [dto, setDto] = useState<TestDto>();
-
-  const getMessage = (dto?: TestDto) => (dto ? dto.messages[dto.messageIndex] : { message: '' });
 
   useEffect(() => {
     disposer.addDispose(
@@ -111,5 +116,5 @@ export const TestMessageContainer = () => {
     };
   }, []);
 
-  return <div>{type === EContainerType.DIFF ? <DiffContentProvider dto={dto} /> : ''}</div>;
+  return <>{type === EContainerType.DIFF ? <DiffContentProvider dto={dto} /> : ''}</>;
 };

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -151,11 +151,9 @@ export const TestMessageContainer = () => {
       testingPeekMessageService.onDidReveal(async (dto: TestDto) => {
         setDto(dto);
         const message = getMessage(dto);
-        console.log('testingPeekMessageService', dto);
         if (dto.isDiffable) {
           setType(EContainerType.DIFF);
         } else if (!(dto.isDiffable || typeof message.message === 'string')) {
-          console.log('testingPeekMessageService', message.message.value);
           setType(EContainerType.MARKDOWN);
         } else {
           setType(EContainerType.PLANTTEXT);

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -58,7 +58,7 @@ const MarkdownContentProvider = React.memo((props: { dto: TestDto | undefined })
   // const openerService: IOpenerService = useInjectable(IOpenerService);
 
   const shadowRootRef = useRef<HTMLDivElement | null>(null);
-  const [message, useMessage] = useState<IMarkdownString | null>(null);
+  const [message, useMessage] = useState<string>('');
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
 
   React.useEffect(() => {
@@ -68,8 +68,10 @@ const MarkdownContentProvider = React.memo((props: { dto: TestDto | undefined })
         setShadowRoot(shadowRootElement);
       }
 
-      const message = getMessage(dto).message;
-      useMessage(message as IMarkdownString);
+      const mdStr = getMessage(dto).message;
+      // 不处理 \t 制表符
+      const message = mdStr ? (mdStr as IMarkdownString).value.replace(/\t/g, '') : '';
+      useMessage(message);
     }
   }, []);
 
@@ -77,7 +79,7 @@ const MarkdownContentProvider = React.memo((props: { dto: TestDto | undefined })
     <div ref={shadowRootRef} className={'preview-markdown'}>
       {shadowRoot && (
         <ShadowContent root={shadowRoot}>
-          <Markdown content={message?.value!}></Markdown>
+          <Markdown content={message}></Markdown>
         </ShadowContent>
       )}
     </div>
@@ -143,10 +145,11 @@ export const TestMessageContainer = () => {
       testingPeekMessageService.onDidReveal(async (dto: TestDto) => {
         setDto(dto);
         const message = getMessage(dto);
-
+        console.log('testingPeekMessageService', dto);
         if (dto.isDiffable) {
           setType(EContainerType.DIFF);
         } else if (!(dto.isDiffable || typeof message.message === 'string')) {
+          console.log('testingPeekMessageService', message.message.value);
           setType(EContainerType.MARKDOWN);
         } else {
           setType(EContainerType.PLANTTEXT);

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -1,5 +1,5 @@
-import { useInjectable } from '@opensumi/ide-core-browser';
-import { Disposable } from '@opensumi/ide-core-common';
+import { IOpenerService, useInjectable } from '@opensumi/ide-core-browser';
+import { Disposable, Schemas, URI } from '@opensumi/ide-core-common';
 import {
   EditorCollectionService,
   getSimpleEditorOptions,
@@ -55,11 +55,17 @@ const ShadowContent = ({ root, children }) => ReactDOM.createPortal(children, ro
 const MarkdownContentProvider = React.memo((props: { dto: TestDto | undefined }) => {
   const { dto } = props;
 
-  // const openerService: IOpenerService = useInjectable(IOpenerService);
+  const openerService: IOpenerService = useInjectable(IOpenerService);
 
   const shadowRootRef = useRef<HTMLDivElement | null>(null);
   const [message, useMessage] = useState<string>('');
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+
+  const handleLinkClick = (uri: URI) => {
+    if (uri && uri.scheme === Schemas.command) {
+      openerService.open(uri);
+    }
+  };
 
   React.useEffect(() => {
     if (shadowRootRef.current) {
@@ -79,7 +85,7 @@ const MarkdownContentProvider = React.memo((props: { dto: TestDto | undefined })
     <div ref={shadowRootRef} className={'preview-markdown'}>
       {shadowRoot && (
         <ShadowContent root={shadowRoot}>
-          <Markdown content={message}></Markdown>
+          <Markdown content={message} onLinkClick={handleLinkClick}></Markdown>
         </ShadowContent>
       )}
     </div>

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -173,7 +173,7 @@ export const TestMessageContainer = () => {
       ) : type === EContainerType.MARKDOWN ? (
         <MarkdownContentProvider dto={dto} />
       ) : (
-        ''
+        getMessage(dto).message
       )}
     </>
   );

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -3,14 +3,14 @@ import { Disposable } from '@opensumi/ide-core-common';
 import {
   EditorCollectionService,
   getSimpleEditorOptions,
+  IDiffEditor,
   IEditorDocumentModelService,
 } from '@opensumi/ide-editor/lib/browser';
 import { IDiffEditorOptions, IEditorOptions } from '@opensumi/ide-monaco/lib/browser/monaco-api/editor';
-import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { TestPeekMessageToken } from '../../common';
-import { ITestErrorMessage, ITestMessage } from '../../common/testCollection';
+import { ITestErrorMessage } from '../../common/testCollection';
 import { TestDto } from './test-output-peek';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 
@@ -58,6 +58,7 @@ const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
     if (!dto) {
       return;
     }
+    let diffEditor: IDiffEditor;
 
     const { expectedUri, actualUri } = dto;
     Promise.all([
@@ -67,7 +68,7 @@ const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
       const [original, modified] = data;
       const { actual, expected } = getMessage(dto) as ITestErrorMessage;
 
-      const diffEditor = editorCollectionService.createDiffEditor(editorRef.current!, {
+      diffEditor = editorCollectionService.createDiffEditor(editorRef.current!, {
         ...getSimpleEditorOptions(),
         ...diffEditorOptions,
       });
@@ -83,6 +84,12 @@ const DiffContentProvider = (props: { dto: TestDto | undefined }) => {
       diffEditor.originalEditor.monacoEditor.setModel(originalModel);
       diffEditor.modifiedEditor.monacoEditor.setModel(modifiedModel);
     });
+
+    return () => {
+      if (diffEditor) {
+        diffEditor.dispose();
+      }
+    };
   }, []);
 
   return <div ref={editorRef} style={{ height: 'inherit' }}></div>;

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -1,3 +1,5 @@
+import { TestingIsInPeek } from '@opensumi/ide-core-browser/lib/contextkey/testing';
+import { IContextKey, IContextKeyService, Schemas } from '@opensumi/ide-core-browser';
 import * as editorCommon from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
 import { buildTestUri, parseTestUri, TestUriType } from './../../common/testingUri';
 import { Injectable, Optional, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
@@ -68,11 +70,19 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   @Autowired(TestingPeekOpenerServiceToken)
   private readonly testingPeekOpenerService: TestingPeekOpenerServiceImpl;
 
+  @Autowired(IContextKeyService)
+  private readonly contextKeyService: IContextKeyService;
+
   private readonly disposer: Disposable = new Disposable();
 
   private readonly peekView = new MutableDisposable<TestingOutputPeek>();
+  private readonly visible: IContextKey<boolean>;
 
-  constructor(@Optional() private readonly editor: IEditor) {}
+  private currentPeekUri: URI | undefined;
+
+  constructor(@Optional() private readonly editor: IEditor) {
+    this.visible = TestingIsInPeek.bind(this.contextKeyService);
+  }
 
   private retrieveTest(uri: URI): TestDto | undefined {
     const parts = parseTestUri(uri);
@@ -92,10 +102,35 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   public contribute(): IDisposable {
     this.disposer.addDispose(
       this.editor.monacoEditor.onDidChangeModel((e: editorCommon.IModelChangedEvent) => {
+        if (e.newModelUrl?.scheme !== Schemas.file) {
+          return;
+        }
+
         this.testingPeekOpenerService.setPeekContrib(e.newModelUrl as unknown as URI, this);
       }),
     );
+
+    this.disposer.addDispose(
+      Disposable.create(() => {
+        if (this.editor.currentUri) {
+          this.testingPeekOpenerService.delPeekContrib(this.editor.currentUri);
+        }
+      }),
+    );
     return this.disposer;
+  }
+
+  public toggle(uri: URI) {
+    if (this.currentPeekUri?.toString() === uri.toString()) {
+      this.peekView.clear();
+    } else {
+      this.show(uri);
+    }
+  }
+
+  public removePeek() {
+    this.peekView.value?.hide();
+    this.peekView.clear();
   }
 
   public async show(uri: URI): Promise<void> {
@@ -106,8 +141,17 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
 
     if (!this.peekView.value) {
       this.peekView.value = this.injector.get(TestingOutputPeek, [this.editor.monacoEditor]);
+      this.peekView.value.onDidClose(() => {
+        this.visible.set(false);
+        this.currentPeekUri = undefined;
+        this.peekView.value = undefined;
+      });
+
+      this.visible.set(true);
+      this.peekView.value.create();
     }
 
     this.peekView.value.setModel(dto);
+    this.currentPeekUri = uri;
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -141,11 +141,13 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
 
     if (!this.peekView.value) {
       this.peekView.value = this.injector.get(TestingOutputPeek, [this.editor.monacoEditor]);
-      this.peekView.value.onDidClose(() => {
-        this.visible.set(false);
-        this.currentPeekUri = undefined;
-        this.peekView.value = undefined;
-      });
+      this.disposer.addDispose(
+        this.peekView.value.onDidClose(() => {
+          this.visible.set(false);
+          this.currentPeekUri = undefined;
+          this.peekView.value = undefined;
+        }),
+      );
 
       this.visible.set(true);
       this.peekView.value.create();

--- a/packages/testing/src/browser/outputPeek/test-peek-message.service.ts
+++ b/packages/testing/src/browser/outputPeek/test-peek-message.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { Disposable, URI, Emitter } from '@opensumi/ide-core-common';
+import { ITestingPeekMessageService } from '../../common';
+import { TestDto } from './test-output-peek';
+
+@Injectable()
+export class TestingPeekMessageServiceImpl extends Disposable implements ITestingPeekMessageService {
+  public readonly _didReveal = new Emitter<TestDto>();
+  public readonly _visibilityChange = new Emitter<boolean>();
+
+  public readonly onDidReveal = this._didReveal.event;
+  public readonly onVisibilityChange = this._visibilityChange.event;
+}

--- a/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
+++ b/packages/testing/src/browser/outputPeek/test-peek-opener.service.ts
@@ -40,7 +40,11 @@ export class TestingPeekOpenerServiceImpl extends Disposable implements ITesting
 
   private lastUri?: TestUriWithDocument;
 
-  private peekControllerMap: Map<string, TestOutputPeekContribution> = new Map();
+  public readonly peekControllerMap: Map<string, TestOutputPeekContribution> = new Map();
+
+  public get currentUri(): URI | undefined {
+    return this.editorService.currentEditor?.currentUri!;
+  }
 
   private async showPeekFromUri(testUri: TestUriWithDocument, options?: ITextEditorOptions) {
     const editor = this.editorService.currentEditor;
@@ -93,6 +97,12 @@ export class TestingPeekOpenerServiceImpl extends Disposable implements ITesting
     return this;
   }
 
+  public delPeekContrib(uri: URI): this {
+    const uriStr = uri.toString();
+    this.peekControllerMap.delete(uriStr);
+    return this;
+  }
+
   public tryPeekFirstError(result: ITestResult, test: TestResultItem, options?: Partial<ITextEditorOptions>): boolean {
     throw new Error('Method not implemented.');
   }
@@ -112,6 +122,8 @@ export class TestingPeekOpenerServiceImpl extends Disposable implements ITesting
   }
 
   public closeAllPeeks(): void {
-    throw new Error('Method not implemented.');
+    for (const ctor of this.peekControllerMap.values()) {
+      ctor.removePeek();
+    }
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -86,5 +86,15 @@
 
   .body {
     border-color: rgb(241, 76, 76);
+    height: inherit;
+  }
+
+  .test-output-peek-wrapper {
+    height: inherit;
+  }
+
+  .test-output-peek-message-container,
+  .test-output-peek-tree {
+    height: inherit;
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -97,4 +97,11 @@
   .test-output-peek-tree {
     height: inherit;
   }
+
+  .preview-markdown {
+    position: relative;
+    overflow: hidden;
+    padding: 8px 12px 8px 20px;
+    height: calc(100% - 16px);
+  }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -28,9 +28,11 @@
 
 .peekview-widget .head .peekview-title .dirname {
   white-space: nowrap;
+  color: rgba(204, 204, 204, 0.7);
 }
 
 .peekview-widget .head .peekview-title .filename {
+  color: #ffffff;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -28,11 +28,11 @@
 
 .peekview-widget .head .peekview-title .dirname {
   white-space: nowrap;
-  color: rgba(204, 204, 204, 0.7);
+  color: var(--descriptionForeground);
 }
 
 .peekview-widget .head .peekview-title .filename {
-  color: #ffffff;
+  color: var(--kt-accentForeground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -68,8 +68,8 @@
 }
 
 .testing-output-peek-container {
-  border-top-color: rgb(241, 76, 76);
-  border-bottom-color: rgb(241, 76, 76);
+  border-top-color: var(--errorForeground);
+  border-bottom-color: var(--errorForeground);
   height: 416px;
   border-top-width: 1px;
   border-bottom-width: 1px;
@@ -79,13 +79,13 @@
   overflow: hidden;
 
   .head {
-    background-color: rgba(241, 76, 76, 0.1);
+    background-color: var(--testing-peekHeaderBackground);
     height: 22px;
     line-height: 22px;
   }
 
   .body {
-    border-color: rgb(241, 76, 76);
+    border-color: var(--errorForeground);
     height: inherit;
   }
 

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -1,28 +1,67 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { PeekViewWidget } from '@opensumi/ide-monaco-enhance/lib/browser/peek-view';
-import { Injectable } from '@opensumi/di';
+import { Injectable, Autowired } from '@opensumi/di';
 import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import { TestDto } from './test-output-peek';
 import { TestMessageType } from '../../common/testCollection';
 import './test-peek-widget.less';
+import { AppConfig, ConfigProvider, IContextKeyService } from '@opensumi/ide-core-browser';
+import { TestingIsInPeek } from '@opensumi/ide-core-browser/lib/contextkey/testing';
+import { renderMarkdown } from '@opensumi/monaco-editor-core/esm/vs/base/browser/markdownRenderer';
+import { Emitter } from '@opensumi/ide-core-common';
+import { TestMessageContainer } from './test-message-container';
+import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
+import { TestPeekMessageToken } from '../../common';
+
+const firstLine = (str: string) => {
+  const index = str.indexOf('\n');
+  return index === -1 ? str : str.slice(0, index);
+};
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {
+  @Autowired(IContextKeyService)
+  private readonly contextKeyService: IContextKeyService;
+
+  @Autowired(TestPeekMessageToken)
+  private readonly testingPeekMessageService: TestingPeekMessageServiceImpl;
+
+  @Autowired(AppConfig)
+  private configContext: AppConfig;
+
   public current?: TestDto;
   private _wrapper: HTMLDivElement;
 
   constructor(public readonly editor: ICodeEditor) {
     super(editor);
 
+    TestingIsInPeek.bind(this.contextKeyService);
+
     this._wrapper = document.createElement('div');
+    this._wrapper.classList.add('test-output-peek-wrapper');
   }
 
+  /**
+   * 在这里渲染测试结果
+   * 左侧:
+   *  - markdown
+   *  - plantText
+   *  - monaco diff editor (用于 assertEquals)
+   * 右侧:
+   *  - tree
+   */
   protected _fillBody(container: HTMLElement): void {
     container.appendChild(this._wrapper);
-
-    this.setTitle('testing peekview widget title', this.current?.test.label);
     this.setCssClass('testing-output-peek-container');
+    ReactDOM.render(
+      <ConfigProvider value={this.configContext}>
+        <div className='test-output-peek-message-container'>
+          <TestMessageContainer />
+        </div>
+      </ConfigProvider>,
+      this._wrapper,
+    );
   }
 
   protected applyClass(): void {
@@ -30,9 +69,25 @@ export class TestingOutputPeek extends PeekViewWidget {
   }
 
   protected applyStyle(): void {
-    const message = this.current!.messages[this.current!.messageIndex];
+    console.log('applyStyle Method not implemented.');
+  }
 
-    ReactDOM.render(<div>{message.message.toString()}</div>, this._wrapper);
+  public async showInPlace(dto: TestDto) {
+    const message = dto.messages[dto.messageIndex];
+    this.setTitle(
+      firstLine(
+        typeof message.message === 'string' ? message.message : renderMarkdown(message.message).element.outerText,
+      ),
+      dto.test.label,
+    );
+    setTimeout(() => {
+      this.testingPeekMessageService._didReveal.fire(dto);
+      this.testingPeekMessageService._visibilityChange.fire(true);
+    });
+  }
+
+  public hide(): void {
+    super.dispose();
   }
 
   public setModel(dto: TestDto): Promise<void> {
@@ -48,10 +103,13 @@ export class TestingOutputPeek extends PeekViewWidget {
     }
 
     this.current = dto;
+    if (!dto.revealLocation) {
+      return this.showInPlace(dto);
+    }
 
     this.show(dto.revealLocation!.range, message.location?.range.startLineNumber!);
     this.editor.focus();
 
-    return Promise.resolve();
+    return this.showInPlace(dto);
   }
 }

--- a/packages/testing/src/browser/test-decorations.ts
+++ b/packages/testing/src/browser/test-decorations.ts
@@ -1,4 +1,5 @@
-import { Color, RGBA, themeColorFromId } from '@opensumi/ide-theme';
+import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
+import * as editorCommon from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
 import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 import { MouseTargetType } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
 import { MarkdownString } from '@opensumi/monaco-editor-core/esm/vs/base/common/htmlContent';
@@ -7,8 +8,6 @@ import { labelForTestInState, testMessageSeverityColors } from './../common/cons
 import { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import { TestResultImpl, TestResultServiceToken } from './../common/test-result';
 import { ResultChangeEvent, TestResultServiceImpl } from './test.result.service';
-import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
-import * as editorCommon from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { Disposable, IDisposable, IRange, URI, uuid } from '@opensumi/ide-core-common';
 import { IEditor, IEditorFeatureContribution } from '@opensumi/ide-editor/lib/browser';

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -43,7 +43,7 @@ export class TestingOutputPeekDocumentProvider implements IEditorDocumentModelCo
   onDidChangeContent: Event<URI> = this._onDidChangeContent.event;
 
   provideEditorDocumentModelContent(uri: URI, encoding?: string): MaybePromise<string> {
-    return Promise.resolve('??????????????????????');
+    return Promise.resolve('');
   }
   isReadonly(uri: URI): MaybePromise<boolean> {
     return true;

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -74,7 +74,7 @@ export class TestingContribution
   private readonly testingPeekOpenerService: TestingPeekOpenerServiceImpl;
 
   @Autowired()
-  private readonly debugConsoleInputDocumentProvider: TestingOutputPeekDocumentProvider;
+  private readonly testingOutputPeekDocumentProvider: TestingOutputPeekDocumentProvider;
 
   initialize(): void {
     this.testTreeViewModel.initTreeModel();
@@ -163,6 +163,6 @@ export class TestingContribution
   }
 
   registerEditorDocumentModelContentProvider(registry: IEditorDocumentModelContentRegistry) {
-    registry.registerEditorDocumentModelContentProvider(this.debugConsoleInputDocumentProvider);
+    registry.registerEditorDocumentModelContentProvider(this.testingOutputPeekDocumentProvider);
   }
 }

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -16,3 +16,8 @@ export const PeekTestError: Command = {
   id: 'testing.peek.test.error',
   label: 'Peek Output',
 };
+
+export const ClosePeekTest: Command = {
+  id: 'testing.peek.test.close',
+  label: 'Close Peek Output',
+};

--- a/packages/testing/src/common/index.ts
+++ b/packages/testing/src/common/index.ts
@@ -22,6 +22,11 @@ export interface ITestController {
 
 export const TestServiceToken = Symbol('TestService');
 export const TestDecorationsToken = Symbol('TestDecorationsToken');
+export const TestPeekMessageToken = Symbol('TestPeekMessageToken');
+
+export interface ITestingPeekMessageService {
+  onDidReveal: Event<any>;
+}
 
 export interface ITestService {
   readonly collection: MainThreadTestCollection;

--- a/packages/theme/src/common/color-tokens/testing.ts
+++ b/packages/theme/src/common/color-tokens/testing.ts
@@ -1,5 +1,7 @@
 import { localize } from '@opensumi/ide-core-common';
-import { registerColor } from '../color-registry';
+import { registerColor, transparent } from '../color-registry';
+import { contrastBorder } from './base';
+import { editorErrorForeground } from './editor';
 
 export const testingColorIconFailed = registerColor(
   'testing.iconFailed',
@@ -69,4 +71,24 @@ export const testingColorIconSkipped = registerColor(
     hc: '#848484',
   },
   localize('testing.iconSkipped', "Color for the 'Skipped' icon in the test explorer."),
+);
+
+export const testingPeekBorder = registerColor(
+  'testing.peekBorder',
+  {
+    dark: editorErrorForeground,
+    light: editorErrorForeground,
+    hc: contrastBorder,
+  },
+  localize('testing.peekBorder', 'Color of the peek view borders and arrow.'),
+);
+
+export const testingPeekHeaderBackground = registerColor(
+  'testing.peekHeaderBackground',
+  {
+    dark: transparent(editorErrorForeground, 0.1),
+    light: transparent(editorErrorForeground, 0.1),
+    hc: null,
+  },
+  localize('testing.peekBorder', 'Color of the peek view borders and arrow.'),
 );


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

1. 对于 assertEquals 的测试用例是打开 diffEditor 面板来对比查看 expected 和 actual 的值
2. 对于堆栈信息的错误则是打开 markdown 视图并支持 command 命令

![Kapture 2022-01-22 at 15 41 34](https://user-images.githubusercontent.com/20262815/150629838-f00859c5-fb88-48b4-8a0c-5e0220f34f17.gif)


PS: OutputPeek 的右侧文件树还未实现

### Changelog
支持 Testing OutputPeek 查看测试结果
