### PR TITLE
fix: 修复 tabbar 插入 item 后 hidden 状态丢失问题

### DIFF
--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -246,8 +246,11 @@ export class TabbarService extends WithEventBus {
     this.sortedContainers.splice(insertIndex, 0, componentInfo);
     for (let i = insertIndex; i < this.sortedContainers.length; i++) {
       const info = this.sortedContainers[i];
-      const prevState = this.getContainerState(containerId) || {}; // 保留原有的hidden状态
-      this.state.set(info.options!.containerId, { hidden: prevState.hidden, priority: i });
+      const containerId = info.options?.containerId;
+      if (containerId) {
+        const prevState = this.getContainerState(containerId) || {}; // 保留原有的hidden状态
+        this.state.set(containerId, { hidden: prevState.hidden, priority: i });
+      }
     }
     disposables.push(this.registerSideEffects(componentInfo));
     this.eventBus.fire(new TabBarRegistrationEvent({ tabBarId: containerId }));


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution

containerId 同时也是入参的名字，导致之前这里漏了取当前遍历项的 containerId

### Changelog

- 修复 tabbar 插入 item 后 hidden 状态丢失问题
