### PR TITLE
fix: hide pophover if no tooltip

### DIFF
--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -32,6 +32,7 @@ export const Popover: React.FC<{
   title?: string;
   titleClassName?: string;
   action?: string;
+  disable?: boolean;
   onClickAction?: (args: any) => void;
 }> = ({
   delay,
@@ -47,6 +48,7 @@ export const Popover: React.FC<{
   titleClassName,
   action,
   onClickAction,
+  disable,
   ...restProps
 }) => {
   const childEl = React.useRef<HTMLSpanElement | null>(null);
@@ -75,7 +77,7 @@ export const Popover: React.FC<{
   }
 
   function showContent() {
-    if (!contentEl.current || !childEl.current) {
+    if (!contentEl.current || !childEl.current || disable) {
       return;
     }
     clearTimeout(hideContentTimer);

--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -64,7 +64,7 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
     if (hoverContents) {
       return <StatusBarPopover contents={hoverContents} />;
     }
-    return <div>{tooltip || name}</div>;
+    return <div>{tooltip}</div>;
   }, []);
 
   const getColor = (color: string | IThemeColor | undefined): string => {
@@ -90,7 +90,6 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
       className={cls(styles.element, className, {
         [styles.hasCommand]: command || onClick,
       })}
-      title={tooltip}
       onClick={onClick}
       style={{
         color: getColor(propsColor),
@@ -104,6 +103,7 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
         trigger={PopoverTriggerType.hover}
         delay={200}
         position={PopoverPosition.top}
+        disable={!tooltip && !hoverContents}
       >
         <div className={styles.popover_item}>
           {iconClass && <span key={-1} className={cls(styles.icon, iconClass)}></span>}


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

![image](https://user-images.githubusercontent.com/6399899/154883431-3d2a2eb8-ef00-4de6-bfa4-d872caa55f1f.png)


### Changelog

hide pophover if no tooltip