### PR TITLE
fix: 修复 electron 启动命令错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "init:deps": "ts-node ./scripts/bootstrap",
     "init": "npm run init:deps && npm run clean && npm run build:all",
     "start": "node ./scripts/rebuild-native.js && cross-env NODE_ENV=development ts-node ./scripts/start",
-    "start:electron": "cd tools/electron && npm i && npm run link-local && npm run rebuild-native && npm run build && npm run start",
+    "start:electron": "cd tools/electron && npm run rebuild-native && npm run build && npm run start",
     "build:components": "cd packages/components && npm run build:dist",
     "start:lite": "cross-env NODE_ENV=development ts-node ./scripts/start --script=start:lite",
     "prod:lite": "ts-node ./scripts/start --script=prod:lite",


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [x] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

当前 main 分支上执行 `npm run start:electron` 会失败，这个命令会分别执行以下 5 个小命令：
1. cd tools/electron
2. npm i
3. npm run link-local
4. npm run rebuild-native
5. npm run build
6. npm run start

启动 (2) 和 (3) 是不必要的，执行它们反而可能带来错误，因为已经使用了基于 lerna 的 Monorepo 方案，因此，在单独仓库安装依赖会导致依赖丢失，从而导致启动失败。(3) 之所以不需要也是因为 lerna 会自己来完成 Monorepo 内部 package 之间的 link

### Changelog
