### PR TITLE
fix: upgrade electron to 13.6.9 for vulnerability reason

### DIFF
--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -113,7 +113,7 @@
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "css-loader": "^2.1.1",
-    "electron": "13.6.2",
+    "electron": "^13.6.9",
     "file-loader": "^3.0.1",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "html-webpack-plugin": "^3.2.0",

--- a/tools/electron/package.json
+++ b/tools/electron/package.json
@@ -49,7 +49,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.0.3",
     "css-loader": "^2.1.1",
-    "electron": "13.6.2",
+    "electron": "^13.6.9",
     "electron-builder": "^21.2.0",
     "file-loader": "^3.0.1",
     "friendly-errors-webpack-plugin": "^1.7.0",


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
由于 electron 13.5.5 以下有漏洞，升级 electron 到 13.x 最新版本
![image](https://user-images.githubusercontent.com/2226423/159856471-9387434c-0c29-4729-8102-23622926dcb7.png)


### Changelog
fix: upgrade electron to 13.6.9 for vulnerability reason