### PR TITLE
fix: empty editor background show logic

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -13,6 +13,7 @@
 .kt_workbench_editor {
   height: 100%;
   background-color: var(--editor-background);
+  border-top: 1px solid var(--tab-border);
   display: flex;
 }
 .kt_editor_main_wrapper {
@@ -59,7 +60,6 @@
   }
   .kt_editor_tabs {
     display: flex;
-    border-top: 1px solid var(--tab-border);
     .editor_actions {
       flex-shrink: 0;
       height: @TAB_HEIGHT;

--- a/packages/keymaps/src/browser/keymaps.service.ts
+++ b/packages/keymaps/src/browser/keymaps.service.ts
@@ -24,6 +24,7 @@ import {
   ProgressLocation,
   IProgress,
   IProgressStep,
+  Deferred,
 } from '@opensumi/ide-core-browser';
 import { KeymapsParser } from './keymaps-parser';
 import * as fuzzy from 'fuzzy';
@@ -82,6 +83,8 @@ export class KeymapService implements IKeymapService {
   private searchDelayer = new ThrottledDelayer(KeymapService.DEFAULT_SEARCH_DELAY);
   private disposableCollection: DisposableCollection = new DisposableCollection();
 
+  private _whenReadyDeferred: Deferred<void> = new Deferred();
+
   /**
    * fuzzy搜索参数，pre及post用于包裹搜索结果
    * @protected
@@ -112,6 +115,10 @@ export class KeymapService implements IKeymapService {
   @observable.shallow
   keybindings: KeybindingItem[] = [];
 
+  get whenReady() {
+    return this._whenReadyDeferred.promise;
+  }
+
   async init() {
     const keymapUrl = KeymapService.KEYMAP_FILE_URI.toString();
     this.resource = await this.filesystem.getFileStat(keymapUrl);
@@ -129,6 +136,7 @@ export class KeymapService implements IKeymapService {
       // 快捷键绑定文件内容变化，重新更新快捷键信息
       this.reconcile();
     });
+    this._whenReadyDeferred.resolve();
   }
 
   async openResource() {

--- a/packages/keymaps/src/common/keymaps.ts
+++ b/packages/keymaps/src/common/keymaps.ts
@@ -52,6 +52,10 @@ export interface KeybindingItem extends Omit<KeymapItem, 'key'> {
 
 export interface IKeymapService {
   /**
+   * 快捷键是否初始化完成
+   */
+  whenReady: Promise<void>;
+  /**
    * 初始化快捷键注册信息
    */
   init(): Promise<void>;

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -19,7 +19,7 @@ export async function renderApp(opts: IClientAppOpts) {
     process.env.WEBVIEW_HOST || (window.location.hostname === 'localhost' ? '127.0.0.1' : 'localhost');
   opts.webviewEndpoint = `http://${anotherHostName}:8899`;
   opts.editorBackgroundImage =
-    'https://img.alicdn.com/imgextra/i2/O1CN01NR0L1l1M3AUVVdKhq_!!6000000001378-2-tps-152-150.png';
+    'https://img.alicdn.com/imgextra/i2/O1CN01dqjQei1tpbj9z9VPH_!!6000000005951-55-tps-87-78.svg';
   opts.layoutComponent = ToolbarActionBasedLayout;
   opts.clientId = CLIENT_ID;
   opts.didRendered = () => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- 替换新 LOGO
- 让空白编辑器的快捷键能够正常展示
- 支持通过 `editorBackgroundImage` 指定背景图片

dark：
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/9823838/155109372-e11a0a51-e121-4f39-8fd1-0d4a94f15eda.png">

light： 
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/9823838/155109429-4568635d-63c5-421f-b1df-d8eec82b045f.png">


### Changelog

fix empty editor background show logic
