### PR TITLE
feat: remove default supportHosts

### DIFF
--- a/packages/core-browser/src/services/external-uri.service.ts
+++ b/packages/core-browser/src/services/external-uri.service.ts
@@ -12,7 +12,7 @@ export interface IExternalUriService {
   resolveExternalUri(uri: URI): URI;
 }
 
-interface ILocation {
+export interface ILocation {
   address: string;
   port: number;
 }

--- a/packages/remote-opener/__tests__/browser/remote-opener-converter.test.ts
+++ b/packages/remote-opener/__tests__/browser/remote-opener-converter.test.ts
@@ -22,6 +22,7 @@ describe('packages/core-browser/src/remote-opener/converter.contribution.ts', ()
       convert: (port) => `opensumi-${port}-ide.com`,
     };
     disposes.addDispose(remoteOpenerService.registerConverter(converter));
+    disposes.addDispose(remoteOpenerService.registerSupportHosts(['localhost', '127.0.0.1', '0.0.0.0']));
     expect(remoteOpenerService['converter']).toBeDefined();
     expect(remoteOpenerService['converter'].convert('3030')).toBe('opensumi-3030-ide.com');
 
@@ -37,6 +38,7 @@ describe('packages/core-browser/src/remote-opener/converter.contribution.ts', ()
 
   it('register support remote host', () => {
     const disposes = new Disposable();
+    disposes.addDispose(remoteOpenerService.registerSupportHosts(['localhost', '127.0.0.1', '0.0.0.0']));
     disposes.addDispose(remoteOpenerService.registerSupportHosts(['128.168.0.1', '0.0.0.1']));
     expect(remoteOpenerService['supportHosts'].size).toBe(5);
     expect(remoteOpenerService['supportHosts'].has('0.0.0.0')).toBeTruthy();

--- a/packages/remote-opener/__tests__/browser/remote.opener.service.test.ts
+++ b/packages/remote-opener/__tests__/browser/remote.opener.service.test.ts
@@ -55,6 +55,7 @@ describe('packages/remote-opener/src/browser/remote.opener.service.ts', () => {
     };
     const spyOnConverter = jest.spyOn(converter, 'convert');
 
+    disposes.addDispose(remoteOpenerService.registerSupportHosts(['localhost', '127.0.0.1', '0.0.0.0']));
     disposes.addDispose(remoteOpenerService.registerConverter(converter));
 
     const spyOnOpen = jest.spyOn(openerService, 'open');

--- a/packages/remote-opener/src/browser/remote.opener.service.ts
+++ b/packages/remote-opener/src/browser/remote.opener.service.ts
@@ -7,7 +7,8 @@ import { PreferenceService } from '@opensumi/ide-core-browser/lib/preferences';
 import { IOpenerService } from '@opensumi/ide-core-browser/lib/opener';
 import { IRemoteHostConverter, IRemoteOpenerBrowserService } from '../common';
 
-const SUPPORT_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0'];
+// 不预置SUPPORT_HOSTS，改为用户注册，默认走openerService来处理这部分逻辑
+// const SUPPORT_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0'];
 
 @Injectable()
 export class RemoteOpenerBrowserServiceImpl extends RPCService implements IRemoteOpenerBrowserService {
@@ -23,7 +24,7 @@ export class RemoteOpenerBrowserServiceImpl extends RPCService implements IRemot
   @Autowired(IOpenerService)
   private readonly openerService: IOpenerService;
 
-  private supportHosts: Set<string> = new Set(SUPPORT_HOSTS);
+  private supportHosts: Set<string> = new Set();
 
   private converter: IRemoteHostConverter | null = null;
 


### PR DESCRIPTION
### Types

去除掉默认的SupportHost 把自定义能力完全暴露给调用用户。
方便url打开的默认情况直接走OpenerService。

export一个接口，方便集成方继承。

- [x] Other Changes

### Background or solution

### Changelog
