### PR TITLE
fix: editor opentype switcher

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -394,8 +394,14 @@
   .overlay-shadow();
   display: flex;
   > .option {
+    font-size: 12px;
     padding: 5px 10px;
     cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 120px;
+
     &.current_type {
       color: var(--textLink-activeForeground);
     }

--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -22,6 +22,7 @@ import classnames from 'classnames';
 import React from 'react';
 import ReactIs from 'react-is';
 import ReactDOM from 'react-dom';
+import { observer } from 'mobx-react-lite';
 
 import { IEditorOpenType, IResource, WorkbenchEditorService } from '../common';
 import { EditorComponentRegistryImpl } from './component';
@@ -229,7 +230,7 @@ const EditorEmptyComponent: React.FC<{
   );
 };
 
-export const EditorGroupView = ({ group }: { group: EditorGroup }) => {
+export const EditorGroupView = observer(({ group }: { group: EditorGroup }) => {
   const groupWrapperRef = React.useRef<HTMLElement | null>();
 
   const preferenceService = useInjectable(PreferenceService) as PreferenceService;
@@ -311,9 +312,9 @@ export const EditorGroupView = ({ group }: { group: EditorGroup }) => {
       )}
     </div>
   );
-};
+});
 
-export function EditorGroupBody({ group }: { group: EditorGroup }) {
+export const EditorGroupBody = observer(({ group }: { group: EditorGroup }) => {
   const editorBodyRef = React.useRef<HTMLDivElement>(null);
   const editorService = useInjectable(WorkbenchEditorService) as WorkbenchEditorServiceImpl;
   const eventBus = useInjectable(IEventBus) as IEventBus;
@@ -469,7 +470,7 @@ export function EditorGroupBody({ group }: { group: EditorGroup }) {
       <OpenTypeSwitcher options={group.availableOpenTypes} current={group.currentOpenType} group={group} />
     </div>
   );
-}
+});
 
 export const ComponentsWrapper = ({
   component,
@@ -544,39 +545,41 @@ export const ComponentWrapper = ({ component, resource, hidden, ...other }) => {
   );
 };
 
-export const OpenTypeSwitcher = ({
-  options,
-  current,
-  group,
-}: {
-  options: IEditorOpenType[];
-  current: MaybeNull<IEditorOpenType>;
-  group: EditorGroup;
-}) => {
-  if (options.length <= 1) {
-    return null;
-  }
+export const OpenTypeSwitcher = observer(
+  ({
+    options,
+    current,
+    group,
+  }: {
+    options: IEditorOpenType[];
+    current: MaybeNull<IEditorOpenType>;
+    group: EditorGroup;
+  }) => {
+    if (options.length <= 1) {
+      return null;
+    }
 
-  return (
-    <div className={styles.open_type_switcher}>
-      {options.map((option, i) => (
-        <div
-          className={classnames({
-            [styles.option]: true,
-            [styles.current_type]:
-              current && current.type === option.type && current.componentId === option.componentId,
-          })}
-          onClick={() => {
-            group.changeOpenType(option);
-          }}
-          key={i}
-        >
-          {option.title || option.componentId || option.type}
-        </div>
-      ))}
-    </div>
-  );
-};
+    return (
+      <div className={styles.open_type_switcher}>
+        {options.map((option, i) => (
+          <div
+            className={classnames({
+              [styles.option]: true,
+              [styles.current_type]:
+                current && current.type === option.type && current.componentId === option.componentId,
+            })}
+            onClick={() => {
+              group.changeOpenType(option);
+            }}
+            key={i}
+          >
+            {option.title || option.componentId || option.type}
+          </div>
+        ))}
+      </div>
+    );
+  },
+);
 
 function getDragOverPosition(e: DragEvent, element: HTMLElement): DragOverPosition {
   const rect = element.getBoundingClientRect();

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -62,6 +62,7 @@ import {
   EditorComponentDisposeEvent,
   EditorActiveResourceStateChangedEvent,
   CodeEditorDidVisibleEvent,
+  RegisterEditorComponentEvent,
 } from './types';
 import { IGridEditorGroup, EditorGrid, SplitDirection, IEditorGridState } from './grid/grid.service';
 import { makeRandomHexString } from '@opensumi/ide-core-common/lib/functional';
@@ -869,6 +870,15 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       this._currentOpenType = null;
       this.notifyBodyChanged();
       this.displayResourceComponent(this.currentResource, {});
+    }
+  }
+
+  @OnEvent(RegisterEditorComponentEvent)
+  async onRegisterEditorComponentEvent() {
+    if (this.currentResource) {
+      const openTypes = await this.editorComponentRegistry.resolveEditorComponent(this.currentResource);
+      this.availableOpenTypes = openTypes;
+      this.cachedResourcesOpenTypes.set(this.currentResource.uri.toString(), openTypes);
     }
   }
 

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1,4 +1,5 @@
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
+import { observable } from 'mobx';
 import {
   WorkbenchEditorService,
   EditorCollectionService,
@@ -594,6 +595,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
 
   private cachedResourcesOpenTypes = new Map<string, IEditorOpenType[]>();
 
+  @observable.shallow
   availableOpenTypes: IEditorOpenType[] = [];
 
   activeComponents = new Map<IEditorComponent, IResource[]>();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

fix

![image](https://user-images.githubusercontent.com/17701805/155494543-d91e6d8c-4dd4-4dc7-8ca9-c20921669058.png)

and

![image](https://user-images.githubusercontent.com/17701805/155494756-184b6331-edc2-4789-a8ba-e56f096812ea.png)

样式优化
- 字号减小
- 添加 max-width ，超出后显示省略号

![image](https://user-images.githubusercontent.com/17701805/155500313-3e0a76cc-10b0-4e30-9544-92ac39db8878.png)


### Changelog

- 修复某些情况下编辑器打开方式没有被清除的问题
- 修复已打开文件注册 openType 可能不生效的问题
- 优化打开方式开关样式
