### PR TITLE
feat: change vscode.env.language

### DIFF
--- a/packages/core-common/src/localize.ts
+++ b/packages/core-common/src/localize.ts
@@ -109,6 +109,27 @@ export function getLanguageId(scope = 'host'): string {
   return _currentLanguageId;
 }
 
+/**
+ * for vscode extension use.
+ *
+ * vscode consider that `en` and `en-us` are the same language(you can search for `en-us` in their code base).
+ * and their default language is `en`, so we should transform the language id to the vscode language id.
+ *
+ * and vscode fetch the language id from the browser (`navigator.language`) or electron's [`app.getLocale()`](https://www.electronjs.org/zh/docs/latest/api/app#appgetlocale).
+ * they both using Chromium's l10n_util library. Possible values are here: https://source.chromium.org/chromium/chromium/src/+/master:ui/base/l10n/l10n_util.cc
+ *
+ * The language used for the user interface. The format of the string is all lower case (e.g. zh-tw for Traditional Chinese)
+ * see: [language](https://github.com/microsoft/vscode/blob/32b031eeefc4fd27a21659d35070967bfe965bcc/src/vs/base/common/platform.ts#L165)
+ */
+export function getCodeLanguage(): string {
+  const languageId = _currentLanguageId.toLowerCase();
+  return (
+    {
+      'en-us': 'en',
+    }[languageId] ?? languageId
+  );
+}
+
 export function getCurrentLanguageInfo(scope = 'host'): ILocalizationInfo {
   return getLocalizationRegistry(scope).localizationInfo.get(_currentLanguageId)!;
 }

--- a/packages/extension/__tests__/browser/main.thread.env.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.env.test.ts
@@ -151,7 +151,7 @@ describe('MainThreadEnvAPI Test Suites ', () => {
   it('should hava correct env', (done) => {
     expect(extHostEnvAPI.appName).toBe(appConfig.appName);
     expect(extHostEnvAPI.uriScheme).toBe(appConfig.uriScheme);
-    expect(extHostEnvAPI.language).toBe(getLanguageId());
+    expect(extHostEnvAPI.language).toBe(getLanguageId().toLowerCase());
     expect(extHostEnvAPI.sessionId).toBe(envValue.sessionId);
     expect(extHostEnvAPI.machineId).toBe(envValue.machineId);
     done();

--- a/packages/extension/src/browser/vscode/api/main.thread.env.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.env.ts
@@ -11,7 +11,7 @@ import {
   AppConfig,
 } from '@opensumi/ide-core-browser';
 import { HttpOpener } from '@opensumi/ide-core-browser/lib/opener/http-opener';
-import { getLanguageId, URI, firstSessionDateStorageKey } from '@opensumi/ide-core-common';
+import { getCodeLanguage, URI, firstSessionDateStorageKey } from '@opensumi/ide-core-common';
 import { ILoggerManagerClient } from '@opensumi/ide-logs/lib/browser';
 
 import { IMainThreadEnv, IExtHostEnv, ExtHostAPIIdentifier } from '../../../common/vscode';
@@ -68,7 +68,7 @@ export class MainThreadEnv implements IMainThreadEnv {
       uriScheme,
       appHost,
       appRoot: workspaceDir,
-      language: getLanguageId(),
+      language: getCodeLanguage(),
       uiKind: this.appConfig.isElectronRenderer ? UIKind.Desktop : UIKind.Web,
       firstSessionDate: firstSessionDateValue?.date,
     });


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

close: #613 

### Background or solution

### Changelog
Change `vscode.env.language` default value to `en`
