### PR TITLE
fix: fire ws connected after core module initialized

### DIFF
--- a/packages/core-browser/__tests__/bootstrap/connection.test.ts
+++ b/packages/core-browser/__tests__/bootstrap/connection.test.ts
@@ -1,38 +1,37 @@
 import { WebSocket, Server } from 'mock-socket';
 
-import { IEventBus, EventBusImpl, BrowserConnectionErrorEvent } from '@opensumi/ide-core-common';
+import { IEventBus, BrowserConnectionErrorEvent } from '@opensumi/ide-core-common';
 
 import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
+import { ClientAppStateService } from '../../src/application';
 import { createClientConnection2 } from '../../src/bootstrap/connection';
 (global as any).WebSocket = WebSocket;
 
 describe('packages/core-browser/src/bootstrap/connection.test.ts', () => {
   let injector: MockInjector;
   let eventBus: IEventBus;
-  let isError = false;
+  let stateService: ClientAppStateService;
   beforeEach(() => {
-    injector = createBrowserInjector(
-      [],
-      new MockInjector([
-        {
-          token: IEventBus,
-          useClass: EventBusImpl,
-        },
-      ]),
-    );
+    injector = createBrowserInjector([]);
 
     eventBus = injector.get(IEventBus);
+  });
+
+  afterEach(() => {
+    injector.disposeAll();
   });
 
   it('handle WebSocket BrowserConnectionErrorEvent event', async (done) => {
     const fakeWSURL = 'ws://localhost:8089';
     const mockServer = new Server(fakeWSURL);
     eventBus.on(BrowserConnectionErrorEvent, () => {
-      isError = true;
+      mockServer.close();
+      done();
     });
-
+    stateService = injector.get(ClientAppStateService);
     createClientConnection2(injector, [], fakeWSURL, () => {});
+    stateService.state = 'core_module_initialized';
     await new Promise<void>((resolve) => {
       setTimeout(() => {
         resolve();
@@ -40,10 +39,5 @@ describe('packages/core-browser/src/bootstrap/connection.test.ts', () => {
     });
 
     mockServer.simulate('error');
-
-    expect(isError).toBe(true);
-
-    mockServer.close();
-    done();
   });
 });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

fixed #635 

- [x] 🐛 Bug Fixes


### Background or solution

### Changelog
fire ws connected after core module initialized