### PR TITLE
fix: quickopen hide when checkbox trigger blur event

### DIFF
--- a/packages/components/src/checkbox/index.tsx
+++ b/packages/components/src/checkbox/index.tsx
@@ -16,8 +16,11 @@ export const CheckBox: React.FC<
     label?: string;
     size?: 'default' | 'large';
     disabled?: boolean;
+    // 增加父容器的 tabIndex 属性，以便告诉浏览器这是一个可获取焦点的元素
+    // https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null
+    wrapTabIndex?: number;
   }
-> = ({ insertClass, className, label, size = 'default', disabled, checked = false, ...restProps }) => {
+> = ({ insertClass, className, label, size = 'default', disabled, checked = false, wrapTabIndex, ...restProps }) => {
   warning(!insertClass, '`insertClass` was deprecated, please use `className` instead');
 
   const cls = classNames('kt-checkbox', insertClass, className, {
@@ -26,7 +29,7 @@ export const CheckBox: React.FC<
   });
 
   return (
-    <label className={cls}>
+    <label className={cls} tabIndex={wrapTabIndex}>
       <span className='kt-checkbox-lump'>
         <input type='checkbox' disabled={disabled} checked={checked} {...restProps} />
         <span className='kt-checkbox-icon'>

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -145,7 +145,7 @@ export const QuickOpenInput = observer(() => {
 
   return (
     <div className={styles.input}>
-      {widget.canSelectMany && <CheckBox checked={widget.selectAll} onChange={handleSelectAll} />}
+      {widget.canSelectMany && <CheckBox checked={widget.selectAll} wrapTabIndex={0} onChange={handleSelectAll} />}
       <ValidateInput
         validateMessage={validateMessage}
         ref={inputRef}
@@ -308,9 +308,8 @@ export const QuickOpenView = observer(() => {
 
   // https://stackoverflow.com/questions/38019140/react-and-blur-event/38019906#38019906
   const focusInCurrentTarget = React.useCallback(({ relatedTarget, currentTarget }) => {
-    // 点击 checkbox 时 relatedTarget 为 null
     if (relatedTarget === null) {
-      return true;
+      return false;
     }
 
     let node = relatedTarget.parentNode;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

add tabindex=0 to checkbox wrap,see https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null

### Changelog
quickopen hide when blur