### PR TITLE
fix: quick change tabs when opening

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1369,6 +1369,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
 
       if (activeOpenType.type === 'code') {
         const documentRef = await this.getDocumentModelRef(resource.uri);
+        this.resolveTabChanged(_resource, this.currentResource);
         await this.codeEditorReady.onceReady(async () => {
           await this.codeEditor.open(documentRef);
 
@@ -1503,10 +1504,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
         return; // other type not handled
       }
 
-      if (_resource !== this.currentResource) {
-        throw new EditorTabChangedError(); // 在打开过程中已经改变了
-      }
-
+      this.resolveTabChanged(_resource, this.currentResource);
       this._currentOpenType = activeOpenType;
       this.notifyBodyChanged();
 
@@ -1518,6 +1516,13 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       }
 
       this.cachedResourcesActiveOpenTypes.set(resource.uri.toString(), activeOpenType);
+    }
+  }
+
+  private resolveTabChanged(lastResource: IResource, curResource: MaybeNull<IResource>): void {
+    if (lastResource !== curResource) {
+      // 打开过程中改变了tab
+      throw new EditorTabChangedError();
     }
   }
 


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes
### Background or solution
快速切换tab时，需在open前做判断  close #735
### Changelog
修复快速切换打开文件时展示问题 
