### PR TITLE
style: improve error boundary block style

### DIFF
--- a/packages/core-browser/src/react-providers/slot.module.less
+++ b/packages/core-browser/src/react-providers/slot.module.less
@@ -1,0 +1,19 @@
+.error_message {
+  padding: 15px;
+  .title {
+    color: var(--foreground);
+    font-size: 18px;
+  }
+  .detial {
+    white-space: pre-wrap;
+    margin-bottom: 10px;
+    cursor: pointer;
+    .label,
+    .message {
+      color: var(--kt-inputValidation-errorTextForeground);
+    }
+    .label {
+      font-weight: bold;
+    }
+  }
+}

--- a/packages/core-browser/src/react-providers/slot.tsx
+++ b/packages/core-browser/src/react-providers/slot.tsx
@@ -1,15 +1,12 @@
-/**
- * 前端提供一套 Slot 的注册和渲染的机制
- */
-
 import React from 'react';
-import { getDebugLogger } from '@opensumi/ide-core-common';
+import { getDebugLogger, localize } from '@opensumi/ide-core-common';
 import { LayoutConfig } from '../bootstrap';
 import { useInjectable } from '../react-hooks';
 import { ComponentRegistry, ComponentRegistryInfo } from '../layout';
 import { ConfigContext } from './config-provider';
 import { Button } from '@opensumi/ide-components';
 import { IClientApp } from '../browser-module';
+import styles from './slot.module.less';
 
 const logger = getDebugLogger();
 export type SlotLocation = string;
@@ -80,14 +77,13 @@ export class ErrorBoundary extends React.Component {
   render() {
     if (this.state.errorInfo) {
       return (
-        <div>
-          <h2>模块渲染异常</h2>
-          <details style={{ whiteSpace: 'pre-wrap' }}>
-            {this.state.error && (this.state.error as any).toString()}
-            <br />
-            {(this.state.errorInfo as any).componentStack}
+        <div className={styles.error_message}>
+          <h2 className={styles.title}>{localize('view.component.renderedError')}</h2>
+          <details className={styles.detial}>
+            <div className={styles.label}>{this.state.error && (this.state.error as any).toString()}</div>
+            <div className={styles.message}>{(this.state.errorInfo as any).componentStack}</div>
           </details>
-          <Button onClick={() => this.update()}>重新加载</Button>
+          <Button onClick={() => this.update()}>{localize('view.component.tryAgain')}</Button>
         </div>
       );
     }

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -872,6 +872,9 @@ export const localizationBundle = {
     'keyboard.autoDetect.description': "(Current: '{0} ')",
     'keyboard.autoDetect.detail': 'Try to detect the keyboard layout from browser information and pressed keys.',
 
+    'view.component.renderedError': 'View Component Rendering Exception',
+    'view.component.tryAgain': 'Refresh',
+
     // #region Testing
     'test.title': 'Testing',
     'test.result.runFinished': 'Test run at {0}',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -929,6 +929,9 @@ export const localizationBundle = {
     'editor.guides.highlightActiveIndentation': '控制是否突出显示编辑器中活动的缩进参考线。',
     'inlineSuggest.enabled': '控制是否在编辑器中自动显示内联建议。',
 
+    'view.component.renderedError': '视图组件渲染异常',
+    'view.component.tryAgain': '重新加载',
+
     // #region Testing
     'test.title': '测试管理器',
     'test.result.runFinished': '测试运行完成于 {0}',


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes


### Background or solution
before:

<img width="1082" alt="截屏2022-03-02 上午10 43 38" src="https://user-images.githubusercontent.com/9823838/156291337-a1fbd304-0bc1-486b-ab78-b0a46d90b231.png">

after:

<img width="895" alt="截屏2022-03-02 上午11 41 50" src="https://user-images.githubusercontent.com/9823838/156291364-c9f24840-bf7a-4a01-a6db-bb6c57853d0d.png">

<img width="623" alt="image" src="https://user-images.githubusercontent.com/9823838/156291301-9f9616fa-8db8-44d6-8117-00daa50df379.png">

这里的“详情”展示是根据系统语言展示，展示不需要做国际化处理

### Changelog

improve error boundary block style
