### PR TITLE
feat: added shortcuts expand panel at the bottom

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -666,7 +666,9 @@ export const localizationBundle = {
 
     'keybinding.combination.tip': '({0}) was pressed, waiting for more keys',
 
-    'layout.tabbar.hide': 'HIDE',
+    'layout.tabbar.toggle': 'Toggle Panel',
+    'layout.tabbar.expand': 'Maximize Bottom Panel',
+    'layout.tabbar.retract': 'Retract Bottom Panel',
     'layout.view.hide': 'HIDE',
     'marketplace.extension.update.now': 'Update now',
     'marketplace.extension.update.delay': 'Update later',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -705,7 +705,9 @@ export const localizationBundle = {
     'keymaps.editorTitle.openKeymap': '打开键盘快捷方式(可视化)',
 
     'keybinding.combination.tip': '已按下({0}), 等待同时按下第二个键',
-    'layout.tabbar.hide': '隐藏面板',
+    'layout.tabbar.toggle': '切换面板',
+    'layout.tabbar.expand': '最大化底部面板',
+    'layout.tabbar.retract': '缩回底部面板',
     'layout.view.hide': '隐藏',
     'status-bar.label.line': '行',
     'status-bar.label.column': '列',

--- a/packages/main-layout/src/browser/main-layout.contribution.ts
+++ b/packages/main-layout/src/browser/main-layout.contribution.ts
@@ -27,9 +27,7 @@ import { CommandContribution, CommandRegistry, Command, CommandService } from '@
 
 import { IMainLayoutService } from '../common';
 
-
 import { RightTabRenderer, LeftTabRenderer, NextBottomTabRenderer } from './tabbar/renderer.view';
-
 
 // NOTE 左右侧面板的展开、折叠命令请使用组合命令 activity-bar.left.toggle，layout命令仅做折叠展开，不处理tab激活逻辑
 export const HIDE_LEFT_PANEL_COMMAND: Command = {
@@ -68,7 +66,7 @@ export const SHOW_BOTTOM_PANEL_COMMAND: Command = {
 export const TOGGLE_BOTTOM_PANEL_COMMAND: Command = {
   id: 'main-layout.bottom-panel.toggle',
   iconClass: getIcon('minus'),
-  label: localize('layout.tabbar.hide', '收起面板'),
+  label: localize('layout.tabbar.toggle'),
 };
 export const IS_VISIBLE_BOTTOM_PANEL_COMMAND: Command = {
   id: 'main-layout.bottom-panel.is-visible',
@@ -84,12 +82,12 @@ export const SET_PANEL_SIZE_COMMAND: Command = {
 };
 export const EXPAND_BOTTOM_PANEL: Command = {
   id: 'main-layout.bottom-panel.expand',
-  label: localize('layout.tabbar.expand', '最大化面板'),
+  label: localize('layout.tabbar.expand'),
   iconClass: getIcon('expand'),
 };
 export const RETRACT_BOTTOM_PANEL: Command = {
   id: 'main-layout.bottom-panel.retract',
-  label: localize('layout.tabbar.retract', '恢复面板'),
+  label: localize('layout.tabbar.retract'),
   iconClass: getIcon('shrink'),
 };
 
@@ -318,6 +316,16 @@ export class MainLayoutModuleContribution
     this.keybindingRegistry.registerKeybinding({
       keybinding: 'ctrlcmd+j',
       command: TOGGLE_BOTTOM_PANEL_COMMAND.id,
+    });
+    this.keybindingRegistry.registerKeybinding({
+      keybinding: 'ctrlcmd+shift+j',
+      command: EXPAND_BOTTOM_PANEL.id,
+      when: '!bottomFullExpanded',
+    });
+    this.keybindingRegistry.registerKeybinding({
+      keybinding: 'ctrlcmd+shift+j',
+      command: RETRACT_BOTTOM_PANEL.id,
+      when: 'bottomFullExpanded',
     });
   }
 }

--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -141,7 +141,7 @@ export class TabbarService extends WithEventBus {
     this.menuRegistry.registerMenuItem(this.menuId, {
       command: {
         id: this.registerGlobalToggleCommand(),
-        label: localize('layout.tabbar.hide', '隐藏'),
+        label: localize('layout.tabbar.toggle'),
       },
       group: '0_global',
       when: 'triggerWithTab == true',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
close #619 

起因，由于切换底部面板最大化是两个 command，需要提供默认的 when 去区分。 具体看：#619 

- 修复之前翻译
- 支持最大化切换，提供默认的 when 设置

效果：
![screenshort_20220314-115845](https://user-images.githubusercontent.com/2226423/158104937-2a9679b1-7a89-48c6-bf74-b594ff5688c9.gif)


### Changelog
添加底部面板最大化快捷键