### PR TITLE
feat: support message output peek tree

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -862,6 +862,7 @@ export const localizationBundle = {
     // #region Testing
     'test.title': 'Testing',
     'test.result.runFinished': 'Test run at {0}',
+    'test.task.unnamed': 'Unnamed Task',
     // #endregion
   },
 };

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -861,6 +861,7 @@ export const localizationBundle = {
 
     // #region Testing
     'test.title': 'Testing',
+    'test.result.runFinished': 'Test run at {0}',
     // #endregion
   },
 };

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -920,6 +920,7 @@ export const localizationBundle = {
     // #region Testing
     'test.title': '测试管理器',
     'test.result.runFinished': '测试运行完成于 {0}',
+    'test.task.unnamed': '未命名任务',
     // #endregion
   },
 };

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -919,6 +919,7 @@ export const localizationBundle = {
 
     // #region Testing
     'test.title': '测试管理器',
+    'test.result.runFinished': '测试运行完成于 {0}',
     // #endregion
   },
 };

--- a/packages/testing/src/browser/components/testing.explorer.tree.tsx
+++ b/packages/testing/src/browser/components/testing.explorer.tree.tsx
@@ -7,7 +7,7 @@ import { ITestTreeData, ITestTreeItem, ITestTreeViewModel, TestTreeViewModelToke
 import { TestItemExpandState, TestRunProfileBitset } from '../../common/testCollection';
 import { GoToTestCommand, RuntTestCommand } from '../../common/commands';
 import { ITestService, TestServiceToken } from '../../common';
-import { testingStatesToIcons, testStatesToIconColors } from '../icons/icons';
+import { getIconWithColor } from '../icons/icons';
 import { BasicCompositeTreeNode } from '@opensumi/ide-components/lib/recycle-tree/basic/tree-node.define';
 import { TestingExplorerInlineMenus } from '../../common/testing-view';
 
@@ -20,10 +20,7 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
 
   const [treeData, setTreeData] = useState<ITestTreeData[]>([]);
 
-  const getItemIcon = React.useCallback(
-    (item: ITestTreeItem) => `${testingStatesToIcons.get(item.state)} ${testStatesToIconColors[item.state]}` || '',
-    [],
-  );
+  const getItemIcon = React.useCallback((item: ITestTreeItem) => getIconWithColor(item.state), []);
 
   const asTreeData = React.useCallback(
     (item: ITestTreeItem): ITestTreeData => ({

--- a/packages/testing/src/browser/components/testing.module.less
+++ b/packages/testing/src/browser/components/testing.module.less
@@ -7,3 +7,20 @@
     }
   }
 }
+
+.test_output_peek_message_container,
+.test_output_peek_tree {
+  height: 100%;
+}
+
+.test_output_peek_tree {
+  background-color: var(--peekViewResult-background);
+  color: var(--peekViewResult-lineForeground);
+}
+
+.preview_markdown {
+  position: relative;
+  overflow: hidden;
+  padding: 8px 12px 8px 20px;
+  height: calc(100% - 16px);
+}

--- a/packages/testing/src/browser/icons/icons.ts
+++ b/packages/testing/src/browser/icons/icons.ts
@@ -24,3 +24,6 @@ export const testingStatesToIcons = new Map<TestResultState, string>([
 
 export const testingRunIcon = getExternalIcon('run');
 export const testingRunAllIcon = getExternalIcon('run-all');
+
+export const getIconWithColor = (state: TestResultState) =>
+  `${testingStatesToIcons.get(state)} ${testStatesToIconColors[state]}` || '';

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -167,7 +167,7 @@ export const TestMessageContainer = () => {
   }, []);
 
   return (
-    <>
+    <div className='test-output-peek-message-container' style={{ height: '100%' }}>
       {type === EContainerType.DIFF ? (
         <DiffContentProvider dto={dto} />
       ) : type === EContainerType.MARKDOWN ? (
@@ -175,6 +175,6 @@ export const TestMessageContainer = () => {
       ) : (
         getMessage(dto).message
       )}
-    </>
+    </div>
   );
 };

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -16,6 +16,8 @@ import { TestDto } from './test-output-peek';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 import { Markdown } from '@opensumi/ide-markdown';
 
+import styles from '../components/testing.module.less';
+
 enum EContainerType {
   DIFF,
   PLANTTEXT,
@@ -82,7 +84,7 @@ const MarkdownContentProvider = React.memo((props: { dto: TestDto | undefined })
   }, []);
 
   return (
-    <div ref={shadowRootRef} className={'preview-markdown'}>
+    <div ref={shadowRootRef} className={styles.preview_markdown}>
       {shadowRoot && (
         <ShadowContent root={shadowRoot}>
           <Markdown content={message} onLinkClick={handleLinkClick}></Markdown>
@@ -167,7 +169,7 @@ export const TestMessageContainer = () => {
   }, []);
 
   return (
-    <div className='test-output-peek-message-container' style={{ height: '100%' }}>
+    <div className={styles.test_output_peek_message_container} style={{ height: '100%' }}>
       {type === EContainerType.DIFF ? (
         <DiffContentProvider dto={dto} />
       ) : type === EContainerType.MARKDOWN ? (

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -95,7 +95,12 @@
 
   .test-output-peek-message-container,
   .test-output-peek-tree {
-    height: inherit;
+    height: 100%;
+  }
+
+  .test-output-peek-tree {
+    background-color: var(--peekViewResult-background);
+    color: var(--peekViewResult-lineForeground);
   }
 
   .preview-markdown {

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -70,7 +70,6 @@
 .testing-output-peek-container {
   border-top-color: var(--errorForeground);
   border-bottom-color: var(--errorForeground);
-  height: 416px;
   border-top-width: 1px;
   border-bottom-width: 1px;
   border-top-style: solid;
@@ -91,22 +90,5 @@
 
   .test-output-peek-wrapper {
     height: inherit;
-  }
-
-  .test-output-peek-message-container,
-  .test-output-peek-tree {
-    height: 100%;
-  }
-
-  .test-output-peek-tree {
-    background-color: var(--peekViewResult-background);
-    color: var(--peekViewResult-lineForeground);
-  }
-
-  .preview-markdown {
-    position: relative;
-    overflow: hidden;
-    padding: 8px 12px 8px 20px;
-    height: calc(100% - 16px);
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -14,11 +14,7 @@ import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 import { TestPeekMessageToken } from '../../common';
 import { TestTreeContainer } from './test-tree-container';
 import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
-
-const firstLine = (str: string) => {
-  const index = str.indexOf('\n');
-  return index === -1 ? str : str.slice(0, index);
-};
+import { firstLine } from '../../common/testingStates';
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -16,6 +16,8 @@ import { TestTreeContainer } from './test-tree-container';
 import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 import { firstLine } from '../../common/testingStates';
 
+import styles from '../components/testing.module.less';
+
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {
   @Autowired(IContextKeyService)

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -9,10 +9,11 @@ import './test-peek-widget.less';
 import { AppConfig, ConfigProvider, IContextKeyService } from '@opensumi/ide-core-browser';
 import { TestingIsInPeek } from '@opensumi/ide-core-browser/lib/contextkey/testing';
 import { renderMarkdown } from '@opensumi/monaco-editor-core/esm/vs/base/browser/markdownRenderer';
-import { Emitter } from '@opensumi/ide-core-common';
 import { TestMessageContainer } from './test-message-container';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 import { TestPeekMessageToken } from '../../common';
+import { TestTreeContainer } from './test-tree-container';
+import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 
 const firstLine = (str: string) => {
   const index = str.indexOf('\n');
@@ -56,9 +57,10 @@ export class TestingOutputPeek extends PeekViewWidget {
     this.setCssClass('testing-output-peek-container');
     ReactDOM.render(
       <ConfigProvider value={this.configContext}>
-        <div className='test-output-peek-message-container'>
+        <SplitPanel overflow='hidden' id='testing-message-horizontal' flex={1}>
           <TestMessageContainer />
-        </div>
+          <TestTreeContainer />
+        </SplitPanel>
       </ConfigProvider>,
       this._wrapper,
     );

--- a/packages/testing/src/browser/outputPeek/test-tree-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-tree-container.tsx
@@ -2,21 +2,14 @@ import { BasicRecycleTree } from '@opensumi/ide-components';
 import { useInjectable } from '@opensumi/ide-core-browser';
 import { Disposable, localize } from '@opensumi/ide-core-common';
 import { Iterable } from '@opensumi/monaco-editor-core/esm/vs/base/common/iterator';
-import React, { useEffect, useRef, useState } from 'react';
-import ReactDOM from 'react-dom';
+import React, { useEffect, useState } from 'react';
 import { TestPeekMessageToken } from '../../common';
 import { ITestResult, maxCountPriority, resultItemParents, TestResultServiceToken } from '../../common/test-result';
-import {
-  ITestMessage,
-  ITestTaskState,
-  TestItemExpandState,
-  TestResultItem,
-  TestResultState,
-} from '../../common/testCollection';
+import { ITestMessage, ITestTaskState, TestResultItem, TestResultState } from '../../common/testCollection';
 import { firstLine } from '../../common/testingStates';
 import { buildTestUri, TestUriType } from '../../common/testingUri';
 import { ITestTreeData } from '../../common/tree-view.model';
-import { getIconWithColor, testingStatesToIcons, testStatesToIconColors } from '../icons/icons';
+import { getIconWithColor } from '../icons/icons';
 import { TestResultServiceImpl } from '../test.result.service';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 
@@ -44,16 +37,6 @@ export const TestTreeContainer = () => {
   const [treeData, setTreeData] = useState<ITestBaseTree<ITestResult>[]>([]);
 
   useEffect(() => {
-    disposer.addDispose(
-      testResultService.onTestChanged((e) => {
-        console.log('testResultService.onTestChanged', e);
-      }),
-    );
-    disposer.addDispose(
-      testResultService.onResultsChanged((e) => {
-        console.log('testResultService.onResultsChanged', e);
-      }),
-    );
     disposer.addDispose(testingPeekMessageService.onDidReveal((dto) => {}));
 
     const toTreeResult = testResultService.results.map((e) => getRootChildren(e));
@@ -66,7 +49,6 @@ export const TestTreeContainer = () => {
     if (!node) {
       return null;
     }
-    console.log(node);
     if (node.children && node.children.length > 0) {
       return node.children;
     }

--- a/packages/testing/src/browser/outputPeek/test-tree-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-tree-container.tsx
@@ -1,0 +1,76 @@
+import { BasicRecycleTree } from '@opensumi/ide-components';
+import { useInjectable } from '@opensumi/ide-core-browser';
+import { Disposable } from '@opensumi/ide-core-common';
+import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { TestPeekMessageToken } from '../../common';
+import { ITestResult, maxCountPriority, TestResultServiceToken } from '../../common/test-result';
+import { TestItemExpandState, TestResultState } from '../../common/testCollection';
+import { ITestTreeData } from '../../common/tree-view.model';
+import { testingStatesToIcons, testStatesToIconColors } from '../icons/icons';
+import { TestResultServiceImpl } from '../test.result.service';
+import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
+
+export const TestTreeContainer = () => {
+  const disposer: Disposable = new Disposable();
+  const testResultService: TestResultServiceImpl = useInjectable(TestResultServiceToken);
+  const testingPeekMessageService: TestingPeekMessageServiceImpl = useInjectable(TestPeekMessageToken);
+
+  const [treeData, setTreeData] = useState<ITestTreeData<ITestResult>[]>([]);
+
+  const getItemIcon = React.useCallback((item: ITestResult) => {
+    const state = item.completedAt === undefined ? TestResultState.Running : maxCountPriority(item.counts);
+    return `${testingStatesToIcons.get(state)} ${testStatesToIconColors[state]}` || '';
+  }, []);
+
+  const asTreeData = React.useCallback(
+    (item: ITestResult): ITestTreeData<ITestResult> => ({
+      label: item.name,
+      get icon() {
+        return getItemIcon(item);
+      },
+      rawItem: item,
+      get children() {
+        return null;
+      },
+    }),
+    [],
+  );
+
+  const resolveTestChildren = React.useCallback((node?: ITestTreeData) => {
+    if (!node) {
+      return null;
+    }
+    if (node.children && node.children.length > 0) {
+      return node.children;
+    }
+    return [];
+  }, []);
+
+  useEffect(() => {
+    disposer.addDispose(
+      testResultService.onTestChanged((e) => {
+        console.log('testResultService.onTestChanged', e);
+      }),
+    );
+    disposer.addDispose(
+      testResultService.onResultsChanged((e) => {
+        console.log('testResultService.onResultsChanged', e);
+      }),
+    );
+    disposer.addDispose(testingPeekMessageService.onDidReveal((dto) => {}));
+
+    const toTreeResult = testResultService.results.map(asTreeData);
+    setTreeData(toTreeResult);
+
+    return disposer.dispose;
+  }, []);
+
+  return (
+    <div className='test-output-peek-tree'>
+      {treeData.length > 0 && (
+        <BasicRecycleTree treeData={treeData} height={900} resolveChildren={resolveTestChildren} />
+      )}
+    </div>
+  );
+};

--- a/packages/testing/src/browser/outputPeek/test-tree-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-tree-container.tsx
@@ -13,6 +13,8 @@ import { getIconWithColor } from '../icons/icons';
 import { TestResultServiceImpl } from '../test.result.service';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 
+import styles from '../components/testing.module.less';
+
 enum ETestTreeType {
   RESULT = 'result',
   TEST = 'test',
@@ -157,9 +159,9 @@ export const TestTreeContainer = () => {
   );
 
   return (
-    <div className='test-output-peek-tree'>
+    <div className={styles.test_output_peek_tree}>
       {treeData.length > 0 && (
-        <BasicRecycleTree treeData={treeData} height={900} resolveChildren={resolveTestChildren} />
+        <BasicRecycleTree treeData={treeData} height={500} resolveChildren={resolveTestChildren} />
       )}
     </div>
   );

--- a/packages/testing/src/browser/outputPeek/test-tree-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-tree-container.tsx
@@ -79,7 +79,8 @@ export const TestTreeContainer = () => {
   }, []);
 
   const getTaskChildren = React.useCallback(
-    (result: ITestResult, test: TestResultItem, taskId: number): Iterable<ITestBaseTree<ITestMessage>> => Iterable.map(test.tasks[0].messages, (m, messageIndex) => {
+    (result: ITestResult, test: TestResultItem, taskId: number): Iterable<ITestBaseTree<ITestMessage>> =>
+      Iterable.map(test.tasks[0].messages, (m, messageIndex) => {
         const { message, location } = test.tasks[taskId].messages[messageIndex];
 
         const uri = buildTestUri({
@@ -93,6 +94,7 @@ export const TestTreeContainer = () => {
         return {
           type: ETestTreeType.MESSAGE,
           context: uri,
+          // ** 这里应该解析 markdown 转为纯文本信息 **
           label: firstLine(typeof message === 'string' ? message : message.value),
           id: uri.toString(),
           icon: '',

--- a/packages/testing/src/browser/outputPeek/test-tree-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-tree-container.tsx
@@ -1,51 +1,39 @@
 import { BasicRecycleTree } from '@opensumi/ide-components';
 import { useInjectable } from '@opensumi/ide-core-browser';
 import { Disposable } from '@opensumi/ide-core-common';
+import { Iterable } from '@opensumi/monaco-editor-core/esm/vs/base/common/iterator';
 import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { TestPeekMessageToken } from '../../common';
-import { ITestResult, maxCountPriority, TestResultServiceToken } from '../../common/test-result';
-import { TestItemExpandState, TestResultState } from '../../common/testCollection';
+import { ITestResult, maxCountPriority, resultItemParents, TestResultServiceToken } from '../../common/test-result';
+import { TestItemExpandState, TestResultItem, TestResultState } from '../../common/testCollection';
 import { ITestTreeData } from '../../common/tree-view.model';
 import { testingStatesToIcons, testStatesToIconColors } from '../icons/icons';
 import { TestResultServiceImpl } from '../test.result.service';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
+
+enum ETestTreeType {
+  RESULT = 'result',
+  TEST = 'test',
+  TASK = 'task',
+  MESSAGE = 'message',
+}
+
+interface ITestBaseTree<T> extends ITestTreeData<T> {
+  type: string;
+  context: unknown;
+  id: string;
+  label: string;
+  description?: string;
+  ariaLabel?: string;
+}
 
 export const TestTreeContainer = () => {
   const disposer: Disposable = new Disposable();
   const testResultService: TestResultServiceImpl = useInjectable(TestResultServiceToken);
   const testingPeekMessageService: TestingPeekMessageServiceImpl = useInjectable(TestPeekMessageToken);
 
-  const [treeData, setTreeData] = useState<ITestTreeData<ITestResult>[]>([]);
-
-  const getItemIcon = React.useCallback((item: ITestResult) => {
-    const state = item.completedAt === undefined ? TestResultState.Running : maxCountPriority(item.counts);
-    return `${testingStatesToIcons.get(state)} ${testStatesToIconColors[state]}` || '';
-  }, []);
-
-  const asTreeData = React.useCallback(
-    (item: ITestResult): ITestTreeData<ITestResult> => ({
-      label: item.name,
-      get icon() {
-        return getItemIcon(item);
-      },
-      rawItem: item,
-      get children() {
-        return null;
-      },
-    }),
-    [],
-  );
-
-  const resolveTestChildren = React.useCallback((node?: ITestTreeData) => {
-    if (!node) {
-      return null;
-    }
-    if (node.children && node.children.length > 0) {
-      return node.children;
-    }
-    return [];
-  }, []);
+  const [treeData, setTreeData] = useState<ITestBaseTree<ITestResult>[]>([]);
 
   useEffect(() => {
     disposer.addDispose(
@@ -60,11 +48,66 @@ export const TestTreeContainer = () => {
     );
     disposer.addDispose(testingPeekMessageService.onDidReveal((dto) => {}));
 
-    const toTreeResult = testResultService.results.map(asTreeData);
+    const toTreeResult = testResultService.results.map((e) => getRootChildren(e));
     setTreeData(toTreeResult);
 
     return disposer.dispose;
   }, []);
+
+  const resolveTestChildren = React.useCallback((node?: ITestBaseTree<unknown>) => {
+    if (!node) {
+      return null;
+    }
+    console.log(node);
+    if (node.children && node.children.length > 0) {
+      return node.children;
+    }
+    return [];
+  }, []);
+
+  const getItemIcon = React.useCallback((item: ITestResult) => {
+    const state = item.completedAt === undefined ? TestResultState.Running : maxCountPriority(item.counts);
+    return `${testingStatesToIcons.get(state)} ${testStatesToIconColors[state]}` || '';
+  }, []);
+
+  const getResultChildren = React.useCallback((result: ITestResult): Iterable<ITestBaseTree<TestResultItem>> => {
+    const tests = Iterable.filter(result.tests, (test) => test.tasks.some((t) => t.messages.length > 0));
+    return Iterable.map(tests, (test) => {
+      let description = '';
+      for (const parent of resultItemParents(result, test)) {
+        if (parent !== test) {
+          description = description ? parent.item.label + ' › ' + description : parent.item.label;
+        }
+      }
+      return {
+        type: ETestTreeType.TEST,
+        context: test.item.extId,
+        id: `${result.id}/${test.item.extId}`,
+        label: test.item.label,
+        get icon() {
+          return testingStatesToIcons.get(test.computedState) || '';
+        },
+        notExpandable: false,
+        description,
+        rawItem: test,
+      };
+    });
+  }, []);
+
+  const getRootChildren = React.useCallback((item: ITestResult): ITestBaseTree<ITestResult> => ({
+      type: ETestTreeType.RESULT,
+      context: item.id,
+      id: item.id,
+      label: item.name,
+      get icon() {
+        return getItemIcon(item);
+      },
+      notExpandable: false,
+      rawItem: item,
+      get children() {
+        return Array.from(getResultChildren(item));
+      },
+    }), []);
 
   return (
     <div className='test-output-peek-tree'>

--- a/packages/testing/src/common/test-result.ts
+++ b/packages/testing/src/common/test-result.ts
@@ -1,4 +1,4 @@
-import { Emitter } from '@opensumi/ide-core-common';
+import { Emitter, formatLocalize, localize } from '@opensumi/ide-core-common';
 import { IComputedStateAccessor, refreshComputedState } from './getComputedState';
 import {
   ExtensionRunTestsRequest,
@@ -75,7 +75,19 @@ export interface ITestResultService {
   readonly results: ReadonlyArray<ITestResult>;
 }
 
+export const maxCountPriority = (counts: Readonly<TestStateCount>) => {
+  for (const state of statesInOrder) {
+    if (counts[state] > 0) {
+      return state;
+    }
+  }
+
+  return TestResultState.Unset;
+};
+
 export interface ITestResult {
+  readonly counts: Readonly<TestStateCount>;
+
   readonly id: string;
 
   readonly completedAt: number | undefined;
@@ -114,7 +126,7 @@ export class TestResultImpl implements ITestResult {
 
   private _completedAt?: number;
 
-  public readonly name: string;
+  public readonly name: string = formatLocalize('test.result.runFinished', new Date().toLocaleString());
   public readonly tasks: ITestRunTaskResults[] = [];
   public readonly onChange = this.changeEmitter.event;
   public readonly onComplete = this.completeEmitter.event;

--- a/packages/testing/src/common/test-result.ts
+++ b/packages/testing/src/common/test-result.ts
@@ -85,6 +85,14 @@ export const maxCountPriority = (counts: Readonly<TestStateCount>) => {
   return TestResultState.Unset;
 };
 
+export const resultItemParents = function* (results: ITestResult, item: TestResultItem) {
+  let i: TestResultItem | undefined = item;
+  while (i) {
+    yield i;
+    i = i.parent ? results.getStateById(i.parent) : undefined;
+  }
+};
+
 export interface ITestResult {
   readonly counts: Readonly<TestStateCount>;
 

--- a/packages/testing/src/common/testingStates.ts
+++ b/packages/testing/src/common/testingStates.ts
@@ -5,7 +5,11 @@
 
 import { TestResultState } from './testCollection';
 
-export interface TreeStateNode { statusNode: true; state: TestResultState; priority: number }
+export interface TreeStateNode {
+  statusNode: true;
+  state: TestResultState;
+  priority: number;
+}
 
 /**
  * List of display priorities for different run states. When tests update,
@@ -59,3 +63,8 @@ export const statesInOrder = Object.keys(statePriority)
   .sort(cmpPriority);
 
 export const isRunningState = (s: TestResultState) => s === TestResultState.Queued || s === TestResultState.Running;
+
+export const firstLine = (str: string) => {
+  const index = str.indexOf('\n');
+  return index === -1 ? str : str.slice(0, index);
+};

--- a/packages/testing/src/common/tree-view.model.ts
+++ b/packages/testing/src/common/tree-view.model.ts
@@ -36,6 +36,6 @@ export interface ITestTreeItem {
   label: string;
 }
 
-export interface ITestTreeData extends IBasicTreeData {
-  rawItem: ITestTreeItem;
+export interface ITestTreeData<T = ITestTreeItem> extends IBasicTreeData {
+  rawItem: T;
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

![Kapture 2022-01-26 at 11 32 22](https://user-images.githubusercontent.com/20262815/151099719-fa9bf9ac-c3d9-4d11-974d-433154383387.gif)

PS: 还未实现 testing result storage，正常来说右边的树是测试结果的历史记录

### Changelog
Testing OutputPeek 右侧支持测试用例的树展示
