### PR TITLE
fix: command palette esc Keybinding event

### DIFF
--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -7,7 +7,6 @@ import { TestDto } from './test-output-peek';
 import { TestMessageType } from '../../common/testCollection';
 import './test-peek-widget.less';
 import { AppConfig, ConfigProvider, IContextKeyService } from '@opensumi/ide-core-browser';
-import { TestingIsInPeek } from '@opensumi/ide-core-browser/lib/contextkey/testing';
 import { renderMarkdown } from '@opensumi/monaco-editor-core/esm/vs/base/browser/markdownRenderer';
 import { TestMessageContainer } from './test-message-container';
 import { TestingPeekMessageServiceImpl } from './test-peek-message.service';
@@ -20,9 +19,6 @@ import { AbstractMenuService, MenuId } from '@opensumi/ide-core-browser/lib/menu
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {
-  @Autowired(IContextKeyService)
-  private readonly contextKeyService: IContextKeyService;
-
   @Autowired(TestPeekMessageToken)
   private readonly testingPeekMessageService: TestingPeekMessageServiceImpl;
 
@@ -34,10 +30,8 @@ export class TestingOutputPeek extends PeekViewWidget {
 
   public current?: TestDto;
 
-  constructor(public readonly editor: ICodeEditor) {
+  constructor(public readonly editor: ICodeEditor, private readonly contextKeyService: IContextKeyService) {
     super(editor, { isResizeable: true });
-
-    TestingIsInPeek.bind(this.contextKeyService);
   }
 
   /**

--- a/packages/testing/src/browser/test-contextkey.service.ts
+++ b/packages/testing/src/browser/test-contextkey.service.ts
@@ -1,0 +1,22 @@
+import { Optional, Injectable, Autowired } from '@opensumi/di';
+import { IContextKeyService, IContextKey, IScopedContextKeyService } from '@opensumi/ide-core-browser';
+import { TestingIsPeekVisible } from '@opensumi/ide-core-browser/lib/contextkey/testing';
+
+@Injectable()
+export class TestContextKey {
+  @Autowired(IContextKeyService)
+  private readonly globalContextKeyService: IContextKeyService;
+
+  private _contextKeyService: IScopedContextKeyService | undefined;
+
+  public readonly contextTestingIsPeekVisible: IContextKey<boolean>;
+
+  constructor(@Optional() dom?: HTMLElement) {
+    this._contextKeyService = this.globalContextKeyService.createScoped(dom);
+    this.contextTestingIsPeekVisible = TestingIsPeekVisible.bind(this.contextKeyScoped);
+  }
+
+  public get contextKeyScoped(): IScopedContextKeyService {
+    return this._contextKeyService!;
+  }
+}

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -27,6 +27,8 @@ import {
   getIcon,
   KeybindingContribution,
   KeybindingRegistry,
+  KeybindingScope,
+  KeybindingWeight,
   MaybePromise,
   TabBarToolbarContribution,
   ToolbarRegistry,
@@ -63,6 +65,7 @@ import { TestResultServiceToken } from '../common/test-result';
 import { MarkdownEditorComponent } from '@opensumi/ide-markdown/lib/browser/editor.markdown';
 import { MARKDOWN_EDITOR_COMPONENT_ID } from '@opensumi/ide-markdown/lib/browser/contribution';
 import { Testing } from '../common/constants';
+import { TestingIsPeekVisible } from '@opensumi/ide-core-browser/lib/contextkey/testing';
 
 @Injectable()
 export class TestingOutputPeekDocumentProvider implements IEditorDocumentModelContentProvider {
@@ -350,6 +353,7 @@ export class TestingContribution
     keybindings.registerKeybinding({
       command: ClosePeekTest.id,
       keybinding: 'esc',
+      when: TestingIsPeekVisible.equalsTo(true),
     });
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复命令面板按 esc 键无法隐藏的问题
