### PR TITLE
Alpha: 支持终端恢复和重连能力

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:components": "cd packages/components && npm run build:dist",
     "start:lite": "cross-env NODE_ENV=development ts-node ./scripts/start --script=start:lite",
     "bundle:lite": "ts-node ./scripts/start --script=bundle:lite",
+    "start:pty-service": "KTLOG_SHOW_DEBUG=1 npx ts-node packages/terminal-next/src/node/pty.proxy.ts",
     "create": "ts-node ./scripts/create",
     "add:node": "ts-node ./scripts/add-node",
     "add:browser": "ts-node ./scripts/add-browser",

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -52,8 +52,7 @@
       "../../packages"
     ],
     "events": {
-      "restart": "lsof -i :8000 -t | xargs kill",
-      "crash": "lsof -i :8000 -t | xargs kill"
+      "crash": "kill -9 $(lsof -t -i:8080 -sTCP:LISTEN)"
     },
     "ext": "js,json,ts",
     "delay": "2000"

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -51,7 +51,12 @@
     "watch": [
       "../../packages"
     ],
-    "ext": "js,json,ts"
+    "events": {
+      "restart": "lsof -i :8000 -t | xargs kill",
+      "crash": "lsof -i :8000 -t | xargs kill"
+    },
+    "ext": "js,json,ts",
+    "delay": "2000"
   },
   "dependencies": {
     "@opensumi/ide-addons": "2.15.7",

--- a/packages/terminal-next/src/browser/terminal.restore.ts
+++ b/packages/terminal-next/src/browser/terminal.restore.ts
@@ -1,7 +1,8 @@
 import { Injectable, Autowired } from '@opensumi/di';
+import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser/ws-channel-handler';
 import { Disposable } from '@opensumi/ide-core-common';
 
-import { ITerminalRestore, ITerminalController, ITerminalInternalService } from '../common';
+import { ITerminalRestore, ITerminalController, ITerminalInternalService, ITerminalBrowserHistory } from '../common';
 
 @Injectable()
 export class TerminalRestore extends Disposable implements ITerminalRestore {
@@ -10,6 +11,9 @@ export class TerminalRestore extends Disposable implements ITerminalRestore {
 
   @Autowired(ITerminalInternalService)
   protected readonly service: ITerminalInternalService;
+
+  @Autowired(WSChannelHandler)
+  protected readonly wsChannelHandler: WSChannelHandler;
 
   get storageKey() {
     return 'KAITIAN';
@@ -24,9 +28,28 @@ export class TerminalRestore extends Disposable implements ITerminalRestore {
   restore() {
     const key = this.storageKey;
     const history = window.localStorage.getItem(key);
+    // TODO: 考虑迁移到controller中
+    const currentClientId = this.wsChannelHandler.clientId;
+    // HACK: 因为现在的终端重连是有问题的，是ClientID机制导致的，因此在拿出记录恢复终端的时候，需要把里面的ClientID替换为当前活跃窗口的ClientID
+    // 同时在独立PtyService中，把终端重连的标识转变为真正的realSessionId  也就是 ${clientId}|${realSessionId}
     if (history) {
       try {
-        return this.controller.recovery(JSON.parse(history));
+        const historyObj = JSON.parse(history) as ITerminalBrowserHistory;
+        const currentRealSessionId = historyObj.current?.split('|')?.[1];
+        if (historyObj.current) {
+          historyObj.current = `${currentClientId}|${currentRealSessionId}`;
+        }
+        historyObj.groups = historyObj.groups.map((group) => {
+          if (Array.isArray(group)) {
+            // 替换clientId为当前窗口ClientID
+            return group.map((item) => `${currentClientId}|${(item as string)?.split('|')?.[1]}`);
+          } else {
+            return group;
+          }
+        });
+        // eslint-disable-next-line no-console
+        console.log('restore: history', JSON.parse(history), 'historyObj', historyObj);
+        return this.controller.recovery(historyObj);
       } catch {
         /** nothing */
       }

--- a/packages/terminal-next/src/browser/terminal.service.ts
+++ b/packages/terminal-next/src/browser/terminal.service.ts
@@ -78,8 +78,8 @@ export class NodePtyTerminalService implements ITerminalService {
   }
 
   async check(ids: string[]) {
-    const ensureResult = await this.serviceClientRPC.ensureTerminal(ids);
-    return ensureResult;
+    // TODO: 真正使用PtyServiceProxy检查SessionId/Pid存活，暂时先无脑true
+    return true;
   }
 
   private _createCustomWebSocket = (sessionId: string, pty: INodePtyInstance): ITerminalConnection => ({

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -252,7 +252,6 @@ export interface ITerminalNodeService {
   setClient(clientId: string, client: ITerminalServiceClient): void;
   closeClient(clientId: string): void;
   ensureClientTerminal(clientId: string, terminalIdArr: string[]): boolean;
-  getServiceClientMap(): Map<string, ITerminalServiceClient>;
 }
 
 export const ITerminalProcessService = Symbol('ITerminalProcessService');

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -1,4 +1,5 @@
 import { IPty as INodePty } from 'node-pty';
+import * as pty from 'node-pty';
 import type vscode from 'vscode';
 import { Terminal as XTerm } from 'xterm';
 
@@ -9,7 +10,6 @@ import { ITerminalError } from './error';
 import { ITerminalEnvironment, ITerminalProcessExtHostProxy, TerminalLocation } from './extension';
 import { IDetectProfileOptions, ITerminalProfile } from './profile';
 import { WindowsShellType } from './shell';
-import * as pty from 'node-pty';
 
 export interface IPtyProcess extends INodePty {
   /**
@@ -32,12 +32,14 @@ export interface IPtyProxyRPCService {
    * @param file 启动的程序 如/bin/bash
    * @param args 启动参数 argv (具体参考node-pty参数文档)
    * @param options 启动终端options (具体参考node-pty参数文档)
+   * @param sessionId (可选)传入启动终端的sessionId，通常用于terminal重连的场景
    * @returns 返回符合IPty接口的远程执行RPC对象，实际上内容是IPty的静态常量，没有function，需要做二次包装
    */
   $spawn(
     file: string,
     args: string[] | string,
     options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+    sessionId?: string,
   ): Promise<pty.IPty>;
   /**
    * pty数据onData回调代理
@@ -250,6 +252,7 @@ export interface ITerminalNodeService {
   setClient(clientId: string, client: ITerminalServiceClient): void;
   closeClient(clientId: string): void;
   ensureClientTerminal(clientId: string, terminalIdArr: string[]): boolean;
+  getServiceClientMap(): Map<string, ITerminalServiceClient>;
 }
 
 export const ITerminalProcessService = Symbol('ITerminalProcessService');

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -9,6 +9,7 @@ import { ITerminalError } from './error';
 import { ITerminalEnvironment, ITerminalProcessExtHostProxy, TerminalLocation } from './extension';
 import { IDetectProfileOptions, ITerminalProfile } from './profile';
 import { WindowsShellType } from './shell';
+import * as pty from 'node-pty';
 
 export interface IPtyProcess extends INodePty {
   /**
@@ -21,6 +22,73 @@ export interface IPtyProcess extends INodePty {
 
 export const ITerminalServicePath = 'ITerminalServicePath';
 export const ITerminalProcessPath = 'ITerminalProcessPath';
+
+export const PTY_SERVICE_PROXY_PROTOCOL = 'PTY_SERVICE_PROXY_PROTOCOL';
+export const PTY_SERVICE_PROXY_CALLBACK_PROTOCOL = 'PTY_SERVICE_PROXY_CALLBACK_PROTOCOL';
+export const PTY_SERVICE_PROXY_SERVER_PORT = 10111;
+export interface IPtyProxyRPCService {
+  /**
+   * 远程spawn pty进程，开启终端，返回符合IPty接口的远程执行对象
+   * @param file 启动的程序 如/bin/bash
+   * @param args 启动参数 argv (具体参考node-pty参数文档)
+   * @param options 启动终端options (具体参考node-pty参数文档)
+   * @returns 返回符合IPty接口的远程执行RPC对象，实际上内容是IPty的静态常量，没有function，需要做二次包装
+   */
+  $spawn(
+    file: string,
+    args: string[] | string,
+    options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+  ): Promise<pty.IPty>;
+  /**
+   * pty数据onData回调代理
+   * @param callId 指定callId的方法回调注册
+   * @param pid pty进程的pid，用于辨识pty进程
+   */
+  $onData(callId: number, pid: number): void;
+  /**
+   * pty数据onExit回调代理
+   * @param callId 指定callId的方法回调注册
+   * @param pid pty进程的pid，用于辨识pty进程
+   */
+  $onExit(callId: number, pid: number): void;
+  /**
+   * pty数据on回调代理
+   * @param callId 指定callId的方法回调注册
+   * @param pid pty进程的pid，用于辨识pty进程
+   */
+  $on(callId: number, pid: number, event: any): void;
+  /**
+   * resize方法RPC转发
+   * @param pid pty进程的pid，用于辨识pty进程
+   * @param columns 列数
+   * @param rows 行数
+   */
+  $resize(pid: number, columns: number, rows: number): void;
+  /**
+   * 远程pty写入数据的RPC转发
+   * @param pid pty进程的pid，用于辨识pty进程
+   * @param data 终端stdin写入的数据
+   */
+  $write(pid: number, data: string): void;
+  /**
+   * kill pty 的RPC转发
+   * @param pid pty进程的pid，用于辨识pty进程
+   * @param signal The signal to use, defaults to SIGHUP. This parameter is not supported onWindows.
+   */
+  $kill(pid: number, signal?: string): void;
+  /**
+   * pause pty 的RPC转发
+   * Pauses the pty for customizable flow control.
+   * @param pid pty进程的pid，用于辨识pty进程
+   */
+  $pause(pid: number): void;
+  /**
+   * resume pty 的RPC转发
+   * Resumes the pty for customizable flow control.
+   * @param pid pty进程的pid，用于辨识pty进程
+   */
+  $resume(pid: number): void;
+}
 
 export interface Terminal {
   readonly xterm: XTerm;

--- a/packages/terminal-next/src/node/index.ts
+++ b/packages/terminal-next/src/node/index.ts
@@ -14,6 +14,7 @@ import { TerminalProcessServiceImpl } from './terminal.process.service';
 import { ITerminalProfileServiceNode, TerminalProfileServiceNode } from './terminal.profile.service';
 import { TerminalServiceImpl } from './terminal.service';
 import { TerminalServiceClientImpl } from './terminal.service.client';
+import { PtyServiceManager, PtyServiceManagerToken } from './pty.manager';
 
 @Injectable()
 export class TerminalNodePtyModule extends NodeModule {
@@ -37,6 +38,10 @@ export class TerminalNodePtyModule extends NodeModule {
     {
       token: ITerminalProfileServiceNode,
       useClass: TerminalProfileServiceNode,
+    },
+    {
+      token: PtyServiceManagerToken,
+      useClass: PtyServiceManager,
     },
   ];
 

--- a/packages/terminal-next/src/node/pty.manager.ts
+++ b/packages/terminal-next/src/node/pty.manager.ts
@@ -1,8 +1,12 @@
 /* eslint-disable no-console */
 import net from 'net';
+
 import * as pty from 'node-pty';
+
 import { Injectable } from '@opensumi/di';
-import { RPCServiceCenter, createSocketConnection, initRPCService } from '@opensumi/ide-connection';
+import { RPCServiceCenter, initRPCService } from '@opensumi/ide-connection';
+import { createSocketConnection } from '@opensumi/ide-connection/lib/node';
+
 import {
   IPtyProxyRPCService,
   PTY_SERVICE_PROXY_CALLBACK_PROTOCOL,
@@ -61,8 +65,9 @@ export class PtyServiceManager {
     file: string,
     args: string[] | string,
     options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+    sessionId?: string,
   ): Promise<pty.IPty> {
-    const iPtyRemoteProxy = (await this.ptyServiceProxy.$spawn(file, args, options)) as pty.IPty;
+    const iPtyRemoteProxy = (await this.ptyServiceProxy.$spawn(file, args, options, sessionId)) as pty.IPty;
     // 局部功能的Ipty, 代理所有常量
     // TODO 改造ptyServiceProxy，支持常量的返回 以及方法的代理
     return new PtyProcessProxy(iPtyRemoteProxy, this);
@@ -102,6 +107,7 @@ export class PtyServiceManager {
   }
 }
 
+// Pty进程的Remote代理
 class PtyProcessProxy implements pty.IPty {
   private ptyServiceManager: PtyServiceManager;
   constructor(iptyProxy: pty.IPty, ptyServiceManager: PtyServiceManager) {

--- a/packages/terminal-next/src/node/pty.manager.ts
+++ b/packages/terminal-next/src/node/pty.manager.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-console */
+import net from 'net';
+import * as pty from 'node-pty';
+import { Injectable } from '@opensumi/di';
+import { RPCServiceCenter, createSocketConnection, initRPCService } from '@opensumi/ide-connection';
+import { IPtyServiceProxy } from './pty.proxy';
+
+export const PtyServiceManagerToken = Symbol('PtyServiceManager');
+
+// 在IDE容器中远程运行，与DEV Server通信
+@Injectable()
+export class PtyServiceManager {
+  private callId = 0;
+  private callbackMap = new Map<number, (...args: any[]) => void>();
+  private ptyServiceProxy: IPtyServiceProxy; // TODO: 补充interface { $method }
+
+  constructor() {
+    this.initRemoteConnection();
+  }
+
+  initRemoteConnection() {
+    const clientCenter = new RPCServiceCenter();
+    const { getRPCService: clientGetRPCService, createRPCService } = initRPCService(clientCenter);
+    // const self = this;
+    // TODO: 思考any是否应该在这里用 亦或者做空判断
+    const getService: IPtyServiceProxy = clientGetRPCService('PTY_SERVICE') as any;
+    this.ptyServiceProxy = getService;
+
+    // 处理回调
+    createRPCService('PTY_SERVICE_Callback', {
+      $callback: async (callId, ...args) => {
+        const callback = this.callbackMap.get(callId);
+        console.log('PTY_SERVICE_Callback', callId, args);
+        if (!callback) {
+          return Promise.reject(new Error(`no found callback: ${callId}`));
+        }
+        callback(...args);
+      },
+    });
+    const socket = new net.Socket();
+    socket.connect({ port: 10111 });
+
+    // 连接绑定
+    clientCenter.setConnection(createSocketConnection(socket));
+    return getService;
+  }
+
+  addNewCallback(pid: number, callback: (...args: any[]) => void) {
+    const callId = this.callId++;
+    this.callbackMap.set(callId, callback);
+    return callId;
+    // TODO: dispose 逻辑
+  }
+
+  async spawn(
+    file: string,
+    args: string[] | string,
+    options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+  ): Promise<pty.IPty> {
+    const iPtyRemoteProxy = (await this.ptyServiceProxy.$spawn(file, args, options)) as pty.IPty;
+    // 局部功能的Ipty, 代理所有常量
+    // TODO 改造ptyServiceProxy，支持常量的返回 以及方法的代理
+    return new PtyProcessProxy(iPtyRemoteProxy, this);
+  }
+
+  // 实现Ipty的需要回调的逻辑接口，同时注入
+  onData(pid: number, listener: (e: string) => any) {
+    const callId = this.addNewCallback(pid, listener);
+    this.ptyServiceProxy.$onData(callId, pid);
+  }
+  onExit(pid: number, listener: (e: { exitCode: number; signal?: number }) => any) {
+    const callId = this.addNewCallback(pid, listener);
+    this.ptyServiceProxy.$onExit(callId, pid);
+  }
+
+  on(pid: number, event: 'data', listener: (data: string) => void): void;
+  on(pid: number, event: 'exit', listener: (exitCode: number, signal?: number) => void): void;
+  on(pid: number, event: any, listener: (data: any) => void): void {
+    const callId = this.addNewCallback(pid, listener);
+    this.ptyServiceProxy.$on(callId, pid, event);
+  }
+
+  resize(pid: number, columns: number, rows: number): void {
+    this.ptyServiceProxy.$resize(pid, columns, rows);
+  }
+  write(pid: number, data: string): void {
+    this.ptyServiceProxy.$write(pid, data);
+  }
+  kill(pid: number, signal?: string): void {
+    this.ptyServiceProxy.$kill(pid, signal);
+  }
+  pause(pid: number): void {
+    this.ptyServiceProxy.$pause(pid);
+  }
+  resume(pid: number): void {
+    this.ptyServiceProxy.$resume(pid);
+  }
+}
+
+class PtyProcessProxy implements pty.IPty {
+  private ptyServiceManager: PtyServiceManager;
+  constructor(iptyProxy: pty.IPty, ptyServiceManager: PtyServiceManager) {
+    this.ptyServiceManager = ptyServiceManager;
+    this.pid = iptyProxy.pid;
+    this.cols = iptyProxy.cols;
+    this.rows = iptyProxy.rows;
+    this.process = iptyProxy.process;
+    this.handleFlowControl = iptyProxy.handleFlowControl;
+
+    this.onData = (listener: (e: string) => any) => {
+      this.ptyServiceManager.onData(this.pid, listener);
+      const disposeable = {
+        dispose: () => {},
+      };
+      return disposeable;
+    };
+
+    this.onExit = (listener: (e: { exitCode: number; signal?: number }) => any) => {
+      this.ptyServiceManager.onExit(this.pid, listener);
+      const disposeable = {
+        dispose: () => {},
+      };
+      return disposeable;
+    };
+  }
+  pid: number;
+  cols: number;
+  rows: number;
+  process: string;
+  handleFlowControl: boolean;
+
+  onData: pty.IEvent<string>;
+  onExit: pty.IEvent<{ exitCode: number; signal?: number }>;
+
+  on(event: 'data', listener: (data: string) => void): void;
+  on(event: 'exit', listener: (exitCode: number, signal?: number) => void): void;
+  on(event: any, listener: any): void {
+    this.ptyServiceManager.on(this.pid, event, listener);
+  }
+  resize(columns: number, rows: number): void {
+    this.ptyServiceManager.resize(this.pid, columns, rows);
+  }
+  write(data: string): void {
+    this.ptyServiceManager.write(this.pid, data);
+  }
+  kill(signal?: string): void {
+    this.ptyServiceManager.kill(this.pid, signal);
+  }
+  pause(): void {
+    this.ptyServiceManager.pause(this.pid);
+  }
+  resume(): void {
+    this.ptyServiceManager.resume(this.pid);
+  }
+}

--- a/packages/terminal-next/src/node/pty.manager.ts
+++ b/packages/terminal-next/src/node/pty.manager.ts
@@ -21,6 +21,7 @@ export const PtyServiceManagerToken = Symbol('PtyServiceManager');
 export class PtyServiceManager {
   private callId = 0;
   private callbackMap = new Map<number, (...args: any[]) => void>();
+  // Pty终端服务的代理，在双容器模式下采用RPC连接，单容器模式下直连
   private ptyServiceProxy: IPtyProxyRPCService;
 
   constructor() {
@@ -39,7 +40,6 @@ export class PtyServiceManager {
     createRPCService(PTY_SERVICE_PROXY_CALLBACK_PROTOCOL, {
       $callback: async (callId, ...args) => {
         const callback = this.callbackMap.get(callId);
-        console.log(PTY_SERVICE_PROXY_CALLBACK_PROTOCOL, callId, args);
         if (!callback) {
           return Promise.reject(new Error(`no found callback: ${callId}`));
         }

--- a/packages/terminal-next/src/node/pty.proxy.ts
+++ b/packages/terminal-next/src/node/pty.proxy.ts
@@ -1,0 +1,114 @@
+/* eslint-disable no-console */
+import net from 'net';
+import * as pty from 'node-pty';
+import { RPCServiceCenter, createSocketConnection, initRPCService } from '@opensumi/ide-connection';
+
+export interface IPtyServiceProxy {
+  $spawn(
+    file: string,
+    args: string[] | string,
+    options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+  ): Promise<pty.IPty>;
+  $onData(callId: number, pid: number): void;
+  $onExit(callId: number, pid: number): void;
+  $on(callId: number, pid: number, event: any): void;
+  $resize(pid: number, columns: number, rows: number): void;
+  $write(pid: number, data: string): void;
+  $kill(pid: number, signal?: string): void;
+  $pause(pid: number): void;
+  $resume(pid: number): void;
+}
+
+// 在DEV容器中远程运行，与IDE Server通信
+class PtyServiceProxy {
+  private readonly ptyServiceCenter: RPCServiceCenter;
+  private ptyInstanceMap = new Map<number, pty.IPty>();
+
+  constructor() {
+    this.ptyServiceCenter = new RPCServiceCenter();
+    this.createSocket();
+    const { createRPCService, getRPCService } = initRPCService(this.ptyServiceCenter);
+
+    const $callback: (callId: number, ...args) => void = (getRPCService('PTY_SERVICE_Callback') as any).$callback;
+    const self = this;
+    const ptyServiceProxy: IPtyServiceProxy = {
+      $spawn(file: string, args: string[] | string, options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions): any {
+        console.log('ptyServiceCenter: spawn', file, args, options);
+        const ptyInstance = pty.spawn(file, args, options);
+        self.ptyInstanceMap.set(ptyInstance.pid, ptyInstance);
+        const ptyInstanceSimple = {
+          pid: ptyInstance.pid,
+          cols: ptyInstance.cols,
+          rows: ptyInstance.rows,
+          process: ptyInstance.process,
+          handleFlowControl: ptyInstance.handleFlowControl,
+        };
+        console.log('ptyServiceCenter: spawn', ptyInstanceSimple);
+        return ptyInstanceSimple;
+        // (getRPCService('PTY_SERVICE_Callback') as any).$callback('call back test');
+      },
+      $onData(callId: number, pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.onData((e) => {
+          console.log('ptyServiceCenter: onData', e, 'pid:', pid);
+          $callback(callId, e);
+        });
+      },
+      $onExit(callId: number, pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.onExit((e) => {
+          $callback(callId, e);
+        });
+      },
+      $on(callId: number, pid: number, event: any): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.on(event, (e) => {
+          $callback(callId, e);
+        });
+      },
+      $resize(pid: number, columns: number, rows: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.resize(columns, rows);
+      },
+      $write(pid: number, data: string): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        console.log('ptyServiceCenter: write', data, 'pid:', pid);
+        ptyInstance?.write(data);
+      },
+      $kill(pid: number, signal?: string): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.kill(signal);
+      },
+      $pause(pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.pause();
+      },
+      $resume(pid: number): void {
+        const ptyInstance = self.ptyInstanceMap.get(pid);
+        ptyInstance?.resume();
+      },
+    };
+
+    createRPCService('PTY_SERVICE', ptyServiceProxy);
+  }
+
+  private createSocket() {
+    const server = net.createServer();
+    server.on('connection', (connection) => {
+      console.log('ptyServiceCenter: new connections coming in');
+      this.setProxyConnection(connection);
+    });
+    server.listen(10111);
+    console.log('ptyServiceCenter: listening on 10111');
+  }
+
+  private setProxyConnection(connection: net.Socket) {
+    const serverConnection = createSocketConnection(connection);
+    this.ptyServiceCenter.setConnection(serverConnection);
+    connection.on('close', () => {
+      this.ptyServiceCenter.removeConnection(serverConnection);
+    });
+  }
+}
+
+new PtyServiceProxy();

--- a/packages/terminal-next/src/node/pty.proxy.ts
+++ b/packages/terminal-next/src/node/pty.proxy.ts
@@ -1,8 +1,13 @@
 /* eslint-disable no-console */
 import net from 'net';
+
+import { pick } from 'lodash';
 import * as pty from 'node-pty';
-import { RPCServiceCenter, createSocketConnection, initRPCService } from '@opensumi/ide-connection';
+
+import { RPCServiceCenter, initRPCService } from '@opensumi/ide-connection';
+import { createSocketConnection } from '@opensumi/ide-connection/lib/node';
 import { getDebugLogger } from '@opensumi/ide-core-node';
+
 import {
   IPtyProxyRPCService,
   PTY_SERVICE_PROXY_CALLBACK_PROTOCOL,
@@ -11,25 +16,57 @@ import {
 } from '../common';
 
 // 在DEV容器中远程运行，与IDE Server通信
+
+type PID = number;
+type SessionId = string;
+
 class PtyServiceProxy {
   private readonly ptyServiceCenter: RPCServiceCenter;
-  private ptyInstanceMap = new Map<number, pty.IPty>();
+  // Map <pid, pty>
+  private ptyInstanceMap = new Map<PID, pty.IPty>();
+  private ptySessionMap = new Map<SessionId, PID>();
   private readonly debugLogger = getDebugLogger();
 
   constructor() {
     this.ptyServiceCenter = new RPCServiceCenter();
-    this.createSocket();
     const { createRPCService, getRPCService } = initRPCService(this.ptyServiceCenter);
 
     const $callback: (callId: number, ...args) => void = (getRPCService(PTY_SERVICE_PROXY_CALLBACK_PROTOCOL) as any)
       .$callback;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
 
     // Pty 服务的RPC Service创建
     const ptyServiceProxyInstance: IPtyProxyRPCService = {
-      $spawn(file: string, args: string[] | string, options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions): any {
-        const ptyInstance = pty.spawn(file, args, options);
+      $spawn(
+        file: string,
+        args: string[] | string,
+        options: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions,
+        sessionId?: string,
+      ): any {
+        self.debugLogger.log('ptyServiceProxy: spawn sessionId:', sessionId);
+        let ptyInstance: pty.IPty | undefined;
+        if (sessionId) {
+          // 查询SessionId对应的Pid
+          const pid = self.ptySessionMap.get(sessionId) || -10;
+          // 查询Pid是否存活
+          const checkResult = pid > 0 ? self.checkProcess(pid) : false;
+          self.debugLogger.debug('ptyServiceProxy: check process result:', pid, checkResult);
+          if (checkResult) {
+            ptyInstance = self.ptyInstanceMap.get(pid);
+          } else {
+            self.ptyInstanceMap.delete(pid);
+          }
+        }
+
+        if (!ptyInstance) {
+          ptyInstance = pty.spawn(file, args, options);
+        }
+
         self.ptyInstanceMap.set(ptyInstance.pid, ptyInstance);
+        if (sessionId) {
+          self.ptySessionMap.set(sessionId, ptyInstance.pid);
+        }
         // 走RPC序列化的部分，function不走序列化，走单独的RPC调用
         const ptyInstanceSimple = {
           pid: ptyInstance.pid,
@@ -43,14 +80,16 @@ class PtyServiceProxy {
       },
       $onData(callId: number, pid: number): void {
         const ptyInstance = self.ptyInstanceMap.get(pid);
+        $callback(callId, 'TERMINAL TEST');
         ptyInstance?.onData((e) => {
-          self.debugLogger.debug('ptyServiceCenter: onData', e, 'pid:', pid);
+          self.debugLogger.debug('ptyServiceCenter: onData', e, 'pid:', pid, 'callId', callId);
           $callback(callId, e);
         });
       },
       $onExit(callId: number, pid: number): void {
         const ptyInstance = self.ptyInstanceMap.get(pid);
         ptyInstance?.onExit((e) => {
+          self.debugLogger.debug('ptyServiceCenter: onExit', 'pid:', pid, e);
           $callback(callId, e);
         });
       },
@@ -70,8 +109,10 @@ class PtyServiceProxy {
         ptyInstance?.write(data);
       },
       $kill(pid: number, signal?: string): void {
-        const ptyInstance = self.ptyInstanceMap.get(pid);
-        ptyInstance?.kill(signal);
+        // self.debugLogger.debug('ptyServiceCenter: kill', 'pid:', pid);
+        // const ptyInstance = self.ptyInstanceMap.get(pid);
+        // ptyInstance?.kill(signal);
+        // self.ptyInstanceMap.delete(pid);
       },
       $pause(pid: number): void {
         const ptyInstance = self.ptyInstanceMap.get(pid);
@@ -84,6 +125,20 @@ class PtyServiceProxy {
     };
 
     createRPCService(PTY_SERVICE_PROXY_PROTOCOL, ptyServiceProxyInstance);
+  }
+
+  // 检查Pty的PID是否存活
+  private checkProcess(pid: PID) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  public initServer() {
+    this.createSocket();
   }
 
   private createSocket() {
@@ -105,4 +160,6 @@ class PtyServiceProxy {
   }
 }
 
-new PtyServiceProxy();
+const proxy = new PtyServiceProxy();
+proxy.initServer();
+console.log('ptyServiceCenter: init');

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -22,7 +22,7 @@ import { IShellLaunchConfig, ITerminalLaunchError } from '../common';
 import { IProcessReadyEvent, IProcessExitEvent } from '../common/process';
 import { IPtyProcess } from '../common/pty';
 
-import { PtyServiceManager } from './pty.manager';
+import { PtyServiceManager, PtyServiceManagerToken } from './pty.manager';
 import { findExecutable } from './shell';
 
 export const IPtyService = Symbol('IPtyService');
@@ -31,6 +31,9 @@ export const IPtyService = Symbol('IPtyService');
 export class PtyService extends Disposable {
   @Autowired(INodeLogger)
   private readonly logger: INodeLogger;
+
+  @Autowired(PtyServiceManagerToken)
+  private readonly ptyServiceManager: PtyServiceManager;
 
   private readonly _ptyOptions: pty.IPtyForkOptions | pty.IWindowsPtyForkOptions;
   private _ptyProcess: IPtyProcess | undefined;
@@ -41,7 +44,7 @@ export class PtyService extends Disposable {
   readonly onReady = this._onReady.event;
   private readonly _onExit = new Emitter<IProcessExitEvent>();
   readonly onExit = this._onExit.event;
-  private readonly ptyServiceManager = new PtyServiceManager();
+  // private readonly ptyServiceManager = new PtyServiceManager();
   // 终端的sessionId，也就是构造函数传入的id
   private readonly sessionId: string;
 

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -21,9 +21,8 @@ import { getShellPath } from '@opensumi/ide-core-node/lib/bootstrap/shell-path';
 import { IShellLaunchConfig, ITerminalLaunchError } from '../common';
 import { IProcessReadyEvent, IProcessExitEvent } from '../common/process';
 import { IPtyProcess } from '../common/pty';
-
 import { findExecutable } from './shell';
-
+import { PtyServiceManager } from './pty.manager';
 
 export const IPtyService = Symbol('IPtyService');
 
@@ -41,6 +40,7 @@ export class PtyService extends Disposable {
   readonly onReady = this._onReady.event;
   private readonly _onExit = new Emitter<IProcessExitEvent>();
   readonly onExit = this._onExit.event;
+  private readonly ptyServiceManager = new PtyServiceManager();
 
   get pty() {
     return this._ptyProcess;
@@ -191,7 +191,8 @@ export class PtyService extends Disposable {
     const options = this.shellLaunchConfig;
 
     const args = options.args || [];
-    const ptyProcess = pty.spawn(options.executable as string, args, this._ptyOptions);
+    const ptyProcess = await this.ptyServiceManager.spawn(options.executable as string, args, this._ptyOptions);
+    // const ptyProcess1 = pty.spawn(options.executable as string, args, this._ptyOptions);
 
     this.addDispose(
       ptyProcess.onData((e) => {

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -17,7 +17,6 @@ import { WindowsShellType, WINDOWS_DEFAULT_SHELL_PATH_MAPS } from '../common/she
 import { findExecutable, findShellExecutableAsync, getSystemShell, WINDOWS_GIT_BASH_PATHS } from './shell';
 import { ITerminalProfileServiceNode, TerminalProfileServiceNode } from './terminal.profile.service';
 
-
 /**
  * this RPC target: NodePtyTerminalService
  */
@@ -82,6 +81,10 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
       if (pty) {
         this.terminalService.setClient(this.clientId, this);
         this.logger.log(`client ${id} create ${pty.pid} with options `, launchConfig);
+        this.logger.log(
+          `terminal client ${id} and clientID: ${this.clientId} create ${pty.pid} with options `,
+          launchConfig,
+        );
         this.terminalMap.set(id, pty);
         return {
           id,


### PR DESCRIPTION
### Types

Alpha 版本
支持终端恢复和重连能力

使用：
npm run start:pty-service 启动ptyService
npm run start 启动IDE Server

- [x] 🎉 New Features
- [x] Bug Fix


### Background or solution
OpenSumi的终端会在窗口关闭的时候被Kill掉，对于需要长时间运行的任务以及Node程序很是不友好，因此把终端程序独立运行，避免和窗口生命周期的绑定。
同时修复了OpenSumi本身终端RESTORE机制的bug

### Changelog
- 支持终端多容器化改造
- 支持终端重连能力
