### PR TITLE
chore: only show error while running lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare:test": "npm run init:deps && npm run compile && npm run build:worker-host",
     "test:cov": "cross-env NODE_OPTIONS=--max_old_space_size=32768 node ./node_modules/.bin/jest --coverage --forceExit --detectOpenHandles",
     "coverage": "npm run init && npm run test:cov",
-    "ci": "npm run lint && npm run coverage && npm run check:dep",
+    "ci": "npm run lint -- --quiet && npm run coverage && npm run check:dep",
     "download-extension": "cross-env DEBUG=InstallExtension node scripts/download.js",
     "update:iconfont": "ts-node ./scripts/download-iconfont.ts",
     "changelog-old": "node scripts/changelog/index.js",


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

目前 CI 中较多的 warning 影响错误信息的定位

<img width="989" alt="image" src="https://user-images.githubusercontent.com/9823838/156099270-2ce3031e-d38a-440e-8809-88d48b5ba444.png">

### Changelog

only show error while running lint script