### PR TITLE
fix: pty process exit issue

### DIFF
--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -73,8 +73,6 @@ export class PtyService extends Disposable {
         this._ptyProcess.kill();
       }
     } catch (ex) {}
-
-    this.dispose();
   }
 
   async _validateCwd(): Promise<ITerminalLaunchError | undefined> {
@@ -187,13 +185,18 @@ export class PtyService extends Disposable {
     const args = options.args || [];
     const ptyProcess = pty.spawn(options.executable as string, args, this._ptyOptions);
 
-    ptyProcess.onData((e) => {
-      this._onData.fire(e);
-    });
+    this.addDispose(
+      ptyProcess.onData((e) => {
+        this._onData.fire(e);
+      }),
+    );
 
-    ptyProcess.onExit((e) => {
-      this._onExit.fire(e);
-    });
+    this.addDispose(
+      ptyProcess.onExit((e) => {
+        this._onExit.fire(e);
+        this.dispose();
+      }),
+    );
 
     (ptyProcess as IPtyProcess).bin = options.executable as string;
     (ptyProcess as IPtyProcess).launchConfig = options;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
[测试版](https://github.com/opensumi/core/issues/453) 这里有两个问题

#### ptyService.kill 并没有 kill 掉 pty 进程
```ts
kill() {
    if(this.disposed) {
        return;
    }
}
```
因为 `this.disposed` 的实现是判断 disposables. length === 0, 而 ptyService 中没有注册任何 disposable，导致在这一步认为已经 `disposed`，直接返回，导致 pty 进程没有退出

为 `pty.onExit` 和 `pty.onData` 注册 disposable 后出现第二个问题

#### dispose 过早导致事件没有触发
在 kill 中调用 `ptyProcess.kill` 后直接 dispose ，导致之前的事件监听一并被清理，没有触发退出事件


#### 修复
1. 为 `pty.onExit` 和 `pty.onData` 注册 disposable 
2. 在 onExit 事件回调里执行 dispose 清理事件监听

### Changelog
