### PR TITLE
feat: support terminal to open folder and file

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -598,6 +598,9 @@ export const localizationBundle = {
     'terminal.launchFail.cwdDoesNotExist': 'Starting directory (cwd) "{0}" does not exist',
     'terminal.launchFail.executableIsNotFileOrSymlink': 'Path to shell executable "{0}" is not a file or a symlink',
     'terminal.launchFail.executableDoesNotExist': 'Path to shell executable "{0}" does not exist',
+    'terminal.openFile': 'Open file in editor',
+    'terminal.focusFolder': 'Focus folder in explorer',
+    'terminal.openFolder': 'Open folder in new window',
 
     'deugger.menu.setValue': 'Set Value',
     'deugger.menu.setValue.param': 'Please input the value of this variable',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -640,6 +640,9 @@ export const localizationBundle = {
     'terminal.launchFail.cwdDoesNotExist': '终端启动目录 (cwd) "{0}" 不存在',
     'terminal.launchFail.executableIsNotFileOrSymlink': '终端启动的可执行文件 "{0}" 的路径非文件或符号链接',
     'terminal.launchFail.executableDoesNotExist': '终端启动的可执行文件 "{0}" 的路径不存在',
+    'terminal.openFile': '打开文件',
+    'terminal.focusFolder': '聚焦资源管理器中的文件夹',
+    'terminal.openFolder': '在新窗口中打开文件夹',
 
     'deugger.menu.setValue': '设置变量',
     'deugger.menu.setValue.param': '请输入你要改变变量的值',

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -16,9 +16,9 @@ import { convertBufferRangeToViewport } from './helpers';
 // default delay time (ms) for showing tooltip when mouse is over a link
 const DEFAULT_HOVER_DELAY = 500;
 
-export const OPEN_FILE_LABEL = localize('openFile', 'Open file in editor');
-export const FOLDER_IN_WORKSPACE_LABEL = localize('focusFolder', 'Focus folder in explorer');
-export const FOLDER_NOT_IN_WORKSPACE_LABEL = localize('openFolder', 'Open folder in new window');
+export const OPEN_FILE_LABEL = localize('terminal.openFile', 'Open file in editor');
+export const FOLDER_IN_WORKSPACE_LABEL = localize('terminal.focusFolder', 'Focus folder in explorer');
+export const FOLDER_NOT_IN_WORKSPACE_LABEL = localize('terminal.openFolder', 'Open folder in new window');
 
 @Injectable({ multiple: true })
 export class TerminalLink extends Disposable implements ILink {

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -8,12 +8,17 @@ import {
   Event,
   isOSX,
   RunOnceScheduler,
+  localize,
 } from '@opensumi/ide-core-common';
 import { PreferenceService } from '@opensumi/ide-core-browser';
 import { convertBufferRangeToViewport } from './helpers';
 
 // default delay time (ms) for showing tooltip when mouse is over a link
 const DEFAULT_HOVER_DELAY = 500;
+
+export const OPEN_FILE_LABEL = localize('openFile', 'Open file in editor');
+export const FOLDER_IN_WORKSPACE_LABEL = localize('focusFolder', 'Focus folder in explorer');
+export const FOLDER_NOT_IN_WORKSPACE_LABEL = localize('openFolder', 'Open folder in new window');
 
 @Injectable({ multiple: true })
 export class TerminalLink extends Disposable implements ILink {

--- a/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
@@ -2,14 +2,17 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-// Some code copied and modified from https://github.com/microsoft/vscode/blob/1.44.0/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+// Some code copied and modified from https://github.com/microsoft/vscode/blob/1.63.2/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
 
 import type { Terminal, IBufferLine, IViewportRange } from 'xterm';
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import { IDisposable, URI } from '@opensumi/ide-core-common';
+import { CommandService, IDisposable, URI } from '@opensumi/ide-core-common';
 import { OperatingSystem } from '@opensumi/ide-core-common/lib/platform';
+import { IWindowService } from '@opensumi/ide-core-browser/lib/window';
+import { IWorkspaceService } from '@opensumi/ide-workspace/lib/common/workspace-defination';
+import { AppConfig } from '@opensumi/ide-core-browser/lib/react-providers/config-provider';
 import type { TerminalClient } from '../terminal.client';
-import { TerminalLink } from './link';
+import { FOLDER_IN_WORKSPACE_LABEL, FOLDER_NOT_IN_WORKSPACE_LABEL, OPEN_FILE_LABEL, TerminalLink } from './link';
 import { XtermLinkMatcherHandler } from './link-manager';
 import { TerminalBaseLinkProvider } from './base';
 import { getXtermLineContent, convertLinkRangeToBuffer } from './helpers';
@@ -17,8 +20,8 @@ import { getXtermLineContent, convertLinkRangeToBuffer } from './helpers';
 const pathPrefix = '(\\.\\.?|\\~)';
 const pathSeparatorClause = '\\/';
 // '":; are allowed in paths but they are often separators so ignore them
-// Also disallow \\ to prevent a catastropic backtracking case #24798
-const excludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]\'":;\\\\]';
+// Also disallow \\ to prevent a catastropic backtracking case #24795
+const excludedPathCharactersClause = '[^\\0\\s!`&*()\\[\\]\'":;\\\\]';
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar */
 export const unixLocalLinkClause =
   '((' +
@@ -34,7 +37,7 @@ export const unixLocalLinkClause =
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
 const winPathSeparatorClause = '(\\\\|\\/)';
-const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!$`&*()\\[\\]\'":;]';
+const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*()\\[\\]\'":;]';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar */
 export const winLocalLinkClause =
   '((' +
@@ -50,8 +53,8 @@ export const winLocalLinkClause =
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
 replacing space with nonBreakningSpace or space ASCII code - 32. */
 export const lineAndColumnClause = [
-  '((\\S*)", line ((\\d+)( column (\\d+))?))', // "(file path)", line 45 [see #40468]
-  '((\\S*)",((\\d+)(:(\\d+))?))', // "(file path)",45 [see #78205]
+  '((\\S*)[\'"], line ((\\d+)( column (\\d+))?))', // "(file path)", line 45 [see #40468]
+  '((\\S*)[\'"],((\\d+)(:(\\d+))?))', // "(file path)",45 [see #78205]
   '((\\S*) on line ((\\d+)(, column (\\d+))?))', // (file path) on line 8, column 13
   '((\\S*):line ((\\d+)(, column (\\d+))?))', // (file path):line 8, column 13
   '(([^\\s\\(\\)]*)(\\s?[\\(\\[](\\d+)(,\\s?(\\d+))?)[\\)\\]])', // (file path)(45), (file path) (45), (file path)(45,18), (file path) (45,18), (file path)(45, 18), (file path) (45, 18), also with []
@@ -73,6 +76,18 @@ const MAX_LENGTH = 2000;
 export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider {
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
+
+  @Autowired(IWindowService)
+  protected readonly windowService: IWindowService;
+
+  @Autowired(CommandService)
+  private readonly commandService: CommandService;
+
+  @Autowired(IWorkspaceService)
+  private readonly workspaceService: IWorkspaceService;
+
+  @Autowired(AppConfig)
+  private readonly appConfig: AppConfig;
 
   constructor(
     private readonly _xterm: Terminal,
@@ -168,10 +183,19 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
       );
 
       const validatedLink = await new Promise<TerminalLink | undefined>((r) => {
-        this._validationCallback(link, (result) => {
-          if (result && !result.isDirectory) {
+        this._validationCallback(link, async (result) => {
+          if (result) {
+            const label = result.isDirectory
+              ? (await this._isDirectoryInsideWorkspace(result.uri))
+                ? FOLDER_IN_WORKSPACE_LABEL
+                : FOLDER_NOT_IN_WORKSPACE_LABEL
+              : OPEN_FILE_LABEL;
             const activateCallback = this._wrapLinkHandler((event: MouseEvent | undefined, text: string) => {
-              this._activateFileCallback(event, text);
+              if (result.isDirectory) {
+                this._handleLocalFolderLink(result.uri);
+              } else {
+                this._activateFileCallback(event, text);
+              }
             });
             r(
               this.injector.get(TerminalLink, [
@@ -182,7 +206,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
                 activateCallback,
                 this._tooltipCallback,
                 true,
-                undefined,
+                label,
               ]),
             );
           } else {
@@ -202,5 +226,28 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
     const baseLocalLinkClause = this._client.os === OperatingSystem.Windows ? winLocalLinkClause : unixLocalLinkClause;
     // Append line and column number regex
     return new RegExp(`${baseLocalLinkClause}(${lineAndColumnClause})`);
+  }
+
+  private async _handleLocalFolderLink(uri: URI): Promise<void> {
+    // If the folder is within one of the window's workspaces, focus it in the explorer
+    if (await this._isDirectoryInsideWorkspace(uri)) {
+      await this.commandService.executeCommand('revealInExplorer', uri);
+      return;
+    }
+
+    // Open a new window for the folder
+    if (this.appConfig.isElectronRenderer) {
+      this.windowService.openWorkspace(uri, { newWindow: true });
+    }
+  }
+
+  private async _isDirectoryInsideWorkspace(uri: URI) {
+    const folders = await this.workspaceService.roots;
+    for (const folder of folders) {
+      if (URI.parse(folder.uri).isEqualOrParent(uri)) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
close #486 
> 同步 VSCode 1.63.2 版本的正则 `vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.t`
1. 鼠标移到对应的路径，有明确提示行为"Open file in editor"，在新窗口打开文件夹
2. 如果是项目内的文件，有明确的提示"Focus folder in explorer"，并支持在当前工作区打开或者聚焦到对应的目录
3. 如果是项目外的文件，在 Electron 环境通过新窗口打开

![screenshort_20220218-203142](https://user-images.githubusercontent.com/2226423/154900372-dcf1b067-9be4-495e-a2a7-7aaede78d3ef.gif)

### Changelog
support terminal to open folder and file