### PR TITLE
fix: find menu children logic

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -64,7 +64,8 @@ export const MenuActionList: React.FC<{
       }
 
       // hacky: read MenuNode from MenuItem.children.props
-      const menuItem = item.props.children[0].props.data as MenuNode;
+      const child = Array.isArray(item.props.children) ? item.props.children[0] : item.props.children;
+      const menuItem = child.props.data as MenuNode;
       if (!menuItem) {
         return;
       }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fix

![image](https://user-images.githubusercontent.com/17701805/160749198-747bcc07-c6b7-4970-8080-275d015edc4b.png)


rc-menu 升级后，这里的 children 可能不是数组

### Changelog
- find menu children logic