### PR TITLE
feat: improve terminal tab styles

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -215,7 +215,7 @@
       }
       .kt_editor_close_icon {
         &::before {
-          font-size: 12px;
+          font-size: 14px;
         }
       }
       div:nth-child(2) {

--- a/packages/main-layout/src/browser/tabbar/styles.module.less
+++ b/packages/main-layout/src/browser/tabbar/styles.module.less
@@ -171,7 +171,7 @@
   display: flex;
   background-color: var(--kt-panelTitle-background);
   user-select: none;
-  height: 28px;
+  height: var(--tabBar-height);
   align-items: center;
   border-bottom: 1px solid var(--sideBar-border);
   box-sizing: border-box;

--- a/packages/terminal-next/src/browser/component/tab.item.tsx
+++ b/packages/terminal-next/src/browser/component/tab.item.tsx
@@ -2,7 +2,8 @@ import clx from 'classnames';
 import debounce from 'lodash/debounce';
 import React from 'react';
 
-import { getIcon } from '@opensumi/ide-core-browser';
+import { Icon } from '@opensumi/ide-components/lib/icon/icon';
+import { getIcon, getIconClass } from '@opensumi/ide-core-browser';
 import { Loading } from '@opensumi/ide-core-browser/lib/components/loading';
 
 import { ItemProps, ItemType } from '../../common';
@@ -49,7 +50,14 @@ export function renderInfoItem(props: ItemProps) {
         ></input>
       ) : (
         <div id={props.id} className={styles.item_info_name} title={props.name}>
-          {props.name !== '' ? props.name : <Loading />}
+          {props.name !== '' ? (
+            <>
+              <Icon icon={'terminal'} size='small' style={{ marginRight: 4, color: 'inherit' }} />
+              <span className={styles.item_title}>{props.name}</span>
+            </>
+          ) : (
+            <Loading />
+          )}
         </div>
       )}
       {props.editable ? (
@@ -61,7 +69,7 @@ export function renderInfoItem(props: ItemProps) {
             event.stopPropagation();
             handleClose();
           }}
-        ></div>
+        />
       )}
     </div>
   );
@@ -77,7 +85,7 @@ export function renderAddItem(props: ItemProps) {
         [styles.item_add]: true,
       })}
       onClick={() => handleAdd()}
-    ></div>
+    />
   );
 }
 

--- a/packages/terminal-next/src/browser/component/tab.module.less
+++ b/packages/terminal-next/src/browser/component/tab.module.less
@@ -26,11 +26,15 @@
   padding: 0px 12px 0px 12px;
   cursor: pointer;
   user-select: none;
-  height: 28px;
+  height: var(--tabBar-height);
+  line-height: var(--tabBar-height);
+  font-size: var(--tab-fontSize);
+  min-width: var(--tab-min-size);
   display: flex;
   color: var(--kt-panelTab-inactiveForeground);
   background-color: var(--kt-panelTab-inactiveBackground);
   border-right: 1px solid var(--kt-panelTab-border);
+  border-top: 1px solid transparent;
   max-width: 800px;
   min-width: 105px;
   align-items: center;
@@ -38,7 +42,7 @@
   .close_icon {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;
-    line-height: 24px;
+    line-height: var(--tabBar-height);
     border-right: 0;
   }
   &::before {
@@ -48,7 +52,7 @@
     bottom: 0;
     width: 100%;
     height: 1px;
-    background-color: var(--kt-panelTab-border);
+    background-color: var(--sideBar-border);
   }
 }
 
@@ -59,16 +63,20 @@
 }
 
 .item_info_name {
-  flex: 1;
   margin-right: 8px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  line-height: 20px;
-  height: 20px;
   position: relative;
-  text-indent: 1px;
-  max-width: 160px;
+  width: 160px;
+  display: flex;
+  align-items: center;
+
+  .item_title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 20px;
+    height: 20px;
+  }
 }
 
 .item_info_input {
@@ -88,6 +96,8 @@
   color: var(--kt-panelTab-activeForeground);
   background-color: var(--kt-panelTab-activeBackground);
   position: relative;
+  border-top-color: var(--tab-activeBorderTop);
+
   &::before {
     content: '';
     position: absolute;
@@ -102,11 +112,15 @@
 .item_add {
   display: inline-block;
   padding: 0 6px;
-  line-height: 28px;
+  line-height: var(--tabBar-height);
   cursor: pointer;
   user-select: none;
 }
 
 .close_icon {
+  &::before {
+    font-size: 14px;
+  }
+
   color: var(--kt-panelTabActionIcon-foreground);
 }

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -511,6 +511,7 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     queueMicrotask(() => {
       this._layout();
       this.attach();
+      this.focus();
       if (!this.widget.show) {
         this._show?.promise.then(async () => {
           this._show = new Deferred<void>();

--- a/packages/terminal-next/src/browser/terminal.view.ts
+++ b/packages/terminal-next/src/browser/terminal.view.ts
@@ -152,16 +152,7 @@ export class WidgetGroup extends Disposable implements IWidgetGroup {
 
   @computed
   get snapshot() {
-    if (this.name) {
-      return this.name;
-    } else {
-      let name = '';
-      const length = this.length;
-      this.widgets.forEach((widget, index) => {
-        name += `${widget.name}${index !== length - 1 ? ', ' : ''}`;
-      });
-      return name;
-    }
+    return this.current?.name || this.name;
   }
 
   addWidget(widget: Widget) {


### PR DESCRIPTION
### Types


- [x] 💄 Style Changes


### Background or solution
1. 终端 Tab 栏与编辑器样式保持一致
2. 默认添加 `terminal` icon
3. 拆分终端场景下，tab 标题根据当前激活的终端动态展示
4. 去除了使用逗号分割终端标题的行为
5. 拆分终端后自动聚焦

https://user-images.githubusercontent.com/17701805/159862885-4ad31818-cc10-4a89-abf6-c4fc2b653c59.mp4

### Changelog
- improve terminal tab styles
