### PR TITLE
feat: support output peek horizontal resizeable

### DIFF
--- a/packages/core-common/src/utils/strings.ts
+++ b/packages/core-common/src/utils/strings.ts
@@ -102,6 +102,17 @@ export function escapeRegExpCharacters(value: string): string {
   return value.replace(/[\\\{\}\*\+\?\|\^\$\.\[\]\(\)]/g, '\\$&');
 }
 
+export function count(value: string, character: string): number {
+  let result = 0;
+  const ch = character.charCodeAt(0);
+  for (let i = value.length - 1; i >= 0; i--) {
+    if (value.charCodeAt(i) === ch) {
+      result++;
+    }
+  }
+  return result;
+}
+
 /**
  * Removes all occurrences of needle from the beginning and end of haystack.
  * @param haystack string to trim

--- a/packages/monaco-enhance/src/browser/peek-view.ts
+++ b/packages/monaco-enhance/src/browser/peek-view.ts
@@ -1,8 +1,8 @@
 import { Emitter } from '@opensumi/ide-core-common';
 import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
-import { ZoneWidget } from './zone-widget';
+import { IOptions, ZoneWidget } from './zone-widget';
 
-export interface IPeekViewOptions {
+export interface IPeekViewOptions extends IOptions {
   supportOnTitleClick?: boolean;
 }
 
@@ -20,7 +20,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
   // protected _actionbarWidget?: IMenuAction;
   protected _bodyElement?: HTMLDivElement;
 
-  constructor(protected readonly editor: ICodeEditor, protected readonly options: IPeekViewOptions = {}) {
+  constructor(protected readonly editor: ICodeEditor, readonly options: IPeekViewOptions = {}) {
     super(editor);
   }
 

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -19,11 +19,8 @@ import { TestResultServiceImpl } from '../test.result.service';
 import { TestResultServiceToken } from '../../common/test-result';
 import { TestingPeekOpenerServiceToken } from '../../common/testingPeekOpener';
 import { TestingPeekOpenerServiceImpl } from './test-peek-opener.service';
+import { isDiffable } from '../../common/testingStates';
 
-const isDiffable = (
-  message: ITestErrorMessage,
-): message is ITestErrorMessage & { actualOutput: string; expectedOutput: string } =>
-  message.actual !== undefined && message.expected !== undefined;
 export class TestDto {
   public readonly test: ITestItem;
   public readonly messages: ITestMessage[];

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -14,7 +14,7 @@ import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
 import { TestPeekMessageToken } from '../../common';
 import { TestTreeContainer } from './test-tree-container';
 import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
-import { firstLine } from '../../common/testingStates';
+import { firstLine, hintMessagePeekHeight } from '../../common/testingStates';
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {
@@ -30,7 +30,7 @@ export class TestingOutputPeek extends PeekViewWidget {
   public current?: TestDto;
 
   constructor(public readonly editor: ICodeEditor) {
-    super(editor);
+    super(editor, { isResizeable: true });
 
     TestingIsInPeek.bind(this.contextKeyService);
   }
@@ -103,7 +103,7 @@ export class TestingOutputPeek extends PeekViewWidget {
       return this.showInPlace(dto);
     }
 
-    this.show(dto.revealLocation!.range, message.location?.range.startLineNumber!);
+    this.show(dto.revealLocation!.range, hintMessagePeekHeight(message));
     this.editor.focus();
 
     return this.showInPlace(dto);

--- a/packages/testing/src/common/testingStates.ts
+++ b/packages/testing/src/common/testingStates.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TestResultState } from './testCollection';
+import { ITestErrorMessage, TestResultState } from './testCollection';
 import marked from 'marked';
+import { count } from '@opensumi/ide-core-common';
 
 export interface TreeStateNode {
   statusNode: true;
@@ -72,4 +73,17 @@ export const firstLine = (str: string) => {
 
 const domParser = new DOMParser();
 
-export const parseMarkdownText = (value: string) => domParser.parseFromString(marked.parse(value), 'text/html').documentElement.outerText;
+export const parseMarkdownText = (value: string) =>
+  domParser.parseFromString(marked.parse(value), 'text/html').documentElement.outerText;
+
+export const isDiffable = (
+  message: ITestErrorMessage,
+): message is ITestErrorMessage & { actualOutput: string; expectedOutput: string } =>
+  message.actual !== undefined && message.expected !== undefined;
+
+const hintPeekStrHeight = (str: string | undefined) => Math.min(Math.max(count(str || '', '\n') + 3, 8), 20);
+
+export const hintMessagePeekHeight = (msg: ITestErrorMessage) =>
+  isDiffable(msg)
+    ? Math.max(hintPeekStrHeight(msg.actual), hintPeekStrHeight(msg.expected))
+    : hintPeekStrHeight(typeof msg.message === 'string' ? msg.message : msg.message.value);


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![Kapture 2022-01-28 at 16 04 58](https://user-images.githubusercontent.com/20262815/151510384-21812aad-8f01-4936-acd7-8d80ff5684a2.gif)


之后对于继承于 zone widget 的组件只需要传递 isResizeable options 即可

### Changelog
zone widget 支持高度自定义拖拽能力