### PR TITLE
fix: improve filetree update process

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -51,7 +51,6 @@ export interface ITreeIndent {
 @Injectable()
 export class FileTreeService extends Tree implements IFileTreeService {
   private static DEFAULT_FLUSH_FILE_EVENT_DELAY = 500;
-  private static readonly EXPLORER_FILE_CHANGES_REACT_DELAY = 500;
 
   @Autowired(IFileTreeAPI)
   private readonly fileTreeAPI: IFileTreeAPI;
@@ -426,13 +425,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
     });
     // 处理除了删除/添加/移动事件外的异常事件
     if (!(await this.refreshAffectedNodes(this.getAffectedUris(changes))) && this.isRootAffected(changes)) {
-      // 在文件树场景下，我们无法保证内部事件及真实响应事件的响应时机
-      // 即，如果无法保证内部事件执行完，直接再次响应真实事件，将会遇到不可预期的问题
-      // 如，渲染异常
-      // ref https://github.com/Microsoft/vscode/blob/21c0490036b6d7dfeda74c5a8e9cd40116ace1c5/src/vs/workbench/contrib/files/common/explorerService.ts#L278
-      setTimeout(() => {
-        this.refresh();
-      }, FileTreeService.EXPLORER_FILE_CHANGES_REACT_DELAY);
+      this.refresh();
     }
   }
 
@@ -755,7 +748,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
   /**
    * 刷新指定下的所有子节点
    */
-  async refresh(node: Directory = this.root as Directory, needReload = true) {
+  async refresh(node: Directory = this.root as Directory) {
     this.willRefreshDeferred = new Deferred();
     if (!node) {
       return;

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -378,11 +378,6 @@ export class FileTreeModelService {
     this._decorations.addDecoration(this.loadingDecoration);
   }
 
-  // 在文件树完成刷新操作后再进行下一步动作
-  private async ensurePerformedEffect() {
-    await this.fileTreeService?.willRefreshPromise;
-  }
-
   /**
    * 多选情况下，焦点节点只要一个，选中节点有多个
    * 单选情况下，焦点节点与选中节点均只有一个
@@ -590,7 +585,6 @@ export class FileTreeModelService {
   };
 
   toggleDirectory = async (item: Directory) => {
-    await this.ensurePerformedEffect();
     if (item.expanded) {
       this.fileTreeHandle.collapseNode(item);
     } else {
@@ -881,7 +875,6 @@ export class FileTreeModelService {
 
   // 命令调用
   async collapseAll() {
-    await this.ensurePerformedEffect();
     this.collapsedAllDeferred = new Deferred();
     await this.treeModel.root.collapsedAll();
     const snapshot = this.explorerStorage.get<ISerializableState>(FileTreeModelService.FILE_TREE_SNAPSHOT_KEY);
@@ -901,7 +894,6 @@ export class FileTreeModelService {
 
   // 展开所有缓存目录
   public expandAllCacheDirectory = async () => {
-    await this.ensurePerformedEffect();
     const size = this.treeModel.root.branchSize;
     for (let index = 0; index < size; index++) {
       const file = this.treeModel.root.getTreeNodeAtIndex(index) as Directory;
@@ -1157,7 +1149,6 @@ export class FileTreeModelService {
         let error;
         const isEmptyDirectory = !parent.children || parent.children.length === 0;
         promptHandle.addAddonAfter('loading_indicator');
-        await this.ensurePerformedEffect();
         if (promptHandle.type === TreeNodeType.CompositeTreeNode) {
           if (this.fileTreeService.isCompactMode && isEmptyDirectory && !Directory.isRoot(parent)) {
             this.fileTreeService.ignoreFileEvent(parent.uri, FileChangeType.UPDATED);
@@ -1364,7 +1355,6 @@ export class FileTreeModelService {
   };
 
   private async getPromptTarget(uri: URI, isCreatingFile?: boolean) {
-    await this.ensurePerformedEffect();
     let targetNode: File | Directory;
     // 使用path能更精确的定位新建文件位置，因为软连接情况下可能存在uri一致的情况
     if (uri.isEqual((this.treeModel.root as Directory).uri)) {
@@ -1427,7 +1417,6 @@ export class FileTreeModelService {
   }
 
   async newFilePrompt(uri: URI) {
-    await this.ensurePerformedEffect();
     const targetNode = await this.getPromptTarget(uri, true);
     if (targetNode) {
       this.proxyPrompt(await this.fileTreeHandle.promptNewTreeNode(targetNode as Directory));
@@ -1435,7 +1424,6 @@ export class FileTreeModelService {
   }
 
   async newDirectoryPrompt(uri: URI) {
-    await this.ensurePerformedEffect();
     const targetNode = await this.getPromptTarget(uri, true);
     if (targetNode) {
       this.proxyPrompt(await this.fileTreeHandle.promptNewCompositeTreeNode(targetNode as Directory));
@@ -1443,7 +1431,6 @@ export class FileTreeModelService {
   }
 
   async renamePrompt(uri: URI) {
-    await this.ensurePerformedEffect();
     const targetNode = await this.getPromptTarget(uri);
     if (targetNode) {
       this.proxyPrompt(await this.fileTreeHandle.promptRename(targetNode, uri.displayName));
@@ -1582,8 +1569,6 @@ export class FileTreeModelService {
     if (this._loadSnapshotReady) {
       await this._loadSnapshotReady;
     }
-    // 确保在刷新等动作执行完后进行定位
-    await this.ensurePerformedEffect();
     return this.queueLocation(pathOrUri);
   };
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

优化了文件树的更新队列，移除了原来多余的 500ms 时延，让文件树在频繁的文件变化情况下也能保持 500ms 更新一次的频率，有效保证了更新的稳定性

案例模拟了每 200ms 创建一个文件的情况

![Kapture 2022-02-22 at 16 50 11](https://user-images.githubusercontent.com/9823838/155097291-972e1da0-175b-4128-828e-e1c539e42e7d.gif)


### Changelog

improve filetree update process