### PR TITLE
fix: 修复侧边栏 tab 拖拽时拖拽图显示问题

### DIFF
--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -100,8 +100,11 @@ export const TabbarViewBase: React.FC<{
                       dragImage.classList.add(tabClassName);
                     }
                     document.body.appendChild(dragImage);
-                    e.dataTransfer.setDragImage(dragImage, 0, 0);
-                    setTimeout(() => document.body.removeChild(dragImage), 0);
+                    e.persist();
+                    requestAnimationFrame(() => {
+                        e.dataTransfer.setDragImage(dragImage, 0, 0);
+                        document.body.removeChild(dragImage);
+                    });
                   }
                   tabbarService.handleDragStart(e, containerId);
                 }}


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

拖拽时图片显示成顶栏上的头像部分了。

<img width="267" alt="image" src="https://user-images.githubusercontent.com/6220109/155952655-87826f26-be50-47d4-b157-d8d2feac65be.png">

### Changelog

- 修复侧边栏 tab 拖拽时拖拽图显示问题
