### PR TITLE
WIP: feat: standalone terminal pty service poc

### DIFF
--- a/packages/terminal-next/src/node/index.ts
+++ b/packages/terminal-next/src/node/index.ts
@@ -12,6 +12,7 @@ import {
 import { TerminalProcessServiceImpl } from './terminal.process.service';
 import { PtyService, IPtyService } from './pty';
 import { ITerminalProfileServiceNode, TerminalProfileServiceNode } from './terminal.profile.service';
+import { PtyServiceManager, PtyServiceManagerToken } from './pty.manager';
 
 @Injectable()
 export class TerminalNodePtyModule extends NodeModule {
@@ -35,6 +36,10 @@ export class TerminalNodePtyModule extends NodeModule {
     {
       token: ITerminalProfileServiceNode,
       useClass: TerminalProfileServiceNode,
+    },
+    {
+      token: PtyServiceManagerToken,
+      useClass: PtyServiceManager,
     },
   ];
 

--- a/packages/terminal-next/src/node/pty.manager.ts
+++ b/packages/terminal-next/src/node/pty.manager.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-console */
+import net from 'net';
+import * as pty from 'node-pty';
+import { Injectable } from '@opensumi/di';
+import { RPCServiceCenter, createSocketConnection, initRPCService } from '@opensumi/ide-connection';
+import { IPtyServiceProxy } from './pty.proxy';
+
+export const PtyServiceManagerToken = Symbol('PtyServiceManager');
+
+// 在IDE容器中远程运行，与DEV Server通信
+@Injectable()
+export class PtyServiceManager {
+  private callId = 0;
+  private callbackMap = new Map<number, (...args: any[]) => void>();
+  private ptyServiceProxy: IPtyServiceProxy; // TODO: 补充interface { $method }
+
+  constructor() {
+    this.initRemoteConnection();
+  }
+
+  initRemoteConnection() {
+    const clientCenter = new RPCServiceCenter();
+    const { getRPCService: clientGetRPCService, createRPCService } = initRPCService(clientCenter);
+    // const self = this;
+    // TODO: 思考any是否应该在这里用 亦或者做空判断
+    const getService: IPtyServiceProxy = clientGetRPCService('PTY_SERVICE') as any;
+    this.ptyServiceProxy = getService;
+
+    // 处理回调
+    createRPCService('PTY_SERVICE_Callback', {
+      $callback: async (callId, ...args) => {
+        const callback = this.callbackMap.get(callId);
+        console.log('PTY_SERVICE_Callback', callId, args);
+        if (!callback) {
+          return Promise.reject(new Error(`no found callback: ${callId}`));
+        }
+        callback(...args);
+      },
+    });
+    const socket = new net.Socket();
+    socket.connect({ port: 10111 });
+
+    // 连接绑定
+    clientCenter.setConnection(createSocketConnection(socket));
+    return getService;
+  }
+
+  addNewCallback(pid: number, callback: (...args: any[]) => void) {
+    const callId = this.callId++;
+    this.callbackMap.set(callId, callback);
+    return callId;
+    // TODO: dispose 逻辑
+  }
+
+  async spawn(
+    file: string,
+    args: string[] | string,
+    options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+  ): Promise<pty.IPty> {
+    const iPtyRemoteProxy = (await this.ptyServiceProxy.$spawn(file, args, options)) as pty.IPty;
+    // 局部功能的Ipty, 代理所有常量
+    // TODO 改造ptyServiceProxy，支持常量的返回 以及方法的代理
+    return new PtyProcessProxy(iPtyRemoteProxy, this);
+  }
+
+  // 实现Ipty的需要回调的逻辑接口，同时注入
+  onData(pid: number, listener: (e: string) => any) {
+    const callId = this.addNewCallback(pid, listener);
+    this.ptyServiceProxy.$onData(callId, pid);
+  }
+  onExit(pid: number, listener: (e: { exitCode: number; signal?: number }) => any) {
+    const callId = this.addNewCallback(pid, listener);
+    this.ptyServiceProxy.$onExit(callId, pid);
+  }
+
+  on(pid: number, event: 'data', listener: (data: string) => void): void;
+  on(pid: number, event: 'exit', listener: (exitCode: number, signal?: number) => void): void;
+  on(pid: number, event: any, listener: (data: any) => void): void {
+    const callId = this.addNewCallback(pid, listener);
+    this.ptyServiceProxy.$on(callId, pid, event);
+  }
+
+  resize(pid: number, columns: number, rows: number): void {
+    this.ptyServiceProxy.$resize(pid, columns, rows);
+  }
+  write(pid: number, data: string): void {
+    this.ptyServiceProxy.$write(pid, data);
+  }
+  kill(pid: number, signal?: string): void {
+    this.ptyServiceProxy.$kill(pid, signal);
+  }
+  pause(pid: number): void {
+    this.ptyServiceProxy.$pause(pid);
+  }
+  resume(pid: number): void {
+    this.ptyServiceProxy.$resume(pid);
+  }
+}
+
+class PtyProcessProxy implements pty.IPty {
+  private ptyServiceManager: PtyServiceManager;
+  constructor(iptyProxy: pty.IPty, ptyServiceManager: PtyServiceManager) {
+    this.ptyServiceManager = ptyServiceManager;
+    this.pid = iptyProxy.pid;
+    this.cols = iptyProxy.cols;
+    this.rows = iptyProxy.rows;
+    this.process = iptyProxy.process;
+    this.handleFlowControl = iptyProxy.handleFlowControl;
+
+    this.onData = (listener: (e: string) => any) => {
+      this.ptyServiceManager.onData(this.pid, listener);
+      const disposeable = {
+        dispose: () => {},
+      };
+      return disposeable;
+    };
+
+    this.onExit = (listener: (e: { exitCode: number; signal?: number }) => any) => {
+      this.ptyServiceManager.onExit(this.pid, listener);
+      const disposeable = {
+        dispose: () => {},
+      };
+      return disposeable;
+    };
+  }
+  pid: number;
+  cols: number;
+  rows: number;
+  process: string;
+  handleFlowControl: boolean;
+
+  onData: pty.IEvent<string>;
+  onExit: pty.IEvent<{ exitCode: number; signal?: number }>;
+
+  on(event: 'data', listener: (data: string) => void): void;
+  on(event: 'exit', listener: (exitCode: number, signal?: number) => void): void;
+  on(event: any, listener: any): void {
+    this.ptyServiceManager.on(this.pid, event, listener);
+  }
+  resize(columns: number, rows: number): void {
+    this.ptyServiceManager.resize(this.pid, columns, rows);
+  }
+  write(data: string): void {
+    this.ptyServiceManager.write(this.pid, data);
+  }
+  kill(signal?: string): void {
+    this.ptyServiceManager.kill(this.pid, signal);
+  }
+  pause(): void {
+    this.ptyServiceManager.pause(this.pid);
+  }
+  resume(): void {
+    this.ptyServiceManager.resume(this.pid);
+  }
+}

--- a/packages/terminal-next/src/node/pty.proxy.ts
+++ b/packages/terminal-next/src/node/pty.proxy.ts
@@ -1,0 +1,114 @@
+/* eslint-disable no-console */
+import net from 'net';
+import * as pty from 'node-pty';
+import { RPCServiceCenter, createSocketConnection, initRPCService } from '@opensumi/ide-connection';
+
+export interface IPtyServiceProxy {
+  $spawn(
+    file: string,
+    args: string[] | string,
+    options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+  ): Promise<pty.IPty>;
+  $onData(callId: number, pid: number): void;
+  $onExit(callId: number, pid: number): void;
+  $on(callId: number, pid: number, event: any): void;
+  $resize(pid: number, columns: number, rows: number): void;
+  $write(pid: number, data: string): void;
+  $kill(pid: number, signal?: string): void;
+  $pause(pid: number): void;
+  $resume(pid: number): void;
+}
+
+// 在DEV容器中远程运行，与IDE Server通信
+class PtyServiceProxy {
+  private readonly ptyServiceCenter: RPCServiceCenter;
+  private ptyInstanceMap = new Map<number, pty.IPty>();
+
+  constructor() {
+    this.ptyServiceCenter = new RPCServiceCenter();
+    this.createSocket();
+    const { createRPCService, getRPCService } = initRPCService(this.ptyServiceCenter);
+
+    const $callback: (callId: number, ...args) => void = (getRPCService('PTY_SERVICE_Callback') as any).$callback;
+    const self = this;
+    const ptyServiceProxy: IPtyServiceProxy = {
+      $spawn(file: string, args: string[] | string, options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions): any {
+        console.log('ptyServiceCenter: spawn', file, args, options);
+        const ptyInstance = pty.spawn(file, args, options);
+        self.ptyInstanceMap.set(ptyInstance.pid, ptyInstance);
+        const ptyInstanceSimple = {
+          pid: ptyInstance.pid,
+          cols: ptyInstance.cols,
+          rows: ptyInstance.rows,
+          process: ptyInstance.process,
+          handleFlowControl: ptyInstance.handleFlowControl,
+        };
+        console.log('ptyServiceCenter: spawn', ptyInstanceSimple);
+        return ptyInstanceSimple;
+        // (getRPCService('PTY_SERVICE_Callback') as any).$callback('call back test');
+      },
+      $onData(callId: number, pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.onData((e) => {
+          console.log('ptyServiceCenter: onData', e, 'pid:', pid);
+          $callback(callId, e);
+        });
+      },
+      $onExit(callId: number, pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.onExit((e) => {
+          $callback(callId, e);
+        });
+      },
+      $on(callId: number, pid: number, event: any): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.on(event, (e) => {
+          $callback(callId, e);
+        });
+      },
+      $resize(pid: number, columns: number, rows: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.resize(columns, rows);
+      },
+      $write(pid: number, data: string): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        console.log('ptyServiceCenter: write', data, 'pid:', pid);
+        ptyInstance?.write(data);
+      },
+      $kill(pid: number, signal?: string): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.kill(signal);
+      },
+      $pause(pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.pause();
+      },
+      $resume(pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.resume();
+      },
+    };
+
+    createRPCService('PTY_SERVICE', ptyServiceProxy);
+  }
+
+  private createSocket() {
+    const server = net.createServer();
+    server.on('connection', (connection) => {
+      console.log('ptyServiceCenter: new connections coming in');
+      this.setProxyConnection(connection);
+    });
+    server.listen(10111);
+    console.log('ptyServiceCenter: listening on 10111');
+  }
+
+  private setProxyConnection(connection: net.Socket) {
+    const serverConnection = createSocketConnection(connection);
+    this.ptyServiceCenter.setConnection(serverConnection);
+    connection.on('close', () => {
+      this.ptyServiceCenter.removeConnection(serverConnection);
+    });
+  }
+}
+
+new PtyServiceProxy();

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -19,6 +19,7 @@ import { promises } from 'fs';
 import * as path from '@opensumi/ide-core-common/lib/path';
 import { isWindows } from '@opensumi/ide-core-common/lib/platform';
 import { IProcessReadyEvent, IProcessExitEvent } from '../common/process';
