### PR TITLE
feat: update tabbar resizeHandle logic

### DIFF
--- a/packages/main-layout/src/browser/tabbar/renderer.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/renderer.view.tsx
@@ -5,7 +5,6 @@ import { ComponentRegistryInfo, useInjectable, IEventBus, ResizeEvent } from '@o
 import { PanelContext } from '@opensumi/ide-core-browser/lib/components';
 import { Layout } from '@opensumi/ide-core-browser/lib/components/layout/layout';
 
-
 import { RightTabbarRenderer, LeftTabbarRenderer, BottomTabbarRenderer, NextBottomTabbarRenderer } from './bar.view';
 import {
   RightTabPanelRenderer,
@@ -15,7 +14,6 @@ import {
 } from './panel.view';
 import styles from './styles.module.less';
 import { TabbarServiceFactory, TabbarService } from './tabbar.service';
-
 
 // TODO 将过深的prop挪到这里
 export const TabbarConfig = React.createContext<{
@@ -44,11 +42,11 @@ export const TabRendererBase: React.FC<{
   const rootRef = React.useRef<HTMLDivElement>(null);
   const [fullSize, setFullSize] = React.useState(0);
   React.useLayoutEffect(() => {
+    tabbarService.registerResizeHandle(resizeHandle);
     components.forEach((component) => {
       tabbarService.registerContainer(component.options!.containerId, component);
     });
     tabbarService.updatePanelVisibility();
-    tabbarService.registerResizeHandle(resizeHandle);
     tabbarService.viewReady.resolve();
   }, []);
   React.useEffect(() => {

--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -382,23 +382,28 @@ export class TabbarService extends WithEventBus {
   }
 
   doExpand(expand: boolean) {
-    const { setRelativeSize } = this.resizeHandle!;
-    if (expand) {
-      if (!this.isLatter) {
-        setRelativeSize(1, 0);
+    if (this.resizeHandle) {
+      const { setRelativeSize } = this.resizeHandle;
+      if (expand) {
+        if (!this.isLatter) {
+          setRelativeSize(1, 0);
+        } else {
+          setRelativeSize(0, 1);
+        }
       } else {
-        setRelativeSize(0, 1);
+        // FIXME 底部需要额外的字段记录展开前的尺寸
+        setRelativeSize(2, 1);
       }
-    } else {
-      // FIXME 底部需要额外的字段记录展开前的尺寸
-      setRelativeSize(2, 1);
     }
   }
 
   get isExpanded(): boolean {
-    const { getRelativeSize } = this.resizeHandle!;
-    const relativeSizes = getRelativeSize().join(',');
-    return this.isLatter ? relativeSizes === '0,1' : relativeSizes === '1,0';
+    if (this.resizeHandle) {
+      const { getRelativeSize } = this.resizeHandle;
+      const relativeSizes = getRelativeSize().join(',');
+      return this.isLatter ? relativeSizes === '0,1' : relativeSizes === '1,0';
+    }
+    return false;
   }
 
   @action.bound handleTabClick(e: React.MouseEvent, forbidCollapse?: boolean) {
@@ -682,7 +687,12 @@ export class TabbarService extends WithEventBus {
   }
 
   private handleChange(currentId, previousId) {
-    const { getSize, setSize, lockSize } = this.resizeHandle!;
+    // 这里的 handleChange 是会在 registerResizeHandle 后才会执行
+    // 这里的判断只是防御行为
+    if (!this.resizeHandle) {
+      return;
+    }
+    const { getSize, setSize, lockSize } = this.resizeHandle;
     this.onCurrentChangeEmitter.fire({ previousId, currentId });
     const isCurrentExpanded = this.shouldExpand(currentId);
     if (this.shouldExpand(this.previousContainerId) || isCurrentExpanded) {
@@ -725,7 +735,10 @@ export class TabbarService extends WithEventBus {
   }
 
   protected handleFullExpanded(currentId: string, isCurrentExpanded?: boolean) {
-    const { setRelativeSize, setSize } = this.resizeHandle!;
+    if (!this.resizeHandle) {
+      return;
+    }
+    const { setRelativeSize, setSize } = this.resizeHandle;
     if (currentId) {
       if (isCurrentExpanded) {
         if (!this.isLatter) {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

用户反馈编辑器组件消失：

![image](https://user-images.githubusercontent.com/13938334/160083076-56e226c1-7bd4-4f7a-b9d1-9a299a4fc2f1.png)


目前排查到结果如下：

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/13938334/160082981-1f6887d7-ed28-469a-84bc-eb5ce0f297b9.png">

我们通过 ToolBarActionContribution 调用 registerToolbarAction，使用 createToolbarActionBtn 往 tabbar 上挂这个编辑器按钮（调试器左边的位置）： 
整体大概是这么用的：
```ts
 registry.registerToolbarAction({
      id: 'editor111',
      component: createToolbarActionBtn({
         delegate: () => {
          this.layoutService.bottomExpanded;
        }
      })
});
```

这个按钮会在渲染时（useEffect(, [])）调用这个 delegate 函数，函数中调用了 bottomExpanded。

bottomExpanded 调用后就会产生报错：

![image](https://user-images.githubusercontent.com/13938334/160082883-76dd8726-effb-4053-88fb-f15c1bf8118e.png)

MainLayoutModuleContribution 中是在 initialize 生命周期中初始化的所有 slot，其中会初始化 NextBottomTabRenderer，然后该 render 内部才会把 resizeHandle 注册给 TabBar。

如果在这个 resizeHandle 被注册之前调用 bottomExpanded，就会报错。

所以在我们这个 case 下，渲染 registerToolbarAction 注册的 component 的时机比渲染底部 NextBottomTabRenderer 还早。
目前还不知道这个时序问题是怎么触发的，但 OpenSumi 这里需要容错。

### Changelog
Update tabbar resizeHandle logic