### PR TITLE
fix: cache component resource open types

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -886,7 +886,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
   @OnEvent(RegisterEditorComponentEvent)
   async onRegisterEditorComponentEvent() {
     if (this.currentResource) {
-      const openTypes = await this.editorComponentRegistry.resolveEditorComponent(this.currentResource);
+      const openTypes =
+        this.cachedResourcesOpenTypes.get(this.currentResource.uri.toString()) ||
+        (await this.editorComponentRegistry.resolveEditorComponent(this.currentResource));
       this.availableOpenTypes = openTypes;
       this.cachedResourcesOpenTypes.set(this.currentResource.uri.toString(), openTypes);
     }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复二次打开 webview 文件时显示空白的问题