### PR TITLE
fix: wait until hash service initialize before accept external change

### DIFF
--- a/packages/editor/src/browser/doc-model/editor-document-model-service.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model-service.ts
@@ -181,6 +181,9 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
 
   @OnEvent(EditorDocumentModelOptionExternalUpdatedEvent)
   async acceptExternalChange(e: EditorDocumentModelOptionExternalUpdatedEvent) {
+    if (!this.hashCalculateService.initialized) {
+      await this.hashCalculateService.initialize();
+    }
     const doc = this.editorDocModels.get(e.payload.toString());
     if (doc) {
       if (doc.dirty) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

provider.onDidChangeContent may be triggered at very early stage. 

### Changelog
wait until hash service initialize before accept external change, fixing possible issues.
