### PR TITLE
fix: electron window header hight incorrect

### DIFF
--- a/packages/core-electron-main/browser-preload/index.js
+++ b/packages/core-electron-main/browser-preload/index.js
@@ -23,6 +23,7 @@ electronEnv.createNetConnection = createNetConnection;
 electronEnv.createRPCNetConnection = createRPCNetConnection;
 
 electronEnv.platform = os.platform();
+electronEnv.osRelease = os.release();
 
 electronEnv.isElectronRenderer = true;
 electronEnv.BufferBridge = Buffer;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
给 electronEnv 增加 os 版本，指定 bigSur 及以上的 macOS 窗口， header 要适应新系统的高度
![image](https://user-images.githubusercontent.com/2226423/159670469-cd0499b2-14b0-4691-884b-4f9e10487950.png)


### Changelog
fix: electron window header hight incorrect