### PR TITLE
fix: use web save dialog in Remote Mode

### DIFF
--- a/packages/editor/src/browser/fs-resource/fs-resource.ts
+++ b/packages/editor/src/browser/fs-resource/fs-resource.ts
@@ -5,6 +5,7 @@ import {
   MaybePromise,
   WithEventBus,
   localize,
+  formatLocalize,
   MessageType,
   LRUMap,
   IApplicationService,
@@ -173,7 +174,7 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
       [localize('file.prompt.cancel', '取消')]: AskSaveResult.CANCEL,
     };
     const selection = await this.dialogService.open(
-      localize('saveChangesMessage').replace('{0}', resource.name),
+      formatLocalize('saveChangesMessage', resource.name),
       MessageType.Info,
       Object.keys(buttons),
     );

--- a/packages/file-tree-next/src/browser/dialog/window-dialog.service.tsx
+++ b/packages/file-tree-next/src/browser/dialog/window-dialog.service.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { Injectable, Injector, Autowired, INJECTOR_TOKEN } from '@opensumi/di';
 import {
-  isElectronRenderer,
   electronEnv,
   URI,
   MessageType,
   StorageProvider,
   IStorage,
   STORAGE_NAMESPACE,
+  AppConfig,
 } from '@opensumi/ide-core-browser';
 import { IElectronMainUIService } from '@opensumi/ide-core-common/lib/electron';
 import { isMacintosh } from '@opensumi/ide-core-common/lib/platform';
@@ -33,9 +33,11 @@ export class WindowDialogServiceImpl implements IWindowDialogService {
   @Autowired(StorageProvider)
   private storageProvider: StorageProvider;
 
+  @Autowired(AppConfig)
+  private readonly appConfig: AppConfig;
+
   private recentGlobalStorage: IStorage;
 
-  private _userHome: URI;
   private _whenReady: Promise<void>;
   private _defaultUri: URI;
 
@@ -75,7 +77,7 @@ export class WindowDialogServiceImpl implements IWindowDialogService {
       canSelectFolders: false,
       canSelectMany: false,
     };
-    if (isElectronRenderer()) {
+    if (this.appConfig.isElectronRenderer && !this.appConfig.isRemote) {
       const electronUi = this.injector.get(IElectronMainUIService) as IElectronMainUIService;
       const properties: Array<
         | 'openFile'
@@ -145,7 +147,7 @@ export class WindowDialogServiceImpl implements IWindowDialogService {
   // https://code.visualstudio.com/api/references/vscode-api#SaveDialogOptions
   async showSaveDialog(options: ISaveDialogOptions = {}): Promise<URI | undefined> {
     await this.whenReady;
-    if (isElectronRenderer()) {
+    if (this.appConfig.isElectronRenderer && !this.appConfig.isRemote) {
       const defaultUri = options.defaultUri || this.defaultUri;
       const electronUi = this.injector.get(IElectronMainUIService) as IElectronMainUIService;
       const res = await electronUi.showSaveDialog(electronEnv.currentWindowId, {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
- 在 Remote 模式下，文件在远端，使用远端的文件保存窗口。
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/2226423/158757828-6c68982d-5e46-4a04-a3eb-fbcaa7593d5f.png">


### Changelog
use web save dialog in Remote Mode