### PR TITLE
fix: toolbar popover autohide not working

### DIFF
--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -391,22 +391,28 @@ class ToolbarBtnDelegate implements IToolbarActionBtnDelegate {
           }
           const disposer = new Disposable();
           disposer.addDispose(
-            new DomListener(window, 'click', (e: MouseEvent) => {
-              if (e.target && ele.contains(e.target as Node)) {
-                return;
-              }
-              const rect = ele.getBoundingClientRect();
-              if (
-                rect.x <= e.clientX &&
-                rect.x + rect.width >= e.clientX &&
-                rect.y <= e.clientY &&
-                rect.y + rect.height >= e.clientY
-              ) {
-                // 点击在区域内，这里防止点击 target 已经被移除导致误判
-                return;
-              }
-              this.hidePopOver();
-            }),
+            new DomListener(
+              window,
+              'click',
+              (e: MouseEvent) => {
+                if (e.target && ele.contains(e.target as Node)) {
+                  return;
+                }
+                const rect = ele.getBoundingClientRect();
+                if (
+                  rect.x <= e.clientX &&
+                  rect.x + rect.width >= e.clientX &&
+                  rect.y <= e.clientY &&
+                  rect.y + rect.height >= e.clientY
+                ) {
+                  // 点击在区域内，这里防止点击 target 已经被移除导致误判
+                  return;
+                }
+                this.hidePopOver();
+              },
+              // 在捕获阶段处理，避免其他元素阻止冒泡导致不自动隐藏不生效
+              true,
+            ),
           );
           this._popOverClickOutsideDisposer = disposer;
         });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

编辑器的文件树点击事件好像阻止了冒泡，导致点文件树时工具栏上的 popover 没法自动收起

### Changelog

- 修复阻止冒泡导致的 popover 自动隐藏不生效问题
