### PR TITLE
feat: implememt window editor tabs API

### DIFF
--- a/packages/extension/__tests__/browser/main.thread.decoration.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.decoration.test.ts
@@ -82,6 +82,7 @@ describe('MainThreadDecorationAPI Test Suites ', () => {
         {} as any,
         {} as any,
         {} as any,
+        {} as any,
       );
       done();
     }, 0);

--- a/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
@@ -21,6 +21,7 @@ import {
   IMainThreadWebviewView,
   IMainThreadSecret,
   IMainThreadTesting,
+  IMainThreadEditorTabsShape,
 } from '../../../common/vscode'; // '../../common';
 import { MainThreadCommands } from './main.thread.commands';
 import { MainThreadExtensionDocumentData } from './main.thread.doc';
@@ -59,6 +60,7 @@ import { MainThreadCustomEditor } from './main.thread.custom-editor';
 import { MainThreadAuthentication } from './main.thread.authentication';
 import { MainThreadSecret } from './main.thread.secret';
 import { MainThreadTestsImpl } from './main.thread.tests';
+import { MainThreadEditorTabsService } from './main.thread.editor-tabs';
 
 export async function createApiFactory(
   rpcProtocol: IRPCProtocol,
@@ -101,6 +103,7 @@ export async function createApiFactory(
   const MainThreadAuthenticationAPI = injector.get(MainThreadAuthentication, [rpcProtocol]);
   const MainThreadSecretAPI = injector.get(MainThreadSecret, [rpcProtocol]);
   const MainthreadTestAPI = injector.get(MainThreadTestsImpl, [rpcProtocol]);
+  const MainThreadEditorTabsAPI = injector.get(MainThreadEditorTabsService, [rpcProtocol]);
 
   rpcProtocol.set<VSCodeExtensionService>(MainThreadAPIIdentifier.MainThreadExtensionService, extensionService);
   rpcProtocol.set<IMainThreadCommands>(MainThreadAPIIdentifier.MainThreadCommands, MainThreadCommandsAPI);
@@ -142,6 +145,7 @@ export async function createApiFactory(
   );
   rpcProtocol.set<IMainThreadSecret>(MainThreadAPIIdentifier.MainThreadSecret, MainThreadSecretAPI);
   rpcProtocol.set<IMainThreadTesting>(MainThreadAPIIdentifier.MainThreadTests, MainthreadTestAPI);
+  rpcProtocol.set<IMainThreadEditorTabsShape>(MainThreadAPIIdentifier.MainThreadEditorTabs, MainThreadEditorTabsAPI);
 
   await MainThreadWebviewAPI.init();
 
@@ -177,6 +181,7 @@ export async function createApiFactory(
     MainThreadAuthenticationAPI.dispose();
     MainThreadSecretAPI.dispose();
     MainthreadTestAPI.dispose();
+    MainThreadEditorTabsAPI.dispose();
   };
 }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.editor-tabs.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor-tabs.ts
@@ -31,6 +31,14 @@ export class MainThreadEditorTabsService extends Disposable implements IMainThre
         this._pushEditorTabs();
       }),
     );
+    this.addDispose(
+      this.workbenchEditorService.onActiveResourceChange(() => {
+        this._pushEditorTabs();
+      }),
+    );
+    this.workbenchEditorService.contributionsReady.promise.then(() => {
+      this._pushEditorTabs();
+    });
   }
 
   private _pushEditorTabs(): void {
@@ -42,9 +50,9 @@ export class MainThreadEditorTabsService extends Disposable implements IMainThre
         }
         tabs.push({
           group: group.index,
-          name: group.name,
+          name: resource.name,
           resource: resource.uri.toString(),
-          isActive: this.workbenchEditorService.currentEditorGroup.name === group.name,
+          isActive: this.workbenchEditorService.currentResource?.uri === resource.uri,
         });
       }
     }

