### PR TITLE
style: adjust quickOpen style

### DIFF
--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -578,6 +578,7 @@ interface QuickOpenTabBase {
   title: string;
   order: number;
   commandId: string;
+  // 不在 Tab 栏展示（但是功能都可以使用，用户按下 tab 时也不会切换到该功能）
   hideTab?: boolean;
 }
 

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -578,6 +578,7 @@ interface QuickOpenTabBase {
   title: string;
   order: number;
   commandId: string;
+  hideTab?: boolean;
 }
 
 export interface QuickOpenTab extends QuickOpenTabBase {

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -1143,7 +1143,6 @@ export class EditorContribution
       title: localize('quickopen.tab.goToLine'),
       commandId: EDITOR_COMMANDS.GO_TO_LINE.id,
       order: 5,
-      hideTab: true,
     });
   }
 }

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -1140,9 +1140,10 @@ export class EditorContribution
       },
     });
     handlers.registerHandler(this.goToLineQuickOpenHandler, {
-      title: localize('editor.goToLine'),
+      title: localize('quickopen.tab.goToLine'),
       commandId: EDITOR_COMMANDS.GO_TO_LINE.id,
       order: 5,
+      hideTab: true,
     });
   }
 }

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -173,6 +173,7 @@ export const localizationBundle = {
     'quickopen.tab.class': 'Class',
     'quickopen.tab.symbol': 'Symbol',
     'quickopen.tab.command': 'Command',
+    'quickopen.tab.goToLine': 'Go To Line',
     'quickopen.tab.tip.prefix': 'Press',
     'quickopen.tab.tip.suffix': 'to switch',
     'quickOpen.openSide': 'Open on the side',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -140,6 +140,7 @@ export const localizationBundle = {
     'quickopen.tab.class': '类',
     'quickopen.tab.symbol': '符号',
     'quickopen.tab.command': '指令',
+    'quickopen.tab.goToLine': '转到行',
     'quickopen.tab.tip.prefix': '按',
     'quickopen.tab.tip.suffix': '切换搜索类别',
     'quickOpen.openSide': '在侧边打开',

--- a/packages/quick-open/src/browser/components/quick-open-tabs/index.tsx
+++ b/packages/quick-open/src/browser/components/quick-open-tabs/index.tsx
@@ -11,39 +11,55 @@ interface Props {
   tabs: QuickOpenTab[];
   activePrefix: string;
   onChange: (activePrefix: string) => void;
+  toggleTab?: () => void;
 }
 
-export const QuickOpenTabs: React.FC<Props> = ({ tabs, activePrefix, onChange }) => {
+export const QuickOpenTabs: React.FC<Props> = ({ tabs, activePrefix, onChange, toggleTab }) => {
   const keybindingRegistry = useInjectable<KeybindingRegistry>(KeybindingRegistry);
   const getKeybinding = (commandId: string) => {
     const bindings = keybindingRegistry.getKeybindingsForCommand(commandId);
     return bindings ? bindings[0] : undefined;
   };
+
   return (
     <div className={styles.quickopen_tabs}>
-      {tabs.map(({ title, prefix, commandId, order }, i) => {
-        const keybinding = getKeybinding(commandId);
-        return (
-          <div
-            key={prefix}
-            className={styles.quickopen_tabs_item}
-            onMouseDown={(e) => e.preventDefault()} // 使 input 不失去 focus
-            onClick={() => {
-              if (prefix !== activePrefix) {
-                onChange(prefix);
-              }
-            }}
-          >
-            <div className={clx(styles.quickopen_tabs_item_text, { [styles.selected]: activePrefix === prefix })}>
-              {title}
+      <div className={styles.quickopen_tabs_left}>
+        {tabs.map(({ title, prefix, commandId, order }, i) => {
+          const keybinding = getKeybinding(commandId);
+          return (
+            <div
+              key={prefix}
+              className={styles.quickopen_tabs_left_item}
+              onMouseDown={(e) => e.preventDefault()} // 使 input 不失去 focus
+              onClick={() => {
+                if (prefix !== activePrefix) {
+                  onChange(prefix);
+                }
+              }}
+            >
+              <div
+                className={clx(styles.quickopen_tabs_left_item_text, { [styles.selected]: activePrefix === prefix })}
+              >
+                {title}
+              </div>
+              {keybinding && (
+                <KeybindingView keybinding={keybinding} className={styles.keybinding} keyClassName={styles.tab_key} />
+              )}
             </div>
-            {keybinding && (
-              <KeybindingView keybinding={keybinding} className={styles.keybinding} keyClassName={styles.tab_key} />
-            )}
-          </div>
-        );
-      })}
-      <div className={styles.quickopen_tabs_tip}>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          flex: 1,
+        }}
+      ></div>
+      <div
+        className={styles.quickopen_tabs_tip}
+        onClick={() => {
+          toggleTab?.();
+        }}
+      >
         {localize('quickopen.tab.tip.prefix')}
         <span className={styles.tab_key}>Tab</span>
         {localize('quickopen.tab.tip.suffix')}

--- a/packages/quick-open/src/browser/components/quick-open-tabs/style.module.less
+++ b/packages/quick-open/src/browser/components/quick-open-tabs/style.module.less
@@ -4,25 +4,41 @@
   padding: 6px 8px 0;
   margin-bottom: 8px;
   font-size: 12px;
-}
+  &_left {
+    display: flex;
+    flex-wrap: nowrap;
+    &_item {
+      display: flex;
+      height: 24px;
+      margin-right: 16px;
+      width: fit-content;
+      &:last-of-type {
+        margin-left: 0;
+      }
+    }
 
-.quickopen_tabs_item {
-  display: flex;
-  height: 24px;
-  margin-right: 16px;
-  &:last-of-type {
-    margin-left: 0;
+    &_item_text {
+      border-bottom: 2px solid transparent;
+      padding-bottom: 2px;
+      cursor: pointer;
+      width: fit-content;
+      color: var(--foreground);
+      &.selected {
+        border-bottom-color: var(--kt-tab-activeBorder);
+        color: var(--kt-tab-activeForeground);
+      }
+    }
   }
-}
-
-.quickopen_tabs_item_text {
-  border-bottom: 2px solid transparent;
-  padding-bottom: 2px;
-  cursor: pointer;
-  color: var(--foreground);
-  &.selected {
-    border-bottom-color: var(--kt-tab-activeBorder);
-    color: var(--kt-tab-activeForeground);
+  &_tip {
+    order: 1000;
+    text-align: right;
+    color: var(--descriptionForeground);
+    word-break: keep-all;
+    user-select: none;
+    .tab_key {
+      width: 25px;
+      margin: 0 5px;
+    }
   }
 }
 
@@ -54,17 +70,5 @@
   .tab_key {
     box-shadow: inset 0 -1px 0 #bbb;
     background-color: #ddd;
-  }
-}
-
-.quickopen_tabs_tip {
-  flex: 1;
-  order: 1000;
-  text-align: right;
-  color: var(--descriptionForeground);
-
-  .tab_key {
-    width: 25px;
-    margin: 0 5px;
   }
 }

--- a/packages/quick-open/src/browser/prefix-quick-open.service.ts
+++ b/packages/quick-open/src/browser/prefix-quick-open.service.ts
@@ -240,7 +240,6 @@ export class PrefixQuickOpenServiceImpl implements PrefixQuickOpenService {
       skipPrefix,
       valueSelection: select ? [skipPrefix, prefix.length] : undefined,
       ...handlerOptions,
-      ignoreFocusOut: true,
       onClose: (canceled: boolean) => {
         if (handlerOptions.onClose) {
           handlerOptions.onClose(canceled);

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -131,18 +131,6 @@
   align-items: baseline;
 }
 
-.item_keybinding {
-  display: flex;
-  font-size: 11px;
-}
-
-.item_key_sequence {
-  margin-right: 6px;
-  &:last-child {
-    margin-right: 0;
-  }
-}
-
 .input {
   display: flex;
   margin: 4px 10px;

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -1,10 +1,13 @@
 .container {
-  position: absolute;
-  width: 600px;
+  position: relative;
+  max-width: 750px;
+  min-width: 600px;
   z-index: 2000;
   font-size: 12px;
+  margin: auto;
   left: 50%;
-  margin-left: -300px;
+  top: 0;
+  white-space: nowrap;
   :global(.scrollbar-decoration) {
     display: none;
   }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

close: #632 

第一种解法，隐藏该 Tab：

![CleanShot 2022-03-15 at 23 37 47](https://user-images.githubusercontent.com/13938334/158414845-ae83c027-a9b3-41ba-9d52-5019d2166485.gif)

第二种，来自 #636：

![CleanShot 2022-03-15 at 23 46 56](https://user-images.githubusercontent.com/13938334/158416919-4028547b-16e3-4310-88fc-32b1006220ff.gif)


### Changelog
Adjust QuickOpen Tab Style