### PR TITLE
fix: nodemon remove tools watch

### DIFF
--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -46,8 +46,7 @@
       "ts": "node --require ts-node/register"
     },
     "watch": [
-      "../../packages",
-      "../../tools"
+      "../../packages"
     ],
     "ext": "js,json,ts"
   },


### PR DESCRIPTION
### Types

去掉tools目录的nodemon watch 
减少因为extension相关js文件导致频繁的自动更新

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
