### PR TITLE
fix: popover css escape

### DIFF
--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -133,7 +133,7 @@ export const Popover: React.FC<{
     if (!contentEl.current) {
       return;
     }
-    const oldEl = document.body.querySelector(`body > #${id}`);
+    const oldEl = document.body.querySelector(`body > #${CSS.escape(id)}`);
     if (oldEl) {
       document.body.removeChild(oldEl);
     }
@@ -143,7 +143,7 @@ export const Popover: React.FC<{
       showContent();
     }
     return () => {
-      const oldEl = document.body.querySelector(`body > #${id}`);
+      const oldEl = document.body.querySelector(`body > #${CSS.escape(id)}`);
       if (oldEl) {
         document.body.removeChild(oldEl);
       }


### PR DESCRIPTION
### Types

querySelector need escape

- [x] 🐛 Bug Fixes

### Background or solution

![image](https://user-images.githubusercontent.com/6399899/154425991-e5e9b45b-31fd-46a2-842f-ff61c9ea8965.png)


### Changelog
 popover querySelector css escape