### PR TITLE
fix: file tree validation style display problem

### DIFF
--- a/packages/components/src/recycle-tree/prompt/PromptHandle.ts
+++ b/packages/components/src/recycle-tree/prompt/PromptHandle.ts
@@ -131,6 +131,10 @@ export abstract class PromptHandle {
       // 移动到与input-box同级别
       this.$.parentElement?.parentElement?.parentElement?.appendChild(this.$validate);
       this._hasValidateElement = true;
+    } else {
+      this.$.parentElement?.parentElement?.classList.remove('validate-error');
+      this.$.parentElement?.parentElement?.classList.remove('validate-warning');
+      this.$.parentElement?.parentElement?.classList.remove('validate-info');
     }
     let validateBoxClassName = 'validate-message popup ';
     if (validateMessage && validateMessage.type === PROMPT_VALIDATE_TYPE.ERROR) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
closes https://github.com/opensumi/core/issues/628
before：
![QQ截图20220315220149](https://user-images.githubusercontent.com/85668115/158398224-59d37083-d5e5-4bfe-a7ba-5d3575d87bb1.png)
there is a CSS ClassName that should be removed if the validation has been triggered before.

### Changelog

fix file tree validation style display problem