### PR TITLE
fix: fix plain webview may load twice in electron

### DIFF
--- a/packages/webview/src/browser/plain-webview.ts
+++ b/packages/webview/src/browser/plain-webview.ts
@@ -205,8 +205,7 @@ export class ElectronPlainWebview extends Disposable implements IPlainWebview {
 
   private async doLoadURL(): Promise<void> {
     return new Promise<void>(async (resolve) => {
-      await this.webviewDomReady.promise;
-      this.webview!.loadURL(this.url!);
+      this.webview!.src = this.url!;
       const disposer = this.addDispose(
         new DomListener(this.webview!, 'did-finish-load', () => {
           disposer.dispose();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

Calling `loadUrl` on Electron's `plainWebview` instance may result in webview loading twice.

### Changelog
* fix plainWebview may load twice in electron