### PR TITLE
chore: Add intialProps support for sumi type extension 

### DIFF
--- a/packages/extension/src/browser/sumi-browser/contribution/editor.ts
+++ b/packages/extension/src/browser/sumi-browser/contribution/editor.ts
@@ -48,6 +48,8 @@ export class EditorBrowserContributionRunner extends AbstractSumiBrowserContribu
         {
           kaitianExtendService: extendService,
           kaitianExtendSet: extendProtocol,
+          sumiExtendService: extendService,
+          sumiExtendSet: extendProtocol,
         },
       ),
     );

--- a/packages/extension/src/browser/sumi-browser/contribution/editorSide.ts
+++ b/packages/extension/src/browser/sumi-browser/contribution/editorSide.ts
@@ -39,6 +39,8 @@ export class EditorSideBrowserContributionRunner extends AbstractSumiBrowserCont
         initialProps: {
           kaitianExtendService: extendService,
           kaitianExtendSet: extendProtocol,
+          sumiExtendService: extendService,
+          sumiExtendSet: extendProtocol,
         },
         displaysOnResource: () => this.editorService.editorContextKeyService.match(viewContribution?.when),
       }),

--- a/packages/extension/src/browser/sumi-browser/contribution/tabbar.ts
+++ b/packages/extension/src/browser/sumi-browser/contribution/tabbar.ts
@@ -58,6 +58,8 @@ export class TabbarBrowserContributionRunner extends AbstractSumiBrowserContribu
     const initialProps = {
       kaitianExtendService: extendService,
       kaitianExtendSet: extendProtocol,
+      sumiExtendService: extendService,
+      sumiExtendSet: extendProtocol,
     };
     this.layoutService.viewReady.promise.then(() => {
       if (kind === 'add') {

--- a/packages/extension/src/browser/sumi-browser/contribution/toolbar.ts
+++ b/packages/extension/src/browser/sumi-browser/contribution/toolbar.ts
@@ -40,6 +40,8 @@ export class ToolBarBrowserContributionRunner extends AbstractSumiBrowserContrib
           initialProps: {
             kaitianExtendService: extendService,
             kaitianExtendSet: extendProtocol,
+            sumiExtendService: extendService,
+            sumiExtendSet: extendProtocol,
           },
           description: view.description,
           order: view.order,

--- a/packages/types/sumi-browser.d.ts
+++ b/packages/types/sumi-browser.d.ts
@@ -3,6 +3,13 @@ interface IComponentMethod {
 }
 
 interface IComponentProps<N, W = any> {
+  sumiExtendSet: {
+    set<T = IComponentMethod>(methods: T): void;
+  };
+  sumiExtendService: {
+    node: N;
+    worker: W;
+  };
   kaitianExtendSet: {
     set<T = IComponentMethod>(methods: T): void;
   };


### PR DESCRIPTION
### Types
- [x] 🧹 Chores

### Background or solution

### Changelog
Add intialProps support for sumi extension type