### PR TITLE
fix: only web env deal with openNewWindow external prop

### DIFF
--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -18,9 +18,6 @@ export class WindowService implements IWindowService {
   private readonly appConfig: AppConfig;
 
   openNewWindow(url: string, options?: NewWindowOptions): Window | undefined {
-    if (options?.external) {
-      url = this.externalUriService.resolveExternalUri(new URI(url)).toString(true);
-    }
     if (this.appConfig.isElectronRenderer) {
       // Electron 环境下使用 shell.openExternal 方法打开外部 Uri
       const electronMainUIService: IElectronMainUIService = this.injector.get(IElectronMainUIService);
@@ -29,6 +26,9 @@ export class WindowService implements IWindowService {
       electronMainUIService.openExternal(url);
       return undefined;
     } else {
+      if (options?.external) {
+        url = this.externalUriService.resolveExternalUri(new URI(url)).toString(true);
+      }
       const newWindow = window.open(url);
       if (newWindow === null) {
         throw new Error('Cannot open a new window for URL: ' + url);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution
close #35 
不能打开 `http://127.0.0.1:8000` 是因为 Electron 环境不需要处理 localhost 的路径。Web 会通过 external 属性替换 localhost。

### Changelog
- only web env deal with openNewWindow external prop