+import { PtyServiceManager } from './pty.manager';
 
 export const IPtyService = Symbol('IPtyService');
 
@@ -36,6 +37,7 @@ export class PtyService extends Disposable {
   readonly onReady = this._onReady.event;
   private readonly _onExit = new Emitter<IProcessExitEvent>();
   readonly onExit = this._onExit.event;
+  private readonly ptyServiceManager = new PtyServiceManager();
 
   private readonly _initialCwd: string;
 
@@ -183,7 +185,8 @@ export class PtyService extends Disposable {
     const options = this.shellLaunchConfig;
 
     const args = options.args || [];
-    const ptyProcess = pty.spawn(options.executable as string, args, this._ptyOptions);
+    const ptyProcess = await this.ptyServiceManager.spawn(options.executable as string, args, this._ptyOptions);
+    // const ptyProcess1 = pty.spawn(options.executable as string, args, this._ptyOptions);
 
     this.addDispose(
       ptyProcess.onData((e) => {


### PR DESCRIPTION
### Types

终端POC服务采用单独的进程来运行，使用Socket上的RPC连接在做通信，便于终端的多容器或持久化部署。

!! 目前处于POC阶段，暂不合并
持续重构/优化代码中

- [x] 🎉 New Features
- [x] 🪚 Refactors
- [x] Other Changes

### Background or solution
- 在窗口关闭后，terminal服务依旧需要保活而不是被kill掉，便于一些node server在开发容器上运行

### Changelog
- 支持独立PTY服务POC
