### PR TITLE
fix: ws connection error caused by remote opener

### DIFF
--- a/packages/remote-opener/__tests__/node/opener.client.test.ts
+++ b/packages/remote-opener/__tests__/node/opener.client.test.ts
@@ -1,3 +1,4 @@
+import { INodeLogger } from '@opensumi/ide-core-node';
 import {
   IRemoteOpenerClient,
   IRemoteOpenerService,
@@ -9,6 +10,7 @@ import { createNodeInjector } from '../../../../tools/dev-tool/src/injector-help
 
 describe('packages/remote-opener/src/node/opener.client.ts', () => {
   let remoteOpenerClient: IRemoteOpenerClient;
+  let logger: INodeLogger;
 
   beforeEach(() => {
     const injector = createNodeInjector([]);
@@ -16,6 +18,7 @@ describe('packages/remote-opener/src/node/opener.client.ts', () => {
       token: RemoteOpenerClientToken,
       useClass: RemoteOpenerClientImpl,
     });
+    logger = injector.get(INodeLogger);
     remoteOpenerClient = injector.get(RemoteOpenerClientToken);
   });
 
@@ -28,9 +31,9 @@ describe('packages/remote-opener/src/node/opener.client.ts', () => {
     remoteOpenerClient.setRemoteOpenerServiceInstance('mock_clientId', service);
     expect(remoteOpenerClient['remoteOpenerServices'].has('mock_clientId')).toBeTruthy();
     expect(remoteOpenerClient['remoteOpenerServices'].get('mock_clientId')).toBe(service);
-    expect(() => remoteOpenerClient.setRemoteOpenerServiceInstance('mock_clientId', service)).toThrow(
-      new Error('Remote opener service instance for client mock_clientId already set.'),
-    );
+    const spyErrorLog = jest.spyOn(logger, 'error');
+    remoteOpenerClient.setRemoteOpenerServiceInstance('mock_clientId', service);
+    expect(spyErrorLog).toBeCalledWith('Remote opener service instance for client mock_clientId already set.');
   });
 
   it('removeRemoteOpenerServiceInstance should be work', () => {

--- a/packages/remote-opener/src/node/opener.client.ts
+++ b/packages/remote-opener/src/node/opener.client.ts
@@ -15,7 +15,7 @@ export class RemoteOpenerClientImpl implements IRemoteOpenerClient {
 
   setRemoteOpenerServiceInstance(clientId: string, service: IRemoteOpenerService): void {
     if (this.remoteOpenerServices.has(clientId)) {
-      throw new Error(`Remote opener service instance for client ${clientId} already set.`);
+      this.logger.error(`Remote opener service instance for client ${clientId} already set.`);
     }
     this.remoteOpenerServices.set(clientId, service);
   }


### PR DESCRIPTION
### Types

避免Remote Opener异常导致Websocket连接创建失败。在某些网络环境不稳定或者其他未知情况下，setRemoteOpenerServiceInstance会被多次调用，然后抛出异常导致上层connection创建过程被异常中断。

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
WS创建被异常终端导致IDE Crash

### Changelog

- 调整 RemoteOpener 异常抛出行为
