### PR TITLE
feat: use id as hide menu fallback name

### DIFF
--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -291,12 +291,13 @@ export class TabbarService extends WithEventBus {
 
   protected registerHideMenu(componentInfo: ComponentRegistryInfo) {
     const disposables = new DisposableCollection();
+    const containerId = componentInfo.options!.containerId;
 
     disposables.push(
       this.menuRegistry.registerMenuItem(this.menuId, {
         command: {
-          id: this.registerVisibleToggleCommand(componentInfo.options!.containerId, disposables),
-          label: componentInfo.options!.title || '',
+          id: this.registerVisibleToggleCommand(containerId, disposables),
+          label: componentInfo.options!.title || containerId,
         },
         group: '1_widgets',
       }),


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<img width="810" alt="image" src="https://user-images.githubusercontent.com/13938334/156729707-4e0ce073-1347-48b1-a014-69a248e13e3f.png">


### Changelog
Display `containerId` when not set `title` in browserView contributes