--- a/packages/extension/src/browser/vscode/api/main.thread.editor-tabs.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor-tabs.ts
@@ -1,0 +1,50 @@
+import { ExtHostAPIIdentifier } from './../../../common/vscode/index';
+import { IRPCProtocol } from '@opensumi/ide-connection';
+import {
+  IExtHostEditorTabsShape,
+  IMainThreadEditorTabsShape,
+  IEditorTabDto,
+} from './../../../common/vscode/editor-tabs';
+import { URI, Disposable } from '@opensumi/ide-core-common';
+import { Injectable, Autowired, Optional } from '@opensumi/di';
+import { WorkbenchEditorServiceImpl } from '@opensumi/ide-editor/lib/browser/workbench-editor.service';
+import { WorkbenchEditorService } from '@opensumi/ide-editor';
+
+export interface ITabInfo {
+  name: string;
+  resource: URI;
+}
+
+@Injectable({ multiple: true })
+export class MainThreadEditorService extends Disposable implements IMainThreadEditorTabsShape {
+  @Autowired(WorkbenchEditorService)
+  private workbenchEditorService: WorkbenchEditorServiceImpl;
+
+  private readonly proxy: IExtHostEditorTabsShape;
+
+  constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {
+    super();
+    this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostEditorTabs);
+
+    this.addDispose(this.workbenchEditorService.onDidEditorGroupsChanged(this._pushEditorTabs));
+  }
+
+  private _pushEditorTabs(): void {
+    const tabs: IEditorTabDto[] = [];
+    for (const group of this.workbenchEditorService.editorGroups) {
+      for (const resource of group.resources) {
+        if (group.disposed || !resource) {
+          continue;
+        }
+        tabs.push({
+          group: group.index,
+          name: group.name,
+          resource: resource.uri,
+          isActive: this.workbenchEditorService.currentEditorGroup.name === group.name,
+        });
+      }
+    }
+
+    this.proxy.$acceptEditorTabs(tabs);
+  }
+}

--- a/packages/extension/src/browser/vscode/api/main.thread.editor-tabs.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor-tabs.ts
@@ -16,7 +16,7 @@ export interface ITabInfo {
 }
 
 @Injectable({ multiple: true })
-export class MainThreadEditorService extends Disposable implements IMainThreadEditorTabsShape {
+export class MainThreadEditorTabsService extends Disposable implements IMainThreadEditorTabsShape {
   @Autowired(WorkbenchEditorService)
   private workbenchEditorService: WorkbenchEditorServiceImpl;
 
@@ -26,7 +26,11 @@ export class MainThreadEditorService extends Disposable implements IMainThreadEd
     super();
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostEditorTabs);
 
-    this.addDispose(this.workbenchEditorService.onDidEditorGroupsChanged(this._pushEditorTabs));
+    this.addDispose(
+      this.workbenchEditorService.onDidEditorGroupsChanged(() => {
+        this._pushEditorTabs();
+      }),
+    );
   }
 
   private _pushEditorTabs(): void {
@@ -39,7 +43,7 @@ export class MainThreadEditorService extends Disposable implements IMainThreadEd
         tabs.push({
           group: group.index,
           name: group.name,
-          resource: resource.uri,
+          resource: resource.uri.toString(),
           isActive: this.workbenchEditorService.currentEditorGroup.name === group.name,
         });
       }

--- a/packages/extension/src/common/vscode/editor-tabs.ts
+++ b/packages/extension/src/common/vscode/editor-tabs.ts
@@ -1,0 +1,30 @@
+import { Event, IDisposable, URI } from '@opensumi/ide-core-common';
+import type * as vscode from 'vscode';
+
+export interface IEditorTabDto {
+  group: number;
+  name: string;
+  resource: URI;
+  isActive: boolean;
+}
+
+export interface IExtHostEditorTabsShape {
+  $acceptEditorTabs(tabs: IEditorTabDto[]): void;
+}
+
+export interface IEditorTab {
+  name: string;
+  group: number;
+  resource: vscode.Uri;
+  isActive: boolean;
+}
+
+export interface IExtHostEditorTabs extends IExtHostEditorTabsShape {
+  readonly _serviceBrand: undefined;
+  tabs: readonly IEditorTab[];
+  onDidChangeTabs: Event<void>;
+}
+
+export type IMainThreadEditorTabsShape = IDisposable;
+
+export const IExtHostEditorTabs = Symbol('IExtHostEditorTabs');

