### PR TITLE
fix: editor formatting provider preferred logic

### DIFF
--- a/packages/editor/src/browser/format/formatterSelect.ts
+++ b/packages/editor/src/browser/format/formatterSelect.ts
@@ -42,10 +42,9 @@ export class FormattingSelector {
     });
 
     if (preferred) {
-      if (elements[preferred]) {
-        return elements[preferred];
-      } else {
-        // 喜好的插件已经不存在，进入选择
+      const idx = formatters.findIndex((provider: IProvider) => provider.extensionId === preferred);
+      if (idx >= 0) {
+        return formatters[idx];
       }
     } else if (formatters.length < 2) {
       return formatters[0];


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fixes: #661 

对于同一个插件重复调用多次 `registerDocumentFormattingEditProvider` 注册多个 DocumentFormattingEditProvider 的情况下，这里原有的逻辑可能会错误的获取的 Provider

原本的 formatters 是 monaco 内部计算得出的顺序结果，也就是说索引越靠前准确性越高，之前的逻辑在赋值给 elements 是就已经丢失了正确的 formatter (因为它们的 extensionId 一致，forEach 赋值时会后面会直接直接覆盖掉)

### Changelog
- fix document formatting provider bug