### PR TITLE
fix: hide statusbar popover if no command

### DIFF
--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -52,7 +52,6 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
     iconClass,
     className,
     role = 'button',
-    name,
     hoverContents,
     color: propsColor,
     backgroundColor: propsBackgroundColor,
@@ -60,11 +59,16 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
 
   const themeService = useInjectable<IThemeService>(IThemeService);
 
+  const disablePopover = React.useMemo(
+    () => !tooltip && !hoverContents && (!command || !onClick),
+    [tooltip, hoverContents, command, onClick],
+  );
+
   const popoverContent = React.useMemo(() => {
     if (hoverContents) {
       return <StatusBarPopover contents={hoverContents} />;
     }
-    return <div>{tooltip}</div>;
+    return <div className={styles.popover_tooltip}>{tooltip}</div>;
   }, []);
 
   const getColor = (color: string | IThemeColor | undefined): string => {
@@ -103,7 +107,7 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
         trigger={PopoverTriggerType.hover}
         delay={200}
         position={PopoverPosition.top}
-        disable={!tooltip && !hoverContents}
+        disable={disablePopover}
       >
         <div className={styles.popover_item}>
           {iconClass && <span key={-1} className={cls(styles.icon, iconClass)}></span>}

--- a/packages/status-bar/src/browser/status-bar.module.less
+++ b/packages/status-bar/src/browser/status-bar.module.less
@@ -75,12 +75,16 @@
   }
 }
 
+.popover_tooltip,
+.popover_content {
+  font-size: @statusBar-font-size;
+  white-space: nowrap;
+}
+
 .popover_content {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: @statusBar-font-size;
-  white-space: nowrap;
 }
 
 .popover_item {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

Fixed #481 

### Changelog
fix: hide statusbar popover if no command