### PR TITLE
fix: fix Path.join cannot handle relative path correctly

### DIFF
--- a/packages/core-common/__tests__/path.test.ts
+++ b/packages/core-common/__tests__/path.test.ts
@@ -31,6 +31,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import * as path from '../src/path';
+import { Path } from '../src/path';
 import { isWindows } from '../src/platform';
 
 describe('Paths (Node Implementation)', () => {
@@ -717,5 +718,37 @@ describe('Paths (Node Implementation)', () => {
     expect(path.win32.delimiter).toBe(';');
     // posix
     expect(path.posix.delimiter).toBe(':');
+  });
+});
+
+describe('Path.join', () => {
+  // Windows
+  test('join common path in Windows', () => {
+    const path = new Path('/c:/a/b');
+    expect(path.join('c', 'd').toString()).toBe('/c:/a/b/c/d');
+    expect(path.join('e/f').toString()).toBe('/c:/a/b/e/f');
+  });
+
+  test('join relative path in Windows', () => {
+    const path = new Path('/c:/a/b');
+    expect(path.join('./').toString()).toBe('/c:/a/b/');
+    expect(path.join('./././', '././').toString()).toBe('/c:/a/b/');
+    expect(path.join('../', './b/', './', '../', '../', './a').toString()).toBe('/c:/a');
+  });
+
+  // POSIX
+
+  test('join common path in POSIX', () => {
+    const path = new Path('/a/b/');
+    expect(path.join('c', 'd').toString()).toBe('/a/b/c/d');
+    expect(path.join('e/f').toString()).toBe('/a/b/e/f');
+    expect(path.join('l/m', '/n/', 'o/', 'p').toString()).toBe('/a/b/l/m/n/o/p');
+  });
+
+  test('join relative path in POSIX', () => {
+    const path = new Path('/a/b');
+    expect(path.join('./').toString()).toBe('/a/b/');
+    expect(path.join('./././', '././').toString()).toBe('/a/b/');
+    expect(path.join('../', './b/', './', '../', '../', './a').toString()).toBe('/a');
   });
 });

--- a/packages/core-common/src/path.ts
+++ b/packages/core-common/src/path.ts
@@ -159,9 +159,9 @@ export class Path {
     }
 
     if (this.raw.endsWith(Path.separator) || relativePath.startsWith(Path.separator)) {
-      return new Path(this.raw + relativePath);
+      return new Path(posix.join(this.raw, relativePath));
     }
-    return new Path(this.raw + Path.separator + relativePath);
+    return new Path(posix.join(this.raw, Path.separator, relativePath));
   }
 
   toString(): string {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

close #393

### Changelog

- fix: 修复 Path.join 不能正确处理相对路径的问题。
