### PR TITLE
feat: implement forceNewSession and silent to authentication api

### DIFF
--- a/packages/core-common/src/types/authentication.ts
+++ b/packages/core-common/src/types/authentication.ts
@@ -35,6 +35,7 @@ export interface AuthenticationProviderInformation {
 export interface AllowedExtension {
   id: string;
   name: string;
+  allowed?: boolean;
 }
 
 export interface IAuthenticationProvider {
@@ -80,10 +81,17 @@ export interface IAuthenticationService {
   getExtensionSessionId(extensionName: string, providerId: string): Promise<string | undefined>;
   setExtensionSessionId(extensionName: string, providerId: string, sessionId: string): Promise<void>;
   removeExtensionSessionId(extensionName: string, providerId: string): Promise<void>;
-
+  updatedAllowedExtension(
+    providerId: string,
+    accountName: string,
+    extensionId: string,
+    extensionName: string,
+    isAllowed: boolean,
+  ): Promise<void>;
   getAllowedExtensions(providerId: string, accountName: string): Promise<AllowedExtension[]>;
   setAllowedExtensions(providerId: string, accountName: string, allowList: AllowedExtension[]): Promise<void>;
   removeAllowedExtensions(providerId: any, accountName: string): Promise<void>;
+  isAccessAllowed(providerId: string, accountName: string, extensionId: string): Promise<boolean | undefined>;
 
   getAccountUsages(providerId: string, accountName: string): Promise<IAccountUsage[]>;
   addAccountUsage(providerId: string, accountName: string, extensionId: string, extensionName: string): Promise<void>;
@@ -103,4 +111,11 @@ export interface SessionRequest {
 
 export interface SessionRequestInfo {
   [scopes: string]: SessionRequest;
+}
+
+export interface AuthenticationGetSessionOptions {
+  createIfNone: boolean;
+  clearSessionPreference: boolean;
+  forceNewSession?: boolean | { detail: string };
+  silent?: boolean;
 }

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts
@@ -103,7 +103,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
         const session = {
           id: id++ + '',
           accessToken: 'this_is_github_token',
-          account: { label: '蛋总', id: 'xinglong.wangwxl' },
+          account: { label: 'OpenSumi', id: 'opensumi' },
           scopes: scopeList,
         };
         const sessionIndex = sessions.findIndex((s) => s.id === session.id);
@@ -171,7 +171,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     expect(session).toStrictEqual({
       id: '1',
       accessToken: 'this_is_github_token',
-      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      account: { label: 'OpenSumi', id: 'opensumi' },
       scopes: ['getRepo'],
     });
   });
@@ -180,7 +180,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     const session = {
       id: 'test',
       accessToken: 'this_is_gitlab_token',
-      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      account: { label: 'OpenSumi', id: 'opensumi' },
       scopes: ['getRepo'],
     };
     // mock
@@ -206,7 +206,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     const session = {
       id: 'test',
       accessToken: 'this_is_gitlab_token',
-      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      account: { label: 'OpenSumi', id: 'opensumi' },
       scopes: ['getRepo'],
     };
     // mock
@@ -224,7 +224,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     const session = {
       id: 'test',
       accessToken: 'this_is_gitlab_token',
-      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      account: { label: 'OpenSumi', id: 'opensumi' },
       scopes: ['getRepo'],
     };
     // mock
@@ -249,7 +249,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     const session = {
       id: 'test',
       accessToken: 'this_is_gitlab_token',
-      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      account: { label: 'OpenSumi', id: 'opensumi' },
       scopes: ['getRepo'],
     };
     jest.spyOn(authenticationProvider, 'getSessions').mockReturnValue(Promise.resolve([session]));
@@ -326,7 +326,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
         const session = {
           id: 'test',
           accessToken: 'this_is_gitlab_token',
-          account: { label: '蛋总', id: 'xinglong.wangwxl' },
+          account: { label: 'OpenSumi', id: 'opensumi' },
           scopes: scopeList,
         };
         return session;

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts
@@ -137,7 +137,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
   it('get session by default option', async () => {
     const $ensureProvider = jest.spyOn(mainThreadAuthentication, '$ensureProvider');
     const $getSession = jest.spyOn(mainThreadAuthentication, '$getSession');
-    const $requestNewSession = jest.spyOn(mainThreadAuthentication, '$requestNewSession');
+    const $requestNewSession = jest.spyOn(authenticationService, 'requestNewSession');
     const session = await authenticationAPI.getSession('github', ['getRepo']);
     expect($ensureProvider).toBeCalledWith('github');
     expect($getSession).toBeCalledWith('github', ['getRepo'], 'vscode.vim', 'Vim', {});
@@ -160,14 +160,14 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     const $ensureProvider = jest.spyOn(mainThreadAuthentication, '$ensureProvider');
     const $getSession = jest.spyOn(mainThreadAuthentication, '$getSession');
     // 默认点击允许
-    const $loginPrompt = jest.spyOn(mainThreadAuthentication, '$loginPrompt').mockReturnValue(Promise.resolve(true));
+    const loginPrompt = jest.spyOn(mainThreadAuthentication, 'loginPrompt').mockReturnValue(Promise.resolve(true));
     const session = await authenticationAPI.getSession('github', ['getRepo'], {
       createIfNone: true,
     });
     expect(loginSpy).toBeCalledWith(['getRepo']);
     expect($ensureProvider).toBeCalledWith('github');
     expect($getSession).toBeCalledWith('github', ['getRepo'], 'vscode.vim', 'Vim', { createIfNone: true });
-    expect($loginPrompt).toBeCalled();
+    expect(loginPrompt).toBeCalled();
     expect(session).toStrictEqual({
       id: '1',
       accessToken: 'this_is_github_token',
@@ -185,29 +185,115 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
     };
     // mock
     jest.spyOn(authenticationProvider, 'getSessions').mockReturnValue(Promise.resolve([session]));
-    const $selectSession = jest.spyOn(mainThreadAuthentication, '$selectSession');
+    const $selectSession = jest.spyOn(mainThreadAuthentication, 'selectSession');
     const authenticationService: IAuthenticationService = injector.get(IAuthenticationService);
     const removeExtensionSessionId = jest.spyOn(authenticationService, 'removeExtensionSessionId');
     jest.spyOn(authenticationService, 'supportsMultipleAccounts').mockReturnValue(true);
+    const $loginPrompt = jest.spyOn(mainThreadAuthentication, 'loginPrompt').mockReturnValue(Promise.resolve(true));
     const quickPickService: QuickPickService = injector.get(QuickPickService);
     jest.spyOn(quickPickService, 'show').mockReturnValue(Promise.resolve(session));
     await authenticationAPI.getSession('github', ['getRepo'], {
       clearSessionPreference: true,
+      createIfNone: true,
     });
+    expect($loginPrompt).toBeCalled();
     expect($selectSession).toBeCalled();
     // 会清空 session
     expect(removeExtensionSessionId).toBeCalled();
+  });
+
+  it('get session with forceNewSession', async () => {
+    const session = {
+      id: 'test',
+      accessToken: 'this_is_gitlab_token',
+      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      scopes: ['getRepo'],
+    };
+    // mock
+    jest.spyOn(authenticationProvider, 'getSessions').mockReturnValue(Promise.resolve([session]));
+    jest.spyOn(mainThreadAuthentication, 'selectSession').mockReturnValue(Promise.resolve(session));
+    const $loginPrompt = jest.spyOn(mainThreadAuthentication, 'loginPrompt').mockReturnValue(Promise.resolve(true));
+    await authenticationAPI.getSession('github', ['getRepo'], {
+      forceNewSession: true,
+    });
+    expect($loginPrompt).toBeCalled();
+    expect($loginPrompt.mock.calls[0][2]).toBe(true);
+  });
+
+  it.only('get session with silent', async () => {
+    const session = {
+      id: 'test',
+      accessToken: 'this_is_gitlab_token',
+      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      scopes: ['getRepo'],
+    };
+    // mock
+    jest.spyOn(authenticationProvider, 'getSessions').mockReturnValue(Promise.resolve([session]));
+    const $requestNewSession = jest.spyOn(authenticationService, 'requestNewSession');
+    await authenticationAPI.getSession('github', ['getRepo'], {
+      silent: true,
+    });
+    expect($requestNewSession).not.toBeCalled();
+  });
+
+  it('get session errorCase', async () => {
+    jest.spyOn(mainThreadAuthentication, 'loginPrompt').mockReturnValue(Promise.resolve(true));
+    jest.spyOn(authenticationProvider, 'getSessions').mockReturnValue(Promise.resolve([]));
+    try {
+      await authenticationAPI.getSession('github', ['getRepo'], {
+        forceNewSession: true,
+      });
+    } catch (e) {
+      expect(e).toEqual(new Error('No existing sessions found.'));
+    }
+    const session = {
+      id: 'test',
+      accessToken: 'this_is_gitlab_token',
+      account: { label: '蛋总', id: 'xinglong.wangwxl' },
+      scopes: ['getRepo'],
+    };
+    jest.spyOn(authenticationProvider, 'getSessions').mockReturnValue(Promise.resolve([session]));
+    try {
+      await authenticationAPI.getSession('github', ['getRepo'], {
+        forceNewSession: true,
+        createIfNone: true,
+      });
+    } catch (e) {
+      expect(e).toEqual(
+        new Error('Invalid combination of options. Please remove one of the following: forceNewSession, createIfNone'),
+      );
+    }
+    try {
+      await authenticationAPI.getSession('github', ['getRepo'], {
+        forceNewSession: true,
+        silent: true,
+      });
+    } catch (e) {
+      expect(e).toEqual(
+        new Error('Invalid combination of options. Please remove one of the following: forceNewSession, silent'),
+      );
+    }
+    try {
+      await authenticationAPI.getSession('github', ['getRepo'], {
+        createIfNone: true,
+        silent: true,
+      });
+    } catch (e) {
+      expect(e).toEqual(
+        new Error('Invalid combination of options. Please remove one of the following: createIfNone, silent'),
+      );
+    }
   });
 
   it('logout', async () => {
     // 默认点击允许
     const logoutSpy = jest.spyOn(authenticationProvider, 'removeSession');
     const $logout = jest.spyOn(mainThreadAuthentication, '$logout');
-    const $loginPrompt = jest.spyOn(mainThreadAuthentication, '$loginPrompt').mockReturnValue(Promise.resolve(true));
+    const loginPrompt = jest.spyOn(mainThreadAuthentication, 'loginPrompt').mockReturnValue(Promise.resolve(true));
     const session = await authenticationAPI.getSession('github', ['getRepo'], {
       createIfNone: true,
     });
-    expect($loginPrompt).toBeCalled();
+    expect(loginPrompt).toBeCalled();
     await authenticationAPI.logout('github', session.id);
     expect(logoutSpy).toBeCalled();
     expect($logout).toBeCalledWith('github', session.id);
@@ -215,7 +301,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.authentication.test.ts'
 
   it('onDidChangeSessions', (done) => {
     // 默认点击允许
-    jest.spyOn(mainThreadAuthentication, '$loginPrompt').mockReturnValue(Promise.resolve(true));
+    jest.spyOn(mainThreadAuthentication, 'loginPrompt').mockReturnValue(Promise.resolve(true));
     authenticationAPI.onDidChangeSessions((e) => {
       expect(e.provider.id).toBe('github');
       expect(e.provider.label).toBe('GitHub');

--- a/packages/extension/src/common/vscode/authentication.ts
+++ b/packages/extension/src/common/vscode/authentication.ts
@@ -17,7 +17,7 @@ export interface IMainThreadAuthentication {
     extensionName: string,
     options: { createIfNone?: boolean; clearSessionPreference?: boolean },
   ): Promise<AuthenticationSession | undefined>;
-  $selectSession(
+  selectSession(
     providerId: string,
     providerName: string,
     extensionId: string,
@@ -33,7 +33,12 @@ export interface IMainThreadAuthentication {
     extensionId: string,
     extensionName: string,
   ): Promise<boolean>;
-  $loginPrompt(providerName: string, extensionName: string): Promise<boolean>;
+  loginPrompt(
+    providerName: string,
+    extensionName: string,
+    recreatingSession: boolean,
+    detail?: string,
+  ): Promise<boolean>;
   $setTrustedExtensionAndAccountPreference(
     providerId: string,
     accountName: string,
@@ -41,7 +46,6 @@ export interface IMainThreadAuthentication {
     extensionName: string,
     sessionId: string,
   ): Promise<void>;
-  $requestNewSession(providerId: string, scopes: string[], extensionId: string, extensionName: string): Promise<void>;
 
   $getSessions(providerId: string): Promise<ReadonlyArray<AuthenticationSession>>;
   $login(providerId: string, scopes: string[]): Promise<AuthenticationSession>;

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -861,6 +861,7 @@ export const localizationBundle = {
     'authentication.getSessionPlaceholder': "Select an account for '{0}' to use or Esc to cancel",
     'authentication.confirmAuthenticationAccess': "The extension '{0}' wants to access the {1} account '{2}'.",
     'authentication.confirmLogin': "The extension '{0}' wants to sign in using {1}.",
+    'authentication.confirmReLogin': "The extension '{0}' wants to sign in again using {1}.",
     'authentication.signInRequests': 'Sign in to use {0} (1)',
     'authentication.signOut': 'Sign out {0}',
     'authentication.noAccounts': 'You are not signed in to any accounts',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -848,6 +848,7 @@ export const localizationBundle = {
     'authentication.getSessionPlaceholder': "选择一个账户给 '{0}' 使用",
     'authentication.confirmAuthenticationAccess': "扩展 '{0}' 将要使用 '{2}' 访问 {1}",
     'authentication.confirmLogin': "扩展 '{0}' 将要使用 {1} 登录",
+    'authentication.confirmReLogin': "扩展 '{0}' 将要使用 {1} 再次登录",
     'authentication.signInRequests': '登录 {0}',
     'authentication.signOut': '退出 {0}',
     'authentication.noAccounts': '目前没有登录任何账户',

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -42,7 +42,8 @@
       "**/src/browser/**",
       "**/core-browser/**",
       "**/theme/**",
-      "**/src/hosted/**"
+      "**/src/hosted/**",
+      "**/*.d.ts"
     ],
     "verbose": true,
     "execMap": {

--- a/packages/types/vscode/typings/vscode.authentication.d.ts
+++ b/packages/types/vscode/typings/vscode.authentication.d.ts
@@ -60,6 +60,17 @@ declare module 'vscode' {
     createIfNone?: boolean;
 
     /**
+     * Whether we should attempt to reauthenticate even if there is already a session available.
+     *
+     * If true, a modal dialog will be shown asking the user to sign in again. This is mostly used for scenarios
+     * where the token needs to be re minted because it has lost some authorization.
+     *
+     * Defaults to false.
+     */
+    forceNewSession?: boolean | { detail: string };
+
+
+    /**
      * Whether the existing user session preference should be cleared.
      *
      * For authentication providers that support being signed into multiple accounts at once, the user will be
@@ -69,6 +80,18 @@ declare module 'vscode' {
      * Defaults to false.
      */
     clearSessionPreference?: boolean;
+
+    /**
+     * Whether we should show the indication to sign in in the Accounts menu.
+     *
+     * If false, the user will be shown a badge on the Accounts menu with an option to sign in for the extension.
+     * If true, no indication will be shown.
+     *
+     * Defaults to false.
+     *
+     * Note: you cannot use this option with any other options that prompt the user like {@link createIfNone}.
+     */
+    silent?: boolean;
   }
 
   /**


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

<img width="698" alt="93688797-A018-49F7-8A01-0C7B1A10C715" src="https://user-images.githubusercontent.com/6399899/158040914-256a8f0c-4010-44cc-9418-91c8aa988e99.png">


package.json
```json
{
  "publisher": "opensumi",
  "name": "auth-demo",
  "version": "1.0.0",
  "engines": {
    "vscode": "^1.22.0"
  },
  "activationEvents": [
    "*"
  ],
  "main": "./index",
  "contributes": {
    "commands": [
      {
        "command": "auth.login",
        "title": "Login"
      },
      {
        "command": "auth.relogin",
        "title": "Relogin"
      },
      {
        "command": "auth.logout",
        "title": "Logout"
      }
    ]
  },
  "dependencies": {
    "express": "^4.17.1",
    "passport": "^0.4.1",
    "passport-github2": "^0.1.12"
  }
}

```

index.js
```js
const vscode = require('vscode');
const express = require('express');
const passport = require('passport');
const { Strategy: GitHubStrategy } = require('passport-github2');

const AUTH_PORT = 10899;
const clientID = '7629552d4c5f0116620d';
const clientSecret = 'fd24f43e4b0248fed5abba5a1ba49037c67b4bc9';

let init = false;


class Deferred {
  resolve;
  reject;

  promise = new Promise((resolve, reject) => {
    this.resolve = resolve;
    this.reject = reject;
  });
}

function initGitHubStrategy(url) {
  passport.use(new GitHubStrategy({
    clientID,
    clientSecret,
    callbackURL: `${url}/auth/github/callback`,
  }, (accessToken, refreshToken, profile, cb) => {
    // format user
    const user = {
      id: profile.id,
      name: profile.username,
      displayName: profile.displayName,
      photo: profile.photos && profile.photos[0] && profile.photos[0].value,
      accessToken,
      refreshToken,
      profile,
    }
    return cb(null, user);
  }
  ));
}

async function createServer(url, port) {
  if (!init) {
    // gitHub strategy 只需初始化一次
    await initGitHubStrategy(url);
    init = true;
  }

  let serverTimer;
  const userDeferred = new Deferred();

  function cancelServerTimer() {
    clearTimeout(serverTimer);
  }

  const serverPromise = new Promise((resolve, reject) => {
    serverTimer = setTimeout(() => {
      reject(new Error('Timeout waiting for port'));
    }, 5000);

    const app = express();
    app.use(passport.initialize());

    // 使用 passport 进行 github 授权跳转
    app.get('/auth/github', passport.authenticate('github', { session: false }));
    // 授权成功后的回调地址
    app.get('/auth/github/callback', passport.authenticate('github', { session: false }), (req, res) => {
      userDeferred.resolve(req.user);
      res.send('授权成功，请关闭该页面');
    });
    const server = app.listen(port, () => resolve(server));
  });

  let server;
  try {
    server = await serverPromise
  } finally {
    cancelServerTimer();
  }

  return {
    server,
    userDeferred,
  };

}

exports.activate = function (context) {
  const sessions = context.globalState.get('sessions') || [];
  const onDidChangeSessions = new vscode.EventEmitter();

  context.subscriptions.push(vscode.commands.registerCommand('auth.login', async () => {
    const session = await vscode.authentication.getSession('github', [], {
      createIfNone: true,
    });
    vscode.window.showInformationMessage('hello ' + session.account.label);
  }));

  context.subscriptions.push(vscode.commands.registerCommand('auth.relogin', async () => {
    const session = await vscode.authentication.getSession('github', [], {
      forceNewSession: {
        detail: 'I want opensumi~'
      },
    });
    vscode.window.showInformationMessage('hello ' + session.account.label);
  }));

  context.subscriptions.push(vscode.commands.registerCommand('auth.logout', async () => {
    const session = await vscode.authentication.getSession('github', []);
    vscode.authentication.logout('github', session.id);
  }));

  context.subscriptions.push(vscode.authentication.registerAuthenticationProvider('github', 'Github', {
    onDidChangeSessions: onDidChangeSessions.event,
    getSessions: async () => sessions,
    createSession: async (scopes) => {
      const url = `http://0.0.0.0:${AUTH_PORT}`;
      // 启动 auth server，提供回调地址
      const { server, userDeferred } = await createServer(url, AUTH_PORT);
      // 访问验证服务器
      vscode.env.openExternal(vscode.Uri.parse(`${url}/auth/github`));
      // 等待用户进行验证授权
      const user = await userDeferred.promise;
      const session = {
        id: user.id,
        accessToken: user.accessToken,
        account: { label: user.displayName || user.name, id: user.id },
        scopes,
      };
      const sessionIndex = sessions.findIndex((s) => s.id === session.id);
      if (sessionIndex > -1) {
        sessions.splice(sessionIndex, 1, session);
      } else {
        sessions.push(session);
      }
      context.globalState.update('sessions', sessions);
      onDidChangeSessions.fire({ added: [session], removed: [], changed: [] });
      server.close();
      return session;
    },
    removeSession: async (id) => {
      const sessionIndex = sessions.findIndex((session) => session.id === id);
      if (sessionIndex > -1) {
        const session = sessions[sessionIndex];
        sessions.splice(sessionIndex, 1);
        context.globalState.update('sessions', sessions);
        onDidChangeSessions.fire({
          added: [],
          removed: [session],
          changed: [],
        });
      }
    },
  }));
}

```


### Changelog
implement forceNewSession and silent to authentication api