### PR TITLE
fix: 修复 status-bar 元素排版问题

### DIFF
--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -105,34 +105,36 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
         delay={200}
         position={PopoverPosition.top}
       >
-        {iconClass && <span key={-1} className={cls(styles.icon, iconClass)}></span>}
-        {items.map((item, key) => {
-          if (!(typeof item === 'string') && LabelIcon.is(item)) {
-            hasIcon = true;
-            return (
-              <span
-                key={key}
-                className={cls(
-                  styles.icon,
-                  getExternalIcon(item.name),
-                  `${item.animation ? 'iconfont-anim-' + item.animation : ''}`,
-                )}
-              ></span>
-            );
-          } else {
-            // 22px高度限制用于解决文本超长时文本折叠问题
-            return (
-              <span
-                style={{ marginLeft: iconClass || hasIcon ? '2px' : 0, height: '22px', lineHeight: '22px' }}
-                key={key}
-                aria-label={ariaLabel}
-                role={role}
-              >
-                {replaceLocalizePlaceholder(item)}
-              </span>
-            );
-          }
-        })}
+        <div className={styles.popover_item}>
+          {iconClass && <span key={-1} className={cls(styles.icon, iconClass)}></span>}
+          {items.map((item, key) => {
+            if (!(typeof item === 'string') && LabelIcon.is(item)) {
+              hasIcon = true;
+              return (
+                <span
+                  key={key}
+                  className={cls(
+                    styles.icon,
+                    getExternalIcon(item.name),
+                    `${item.animation ? 'iconfont-anim-' + item.animation : ''}`,
+                  )}
+                ></span>
+              );
+            } else {
+              // 22px高度限制用于解决文本超长时文本折叠问题
+              return (
+                <span
+                  style={{ marginLeft: iconClass || hasIcon ? '2px' : 0, height: '22px', lineHeight: '22px' }}
+                  key={key}
+                  aria-label={ariaLabel}
+                  role={role}
+                >
+                  {replaceLocalizePlaceholder(item)}
+                </span>
+              );
+            }
+          })}
+        </div>
       </Popover>
     </div>
   );

--- a/packages/status-bar/src/browser/status-bar.module.less
+++ b/packages/status-bar/src/browser/status-bar.module.less
@@ -82,3 +82,8 @@
   font-size: @statusBar-font-size;
   white-space: nowrap;
 }
+
+.popover_item {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

status-bar 增加了 Popover 后父元素的 flex 作用不到 Popover 里面的 item 导致布局出问题了。

### Changelog

- 修复 status-bar 中 Popover 下元素的布局问题
