### PR TITLE
feat: support output peek actions bar

### DIFF
--- a/packages/core-browser/src/menu/next/menu-id.ts
+++ b/packages/core-browser/src/menu/next/menu-id.ts
@@ -64,6 +64,7 @@ export enum MenuId {
   MarketplaceNoResultsContext = 'marketplace/noResults/context',
   // Testing glyph margin
   TestingGlyphMarginContext = 'testing/glyphMargin/context',
+  TestPeekTitleContext = 'testing/outputPeek/title/context',
 }
 
 export function getTabbarCommonMenuId(location: string) {

--- a/packages/monaco-enhance/src/browser/peek-view.ts
+++ b/packages/monaco-enhance/src/browser/peek-view.ts
@@ -1,4 +1,6 @@
-import { Emitter } from '@opensumi/ide-core-common';
+import { getExternalIcon } from '@opensumi/ide-core-browser';
+import { IMenu } from '@opensumi/ide-core-browser/lib/menu/next';
+import { Emitter, Disposable } from '@opensumi/ide-core-common';
 import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import { IOptions, ZoneWidget } from './zone-widget';
 
@@ -16,8 +18,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
   protected _primaryHeading?: HTMLElement;
   protected _secondaryHeading?: HTMLElement;
   protected _metaHeading?: HTMLElement;
-  // 👇待定
-  // protected _actionbarWidget?: IMenuAction;
+  protected _actionbarElement?: HTMLDivElement;
   protected _bodyElement?: HTMLDivElement;
 
   constructor(protected readonly editor: ICodeEditor, readonly options: IPeekViewOptions = {}) {
@@ -71,13 +72,30 @@ export abstract class PeekViewWidget extends ZoneWidget {
 
     titleElement.append(this._primaryHeading, this._secondaryHeading, this._metaHeading);
 
-    const actionsContainer = document.createElement('div');
-    actionsContainer.classList.add('peekview-actions');
+    this._actionbarElement = document.createElement('div');
+    this._actionbarElement.classList.add('peekview-actions');
 
-    this._headElement!.append(actionsContainer);
+    this._fillActionBarOptions(this._actionbarElement);
+
+    const closeIcon = document.createElement('span');
+    closeIcon.className = `action-item ${getExternalIcon('chrome-close')}`;
+    const listenCloseClick = () => this.dispose();
+
+    closeIcon.addEventListener('click', listenCloseClick);
+    this.addDispose(
+      Disposable.create(() => {
+        closeIcon.removeEventListener('click', listenCloseClick);
+      }),
+    );
+
+    this._actionbarElement.append(closeIcon);
+
+    this._headElement!.append(this._actionbarElement);
   }
 
   protected _fillTitleIcon(container: HTMLElement): void {}
+
+  protected abstract _fillActionBarOptions(container: HTMLElement): void;
 
   protected abstract _fillBody(container: HTMLElement): void;
 

--- a/packages/monaco-enhance/src/browser/peek-view.ts
+++ b/packages/monaco-enhance/src/browser/peek-view.ts
@@ -49,7 +49,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
     container.appendChild(this._bodyElement);
   }
 
-  protected _fillHead(container: HTMLElement, noCloseAction?: boolean): void {
+  protected async _fillHead(container: HTMLElement, noCloseAction?: boolean): Promise<void> {
     const titleElement = document.createElement('div');
     titleElement.classList.add('peekview-title');
 
@@ -75,7 +75,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
     this._actionbarElement = document.createElement('div');
     this._actionbarElement.classList.add('peekview-actions');
 
-    this._fillActionBarOptions(this._actionbarElement);
+    await this._fillActionBarOptions(this._actionbarElement);
 
     const closeIcon = document.createElement('span');
     closeIcon.className = `action-item ${getExternalIcon('chrome-close')}`;
@@ -95,7 +95,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
 
   protected _fillTitleIcon(container: HTMLElement): void {}
 
-  protected abstract _fillActionBarOptions(container: HTMLElement): void;
+  protected abstract _fillActionBarOptions(container: HTMLElement): Promise<void>;
 
   protected abstract _fillBody(container: HTMLElement): void;
 

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -1,9 +1,9 @@
 import { TestingIsInPeek } from '@opensumi/ide-core-browser/lib/contextkey/testing';
-import { IContextKey, IContextKeyService, Schemas } from '@opensumi/ide-core-browser';
+import { EDITOR_COMMANDS, IContextKey, IContextKeyService, Schemas } from '@opensumi/ide-core-browser';
 import * as editorCommon from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
 import { buildTestUri, parseTestUri, TestUriType } from './../../common/testingUri';
 import { Injectable, Optional, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import { Disposable, IDisposable, MutableDisposable, URI } from '@opensumi/ide-core-common';
+import { CommandService, Disposable, IDisposable, MutableDisposable, URI } from '@opensumi/ide-core-common';
 import { IEditor, IEditorFeatureContribution } from '@opensumi/ide-editor/lib/browser';
 import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 import {
@@ -16,7 +16,7 @@ import {
 } from '../../common/testCollection';
 import { TestingOutputPeek } from './test-peek-widget';
 import { TestResultServiceImpl } from '../test.result.service';
-import { TestResultServiceToken } from '../../common/test-result';
+import { ITestResult, TestResultServiceToken } from '../../common/test-result';
 import { TestingPeekOpenerServiceToken } from '../../common/testingPeekOpener';
 import { TestingPeekOpenerServiceImpl } from './test-peek-opener.service';
 import { isDiffable } from '../../common/testingStates';
@@ -70,6 +70,9 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   @Autowired(IContextKeyService)
   private readonly contextKeyService: IContextKeyService;
 
+  @Autowired(CommandService)
+  private readonly commandService: CommandService;
+
   private readonly disposer: Disposable = new Disposable();
 
   private readonly peekView = new MutableDisposable<TestingOutputPeek>();
@@ -79,6 +82,32 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
 
   constructor(@Optional() private readonly editor: IEditor) {
     this.visible = TestingIsInPeek.bind(this.contextKeyService);
+  }
+
+  private allMessages(results: readonly ITestResult[]): {
+    result: ITestResult;
+    test: TestResultItem;
+    taskIndex: number;
+    messageIndex: number;
+  }[] {
+    const messages: {
+      result: ITestResult;
+      test: TestResultItem;
+      taskIndex: number;
+      messageIndex: number;
+    }[] = [];
+
+    for (const result of results) {
+      for (const test of result.tests) {
+        for (let taskIndex = 0; taskIndex < test.tasks.length; taskIndex++) {
+          for (let messageIndex = 0; messageIndex < test.tasks[taskIndex].messages.length; messageIndex++) {
+            messages.push({ result, test, taskIndex, messageIndex });
+          }
+        }
+      }
+    }
+
+    return messages;
   }
 
   private retrieveTest(uri: URI): TestDto | undefined {
@@ -152,5 +181,100 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
 
     this.peekView.value.setModel(dto);
     this.currentPeekUri = uri;
+  }
+
+  public async openAndShow(uri: URI) {
+    const dto = this.retrieveTest(uri);
+    if (!dto) {
+      return;
+    }
+
+    if (!dto.revealLocation || dto.revealLocation.uri.toString() === this.editor.currentUri?.toString()) {
+      return this.show(uri);
+    }
+
+    const ctor = this.testingPeekOpenerService.peekControllerMap.get(uri.toString());
+
+    if (!ctor) {
+      return;
+    }
+
+    this.removePeek();
+
+    await this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, URI.parse(uri.toString()), {
+      preview: true,
+      focus: true,
+    });
+
+    ctor.show(uri);
+  }
+
+  public next() {
+    const dto = this.peekView.value?.current;
+    if (!dto) {
+      return;
+    }
+
+    let found = false;
+    const getAllMessage = this.allMessages(this.testResultService.results);
+
+    for (const { messageIndex, taskIndex, result, test } of getAllMessage) {
+      if (found) {
+        this.openAndShow(
+          buildTestUri({
+            type: TestUriType.ResultMessage,
+            messageIndex,
+            taskIndex,
+            resultId: result.id,
+            testExtId: test.item.extId,
+          }),
+        );
+        return;
+      } else if (
+        dto.test.extId === test.item.extId &&
+        dto.messageIndex === messageIndex &&
+        dto.taskIndex === taskIndex &&
+        dto.resultId === result.id
+      ) {
+        found = true;
+      }
+    }
+  }
+
+  public previous() {
+    const dto = this.peekView.value?.current;
+    if (!dto) {
+      return;
+    }
+
+    let previous: { messageIndex: number; taskIndex: number; result: ITestResult; test: TestResultItem } | undefined;
+
+    const getAllMessage = this.allMessages(this.testResultService.results);
+
+    for (const m of getAllMessage) {
+      if (
+        dto.test.extId === m.test.item.extId &&
+        dto.messageIndex === m.messageIndex &&
+        dto.taskIndex === m.taskIndex &&
+        dto.resultId === m.result.id
+      ) {
+        if (!previous) {
+          return;
+        }
+
+        this.openAndShow(
+          buildTestUri({
+            type: TestUriType.ResultMessage,
+            messageIndex: previous.messageIndex,
+            taskIndex: previous.taskIndex,
+            resultId: previous.result.id,
+            testExtId: previous.test.item.extId,
+          }),
+        );
+        return;
+      }
+
+      previous = m;
+    }
   }
 }

--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -113,21 +113,6 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
     return messages;
   }
 
-  private retrieveTest(uri: URI): TestDto | undefined {
-    const parts = parseTestUri(uri);
-    if (!parts) {
-      return undefined;
-    }
-
-    const { resultId, testExtId, taskIndex, messageIndex } = parts;
-    const test = this.testResultService.getResult(parts.resultId)?.getStateById(testExtId);
-    if (!test || !test.tasks[parts.taskIndex]) {
-      return;
-    }
-
-    return new TestDto(resultId, test, taskIndex, messageIndex);
-  }
-
   public contribute(): IDisposable {
     this.disposer.addDispose(
       this.editor.monacoEditor.onDidChangeModel((e: editorCommon.IModelChangedEvent) => {
@@ -163,8 +148,6 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
       return;
     }
 
-    const options = { pinned: false, revealIfOpened: true };
-
     if (current.isDiffable) {
       this.commandService.executeCommand(
         EDITOR_COMMANDS.API_OPEN_DIFF_EDITOR_COMMAND_ID,
@@ -174,7 +157,7 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
       );
     } else {
       this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, current.messageUri, {
-        preview: true,
+        preview: false,
         focus: true,
       });
     }
@@ -186,7 +169,7 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   }
 
   public async show(uri: URI): Promise<void> {
-    const dto = this.retrieveTest(uri);
+    const dto = this.testResultService.retrieveTest(uri);
     if (!dto) {
       return;
     }
@@ -210,7 +193,7 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   }
 
   public async openAndShow(uri: URI) {
-    const dto = this.retrieveTest(uri);
+    const dto = this.testResultService.retrieveTest(uri);
     if (!dto) {
       return;
     }

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -44,23 +44,14 @@
 }
 
 .peekview-widget .head .peekview-actions {
-  flex: 1;
-  text-align: right;
-  padding-right: 2px;
+  display: flex;
+  justify-content: right;
 
   .action-item {
     line-height: inherit;
     cursor: pointer;
+    margin-left: 6px;
   }
-}
-
-.peekview-widget .head .peekview-actions > .monaco-action-bar {
-  display: inline-block;
-}
-
-.peekview-widget .head .peekview-actions > .monaco-action-bar,
-.peekview-widget .head .peekview-actions > .monaco-action-bar > .actions-container {
-  height: 100%;
 }
 
 .peekview-widget > .body {

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -47,6 +47,11 @@
   flex: 1;
   text-align: right;
   padding-right: 2px;
+
+  .action-item {
+    line-height: inherit;
+    cursor: pointer;
+  }
 }
 
 .peekview-widget .head .peekview-actions > .monaco-action-bar {

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -62,15 +62,17 @@ export class TestingOutputPeek extends PeekViewWidget {
     );
   }
 
-  protected _fillActionBarOptions(container: HTMLElement): void {
+  protected async _fillActionBarOptions(container: HTMLElement): Promise<void> {
     const menus = this.menuService.createMenu(MenuId.TestPeekTitleContext, this.contextKeyService);
-
-    ReactDOM.render(
-      <ConfigProvider value={this.configContext}>
-        <InlineActionBar menus={menus} separator='inline' type='icon' />
-      </ConfigProvider>,
-      container,
-    );
+    return new Promise((res) => {
+      ReactDOM.render(
+        <ConfigProvider value={this.configContext}>
+          <InlineActionBar menus={menus} type='icon' />
+        </ConfigProvider>,
+        container,
+        res,
+      );
+    });
   }
 
   protected applyClass(): void {

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -15,6 +15,8 @@ import { TestPeekMessageToken } from '../../common';
 import { TestTreeContainer } from './test-tree-container';
 import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 import { firstLine, hintMessagePeekHeight } from '../../common/testingStates';
+import { InlineActionBar } from '@opensumi/ide-core-browser/lib/components/actions';
+import { AbstractMenuService, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {
@@ -23,6 +25,9 @@ export class TestingOutputPeek extends PeekViewWidget {
 
   @Autowired(TestPeekMessageToken)
   private readonly testingPeekMessageService: TestingPeekMessageServiceImpl;
+
+  @Autowired(AbstractMenuService)
+  private readonly menuService: AbstractMenuService;
 
   @Autowired(AppConfig)
   private configContext: AppConfig;
@@ -52,6 +57,17 @@ export class TestingOutputPeek extends PeekViewWidget {
           <TestMessageContainer />
           <TestTreeContainer />
         </SplitPanel>
+      </ConfigProvider>,
+      container,
+    );
+  }
+
+  protected _fillActionBarOptions(container: HTMLElement): void {
+    const menus = this.menuService.createMenu(MenuId.TestPeekTitleContext, this.contextKeyService);
+
+    ReactDOM.render(
+      <ConfigProvider value={this.configContext}>
+        <InlineActionBar menus={menus} separator='inline' type='icon' />
       </ConfigProvider>,
       container,
     );

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -67,7 +67,7 @@ export class TestingOutputPeek extends PeekViewWidget {
     return new Promise((res) => {
       ReactDOM.render(
         <ConfigProvider value={this.configContext}>
-          <InlineActionBar menus={menus} type='icon' />
+          <InlineActionBar menus={menus} type='icon' context={[this.editor.getModel()?.uri.toString()!]} />
         </ConfigProvider>,
         container,
         res,

--- a/packages/testing/src/browser/test-tree-view.model.ts
+++ b/packages/testing/src/browser/test-tree-view.model.ts
@@ -179,7 +179,6 @@ export class TestTreeViewModelImpl extends Disposable implements ITestTreeViewMo
           item.ownState = result.ownComputedState;
           item.ownDuration = result.ownDuration;
           const explicitComputed = item.children.size ? undefined : result.computedState;
-          const model = this.treeHandlerApi.getModel();
           refreshComputedState(computedStateAccessor, item, explicitComputed);
           model.dispatchChange();
           this.revealTreeById(result.item.extId, false, false);
@@ -187,7 +186,18 @@ export class TestTreeViewModelImpl extends Disposable implements ITestTreeViewMo
       );
       this.addDispose(
         this.testResultService.onResultsChanged((evt: ResultChangeEvent) => {
-          console.error('Not Implement onResultsChanged case');
+          if (!('removed' in evt)) {
+            return;
+          }
+
+          for (const inTree of [...this.items.values()].sort((a, b) => b.depth - a.depth)) {
+            const lookup = this.testResultService.getStateById(inTree.test.item.extId)?.[1];
+            inTree.ownDuration = lookup?.ownDuration;
+            refreshComputedState(computedStateAccessor, inTree, lookup?.ownComputedState ?? TestResultState.Unset);
+            model.dispatchChange();
+          }
+
+          this.updateEmitter.fire();
         }),
       );
     }

--- a/packages/testing/src/browser/test.result.service.ts
+++ b/packages/testing/src/browser/test.result.service.ts
@@ -152,4 +152,22 @@ export class TestResultServiceImpl implements ITestResultService {
     }
     return undefined;
   }
+
+  public clear() {
+    const keep: ITestResult[] = [];
+    const removed: ITestResult[] = [];
+    for (const result of this.results) {
+      if (result.completedAt !== undefined) {
+        removed.push(result);
+      } else {
+        keep.push(result);
+      }
+    }
+
+    this._results = keep;
+    if (keep.length === 0) {
+      this.hasAnyResults.set(false);
+    }
+    this.changeResultEmitter.fire({ removed });
+  }
 }

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -250,6 +250,18 @@ export class TestingContribution
         }
       }
     };
+
+    commands.registerCommand(GoToPreviousMessage, {
+      execute: async () => {
+        console.log('GoToPreviousMessage');
+      },
+    });
+
+    commands.registerCommand(GoToNextMessage, {
+      execute: async () => {
+        console.log('GoToNextMessage');
+      },
+    });
   }
 
   registerKeybindings(keybindings: KeybindingRegistry): void {
@@ -276,15 +288,15 @@ export class TestingContribution
     /** output peek view actions start */
     menuRegistry.registerMenuItem(MenuId.TestPeekTitleContext, {
       command: GoToPreviousMessage.id,
-      group: '1_has_left',
       iconClass: GoToPreviousMessage.iconClass,
-      order: 1,
+      group: 'navigation',
+      order: 5,
     });
     menuRegistry.registerMenuItem(MenuId.TestPeekTitleContext, {
       command: GoToNextMessage.id,
-      group: '1_has_left',
       iconClass: GoToNextMessage.iconClass,
-      order: 2,
+      group: 'navigation',
+      order: 6,
     });
     /** output peek view actions end */
   }

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -54,6 +54,8 @@ import { TestServiceImpl } from './test.service';
 import { TestServiceToken } from '../common';
 import { TestRunProfileBitset } from '../common/testCollection';
 import { IMenuRegistry, MenuContribution, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
+import { TestResultServiceImpl } from './test.result.service';
+import { TestResultServiceToken } from '../common/test-result';
 
 @Injectable()
 export class TestingOutputPeekDocumentProvider implements IEditorDocumentModelContentProvider {
@@ -113,6 +115,9 @@ export class TestingContribution
 
   @Autowired(TestServiceToken)
   private readonly testService: TestServiceImpl;
+
+  @Autowired(TestResultServiceToken)
+  private readonly testResultService: TestResultServiceImpl;
 
   initialize(): void {
     this.testTreeViewModel.initTreeModel();
@@ -284,8 +289,9 @@ export class TestingContribution
     });
 
     commands.registerCommand(ClearTestResults, {
-      execute: async () => {
-        console.log('ClearTestResults');
+      execute: async (uri: string | undefined) => {
+        this.testResultService.clear();
+        this.commandService.executeCommand(ClosePeekTest.id, uri);
       },
     });
 

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -29,11 +29,13 @@ import {
   URI,
 } from '@opensumi/ide-core-browser';
 import {
+  ClearTestResults,
   ClosePeekTest,
   DebugTestCommand,
   GoToNextMessage,
   GoToPreviousMessage,
   GoToTestCommand,
+  OpenMessageInEditor,
   PeekTestError,
   RuntTestCommand,
   TestingDebugCurrentFile,
@@ -252,14 +254,44 @@ export class TestingContribution
     };
 
     commands.registerCommand(GoToPreviousMessage, {
-      execute: async () => {
-        console.log('GoToPreviousMessage');
+      execute: async (uri: string | undefined) => {
+        uri = uri ?? this.editorService.currentEditor?.currentUri?.toString();
+
+        if (!uri) {
+          return;
+        }
+
+        const ctor = this.testingPeekOpenerService.peekControllerMap.get(uri);
+        if (ctor) {
+          ctor.previous();
+        }
       },
     });
 
     commands.registerCommand(GoToNextMessage, {
+      execute: async (uri: string | undefined) => {
+        uri = uri ?? this.editorService.currentEditor?.currentUri?.toString();
+
+        if (!uri) {
+          return;
+        }
+
+        const ctor = this.testingPeekOpenerService.peekControllerMap.get(uri);
+        if (ctor) {
+          ctor.next();
+        }
+      },
+    });
+
+    commands.registerCommand(ClearTestResults, {
       execute: async () => {
-        console.log('GoToNextMessage');
+        console.log('ClearTestResults');
+      },
+    });
+
+    commands.registerCommand(OpenMessageInEditor, {
+      execute: async () => {
+        console.log('OpenMessageInEditor');
       },
     });
   }
@@ -297,6 +329,18 @@ export class TestingContribution
       iconClass: GoToNextMessage.iconClass,
       group: 'navigation',
       order: 6,
+    });
+    menuRegistry.registerMenuItem(MenuId.TestPeekTitleContext, {
+      command: ClearTestResults.id,
+      iconClass: ClearTestResults.iconClass,
+      group: 'navigation',
+      order: 7,
+    });
+    menuRegistry.registerMenuItem(MenuId.TestPeekTitleContext, {
+      command: OpenMessageInEditor.id,
+      iconClass: OpenMessageInEditor.iconClass,
+      group: 'navigation',
+      order: 9,
     });
     /** output peek view actions end */
   }

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -31,6 +31,8 @@ import {
 import {
   ClosePeekTest,
   DebugTestCommand,
+  GoToNextMessage,
+  GoToPreviousMessage,
   GoToTestCommand,
   PeekTestError,
   RuntTestCommand,
@@ -258,6 +260,7 @@ export class TestingContribution
   }
 
   registerMenus(menuRegistry: IMenuRegistry) {
+    /** glyph margin start */
     menuRegistry.registerMenuItem(MenuId.TestingGlyphMarginContext, {
       command: RuntTestCommand.id,
       group: '1_has_decoration',
@@ -268,6 +271,22 @@ export class TestingContribution
       group: '1_has_decoration',
       order: 2,
     });
+    /** glyph margin end */
+
+    /** output peek view actions start */
+    menuRegistry.registerMenuItem(MenuId.TestPeekTitleContext, {
+      command: GoToPreviousMessage.id,
+      group: '1_has_left',
+      iconClass: GoToPreviousMessage.iconClass,
+      order: 1,
+    });
+    menuRegistry.registerMenuItem(MenuId.TestPeekTitleContext, {
+      command: GoToNextMessage.id,
+      group: '1_has_left',
+      iconClass: GoToNextMessage.iconClass,
+      order: 2,
+    });
+    /** output peek view actions end */
   }
 
   registerEditorFeature(registry: IEditorFeatureRegistry) {

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -34,3 +34,15 @@ export const ClosePeekTest: Command = {
   id: 'testing.peek.test.close',
   label: 'Close Peek Output',
 };
+
+export const GoToPreviousMessage: Command = {
+  id: 'testing.goToPreviousMessage',
+  label: 'Go to Previous Test Failure',
+  iconClass: 'arrowup',
+};
+
+export const GoToNextMessage: Command = {
+  id: 'testing.goToNextMessage',
+  label: 'Go to Next Test Failure',
+  iconClass: 'arrowdown',
+};

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -1,4 +1,4 @@
-import { Command } from '@opensumi/ide-core-browser';
+import { Command, getExternalIcon, getIcon } from '@opensumi/ide-core-browser';
 
 export const RuntTestCommand: Command = {
   id: 'testing.run.test',
@@ -38,11 +38,17 @@ export const ClosePeekTest: Command = {
 export const GoToPreviousMessage: Command = {
   id: 'testing.goToPreviousMessage',
   label: 'Go to Previous Test Failure',
-  iconClass: 'arrowup',
+  iconClass: getIcon('arrowup'),
 };
 
 export const GoToNextMessage: Command = {
   id: 'testing.goToNextMessage',
   label: 'Go to Next Test Failure',
-  iconClass: 'arrowdown',
+  iconClass: getIcon('arrowdown'),
+};
+
+export const ClearTestResults: Command = {
+  id: 'testing.clearTestResults',
+  label: 'Clear All Results',
+  iconClass: getIcon('arrowdown'),
 };

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -50,5 +50,11 @@ export const GoToNextMessage: Command = {
 export const ClearTestResults: Command = {
   id: 'testing.clearTestResults',
   label: 'Clear All Results',
-  iconClass: getIcon('arrowdown'),
+  iconClass: getIcon('delete'),
+};
+
+export const OpenMessageInEditor: Command = {
+  id: 'testing.openMessageInEditor',
+  label: 'Open in Editor',
+  iconClass: getExternalIcon('link-external'),
 };


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

新增以下5个菜单项
- [x] 打开上一个错误测试日志
- [x] 打开下一个错误测试日志
- [x] 清除所有测试日志
- [x] 新标签页打开测试日志
- [x] 关闭当前 output peek 面板

![Kapture 2022-02-07 at 11 55 08](https://user-images.githubusercontent.com/20262815/152722158-a28646c2-817b-43dc-a2e8-72dd43842c0b.gif)


### Changelog
testing output peek 面板支持新标签页打开日志等菜单项
