### PR TITLE
fix: plugin registers browserComponent repeatedly when restart plugin process

### DIFF
--- a/packages/extension/src/browser/extension-instance-management.ts
+++ b/packages/extension/src/browser/extension-instance-management.ts
@@ -54,6 +54,14 @@ export class ExtInstanceManagementService extends Disposable implements Abstract
     this.extensionMap = new Map();
   }
 
+  public disposeExtensionInstancesByPath(paths: string[]) {
+    paths.forEach((path) => {
+      if (this.extensionMap.has(path)) {
+        this.extensionMap.get(path)!.dispose();
+      }
+    });
+  }
+
   public resetExtensionInstances() {
     for (const extensionInstance of this.extensionMap.values()) {
       extensionInstance.reset();

--- a/packages/extension/src/browser/extension-view.service.ts
+++ b/packages/extension/src/browser/extension-view.service.ts
@@ -79,7 +79,7 @@ export class ViewExtProcessService implements AbstractViewExtProcessService {
 
   private extensions: IExtension[] = [];
 
-  // 被激活且在 contributes 中注册了 browserView 的 kaitian 插件
+  // 被激活且在 contributes 中注册了 browserView 的 sumi 插件
   public activatedViewExtensionMap: Map<string, IExtension> = new Map();
 
   public getExtension(extensionId: string): IExtension | undefined {

--- a/packages/extension/src/browser/extension-view.service.ts
+++ b/packages/extension/src/browser/extension-view.service.ts
@@ -173,7 +173,7 @@ export class ViewExtProcessService implements AbstractViewExtProcessService {
   }
 
   public async activeExtension(extension: IExtension, protocol: IRPCProtocol) {
-    const { extendConfig, packageJSON, contributes, path } = extension;
+    const { extendConfig, packageJSON, contributes } = extension;
     // 对使用 kaitian.js 的老插件兼容
     // 因为可能存在即用了 kaitian.js 作为入口，又注册了 kaitianContributes 贡献点的插件
     if (extendConfig?.browser?.main) {

--- a/packages/extension/src/browser/extension-view.service.ts
+++ b/packages/extension/src/browser/extension-view.service.ts
@@ -79,7 +79,7 @@ export class ViewExtProcessService implements AbstractViewExtProcessService {
 
   private extensions: IExtension[] = [];
 
-  // 被激活且在 contributes 中注册了 browserMain 的 kaitian 插件
+  // 被激活且在 contributes 中注册了 browserView 的 kaitian 插件
   public activatedViewExtensionMap: Map<string, IExtension> = new Map();
 
   public getExtension(extensionId: string): IExtension | undefined {
@@ -182,14 +182,12 @@ export class ViewExtProcessService implements AbstractViewExtProcessService {
         '[Deprecated warning]: kaitian.js is deprecated, please use `package.json#kaitianContributes` instead',
       );
       await this.activateExtensionByDeprecatedExtendConfig(extension as Extension);
-      this.activatedViewExtensionMap.set(path, extension);
       return;
     }
 
     // 激活 workerMain/browserMain 相关部分
     if (packageJSON.kaitianContributes && contributes?.browserMain) {
       await this.activeExtensionContributes(extension);
-      this.activatedViewExtensionMap.set(path, extension);
     }
   }
 
@@ -322,6 +320,8 @@ export class ViewExtProcessService implements AbstractViewExtProcessService {
   }
 
   private registerBrowserComponent(browserExported: any, extension: Extension) {
+    this.activatedViewExtensionMap.set(extension.path, extension);
+
     if (browserExported.default) {
       browserExported = browserExported.default;
     }

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -273,7 +273,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
     /**
      * 重启插件进程步骤：
      * 1、重置所有插件实例的状态至未激活
-     * 2、dispose 掉所有被激活且在 contributes 里申明过 browserView 的 kaitian 插件
+     * 2、dispose 掉所有被激活且在 contributes 里申明过 browserView 的 sumi 插件
      * 3、将负责前后端通信的 main.thread 全部 dispose 掉
      * 4、杀掉后端插件进程
      * 5、走正常激活插件流程，重新激活对应插件进程
@@ -281,7 +281,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
      */
     if (!init) {
       this.resetExtensionInstances();
-      this.disposeKaitianViewExtension();
+      this.disposeSumiViewExtension();
       await this.disposeExtProcess();
     }
 
@@ -289,8 +289,8 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
     await Promise.all([this.startNodeExtHost(init), this.startWorkerExtHost(init)]);
 
     if (!init) {
-      // 重启场景下需要将申明过 browserView 的 kaitian 插件的 contributes 重新跑一遍
-      await this.rerunKaitianViewExtensionContributes();
+      // 重启场景下需要将申明过 browserView 的 sumi 插件的 contributes 重新跑一遍
+      await this.rerunSumiViewExtensionContributes();
 
       // 重启场景下把 ActivationEvent 再发一次
       if (this.activationEventService.activatedEventSet.size) {
@@ -551,16 +551,16 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   }
 
   /**
-   * 每次激活 kaitian 插件的时候，都会尝试去激活 kaitianContributes 中的 browserView，会导致 browserView 重复注册
+   * 每次激活 sumi 插件的时候，都会尝试去激活 sumiContributes 中的 browserView，会导致 browserView 重复注册
    * 因此重启场景下需要先将这部分被激活的插件 dispose 掉
    */
-  private disposeKaitianViewExtension() {
+  private disposeSumiViewExtension() {
     const paths = Array.from(this.viewExtensionService.activatedViewExtensionMap.keys());
 
     this.extensionInstanceManageService.disposeExtensionInstancesByPath(paths);
   }
 
-  private async rerunKaitianViewExtensionContributes() {
+  private async rerunSumiViewExtensionContributes() {
     const { activatedViewExtensionMap } = this.viewExtensionService;
     const extensionPaths = Array.from(activatedViewExtensionMap.keys());
 

--- a/packages/extension/src/browser/types.ts
+++ b/packages/extension/src/browser/types.ts
@@ -28,6 +28,12 @@ export abstract class IActivationEventService {
  */
 export abstract class AbstractExtInstanceManagementService {
   abstract dispose(): void;
+
+  /**
+   * 通过路径销毁插件实例 dispose
+   */
+  abstract disposeExtensionInstancesByPath(paths: Array<string>): void;
+
   /**
    * 获取所有插件实例
    */

--- a/packages/extension/src/common/extension.service.ts
+++ b/packages/extension/src/common/extension.service.ts
@@ -49,6 +49,8 @@ export abstract class AbstractWorkerExtProcessService<T = any>
 }
 
 export abstract class AbstractViewExtProcessService {
+  activatedViewExtensionMap: Map<string, IExtension>;
+
   abstract getPortalShadowRoot(extensionId: string): ShadowRoot | undefined;
   abstract activate(): void;
   abstract initExtension(extensions: IExtension[]): void;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
sumi 插件如果申明了 browserView 的 contributes，那么每次插件激活的时候都会重复执行该贡献点。由于插件进程重启的时候会重新激活插件，会导致贡献点被重复执行

### Changelog

修复插件进程重启时带视图组件的 sumi 插件副作用清理逻辑