### PR TITLE
fix: make sure delete files correctly on compressed nodes

### DIFF
--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -997,15 +997,15 @@ export class FileTreeModelService {
       }
     }
 
-    const nodes = this.fileTreeService.sortPaths(uris);
+    const roots = this.fileTreeService.sortPaths(uris);
 
     const toPromise = [] as Promise<boolean>[];
 
-    nodes.forEach((node) => {
-      this.loadingDecoration.addTarget(node);
+    roots.forEach((root) => {
+      this.loadingDecoration.addTarget(root.node);
       toPromise.push(
-        this.deleteFile(node).then((v) => {
-          this.loadingDecoration.removeTarget(node);
+        this.deleteFile(root.node, root.path).then((v) => {
+          this.loadingDecoration.removeTarget(root.node);
           return v;
         }),
       );
@@ -1014,12 +1014,12 @@ export class FileTreeModelService {
     await Promise.all(toPromise);
   }
 
-  async deleteFile(node: File | Directory): Promise<boolean> {
-    const uri = node.uri;
+  async deleteFile(node: File | Directory, path: URI | string): Promise<boolean> {
+    const uri = typeof path === 'string' ? new URI(path) : (path as URI);
     // 提前缓存文件路径
     let targetPath: string | URI | undefined;
     // 当存在activeUri时，即存在压缩目录的子路径被删除
-    if (this.activeUri) {
+    if (path) {
       targetPath = uri;
     } else if (this.focusedFile) {
       // 使用path能更精确的定位新建文件位置，因为软连接情况下可能存在uri一致的情况
@@ -1054,7 +1054,7 @@ export class FileTreeModelService {
     processNode(node);
 
     const effectNode = this.fileTreeService.getNodeByPathOrUri(targetPath);
-    if (effectNode && effectNode.path !== node.path) {
+    if (effectNode && !effectNode.uri.isEqual(uri)) {
       processNode(effectNode);
     }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原有的删除文件依赖文件 URI 去获取节点，在压缩节点情况下，获取到的节点如下所示为 `.../test/fixture`, 但实际期望删除的是 `.../test`, 该 PR 修复改问题

![image](https://user-images.githubusercontent.com/9823838/162352081-38fc32e0-5764-4882-b3b7-47f6650be529.png)


### Changelog

make sure delete files correctly on compressed nodes