### PR TITLE
fix: set default font size for electron

### DIFF
--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -1,7 +1,15 @@
 import { ChildProcess, fork, ForkOptions } from 'child_process';
 import qs from 'querystring';
 
-import { app, BrowserWindow, shell, ipcMain, BrowserWindowConstructorOptions, IpcMainEvent } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  shell,
+  ipcMain,
+  BrowserWindowConstructorOptions,
+  IpcMainEvent,
+  WebPreferences,
+} from 'electron';
 import semver from 'semver';
 import treeKill from 'tree-kill';
 
@@ -17,9 +25,10 @@ const DEFAULT_WINDOW_WIDTH = 1000;
 
 let windowClientCount = 0;
 
-const defaultWebPreferences = {
+const defaultWebPreferences: WebPreferences = {
   webviewTag: true,
   contextIsolation: false,
+  defaultFontSize: 14,
 };
 
 @Injectable({ multiple: true })

--- a/packages/electron-basic/src/browser/welcome/welcome.module.less
+++ b/packages/electron-basic/src/browser/welcome/welcome.module.less
@@ -6,4 +6,8 @@
   > div {
     margin-bottom: 20px;
   }
+
+  .recentRow {
+    padding: 2px;
+  }
 }

--- a/packages/electron-basic/src/browser/welcome/welcome.tsx
+++ b/packages/electron-basic/src/browser/welcome/welcome.tsx
@@ -40,7 +40,7 @@ export const EditorWelcomeComponent: ReactEditorComponent<IWelcomeMetaData> = ({
             workspacePath = FileUri.fsPath(workspace);
           }
           return (
-            <div key={workspace}>
+            <div key={workspace} className={styles.recentRow}>
               <a
                 onClick={() => {
                   windowService.openWorkspace(new URI(workspace), { newWindow: false });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution
- 指定 electron 默认的的 font-size 大小为 13px
close: #805
![1649748565662-c311779d-03b8-4f27-a95d-be1747fc3b44](https://user-images.githubusercontent.com/2226423/162905683-b028d2b7-8ef5-4d5b-95a8-a654dfc78d3e.png)
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/2226423/162905806-22a9b455-8c9e-468c-92db-7b0d428d97be.png">


### Changelog
set default font size for electron