### PR TITLE
feat: implement FileStat permissions api

### DIFF
--- a/packages/core-common/src/types/file.ts
+++ b/packages/core-common/src/types/file.ts
@@ -56,6 +56,11 @@ export interface FileStat {
    * 同 vscode FileType
    */
   type?: FileType;
+
+  /**
+   * 当前文件是否为只读
+   */
+  readonly?: boolean;
 }
 
 export namespace FileStat {

--- a/packages/extension/src/browser/vscode/api/main.thread.file-system.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.file-system.ts
@@ -21,6 +21,7 @@ import {
   FileSystemProviderErrorCode,
   FileOverwriteOptions,
   IExtHostFileSystemInfoShape,
+  FilePermission,
 } from '../../../common/vscode/file-system';
 import { toFileStat, fromFileStat } from '../../../common/vscode/converter';
 import { BinaryBuffer } from '@opensumi/ide-core-common/lib/utils/buffer';
@@ -257,7 +258,7 @@ class RemoteFileSystemProvider implements FileSystemProvider {
 
   // --- forwarding calls
 
-  async stat(resource: Uri) {
+  async stat(resource: Uri): Promise<IFileStat> {
     const stat = await this.doGetStat(resource);
     return stat;
   }
@@ -297,6 +298,9 @@ class RemoteFileSystemProvider implements FileSystemProvider {
     if (mainStat.isDirectory) {
       mainStat.children = await this.doGetChildren(resource, depth);
     }
+    mainStat.readonly =
+      Boolean((stat.permissions ?? 0) & FilePermission.Readonly) ||
+      Boolean(this.capabilities & FileSystemProviderCapabilities.Readonly);
     return mainStat;
   }
 

--- a/packages/extension/src/common/vscode/file-system.ts
+++ b/packages/extension/src/common/vscode/file-system.ts
@@ -65,6 +65,13 @@ export enum FileType {
   SymbolicLink = 64,
 }
 
+export enum FilePermission {
+  /**
+   * File is readonly.
+   */
+  Readonly = 1,
+}
+
 /**
  * The `FileStat`-type represents metadata about a file
  */
@@ -86,6 +93,10 @@ export interface FileStat {
    * The size in bytes.
    */
   size: number;
+  /**
+   * The file permissions.
+   */
+  readonly permissions?: FilePermission;
 }
 
 export interface SourceTargetPair {

--- a/packages/extension/src/hosted/api/vscode/ext.host.file-system.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.file-system.ts
@@ -188,8 +188,9 @@ export class ExtHostFileSystem implements files.IExtHostFileSystemShape {
   }
 
   private static _asIStat(stat: vscode.FileStat): files.FileStat {
-    const { type, ctime, mtime, size } = stat;
-    return { type, ctime, mtime, size };
+    // permissions is proposed api
+    const { type, ctime, mtime, size, permissions } = stat;
+    return { type, ctime, mtime, size, permissions };
   }
 
   $stat(handle: number, resource: UriComponents): Promise<files.FileStat> {

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -536,7 +536,8 @@ export class FileServiceClient implements IFileServiceClient {
     try {
       const uri = new URI(uriString);
       const provider = await this.getProvider(uri.scheme);
-      return !!provider.readonly;
+      const stat = (await provider.stat(this.convertUri(uriString).codeUri)) as FileStat;
+      return !!stat.readonly;
     } catch (e) {
       // 考虑到非 readonly 变readonly 的情况，相对于 readonly 变不 readonly 来说更为严重
       return false;

--- a/packages/types/vscode/typings/vscode.proposed.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.d.ts
@@ -677,4 +677,31 @@ declare module 'vscode' {
   }
 
   //#endregion
+
+  //#region FileSystemProvider stat readonly - https://github.com/microsoft/vscode/issues/73122
+
+  export enum FilePermission {
+    /**
+     * The file is readonly.
+     *
+     * *Note:* All `FileStat` from a `FileSystemProvider` that is registered  with
+     * the option `isReadonly: true` will be implicitly handled as if `FilePermission.Readonly`
+     * is set. As a consequence, it is not possible to have a readonly file system provider
+     * registered where some `FileStat` are not readonly.
+     */
+    Readonly = 1
+  }
+
+  /**
+   * The `FileStat`-type represents metadata about a file
+   */
+  export interface FileStat {
+
+    /**
+     * The permissions of the file, e.g. whether the file is readonly.
+     *
+     * *Note:* This value might be a bitmask, e.g. `FilePermission.Readonly | FilePermission.Other`.
+     */
+    permissions?: FilePermission;
+  }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

在之前，如果实现了 FileSystemProvider ，只有在 registerFileSystemProvider 的时候传递 isReadonly 为 true 才会令打开的文件为只读，且只能令所有打开的文件作为只读

而该 api 就是可以自己实现 stat 方法来决定打开的某一个文件是否为只读模式

![Kapture 2022-03-07 at 11 13 16](https://user-images.githubusercontent.com/20262815/156961887-dc93ad33-3140-49a9-a954-28bc31042977.gif)

### Changelog
实现了 FileStat permissions API