--- a/packages/extension/src/common/vscode/editor-tabs.ts
+++ b/packages/extension/src/common/vscode/editor-tabs.ts
@@ -4,7 +4,7 @@ import type * as vscode from 'vscode';
 export interface IEditorTabDto {
   group: number;
   name: string;
-  resource: URI;
+  resource: string;
   isActive: boolean;
 }
 

--- a/packages/extension/src/common/vscode/index.ts
+++ b/packages/extension/src/common/vscode/index.ts
@@ -100,7 +100,7 @@ export const MainThreadAPIIdentifier = {
   MainThreadSecret: createExtHostContextProxyIdentifier<IMainThreadSecret>('MainThreadSecret'),
   MainThreadReporter: createExtHostContextProxyIdentifier<IMainThreadSecret>('MainThreadReporter'),
   MainThreadTests: createExtHostContextProxyIdentifier<IMainThreadTesting>('MainThreadTests'),
-  MainThreadEditorTabs: createMainContextProxyIdentifier<IMainThreadEditorTabsShape>('MainThreadEditorTabs'),
+  MainThreadEditorTabs: createExtHostContextProxyIdentifier<IMainThreadEditorTabsShape>('MainThreadEditorTabs'),
 };
 
 export const ExtHostAPIIdentifier = {

--- a/packages/extension/src/common/vscode/index.ts
+++ b/packages/extension/src/common/vscode/index.ts
@@ -51,7 +51,8 @@ import { ExtHostFileSystemEvent } from '../../hosted/api/vscode/ext.host.file-sy
 import { IMainThreadUrls, IExtHostUrls } from './urls';
 import { IExtHostAuthentication, IMainThreadAuthentication } from './authentication';
 import { IExtHostSecret, IMainThreadSecret } from './secret';
-import { IExtHostTests } from './tests';
+import { IExtHostTests, IMainThreadTesting } from './tests';
+import { IExtHostEditorTabs, IMainThreadEditorTabsShape } from './editor-tabs';
 
 export const VSCodeExtensionService = Symbol('VSCodeExtensionService');
 export interface VSCodeExtensionService {
@@ -70,35 +71,36 @@ export const MainThreadAPIIdentifier = {
   MainThreadOutput: createMainContextProxyIdentifier<IMainThreadOutput>('MainThreadOutput'),
   MainThreadLanguages: createMainContextProxyIdentifier<IMainThreadLanguages>('MainThreadLanguages'),
   MainThreadExtensionService: createMainContextProxyIdentifier<VSCodeExtensionService>('MainThreadExtensionService'),
-  MainThreadDocuments: createMainContextProxyIdentifier<IMainThreadDocumentsShape>('MainThreadDocuments'),
-  MainThreadEditors: createMainContextProxyIdentifier<IMainThreadEditorsService>('MainThreadEditors'),
-  MainThreadMessages: createMainContextProxyIdentifier<IMainThreadMessage>('MainThreadMessage'),
-  MainThreadWorkspace: createMainContextProxyIdentifier<IMainThreadWorkspace>('MainThreadWorkspace'),
-  MainThreadPreference: createMainContextProxyIdentifier<IMainThreadPreference>('MainThreadPreference'),
-  MainThreadEnv: createMainContextProxyIdentifier<IMainThreadEnv>('MainThreadEnv'),
-  MainThreadQuickOpen: createMainContextProxyIdentifier<IMainThreadQuickOpen>('MainThreadQuickPick'),
-  MainThreadStorage: createMainContextProxyIdentifier<IMainThreadStorage>('MainThreadStorage'),
-  MainThreadFileSystem: createMainContextProxyIdentifier<IMainThreadFileSystemShape>('MainThreadFileSystem'),
-  MainThreadWebview: createMainContextProxyIdentifier<IMainThreadWebview>('MainThreadWebview'),
-  MainThreadWebviewView: createMainContextProxyIdentifier<IMainThreadWebviewView>('MainThreadWebviewView'),
-  MainThreadTreeView: createMainContextProxyIdentifier<IMainThreadTreeView>('MainThreadTreeView'),
-  MainThreadSCM: createMainContextProxyIdentifier<IMainThreadSCMShape>('MainThreadSCM'),
-  MainThreadWindowState: createMainContextProxyIdentifier<MainThreadWindowState>('MainThreadWindowState'),
-  MainThreadDecorations: createMainContextProxyIdentifier<IMainThreadDecorationsShape>('MainThreadDecorations'),
-  MainThreadDebug: createMainContextProxyIdentifier<IMainThreadDebug>('MainThreadDebug'),
-  MainThreadConnection: createMainContextProxyIdentifier<IMainThreadConnection>('MainThreadConnection'),
-  MainThreadTerminal: createMainContextProxyIdentifier<IMainThreadTerminal>('MainThreadTerminal'),
-  MainThreadWindow: createMainContextProxyIdentifier<IMainThreadWindow>('MainThreadWindow'),
-  MainThreadProgress: createMainContextProxyIdentifier<IMainThreadProgress>('MainThreadProgress'),
-  MainThreadTasks: createMainContextProxyIdentifier<IMainThreadTasks>('MainThreadTasks'),
-  MainThreadComments: createMainContextProxyIdentifier<IMainThreadComments>('MainThreadComments'),
-  MainThreadUrls: createMainContextProxyIdentifier<IMainThreadUrls>('MainThreadUrls'),
-  MainThreadTheming: createMainContextProxyIdentifier<IMainThreadTheming>('MainThreadTheming'),
-  MainThreadCustomEditor: createMainContextProxyIdentifier<IMainThreadCustomEditor>('MainThreadCustomEditor'),
-  MainThreadAuthentication: createMainContextProxyIdentifier<IMainThreadAuthentication>('MainThreadAuthentication'),
-  MainThreadSecret: createMainContextProxyIdentifier<IMainThreadSecret>('MainThreadSecret'),
-  MainThreadReporter: createMainContextProxyIdentifier<IMainThreadSecret>('MainThreadReporter'),
-  MainThreadTests: createMainContextProxyIdentifier<IMainThreadSecret>('MainThreadTests'),
+  MainThreadDocuments: createExtHostContextProxyIdentifier<IMainThreadDocumentsShape>('MainThreadDocuments'),
+  MainThreadEditors: createExtHostContextProxyIdentifier<IMainThreadEditorsService>('MainThreadEditors'),
+  MainThreadMessages: createExtHostContextProxyIdentifier<IMainThreadMessage>('MainThreadMessage'),
+  MainThreadWorkspace: createExtHostContextProxyIdentifier<IMainThreadWorkspace>('MainThreadWorkspace'),
+  MainThreadPreference: createExtHostContextProxyIdentifier<IMainThreadPreference>('MainThreadPreference'),
+  MainThreadEnv: createExtHostContextProxyIdentifier<IMainThreadEnv>('MainThreadEnv'),
+  MainThreadQuickOpen: createExtHostContextProxyIdentifier<IMainThreadQuickOpen>('MainThreadQuickPick'),
+  MainThreadStorage: createExtHostContextProxyIdentifier<IMainThreadStorage>('MainThreadStorage'),
+  MainThreadFileSystem: createExtHostContextProxyIdentifier<IMainThreadFileSystemShape>('MainThreadFileSystem'),
+  MainThreadWebview: createExtHostContextProxyIdentifier<IMainThreadWebview>('MainThreadWebview'),
+  MainThreadWebviewView: createExtHostContextProxyIdentifier<IMainThreadWebviewView>('MainThreadWebviewView'),
+  MainThreadTreeView: createExtHostContextProxyIdentifier<IMainThreadTreeView>('MainThreadTreeView'),
+  MainThreadSCM: createExtHostContextProxyIdentifier<IMainThreadSCMShape>('MainThreadSCM'),
+  MainThreadWindowState: createExtHostContextProxyIdentifier<MainThreadWindowState>('MainThreadWindowState'),
+  MainThreadDecorations: createExtHostContextProxyIdentifier<IMainThreadDecorationsShape>('MainThreadDecorations'),
+  MainThreadDebug: createExtHostContextProxyIdentifier<IMainThreadDebug>('MainThreadDebug'),
+  MainThreadConnection: createExtHostContextProxyIdentifier<IMainThreadConnection>('MainThreadConnection'),
+  MainThreadTerminal: createExtHostContextProxyIdentifier<IMainThreadTerminal>('MainThreadTerminal'),
+  MainThreadWindow: createExtHostContextProxyIdentifier<IMainThreadWindow>('MainThreadWindow'),
+  MainThreadProgress: createExtHostContextProxyIdentifier<IMainThreadProgress>('MainThreadProgress'),
+  MainThreadTasks: createExtHostContextProxyIdentifier<IMainThreadTasks>('MainThreadTasks'),
+  MainThreadComments: createExtHostContextProxyIdentifier<IMainThreadComments>('MainThreadComments'),
+  MainThreadUrls: createExtHostContextProxyIdentifier<IMainThreadUrls>('MainThreadUrls'),
+  MainThreadTheming: createExtHostContextProxyIdentifier<IMainThreadTheming>('MainThreadTheming'),
+  MainThreadCustomEditor: createExtHostContextProxyIdentifier<IMainThreadCustomEditor>('MainThreadCustomEditor'),
+  MainThreadAuthentication: createExtHostContextProxyIdentifier<IMainThreadAuthentication>('MainThreadAuthentication'),
+  MainThreadSecret: createExtHostContextProxyIdentifier<IMainThreadSecret>('MainThreadSecret'),
+  MainThreadReporter: createExtHostContextProxyIdentifier<IMainThreadSecret>('MainThreadReporter'),
+  MainThreadTests: createExtHostContextProxyIdentifier<IMainThreadTesting>('MainThreadTests'),
+  MainThreadEditorTabs: createMainContextProxyIdentifier<IMainThreadEditorTabsShape>('MainThreadEditorTabs'),
 };
 
 export const ExtHostAPIIdentifier = {
@@ -139,6 +141,7 @@ export const ExtHostAPIIdentifier = {
   ExtHostAuthentication: createExtHostContextProxyIdentifier<IExtHostAuthentication>('ExtHostAuthentication'),
   ExtHostSecret: createExtHostContextProxyIdentifier<IExtHostSecret>('ExtHostSecret'),
   ExtHostTests: createExtHostContextProxyIdentifier<IExtHostTests>('ExtHostTests'),
+  ExtHostEditorTabs: createExtHostContextProxyIdentifier<IExtHostEditorTabs>('ExtHostEditorTabs'),
 };
 
 export abstract class VSCodeExtensionNodeService {
@@ -186,3 +189,4 @@ export * from './theming';
 export * from './authentication';
 export * from './secret';
 export * from './tests';
+export * from './editor-tabs';

--- a/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
@@ -1,3 +1,4 @@
+import { IExtHostEditorTabs } from './../../../common/vscode/editor-tabs';
 import { ExtHostFileSystemInfo } from './ext.host.file-system-info';
 
 import { IRPCProtocol } from '@opensumi/ide-connection';
@@ -49,6 +50,7 @@ import { ExtHostTheming } from './ext.host.theming';
 import { ExtHostCustomEditorImpl } from './ext.host.custom-editor';
 import { ExtHostAuthentication, createAuthenticationApiFactory } from './ext.host.authentication';
 import { ExtHostTestsImpl } from './ext.host.tests';
+import { ExtHostEditorTabs } from './ext.host.editor-tabs';
 
 export function createApiFactory(
   rpcProtocol: IRPCProtocol,
@@ -173,6 +175,10 @@ export function createApiFactory(
     ExtHostAPIIdentifier.ExtHostTests,
     new ExtHostTestsImpl(rpcProtocol),
   );
+  const extHostEditorTabs = rpcProtocol.set<IExtHostEditorTabs>(
+    ExtHostAPIIdentifier.ExtHostEditorTabs,
+    new ExtHostEditorTabs(rpcProtocol),
+  ) as ExtHostEditorTabs;
 
   rpcProtocol.set(ExtHostAPIIdentifier.ExtHostStorage, extensionService.storage);
 
@@ -197,6 +203,7 @@ export function createApiFactory(
       extHostUrls,
       extHostTheming,
       extHostCustomEditor,
+      extHostEditorTabs,
     ),
     languages: createLanguagesApiFactory(extHostLanguages, extension),
     workspace: createWorkspaceApiFactory(

--- a/packages/extension/src/hosted/api/vscode/ext.host.editor-tabs.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.editor-tabs.ts
@@ -1,0 +1,30 @@
+import { IRPCProtocol } from '@opensumi/ide-connection';
+import { Emitter, Event, URI } from '@opensumi/ide-core-common';
+import { IExtHostEditorTabs, IEditorTab, IEditorTabDto } from './../../../common/vscode/editor-tabs';
+
+export class ExtHostEditorTabs implements IExtHostEditorTabs {
+  readonly _serviceBrand: undefined;
+
+  private readonly _onDidChangeTabs = new Emitter<void>();
+  readonly onDidChangeTabs: Event<void> = this._onDidChangeTabs.event;
+
+  private _tabs: IEditorTab[] = [];
+
+  get tabs(): readonly IEditorTab[] {
+    return this._tabs;
+  }
+
+  constructor(rpcProtocol: IRPCProtocol) {
+    // this.proxy = rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadDecorations);
+  }
+
+  $acceptEditorTabs(tabs: IEditorTabDto[]): void {
+    this._tabs = tabs.map((dto) => ({
+        name: dto.name,
+        group: dto.group,
+        resource: URI.revive(dto.resource),
+        isActive: dto.isActive,
+      }));
+    this._onDidChangeTabs.fire();
+  }
+}

--- a/packages/extension/src/hosted/api/vscode/ext.host.editor-tabs.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.editor-tabs.ts
@@ -1,8 +1,15 @@
+import { MainThreadAPIIdentifier } from './../../../common/vscode/index';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 import { Emitter, Event, URI, Uri } from '@opensumi/ide-core-common';
-import { IExtHostEditorTabs, IEditorTab, IEditorTabDto } from './../../../common/vscode/editor-tabs';
+import {
+  IExtHostEditorTabs,
+  IEditorTab,
+  IEditorTabDto,
+  IMainThreadEditorTabsShape,
+} from './../../../common/vscode/editor-tabs';
 
 export class ExtHostEditorTabs implements IExtHostEditorTabs {
+  private _proxy: IMainThreadEditorTabsShape;
   readonly _serviceBrand: undefined;
 
   private readonly _onDidChangeTabs = new Emitter<void>();
@@ -15,7 +22,7 @@ export class ExtHostEditorTabs implements IExtHostEditorTabs {
   }
 
   constructor(rpcProtocol: IRPCProtocol) {
-    // this.proxy = rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadDecorations);
+    this._proxy = rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadEditorTabs);
   }
 
   $acceptEditorTabs(tabs: IEditorTabDto[]): void {

--- a/packages/extension/src/hosted/api/vscode/ext.host.editor-tabs.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.editor-tabs.ts
@@ -1,5 +1,5 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Emitter, Event, URI } from '@opensumi/ide-core-common';
+import { Emitter, Event, URI, Uri } from '@opensumi/ide-core-common';
 import { IExtHostEditorTabs, IEditorTab, IEditorTabDto } from './../../../common/vscode/editor-tabs';
 
 export class ExtHostEditorTabs implements IExtHostEditorTabs {
@@ -20,11 +20,11 @@ export class ExtHostEditorTabs implements IExtHostEditorTabs {
 
   $acceptEditorTabs(tabs: IEditorTabDto[]): void {
     this._tabs = tabs.map((dto) => ({
-        name: dto.name,
-        group: dto.group,
-        resource: URI.revive(dto.resource),
-        isActive: dto.isActive,
-      }));
+      name: dto.name,
+      group: dto.group,
+      resource: Uri.parse(dto.resource),
+      isActive: dto.isActive,
+    }));
     this._onDidChangeTabs.fire();
   }
 }

--- a/packages/extension/src/hosted/api/vscode/ext.host.window.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.window.api.impl.ts
@@ -33,6 +33,7 @@ import { ExtHostProgress } from './ext.host.progress';
 import { QuickInputOptions } from '@opensumi/ide-quick-open';
 import { ExtHostTheming } from './ext.host.theming';
 import { ExtHostCustomEditorImpl } from './ext.host.custom-editor';
+import { ExtHostEditorTabs } from './ext.host.editor-tabs';
 
 export function createWindowApiFactory(
   extension: IExtensionDescription,
@@ -52,6 +53,7 @@ export function createWindowApiFactory(
   extHostUrls: IExtHostUrls,
   extHostTheming: ExtHostTheming,
   extHostCustomEditor: ExtHostCustomEditorImpl,
+  extHostEditorTabs: ExtHostEditorTabs,
 ): typeof vscode.window {
   const extensionInfo: IExtensionInfo = {
     id: extension.id,
@@ -291,6 +293,12 @@ export function createWindowApiFactory(
       options?: { webviewOptions: { retainContextWhenHidden: boolean } },
     ) {
       return extHostWebviewView.registerWebviewViewProvider(extension, viewId, provider, options?.webviewOptions);
+    },
+    get openEditors() {
+      return extHostEditorTabs.tabs;
+    },
+    get onDidChangeOpenEditors() {
+      return extHostEditorTabs.onDidChangeTabs;
     },
   };
 }

--- a/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
@@ -37,6 +37,7 @@ import { ExtHostTheming } from '../vscode/ext.host.theming';
 import { ExtHostCustomEditorImpl } from '../vscode/ext.host.custom-editor';
 import { createAPIFactory as createSumiAPIFactory } from '../sumi/ext.host.api.impl';
 import { ExtHostFileSystemInfo } from '../vscode/ext.host.file-system-info';
+import { ExtHostEditorTabs } from '../vscode/ext.host.editor-tabs';
 
 export function createAPIFactory(
   rpcProtocol: IRPCProtocol,
@@ -140,6 +141,10 @@ export function createAPIFactory(
   // TODO: 目前 worker reporter 缺少一条通信链路，先默认实现
   const reporter = new DefaultReporter();
   const sumiAPI = createSumiAPIFactory(rpcProtocol, extensionService, 'worker', reporter);
+  const extHostEditorTabs = rpcProtocol.set(
+    ExtHostAPIIdentifier.ExtHostEditorTabs,
+    new ExtHostEditorTabs(rpcProtocol),
+  ) as ExtHostEditorTabs;
 
   return (extension: IExtensionDescription) => ({
     ...workerExtTypes,
@@ -185,6 +190,7 @@ export function createAPIFactory(
       extHostUrls,
       extHostTheming,
       extHostCustomEditor,
+      extHostEditorTabs,
     ),
     comments: createCommentsApiFactory(extension, extHostComments),
     // Sumi 扩展 API

--- a/packages/types/vscode/typings/vscode.proposed.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.d.ts
@@ -208,34 +208,34 @@ declare module 'vscode' {
    */
   export class FileDecoration {
 
-  /**
-   * A very short string that represents this decoration.
-   */
+    /**
+     * A very short string that represents this decoration.
+     */
     badge?: string;
 
-  /**
-   * A human-readable tooltip for this decoration.
-   */
+    /**
+     * A human-readable tooltip for this decoration.
+     */
     tooltip?: string;
 
-  /**
-   * The color of this decoration.
-   */
+    /**
+     * The color of this decoration.
+     */
     color?: ThemeColor;
 
-  /**
-   * A flag expressing that this decoration should be
-   * propagated to its parents.
-   */
+    /**
+     * A flag expressing that this decoration should be
+     * propagated to its parents.
+     */
     propagate?: boolean;
 
-  /**
-   * Creates a new decoration.
-   *
-   * @param badge A letter that represents the decoration.
-   * @param tooltip The tooltip of the decoration.
-   * @param color The color of the decoration.
-   */
+    /**
+     * Creates a new decoration.
+     *
+     * @param badge A letter that represents the decoration.
+     * @param tooltip The tooltip of the decoration.
+     * @param color The color of the decoration.
+     */
     constructor(badge?: string, tooltip?: string, color?: ThemeColor);
   }
 
@@ -245,35 +245,35 @@ declare module 'vscode' {
    */
   export interface FileDecorationProvider {
 
-  /**
-   * An optional event to signal that decorations for one or many files have changed.
-   *
-   * *Note* that this event should be used to propagate information about children.
-   *
-   * @see {@link EventEmitter}
-   */
+    /**
+     * An optional event to signal that decorations for one or many files have changed.
+     *
+     * *Note* that this event should be used to propagate information about children.
+     *
+     * @see {@link EventEmitter}
+     */
     onDidChange: Event<undefined | Uri | Uri[]>;
 
-  /**
-   * An optional event to signal that decorations for one or many files have changed.
-   *
-   * *Note* that this event should be used to propagate information about children.
-   *
-   * @see [EventEmitter](#EventEmitter)
-   */
-  onDidChangeFileDecorations?: Event<undefined | Uri | Uri[]>;
+    /**
+     * An optional event to signal that decorations for one or many files have changed.
+     *
+     * *Note* that this event should be used to propagate information about children.
+     *
+     * @see [EventEmitter](#EventEmitter)
+     */
+    onDidChangeFileDecorations?: Event<undefined | Uri | Uri[]>;
 
-  /**
-   * Provide decorations for a given uri.
-   *
-   * *Note* that this function is only called when a file gets rendered in the UI.
-   * This means a decoration from a descendent that propagates upwards must be signaled
-   * to the editor via the {@link FileDecorationProvider.onDidChangeFileDecorations onDidChangeFileDecorations}-event.
-   *
-   * @param uri The uri of the file to provide a decoration for.
-   * @param token A cancellation token.
-   * @returns A decoration or a thenable that resolves to such.
-   */
+    /**
+     * Provide decorations for a given uri.
+     *
+     * *Note* that this function is only called when a file gets rendered in the UI.
+     * This means a decoration from a descendent that propagates upwards must be signaled
+     * to the editor via the {@link FileDecorationProvider.onDidChangeFileDecorations onDidChangeFileDecorations}-event.
+     *
+     * @param uri The uri of the file to provide a decoration for.
+     * @param token A cancellation token.
+     * @returns A decoration or a thenable that resolves to such.
+     */
     provideFileDecoration(uri: Uri, token: CancellationToken): ProviderResult<FileDecoration>;
   }
 
@@ -658,5 +658,23 @@ declare module 'vscode' {
      */
     provideInlayHints(model: TextDocument, range: Range, token: CancellationToken): ProviderResult<InlayHint[]>;
   }
+  //#endregion
+
+  //#region https://github.com/Microsoft/vscode/issues/15178
+
+  // TODO@API must be a class
+  export interface OpenEditorInfo {
+    name: string;
+    resource: Uri;
+    isActive: boolean;
+  }
+
+  export namespace window {
+    export const openEditors: ReadonlyArray<OpenEditorInfo>;
+
+    // todo@API proper event type
+    export const onDidChangeOpenEditors: Event<void>;
+  }
+
   //#endregion
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

在插件里通过 vsocde.window.openEditors 可获取多个 editor group 下的所有 tabs 信息
![image](https://user-images.githubusercontent.com/20262815/156291320-03466c89-1ecb-48a3-9df0-d614c1189aad.png)

![image](https://user-images.githubusercontent.com/20262815/156291487-b981e59a-1c1e-4db1-8562-75f26c0641b8.png)

### Changelog
实现 vscode.OpenEditorInfo API