### PR TITLE
fix: statusbar of terminal environment use markdown tooltip

### DIFF
--- a/packages/core-common/src/utils/index.ts
+++ b/packages/core-common/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './decorators';
 export * from './file-uri';
 export * from './paths';
 export * from './ansi';
+export * from './markdown';

--- a/packages/core-common/src/utils/markdown.ts
+++ b/packages/core-common/src/utils/markdown.ts
@@ -1,0 +1,8 @@
+import { IMarkdownString } from '../types/markdown';
+
+export function toMarkdownString(str: string, opts?: Omit<IMarkdownString, 'value'>): IMarkdownString {
+  return {
+    value: str,
+    ...opts,
+  };
+}

--- a/packages/terminal-next/src/browser/terminal.environment.service.ts
+++ b/packages/terminal-next/src/browser/terminal.environment.service.ts
@@ -4,7 +4,15 @@ import React from 'react';
 
 import { Injectable, Autowired } from '@opensumi/di';
 import { getIcon, StatusBarAlignment, StatusBarEntryAccessor } from '@opensumi/ide-core-browser';
-import { CommandService, Emitter, Event, ILogger, localize, raceTimeout } from '@opensumi/ide-core-common';
+import {
+  CommandService,
+  Emitter,
+  Event,
+  ILogger,
+  localize,
+  raceTimeout,
+  toMarkdownString,
+} from '@opensumi/ide-core-common';
 import { IDialogService } from '@opensumi/ide-overlay/lib/common';
 import { IStatusBarService } from '@opensumi/ide-status-bar/lib/common';
 import { IWorkspaceStorageService } from '@opensumi/ide-workspace/lib/common';
@@ -150,7 +158,7 @@ export class TerminalEnvironmentService implements IEnvironmentVariableService {
       iconClass: getIcon('warning-circle-fill'),
       color: 'orange',
       alignment: StatusBarAlignment.RIGHT,
-      tooltip: localize('terminal.environment.changed') + '\n\n```\n' + changes.join('\n') + '\n```',
+      tooltip: toMarkdownString(localize('terminal.environment.changed') + '\n\n```\n' + changes.join('\n') + '\n```'),
       onClick: () => this.onDidClickStatusBarEntry(diff),
     });
   }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

before:

![image](https://user-images.githubusercontent.com/6399899/160801548-b422e629-cdf8-4951-b3f1-c99159a52812.png)


after:

![image](https://user-images.githubusercontent.com/6399899/160801653-049b1af5-8abb-40fa-b839-fe44ff7a955a.png)


### Changelog
statusbar of terminal environment use markdown tooltip