### PR TITLE
chore: upgrade simple-git to v3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "rimraf": "^3.0.2",
     "runscript": "^1.4.0",
     "semver": "^6.3.0",
-    "simple-git": "^2.34.2",
+    "simple-git": "^3.3.0",
     "strip-html-comments": "^1.0.0",
     "temp": "^0.9.0",
     "text-encoding": "^0.7.0",


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

> The package simple-git before 3.3.0 is vulnerable to Command Injection via argument injection. When calling the .fetch(remote, branch, handlerFn) function, both the remote and branch parameters are passed to the git fetch subcommand. By injecting some git options, it was possible to get arbitrary command execution.

### Changelog

- upgrade simple-git to v3.3.0
