### PR TITLE
fix: use onMouseDown to run quickopen item

### DIFF
--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -229,7 +229,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           onChange={(event) => (data.checked = (event.target as HTMLInputElement).checked)}
         />
       )}
-      <div className={styles.item_label_container} onClick={runQuickOpenItem}>
+      <div className={styles.item_label_container} onMouseDown={runQuickOpenItem}>
         <div className={styles.item_label}>
           {iconClass && <span className={clx(styles.item_icon, iconClass)}></span>}
           <HighlightLabel


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

onClick too late, cause the onBlur first, replaced by MouseDown

### Changelog

fix: use onMouseDown to run quickopen item