### PR TITLE
fix: wrap replace button with observer on search panel

### DIFF
--- a/packages/search/src/browser/search.replace.widget.tsx
+++ b/packages/search/src/browser/search.replace.widget.tsx
@@ -1,4 +1,5 @@
 import React, { RefObject } from 'react';
+import { observer } from 'mobx-react-lite';
 import { localize } from '@opensumi/ide-core-common/lib/localize';
 import { Input } from '@opensumi/ide-components';
 import styles from './search.module.less';
@@ -16,35 +17,37 @@ interface SearchReplaceWidgetProps {
 }
 
 export const SearchReplaceWidget = React.memo(
-  ({
-    replaceValue,
-    resultTotal = { resultNum: 0, fileNum: 0 },
-    onSearch,
-    onReplaceRuleChange,
-    replaceInputEl,
-    doReplaceAll,
-  }: SearchReplaceWidgetProps) => (
-    <div className={styles.search_and_replace_container}>
-      <div className={styles.search_and_replace_fields}>
-        <div className={styles.replace_field}>
-          <Input
-            value={replaceValue}
-            id='replace-input-field'
-            title={localize('search.replace.label')}
-            type='text'
-            placeholder={localize('search.replace.title')}
-            onKeyUp={onSearch}
-            onChange={onReplaceRuleChange}
-            ref={replaceInputEl}
-          />
-          <div
-            className={`${styles.replace_all_button} ${resultTotal.resultNum > 0 ? '' : styles.disabled}`}
-            onClick={doReplaceAll}
-          >
-            <span>{localize('search.replaceAll.label')}</span>
+  observer(
+    ({
+      replaceValue,
+      resultTotal = { resultNum: 0, fileNum: 0 },
+      onSearch,
+      onReplaceRuleChange,
+      replaceInputEl,
+      doReplaceAll,
+    }: SearchReplaceWidgetProps) => (
+      <div className={styles.search_and_replace_container}>
+        <div className={styles.search_and_replace_fields}>
+          <div className={styles.replace_field}>
+            <Input
+              value={replaceValue}
+              id='replace-input-field'
+              title={localize('search.replace.label')}
+              type='text'
+              placeholder={localize('search.replace.title')}
+              onKeyUp={onSearch}
+              onChange={onReplaceRuleChange}
+              ref={replaceInputEl}
+            />
+            <div
+              className={`${styles.replace_all_button} ${resultTotal.resultNum > 0 ? '' : styles.disabled}`}
+              onClick={doReplaceAll}
+            >
+              <span>{localize('search.replaceAll.label')}</span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    ),
   ),
 );


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fixed #367 

### Changelog

wrap replace button with observer on search panel