### PR TITLE
feat: 💄  improve shadow styles

### DIFF
--- a/packages/components/src/style/mixins.less
+++ b/packages/components/src/style/mixins.less
@@ -8,7 +8,7 @@
 
 // a11y 提示弹层/快捷键表单弹层/搜索弹层
 .overlay-shadow(@color: var(--widget-shadow)) {
-  box-shadow: 0 2px 8px @color;
+  box-shadow: rgba(0, 0, 0, 0.133) 0px 3.2px 7.2px 0px, rgba(0, 0, 0, 0.11) 0px 0.6px 1.8px 0px;
 }
 
 // quick-open/debug toolbar

--- a/packages/core-browser/src/style/override.less
+++ b/packages/core-browser/src/style/override.less
@@ -12,7 +12,7 @@
       background-color: var(--menu-background) !important;
       border: none !important;
       .overlay-shadow(var(--kt-menu-shadow)) !important;
-      border-radius: 0 !important;
+      border-radius: 2px !important;
       min-width: 200px;
 
       .@{clsx}-item,

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -19,7 +19,7 @@
 .quickopen_list {
   color: var(--quickInput-foreground);
   background-color: var(--quickInput-background);
-  box-shadow: var(--widget-shadow) 0px 5px 8px;
+  box-shadow: rgba(0, 0, 0, 0.133) 0px 3.2px 7.2px 0px, rgba(0, 0, 0, 0.11) 0px 0.6px 1.8px 0px;
 }
 
 .quickopen_list {

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -24,6 +24,8 @@
 
 .quickopen_list {
   cursor: pointer;
+  border-radius: 0px 0px 2px 2px;
+  overflow: hidden;
 }
 
 .validate_error {


### PR DESCRIPTION
### Types


- [x] 💄 Style Changes

### Background or solution

原有的 quickOpen 和 menu 边角样式太锐，优化了阴影并添加了圆角

before
![image](https://user-images.githubusercontent.com/17701805/156520408-ce78db0d-5349-4262-af87-8fdbe260ac79.png)


after

![image](https://user-images.githubusercontent.com/17701805/156522142-2cd63008-47d4-4c7b-85bb-041f99c6d8c0.png)

### Changelog
- improve menus box-shadow
- add border-radius 