### PR TITLE
chore: remove unused export

### DIFF
--- a/packages/addons/__test__/node/inde.test.ts
+++ b/packages/addons/__test__/node/inde.test.ts
@@ -1,6 +1,6 @@
 import { createNodeInjector } from '../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
-import { AddonsModule } from '../../src';
+import { AddonsModule } from '../../src/node';
 
 describe('test for ', () => {
   let injector: MockInjector;

--- a/packages/addons/src/index.ts
+++ b/packages/addons/src/index.ts
@@ -1,1 +1,1 @@
-export * from './node';
+export * from './common';

--- a/packages/express-file-server/src/index.ts
+++ b/packages/express-file-server/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/extension-manager/src/index.ts
+++ b/packages/extension-manager/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/file-search/__tests__/node/file-search.service.test.ts
+++ b/packages/file-search/__tests__/node/file-search.service.test.ts
@@ -4,9 +4,10 @@ import { CancellationTokenSource } from '@opensumi/ide-core-common';
 import { FileUri, URI, AppConfig, INodeLogger, NodeLogger } from '@opensumi/ide-core-node';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { LogServiceModule } from '@opensumi/ide-logs/lib/node';
-import { ProcessModule } from '@opensumi/ide-process';
+import { ProcessModule } from '@opensumi/ide-process/lib/node';
 
-import { FileSearchModule, IFileSearchService } from '../../src';
+import { IFileSearchService } from '../../src';
+import { FileSearchModule } from '../../src/node';
 
 describe('search-service', () => {
   const injector = createNodeInjector([FileSearchModule, ProcessModule, LogServiceModule]);

--- a/packages/file-search/src/index.ts
+++ b/packages/file-search/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/process/__tests__/node/index.test.ts
+++ b/packages/process/__tests__/node/index.test.ts
@@ -3,8 +3,9 @@ import stream from 'stream';
 
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 
-import { ProcessModule, IProcessManage, IProcessFactory } from '../../src/';
+import { IProcessManage, IProcessFactory } from '../../src/';
 import { ProcessErrorEvent, IProcessStartEvent } from '../../src/common';
+import { ProcessModule } from '../../src/node';
 
 const FORK_TEST_FILE = path.join(__dirname, '../../scripts/process-fork-test.js');
 

--- a/packages/process/src/index.ts
+++ b/packages/process/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/search/__tests__/node/content-search.service.test.ts
+++ b/packages/search/__tests__/node/content-search.service.test.ts
@@ -10,7 +10,7 @@ import { isWindows } from '@opensumi/ide-core-common';
 import { FileUri, AppConfig, INodeLogger, NodeLogger } from '@opensumi/ide-core-node';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { LogServiceModule } from '@opensumi/ide-logs/lib/node';
-import { ProcessModule } from '@opensumi/ide-process';
+import { ProcessModule } from '@opensumi/ide-process/lib/node';
 
 import { SearchModule, IContentSearchServer, ContentSearchResult, SEARCH_STATE } from '../../src';
 

--- a/packages/search/__tests__/node/content-search.service.test.ts
+++ b/packages/search/__tests__/node/content-search.service.test.ts
@@ -12,7 +12,8 @@ import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { LogServiceModule } from '@opensumi/ide-logs/lib/node';
 import { ProcessModule } from '@opensumi/ide-process/lib/node';
 
-import { SearchModule, IContentSearchServer, ContentSearchResult, SEARCH_STATE } from '../../src';
+import { IContentSearchServer, ContentSearchResult, SEARCH_STATE } from '../../src';
+import { SearchModule } from '../../src/node';
 
 // Allow creating temporary files, but remove them when we are done.
 const track = temp.track();

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/startup/entry/web/server.ts
+++ b/packages/startup/entry/web/server.ts
@@ -1,5 +1,5 @@
 import { startServer } from '@opensumi/ide-dev-tool/src/server';
-import { ExpressFileServerModule } from '@opensumi/ide-express-file-server';
+import { ExpressFileServerModule } from '@opensumi/ide-express-file-server/lib/node';
 import { OpenerModule } from '@opensumi/ide-remote-opener/lib/node';
 
 import { CommonNodeModules } from '../../src/node/common-modules';

--- a/packages/startup/src/node/common-modules.ts
+++ b/packages/startup/src/node/common-modules.ts
@@ -1,14 +1,14 @@
 import { AddonsModule } from '@opensumi/ide-addons/lib/node';
 import { NodeModule, ConstructorOf } from '@opensumi/ide-core-node';
 import { ServerCommonModule } from '@opensumi/ide-core-node';
-import { OpenVsxExtensionManagerModule } from '@opensumi/ide-extension-manager';
+import { OpenVsxExtensionManagerModule } from '@opensumi/ide-extension-manager/lib/node';
 import { ExtensionModule } from '@opensumi/ide-extension/lib/node';
 import { FileSchemeNodeModule } from '@opensumi/ide-file-scheme/lib/node';
-import { FileSearchModule } from '@opensumi/ide-file-search';
+import { FileSearchModule } from '@opensumi/ide-file-search/lib/node';
 import { FileServiceModule } from '@opensumi/ide-file-service/lib/node';
 import { LogServiceModule } from '@opensumi/ide-logs/lib/node';
-import { ProcessModule } from '@opensumi/ide-process';
-import { SearchModule } from '@opensumi/ide-search';
+import { ProcessModule } from '@opensumi/ide-process/lib/node';
+import { SearchModule } from '@opensumi/ide-search/lib/node';
 import { TerminalNodePtyModule } from '@opensumi/ide-terminal-next/lib/node';
 
 export const CommonNodeModules: ConstructorOf<NodeModule>[] = [

--- a/packages/task/src/index.ts
+++ b/packages/task/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/packages/task/src/node/index.ts
+++ b/packages/task/src/node/index.ts
@@ -1,7 +1,0 @@
-import { Provider, Injectable } from '@opensumi/di';
-import { NodeModule } from '@opensumi/ide-core-node';
-
-@Injectable()
-export class TaskModule extends NodeModule {
-  providers: Provider[] = [];
-}

--- a/tools/electron/src/browser/index.ts
+++ b/tools/electron/src/browser/index.ts
@@ -13,7 +13,6 @@ import { DecorationModule } from '@opensumi/ide-decoration/lib/browser';
 import { EditorModule } from '@opensumi/ide-editor/lib/browser';
 import { ElectronBasicModule } from '@opensumi/ide-electron-basic/lib/browser';
 import { ExplorerModule } from '@opensumi/ide-explorer/lib/browser';
-// import { Terminal2Module } from '@opensumi/ide-terminal2/lib/browser';
 import { OpenVsxExtensionManagerModule } from '@opensumi/ide-extension-manager/lib/browser';
 import { ExtensionStorageModule } from '@opensumi/ide-extension-storage/lib/browser';
 import { ExtensionModule } from '@opensumi/ide-extension/lib/browser';

--- a/tools/electron/src/modules/topbar/index.ts
+++ b/tools/electron/src/modules/topbar/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';

--- a/tools/electron/src/node/index.ts
+++ b/tools/electron/src/node/index.ts
@@ -4,10 +4,10 @@ import { ServerCommonModule } from '@opensumi/ide-core-node';
 import { OpenVsxExtensionManagerModule } from '@opensumi/ide-extension-manager';
 import { ExtensionModule } from '@opensumi/ide-extension/lib/node';
 import { FileSchemeNodeModule } from '@opensumi/ide-file-scheme/lib/node';
-import { FileSearchModule } from '@opensumi/ide-file-search';
+import { FileSearchModule } from '@opensumi/ide-file-search/lib/node';
 import { FileServiceModule } from '@opensumi/ide-file-service/lib/node';
 import { LogServiceModule } from '@opensumi/ide-logs/lib/node';
-import { ProcessModule } from '@opensumi/ide-process';
+import { ProcessModule } from '@opensumi/ide-process/lib/node';
 import { SearchModule } from '@opensumi/ide-search';
 import { TerminalNodePtyModule } from '@opensumi/ide-terminal-next/lib/node';
 

--- a/tools/electron/src/node/index.ts
+++ b/tools/electron/src/node/index.ts
@@ -1,10 +1,8 @@
-import { TopBarModule } from 'modules/topbar';
-
 import { AddonsModule } from '@opensumi/ide-addons/lib/node';
 import { NodeModule, ConstructorOf } from '@opensumi/ide-core-node';
 import { ServerCommonModule } from '@opensumi/ide-core-node';
-import { ExtensionModule } from '@opensumi/ide-extension';
 import { OpenVsxExtensionManagerModule } from '@opensumi/ide-extension-manager';
+import { ExtensionModule } from '@opensumi/ide-extension/lib/node';
 import { FileSchemeNodeModule } from '@opensumi/ide-file-scheme/lib/node';
 import { FileSearchModule } from '@opensumi/ide-file-search';
 import { FileServiceModule } from '@opensumi/ide-file-service/lib/node';
@@ -14,7 +12,6 @@ import { SearchModule } from '@opensumi/ide-search';
 import { TerminalNodePtyModule } from '@opensumi/ide-terminal-next/lib/node';
 
 import { startServer } from './server';
-
 
 export const CommonNodeModules: ConstructorOf<NodeModule>[] = [
   ServerCommonModule,

--- a/tools/template/src/index.ts
+++ b/tools/template/src/index.ts
@@ -1,2 +1,1 @@
 export * from './common';
-export * from './node';


### PR DESCRIPTION
### Types


- [x] 💄 Code Style Changes

### Background or solution
fixes #633 

集成可能需要修改的

将

```ts
import { ExtensionModule } from '@opensumi/ide-extension';
import { ProcessModule } from '@opensumi/ide-process';
import { ExpressFileServerModule } from '@opensumi/ide-express-file-server';
import { SearchModule } from '@opensumi/ide-search';

```
修改为

```ts
import { ExtensionModule } from '@opensumi/ide-extension/lib/node';`
import { ProcessModule } from '@opensumi/ide-process/lib/node';
import { ExpressFileServerModule } from '@opensumi/ide-express-file-server/lib/node';
import { SearchModule } from '@opensumi/ide-search/lib/node';
```

### Changelog
- remove unused export