### PR TITLE
fix: ensure refresh task before location file on filetree

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -250,7 +250,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
   async resolveChildren(parent?: Directory) {
     let children: (File | Directory)[] = [];
     if (!parent) {
-      // 加载根目录
+      // 加载根目录
       if (!this._roots) {
         this._roots = await this.workspaceService.roots;
       }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog

ensure refresh task before location file on filetree