### PR TITLE
fix: peek view context key scoped

### DIFF
--- a/packages/testing/src/browser/outputPeek/test-output-peek.ts
+++ b/packages/testing/src/browser/outputPeek/test-output-peek.ts
@@ -75,7 +75,7 @@ export class TestOutputPeekContribution implements IEditorFeatureContribution {
   private currentPeekUri: URI | undefined;
 
   constructor(@Optional() private readonly editor: IEditor) {
-    this.testContextKey = this.injector.get(TestContextKey, [this.editor.monacoEditor.getContainerDomNode()]);
+    this.testContextKey = this.injector.get(TestContextKey, [(this.editor.monacoEditor as any)._contextKeyService]);
   }
 
   private allMessages(results: readonly ITestResult[]): {

--- a/packages/testing/src/browser/test-contextkey.service.ts
+++ b/packages/testing/src/browser/test-contextkey.service.ts
@@ -1,3 +1,5 @@
+import { IContextKeyServiceTarget } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
+import { ContextKeyService } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/browser/contextKeyService';
 import { Optional, Injectable, Autowired } from '@opensumi/di';
 import { IContextKeyService, IContextKey, IScopedContextKeyService } from '@opensumi/ide-core-browser';
 import { TestingIsPeekVisible } from '@opensumi/ide-core-browser/lib/contextkey/testing';
@@ -11,7 +13,7 @@ export class TestContextKey {
 
   public readonly contextTestingIsPeekVisible: IContextKey<boolean>;
 
-  constructor(@Optional() dom?: HTMLElement) {
+  constructor(@Optional() dom?: HTMLElement | IContextKeyServiceTarget | ContextKeyService) {
     this._contextKeyService = this.globalContextKeyService.createScoped(dom);
     this.contextTestingIsPeekVisible = TestingIsPeekVisible.bind(this.contextKeyScoped);
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

由于错误的使用 monaco editor dom 来创建 context key scoped ，会导致很多 monaco 自身事件（如撤销、回退等）失效。
所以直接采用 monaco 自身的 contextKeyService 来创建 scoped

### Changelog
修复撤销、回退失效的问题