### PR TITLE
fix: merge equal code type on editor component

### DIFF
--- a/packages/editor/src/browser/component.ts
+++ b/packages/editor/src/browser/component.ts
@@ -1,3 +1,5 @@
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
 import ReactDOM from 'react-dom';
 
 import { Injectable, Autowired } from '@opensumi/di';
@@ -121,7 +123,7 @@ export class EditorComponentRegistryImpl implements EditorComponentRegistry {
       const wb = b.weight || 0;
       return wb - wa;
     });
-    return results;
+    return uniqWith(results, isEqual);
   }
 
   private calculateSchemeResolver(scheme: string): IEditorComponentResolver[] {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

部分视图设置可能因为激活、写法问题导致对同一个 schema 注册了相同内容，这里在获取 SchemaResolver 的时候做了一下 array 的去重处理，防止出现下面的视觉问题：

![image](https://user-images.githubusercontent.com/9823838/162912433-359624dc-3ddd-47bd-bd64-86becd63142b.png)

### Changelog

merge equal code type on editor component

