### PR TITLE
fix: process multi-line output in task

### DIFF
--- a/packages/remote-cli/package.json
+++ b/packages/remote-cli/package.json
@@ -5,6 +5,7 @@
     "lib"
   ],
   "preview": true,
+  "private": true,
   "license": "MIT",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/task/src/browser/problem-line-matcher.ts
+++ b/packages/task/src/browser/problem-line-matcher.ts
@@ -268,7 +268,11 @@ export abstract class AbstractLineMatcher {
       }
     }
     if (result === null || result === Severity.Ignore) {
-      result = Severity.fromValue(this.matcher.severity as string) || Severity.Error;
+      if (typeof this.matcher.severity === 'string') {
+        result = Severity.fromValue(this.matcher.severity) || Severity.Error;
+      } else {
+        result = this.matcher.severity || Severity.Error;
+      }
     }
     return Severity.toDiagnosticSeverity(result as Severity);
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
- process multi-line output in task
- ignore equals problem data