### PR TITLE
feat: support type hierarchy api

### DIFF
--- a/packages/core-common/src/disposable.ts
+++ b/packages/core-common/src/disposable.ts
@@ -351,3 +351,21 @@ export class MutableDisposable<T extends IDisposable> implements IDisposable {
     this._value = undefined;
   }
 }
+
+export class RefCountedDisposable {
+  private _counter = 1;
+
+  constructor(private readonly _disposable: IDisposable) {}
+
+  acquire() {
+    this._counter++;
+    return this;
+  }
+
+  release() {
+    if (--this._counter === 0) {
+      this._disposable.dispose();
+    }
+    return this;
+  }
+}

--- a/packages/editor/src/browser/index.ts
+++ b/packages/editor/src/browser/index.ts
@@ -14,6 +14,7 @@ import {
   IMonacoCommandsRegistry,
 } from '@opensumi/ide-monaco/lib/browser/contrib/command';
 import { ITextmateTokenizer } from '@opensumi/ide-monaco/lib/browser/contrib/tokenizer';
+import { ITypeHierarchyService } from '@opensumi/ide-monaco/lib/browser/contrib/typeHierarchy';
 
 import { EditorCollectionService, WorkbenchEditorService, ResourceService, ILanguageService } from '../common';
 import { IDocPersistentCacheProvider } from '../common/doc-cache';
@@ -36,7 +37,12 @@ import { LanguageStatusContribution } from './language/language-status.contribut
 import { LanguageStatusService } from './language/language-status.service';
 import { LanguageService } from './language/language.service';
 import { EditorActionRegistryImpl } from './menu/editor.menu';
-import { CallHierarchyContribution, CallHierarchyService } from './monaco-contrib';
+import {
+  CallHierarchyContribution,
+  CallHierarchyService,
+  TypeHierarchyService,
+  TypeHierarchyContribution,
+} from './monaco-contrib';
 import {
   MonacoActionRegistry,
   MonacoCommandRegistry,
@@ -132,6 +138,10 @@ export class EditorModule extends BrowserModule {
       useClass: CallHierarchyService,
     },
     {
+      token: ITypeHierarchyService,
+      useClass: TypeHierarchyService,
+    },
+    {
       token: ICommandServiceToken,
       useClass: MonacoCommandService,
     },
@@ -160,6 +170,7 @@ export class EditorModule extends BrowserModule {
     SaveParticipantsContribution,
     FileSystemResourceContribution,
     CallHierarchyContribution,
+    TypeHierarchyContribution,
     LanguageStatusContribution,
   ];
   contributionProvider = BrowserEditorContribution;

--- a/packages/editor/src/browser/monaco-contrib/callHierarchy/callHierarchy.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/callHierarchy/callHierarchy.service.ts
@@ -5,6 +5,7 @@ import {
   IPosition,
   isFunction,
   isNonEmptyArray,
+  RefCountedDisposable,
   onUnexpectedExternalError,
   URI,
   Uri,
@@ -28,22 +29,6 @@ declare type ProviderResult<T> = T | undefined | null | Thenable<T | undefined |
  *--------------------------------------------------------------------------------------------*/
 // Some code copied and modified from https://github.com/microsoft/vscode/tree/main/src/vs/workbench/contrib/callHierarchy/common/callHierarchy.ts
 
-class RefCountedDisposabled {
-  constructor(private readonly _disposable: IDisposable, private _counter = 1) {}
-
-  acquire() {
-    this._counter++;
-    return this;
-  }
-
-  release() {
-    if (--this._counter === 0) {
-      this._disposable.dispose();
-    }
-    return this;
-  }
-}
-
 export class CallHierarchyModel {
   static async create(
     model: ITextModel,
@@ -62,7 +47,7 @@ export class CallHierarchyModel {
       session.roots.reduce((p, c) => p + c._sessionId, ''),
       provider,
       session.roots,
-      new RefCountedDisposabled(session),
+      new RefCountedDisposable(session),
     );
   }
 
@@ -72,7 +57,7 @@ export class CallHierarchyModel {
     readonly id: string,
     readonly provider: CallHierarchyProvider,
     readonly roots: CallHierarchyItem[],
-    readonly ref: RefCountedDisposabled,
+    readonly ref: RefCountedDisposable,
   ) {
     this.root = roots[0];
   }

--- a/packages/editor/src/browser/monaco-contrib/index.ts
+++ b/packages/editor/src/browser/monaco-contrib/index.ts
@@ -1,2 +1,4 @@
 export * from './callHierarchy/callHierarchy.contribution';
 export * from './callHierarchy/callHierarchy.service';
+export * from './typeHierarchy/typeHierarchy.contribution';
+export * from './typeHierarchy/typeHierarchy.service';

--- a/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.contribution.ts
+++ b/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.contribution.ts
@@ -1,0 +1,45 @@
+import { Autowired } from '@opensumi/di';
+import {
+  Domain,
+  CommandContribution,
+  CommandRegistry,
+  Event,
+  IContextKeyService,
+  IContextKey,
+  Uri,
+} from '@opensumi/ide-core-browser';
+import { ITypeHierarchyService, TypeHierarchyItem } from '@opensumi/ide-monaco/lib/browser/contrib/typeHierarchy';
+import { Position } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/position';
+
+export const executePrepareTypeHierarchyCommand = {
+  id: '_executePrepareTypeHierarchy',
+};
+
+export const executeProvideSupertypesCommand = {
+  id: '_executeProvideSupertypes',
+};
+
+export const executeProvideSubtypesCommand = {
+  id: '_executeProvideSubtypes',
+};
+
+@Domain(CommandContribution)
+export class TypeHierarchyContribution implements CommandContribution {
+  @Autowired(ITypeHierarchyService)
+  protected readonly typeHierarchyService: ITypeHierarchyService;
+
+  registerCommands(commands: CommandRegistry) {
+    commands.registerCommand(executePrepareTypeHierarchyCommand, {
+      execute: (resource: Uri, position: Position) =>
+        this.typeHierarchyService.prepareTypeHierarchyProvider(resource, position),
+    });
+
+    commands.registerCommand(executeProvideSupertypesCommand, {
+      execute: (item: TypeHierarchyItem) => this.typeHierarchyService.provideSupertypes(item),
+    });
+
+    commands.registerCommand(executeProvideSubtypesCommand, {
+      execute: (item: TypeHierarchyItem) => this.typeHierarchyService.provideSubtypes(item),
+    });
+  }
+}

--- a/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import {
+  CancellationToken,
+  IPosition,
+  IDisposable,
+  isFunction,
+  isNonEmptyArray,
+  RefCountedDisposable,
+  onUnexpectedExternalError,
+  URI,
+  Uri,
+} from '@opensumi/ide-core-common';
+import {
+  TypeHierarchyItem,
+  ITypeHierarchyService,
+  TypeHierarchyProvider,
+  TypeHierarchyProviderRegistry,
+} from '@opensumi/ide-monaco/lib/browser/contrib/typeHierarchy';
+import { ITextModel, Position } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
+
+import { IEditorDocumentModelService } from '../../doc-model/types';
+
+export class TypeHierarchyModel {
+  static async create(
+    model: ITextModel,
+    position: IPosition,
+    token: CancellationToken,
+  ): Promise<TypeHierarchyModel | undefined> {
+    const [provider] = TypeHierarchyProviderRegistry.ordered(model);
+    if (!provider) {
+      return undefined;
+    }
+    const session = await provider.prepareTypeHierarchy(model, position, token);
+    if (!session) {
+      return undefined;
+    }
+    return new TypeHierarchyModel(
+      session.roots.reduce((p, c) => p + c._sessionId, ''),
+      provider,
+      session.roots,
+      new RefCountedDisposable(session),
+    );
+  }
+
+  readonly root: TypeHierarchyItem;
+
+  private constructor(
+    readonly id: string,
+    readonly provider: TypeHierarchyProvider,
+    readonly roots: TypeHierarchyItem[],
+    readonly ref: RefCountedDisposable,
+  ) {
+    this.root = roots[0];
+  }
+
+  dispose(): void {
+    this.ref.release();
+  }
+
+  fork(item: TypeHierarchyItem): TypeHierarchyModel {
+    const that = this;
+    return new (class extends TypeHierarchyModel {
+      constructor() {
+        super(that.id, that.provider, [item], that.ref.acquire());
+      }
+    })();
+  }
+
+  async provideSupertypes(item: TypeHierarchyItem, token: CancellationToken): Promise<TypeHierarchyItem[]> {
+    try {
+      const result = await this.provider.provideSupertypes(item, token);
+      if (isNonEmptyArray(result)) {
+        return result;
+      }
+    } catch (e) {
+      onUnexpectedExternalError(e);
+    }
+    return [];
+  }
+
+  async provideSubtypes(item: TypeHierarchyItem, token: CancellationToken): Promise<TypeHierarchyItem[]> {
+    try {
+      const result = await this.provider.provideSubtypes(item, token);
+      if (isNonEmptyArray(result)) {
+        return result;
+      }
+    } catch (e) {
+      onUnexpectedExternalError(e);
+    }
+    return [];
+  }
+}
+
+@Injectable()
+export class TypeHierarchyService implements ITypeHierarchyService {
+  @Autowired(IEditorDocumentModelService)
+  protected readonly modelService: IEditorDocumentModelService;
+
+  private models: Map<string, TypeHierarchyModel> = new Map<string, TypeHierarchyModel>();
+
+  registerTypeHierarchyProvider(selector: any, provider: TypeHierarchyProvider) {
+    TypeHierarchyProviderRegistry.register(selector, provider);
+  }
+
+  async prepareTypeHierarchyProvider(resource: Uri, position: Position) {
+    let textModel = this.modelService.getModelReference(URI.parse(resource.toString()))?.instance.getMonacoModel();
+    let textModelReference: IDisposable | undefined;
+    if (!textModel) {
+      const result = await this.modelService.createModelReference(URI.parse(resource.toString()));
+      textModel = result.instance.getMonacoModel();
+      textModelReference = result;
+    }
+
+    try {
+      const model = await TypeHierarchyModel.create(textModel, position, CancellationToken.None);
+      if (!model) {
+        return [];
+      }
+
+      this.models.set(model.id, model);
+      this.models.forEach((value, key, map) => {
+        if (map.size > 10) {
+          value.dispose();
+          this.models.delete(key);
+        }
+      });
+
+      return [model.root];
+    } finally {
+      if (isFunction(textModel?.dispose)) {
+        textModel.dispose();
+      }
+      textModelReference?.dispose();
+    }
+  }
+}

--- a/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
@@ -133,4 +133,24 @@ export class TypeHierarchyService implements ITypeHierarchyService {
       textModelReference?.dispose();
     }
   }
+
+  async provideSupertypes(item: TypeHierarchyItem) {
+    // find model
+    const model = this.models.get(item._sessionId);
+    if (!model) {
+      return undefined;
+    }
+
+    return model.provideSupertypes(item, CancellationToken.None);
+  }
+
+  async provideSubtypes(item: TypeHierarchyItem) {
+    // find model
+    const model = this.models.get(item._sessionId);
+    if (!model) {
+      return undefined;
+    }
+
+    return model.provideSubtypes(item, CancellationToken.None);
+  }
 }

--- a/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
@@ -127,9 +127,6 @@ export class TypeHierarchyService implements ITypeHierarchyService {
 
       return [model.root];
     } finally {
-      if (isFunction(textModel?.dispose)) {
-        textModel.dispose();
-      }
       textModelReference?.dispose();
     }
   }

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -27,6 +27,7 @@ import {
   LanguageSelector,
 } from '@opensumi/ide-editor/lib/browser';
 import { ICallHierarchyService } from '@opensumi/ide-monaco/lib/browser/contrib/callHierarchy';
+import { ITypeHierarchyService } from '@opensumi/ide-monaco/lib/browser/contrib/typeHierarchy';
 import type { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import * as modes from '@opensumi/monaco-editor-core/esm/vs/editor/common/modes';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
@@ -56,7 +57,9 @@ import {
   SerializedLanguageConfiguration,
   WorkspaceSymbolProvider,
   ICallHierarchyItemDto,
+  ITypeHierarchyItemDto,
   CallHierarchyItem,
+  TypeHierarchyItem,
   IWorkspaceEditDto,
   ResourceTextEditDto,
   ResourceFileEditDto,
@@ -89,6 +92,9 @@ export class MainThreadLanguages implements IMainThreadLanguages {
 
   @Autowired(ICallHierarchyService)
   protected readonly callHierarchyService: ICallHierarchyService;
+
+  @Autowired(ITypeHierarchyService)
+  protected readonly typeHierarchyService: ITypeHierarchyService;
 
   @Autowired(IEvaluatableExpressionService)
   protected readonly evaluatableExpressionService: IEvaluatableExpressionService;
@@ -1343,6 +1349,61 @@ export class MainThreadLanguages implements IMainThreadLanguages {
       },
     };
   }
+
+  // --- type hierarchy
+  $registerTypeHierarchyProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    const languageSelector = fromLanguageSelector(selector);
+    const provider = this.createTypeHierarchyProvider(handle, languageSelector);
+
+    this.typeHierarchyService.registerTypeHierarchyProvider(selector, provider);
+  }
+
+  private createTypeHierarchyProvider(handle: number, selector: LanguageSelector | undefined) {
+    return {
+      prepareTypeHierarchy: async (document, position, token) => {
+        const items = await this.proxy.$prepareTypeHierarchy(handle, document.uri, position, token);
+        if (!items) {
+          return undefined;
+        }
+        return {
+          dispose: () => {
+            for (const item of items) {
+              this.proxy.$releaseTypeHierarchy(handle, item._sessionId);
+            }
+          },
+          roots: items.map(this.reviveTypeHierarchyItemDto),
+        };
+      },
+
+      provideSupertypes: async (item, token) => {
+        const supertypes = await this.proxy.$provideTypeHierarchySupertypes(
+          handle,
+          item._sessionId,
+          item._itemId,
+          token,
+        );
+        if (!supertypes) {
+          return supertypes;
+        }
+        return supertypes.map(this.reviveTypeHierarchyItemDto);
+      },
+      provideSubtypes: async (item, token) => {
+        const subtypes = await this.proxy.$provideTypeHierarchySubtypes(handle, item._sessionId, item._itemId, token);
+        if (!subtypes) {
+          return subtypes;
+        }
+        return subtypes.map(this.reviveTypeHierarchyItemDto);
+      },
+    };
+  }
+
+  private reviveTypeHierarchyItemDto(data: ITypeHierarchyItemDto | undefined): TypeHierarchyItem {
+    if (data) {
+      data.uri = URI.revive(data.uri);
+    }
+    return data as TypeHierarchyItem;
+  }
+
   // #region Semantic Tokens
   $registerDocumentSemanticTokensProvider(
     handle: number,

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1298,6 +1298,47 @@ export namespace CallHierarchyItem {
   }
 }
 
+export namespace TypeHierarchyItem {
+
+	export function to(item: model.ITypeHierarchyItemDto): types.TypeHierarchyItem {
+		const result = new types.TypeHierarchyItem(
+			SymbolKind.to(item.kind),
+			item.name,
+			item.detail || '',
+			URI.revive(item.uri),
+			Range.to(item.range),
+			Range.to(item.selectionRange)
+		);
+
+		result._sessionId = item._sessionId;
+		result._itemId = item._itemId;
+
+		return result;
+	}
+
+	export function from(item: vscode.TypeHierarchyItem, sessionId?: string, itemId?: string): model.ITypeHierarchyItemDto {
+
+		sessionId = sessionId ?? (item as types.TypeHierarchyItem)._sessionId;
+		itemId = itemId ?? (item as types.TypeHierarchyItem)._itemId;
+
+		if (sessionId === undefined || itemId === undefined) {
+			throw new Error('invalid item');
+		}
+
+		return {
+			_sessionId: sessionId,
+			_itemId: itemId,
+			kind: SymbolKind.from(item.kind),
+			name: item.name,
+			detail: item.detail ?? '',
+			uri: item.uri,
+			range: Range.from(item.range),
+			selectionRange: Range.from(item.selectionRange),
+			tags: item.tags?.map(SymbolTag.from),
+		};
+	}
+}
+
 export namespace CallHierarchyIncomingCall {
   export function to(item: model.IIncomingCallDto): types.CallHierarchyIncomingCall {
     return new types.CallHierarchyIncomingCall(

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -2687,6 +2687,29 @@ export class CallHierarchyOutgoingCall {
   }
 }
 
+@es5ClassCompat
+export class TypeHierarchyItem {
+  _sessionId?: string;
+  _itemId?: string;
+
+  kind: SymbolKind;
+  tags?: SymbolTag[];
+  name: string;
+  detail?: string;
+  uri: Uri;
+  range: Range;
+  selectionRange: Range;
+
+  constructor(kind: SymbolKind, name: string, detail: string, uri: Uri, range: Range, selectionRange: Range) {
+    this.kind = kind;
+    this.name = name;
+    this.detail = detail;
+    this.uri = uri;
+    this.range = range;
+    this.selectionRange = selectionRange;
+  }
+}
+
 export enum ViewColumn {
   Active = -1,
   Beside = -2,

--- a/packages/extension/src/common/vscode/languages.ts
+++ b/packages/extension/src/common/vscode/languages.ts
@@ -11,6 +11,7 @@ import {
   DocumentRangeFormattingEditProvider,
   DocumentFormattingEditProvider,
   CallHierarchyProvider,
+  TypeHierarchyProvider,
   InlayHintsProvider,
 } from 'vscode';
 import { SymbolInformation } from 'vscode-languageserver-types';
@@ -56,6 +57,7 @@ import {
   ISerializedSignatureHelpProviderMetadata,
   SelectionRange,
   ICallHierarchyItemDto,
+  ITypeHierarchyItemDto,
   IOutgoingCallDto,
   IIncomingCallDto,
   CodeLens,
@@ -140,6 +142,7 @@ export interface IMainThreadLanguages {
   $registerSelectionRangeProvider(handle: number, selector: SerializedDocumentFilter[]): void;
   $registerDeclarationProvider(handle: number, selector: SerializedDocumentFilter[]): void;
   $registerCallHierarchyProvider(handle: number, selector: SerializedDocumentFilter[]): void;
+  $registerTypeHierarchyProvider(handle: number, selector: SerializedDocumentFilter[]): void;
   $registerDocumentSemanticTokensProvider(
     handle: number,
     selector: SerializedDocumentFilter[],
@@ -402,6 +405,30 @@ export interface IExtHostLanguages {
     itemId: string,
     token: CancellationToken,
   ): Promise<IOutgoingCallDto[] | undefined>;
+  registerTypeHierarchyProvider(
+    extension: IExtensionDescription,
+    selector: DocumentSelector,
+    provider: TypeHierarchyProvider,
+  ): Disposable;
+  $prepareTypeHierarchy(
+    handle: number,
+    resource: UriComponents,
+    position: Position,
+    token: CancellationToken,
+  ): Promise<ICallHierarchyItemDto[] | undefined>;
+  $provideTypeHierarchySupertypes(
+    handle: number,
+    sessionId: string,
+    itemId: string,
+    token: CancellationToken,
+  ): Promise<ITypeHierarchyItemDto[] | undefined>;
+  $provideTypeHierarchySubtypes(
+    handle: number,
+    sessionId: string,
+    itemId: string,
+    token: CancellationToken,
+  ): Promise<ITypeHierarchyItemDto[] | undefined>;
+  $releaseTypeHierarchy(handle: number, sessionId: string): void;
   $provideDocumentSemanticTokens(
     handle: number,
     resource: UriComponents,

--- a/packages/extension/src/common/vscode/languages.ts
+++ b/packages/extension/src/common/vscode/languages.ts
@@ -405,11 +405,7 @@ export interface IExtHostLanguages {
     itemId: string,
     token: CancellationToken,
   ): Promise<IOutgoingCallDto[] | undefined>;
-  registerTypeHierarchyProvider(
-    extension: IExtensionDescription,
-    selector: DocumentSelector,
-    provider: TypeHierarchyProvider,
-  ): Disposable;
+  registerTypeHierarchyProvider(selector: DocumentSelector, provider: TypeHierarchyProvider): Disposable;
   $prepareTypeHierarchy(
     handle: number,
     resource: UriComponents,

--- a/packages/extension/src/common/vscode/model.api.ts
+++ b/packages/extension/src/common/vscode/model.api.ts
@@ -14,6 +14,8 @@ import {
 import { ISingleEditOperation } from '@opensumi/ide-editor';
 // eslint-disable-next-line import/no-restricted-paths
 import type { CallHierarchyItem } from '@opensumi/ide-monaco/lib/browser/contrib/callHierarchy';
+// eslint-disable-next-line import/no-restricted-paths
+import type { TypeHierarchyItem } from '@opensumi/ide-monaco/lib/browser/contrib/typeHierarchy';
 import type { CompletionItemLabel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/modes';
 import { LanguageFeatureRegistry } from '@opensumi/monaco-editor-core/esm/vs/editor/common/modes/languageFeatureRegistry';
 import type { languages, editor } from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
@@ -21,7 +23,7 @@ import type { languages, editor } from '@opensumi/monaco-editor-core/esm/vs/edit
 // 内置的api类型声明
 
 import { IndentAction, SymbolKind } from './ext-types';
-export { IMarkdownString, SymbolTag, CallHierarchyItem };
+export { IMarkdownString, SymbolTag, CallHierarchyItem, TypeHierarchyItem };
 
 export interface IRawColorInfo {
   color: [number, number, number, number];
@@ -685,6 +687,8 @@ export enum CompletionItemTag {
 export type Dto<T> = T extends { toJSON(): infer U } ? U : T extends object ? { [k in keyof T]: Dto<T[k]> } : T;
 
 export type ICallHierarchyItemDto = Dto<CallHierarchyItem>;
+
+export type ITypeHierarchyItemDto = Dto<TypeHierarchyItem>;
 
 export interface IIncomingCallDto {
   from: ICallHierarchyItemDto;

--- a/packages/extension/src/hosted/api/vscode/ext.host.api.command.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.command.ts
@@ -13,7 +13,6 @@ import * as typeConverters from '../../../common/vscode/converter';
 import * as types from '../../../common/vscode/ext-types';
 import * as modes from '../../../common/vscode/model.api';
 
-
 import { CommandsConverter } from './ext.host.command';
 
 type IPosition = modes.Position;
@@ -63,6 +62,13 @@ export class ApiCommandArgument<V, O = V> {
     'A call hierarchy item',
     (v) => v instanceof types.CallHierarchyItem,
     typeConverters.CallHierarchyItem.to,
+  );
+
+  static readonly TypeHierarchyItem = new ApiCommandArgument(
+    'item',
+    'A type hierarchy item',
+    (v) => v instanceof types.TypeHierarchyItem,
+    typeConverters.TypeHierarchyItem.to,
   );
 
   constructor(
@@ -356,6 +362,41 @@ export const newCommands: ApiCommand[] = [
       (v) => v.map(typeConverters.CallHierarchyOutgoingCall.to),
     ),
   ),
+
+  // --- type hierarchy
+  new ApiCommand(
+    'vscode.prepareTypeHierarchy',
+    '_executePrepareTypeHierarchy',
+    'Prepare type hierarchy at a position inside a document',
+    [ApiCommandArgument.Uri, ApiCommandArgument.Position],
+    new ApiCommandResult<modes.ITypeHierarchyItemDto[], types.TypeHierarchyItem[]>(
+      'A TypeHierarchyItem or undefined',
+      (v) => v.map(typeConverters.TypeHierarchyItem.to),
+    ),
+  ),
+
+  new ApiCommand(
+    'vscode.provideSupertypes',
+    '_executeProvideSupertypes',
+    'Compute supertypes for an item',
+    [ApiCommandArgument.TypeHierarchyItem],
+    new ApiCommandResult<modes.ITypeHierarchyItemDto[], types.TypeHierarchyItem[]>(
+      'A TypeHierarchyItem or undefined',
+      (v) => v.map(typeConverters.TypeHierarchyItem.to),
+    ),
+  ),
+
+  new ApiCommand(
+    'vscode.provideSubtypes',
+    '_executeProvideSubtypes',
+    'Compute subtypes for an item',
+    [ApiCommandArgument.TypeHierarchyItem],
+    new ApiCommandResult<modes.ITypeHierarchyItemDto[], types.TypeHierarchyItem[]>(
+      'A TypeHierarchyItem or undefined',
+      (v) => v.map(typeConverters.TypeHierarchyItem.to),
+    ),
+  ),
+
   // --- rename
   new ApiCommand(
     'vscode.executeDocumentRenameProvider',

--- a/packages/extension/src/hosted/api/vscode/ext.host.language.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.language.ts
@@ -273,7 +273,7 @@ export function createLanguagesApiFactory(
       return extHostLanguages.registerCallHierarchyProvider(selector, provider);
     },
     registerTypeHierarchyProvider(selector: DocumentSelector, provider: TypeHierarchyProvider): Disposable {
-      return extHostLanguages.registerTypeHierarchyProvider(extension, selector, provider);
+      return extHostLanguages.registerTypeHierarchyProvider(selector, provider);
     },
     registerDocumentSemanticTokensProvider(
       selector: DocumentSelector,
@@ -1074,11 +1074,7 @@ export class ExtHostLanguages implements IExtHostLanguages {
     this.withAdapter(handle, CallHierarchyAdapter, (adapter) => Promise.resolve(adapter.releaseSession(sessionId)));
   }
 
-  registerTypeHierarchyProvider(
-    extension: IExtensionDescription,
-    selector: DocumentSelector,
-    provider: TypeHierarchyProvider,
-  ): Disposable {
+  registerTypeHierarchyProvider(selector: DocumentSelector, provider: TypeHierarchyProvider): Disposable {
     const callId = this.addNewAdapter(new TypeHierarchyAdapter(this.documents, provider));
     this.proxy.$registerTypeHierarchyProvider(callId, this.transformDocumentSelector(selector));
     return this.createDisposable(callId);

--- a/packages/extension/src/hosted/api/vscode/language/type-hierarchy.ts
+++ b/packages/extension/src/hosted/api/vscode/language/type-hierarchy.ts
@@ -1,0 +1,95 @@
+import type vscode from 'vscode';
+
+import { Uri, CancellationToken } from '@opensumi/ide-core-common';
+import { IdGenerator } from '@opensumi/ide-core-common/lib/id-generator';
+
+import { ExtensionDocumentDataManager } from '../../../../common/vscode';
+import * as Converter from '../../../../common/vscode/converter';
+import { Position, ITypeHierarchyItemDto } from '../../../../common/vscode/model.api';
+
+export class TypeHierarchyAdapter {
+  private readonly _idPool = new IdGenerator('');
+  private readonly _cache = new Map<string, Map<string, vscode.TypeHierarchyItem>>();
+
+  constructor(
+    private readonly _documents: ExtensionDocumentDataManager,
+    private readonly _provider: vscode.TypeHierarchyProvider,
+  ) {}
+
+  async prepareSession(
+    uri: Uri,
+    position: Position,
+    token: CancellationToken,
+  ): Promise<ITypeHierarchyItemDto[] | undefined> {
+    const documentData = this._documents.getDocumentData(uri);
+
+    if (!documentData) {
+      return Promise.reject(new Error(`There is no document for ${uri}`));
+    }
+
+    const doc = documentData.document;
+    const pos = Converter.Position.to(position);
+
+    const items = await this._provider.prepareTypeHierarchy(doc, pos, token);
+    if (!items) {
+      return undefined;
+    }
+
+    const sessionId = this._idPool.nextId();
+    this._cache.set(sessionId, new Map());
+
+    if (Array.isArray(items)) {
+      return items.map((item) => this._cacheAndConvertItem(sessionId, item));
+    } else {
+      return [this._cacheAndConvertItem(sessionId, items)];
+    }
+  }
+
+  async provideSupertypes(
+    sessionId: string,
+    itemId: string,
+    token: CancellationToken,
+  ): Promise<ITypeHierarchyItemDto[] | undefined> {
+    const item = this._itemFromCache(sessionId, itemId);
+    if (!item) {
+      throw new Error('missing type hierarchy item');
+    }
+    const supertypes = await this._provider.provideTypeHierarchySupertypes(item, token);
+    if (!supertypes) {
+      return undefined;
+    }
+    return supertypes.map((supertype) => this._cacheAndConvertItem(sessionId, supertype));
+  }
+
+  async provideSubtypes(
+    sessionId: string,
+    itemId: string,
+    token: CancellationToken,
+  ): Promise<ITypeHierarchyItemDto[] | undefined> {
+    const item = this._itemFromCache(sessionId, itemId);
+    if (!item) {
+      throw new Error('missing type hierarchy item');
+    }
+    const subtypes = await this._provider.provideTypeHierarchySubtypes(item, token);
+    if (!subtypes) {
+      return undefined;
+    }
+    return subtypes.map((subtype) => this._cacheAndConvertItem(sessionId, subtype));
+  }
+
+  releaseSession(sessionId: string): void {
+    this._cache.delete(sessionId);
+  }
+
+  private _cacheAndConvertItem(sessionId: string, item: vscode.TypeHierarchyItem): ITypeHierarchyItemDto {
+    const map = this._cache.get(sessionId)!;
+    const dto = Converter.TypeHierarchyItem.from(item, sessionId, map.size.toString(36));
+    map.set(dto._itemId, item);
+    return dto;
+  }
+
+  private _itemFromCache(sessionId: string, itemId: string): vscode.TypeHierarchyItem | undefined {
+    const map = this._cache.get(sessionId);
+    return map?.get(itemId);
+  }
+}

--- a/packages/monaco/src/browser/contrib/index.ts
+++ b/packages/monaco/src/browser/contrib/index.ts
@@ -1,1 +1,2 @@
 export * from './callHierarchy';
+export * from './typeHierarchy';

--- a/packages/monaco/src/browser/contrib/typeHierarchy.ts
+++ b/packages/monaco/src/browser/contrib/typeHierarchy.ts
@@ -1,0 +1,51 @@
+import type { Uri as URI, IRange, SymbolTag, IPosition, CancellationToken } from '@opensumi/ide-core-common';
+import type { Position } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/position';
+import type { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
+import type { ProviderResult, SymbolKind } from '@opensumi/monaco-editor-core/esm/vs/editor/common/modes';
+import { LanguageFeatureRegistry } from '@opensumi/monaco-editor-core/esm/vs/editor/common/modes/languageFeatureRegistry';
+
+export const enum TypeHierarchyDirection {
+  Subtypes = 'subtypes',
+  Supertypes = 'supertypes',
+}
+
+export interface TypeHierarchyItem {
+  _sessionId: string;
+  _itemId: string;
+  kind: SymbolKind;
+  name: string;
+  detail?: string;
+  uri: URI;
+  range: IRange;
+  selectionRange: IRange;
+  tags?: SymbolTag[];
+}
+
+export interface TypeHierarchySession {
+  roots: TypeHierarchyItem[];
+  dispose(): void;
+}
+
+export interface TypeHierarchyProvider {
+  prepareTypeHierarchy(
+    document: ITextModel,
+    position: IPosition,
+    token: CancellationToken,
+  ): ProviderResult<TypeHierarchySession>;
+  provideSupertypes(item: TypeHierarchyItem, token: CancellationToken): ProviderResult<TypeHierarchyItem[]>;
+  provideSubtypes(item: TypeHierarchyItem, token: CancellationToken): ProviderResult<TypeHierarchyItem[]>;
+}
+
+export interface ITypeHierarchyService {
+  registerTypeHierarchyProvider: (selector: any, provider: TypeHierarchyProvider) => void;
+
+  prepareTypeHierarchyProvider: (resource: URI, position: Position) => Promise<TypeHierarchyItem[]>;
+
+  provideSupertypes: (item: TypeHierarchyItem) => Promise<TypeHierarchyItem[]>;
+
+  provideSubtypes: (item: TypeHierarchyItem) => Promise<TypeHierarchyItem[]>;
+}
+
+export const ITypeHierarchyService = Symbol('ICallHierarchyService');
+
+export const TypeHierarchyProviderRegistry = new LanguageFeatureRegistry<TypeHierarchyProvider>();

--- a/packages/monaco/src/browser/contrib/typeHierarchy.ts
+++ b/packages/monaco/src/browser/contrib/typeHierarchy.ts
@@ -41,11 +41,11 @@ export interface ITypeHierarchyService {
 
   prepareTypeHierarchyProvider: (resource: URI, position: Position) => Promise<TypeHierarchyItem[]>;
 
-  provideSupertypes: (item: TypeHierarchyItem) => Promise<TypeHierarchyItem[]>;
+  provideSupertypes: (item: TypeHierarchyItem) => ProviderResult<TypeHierarchyItem[]>;
 
-  provideSubtypes: (item: TypeHierarchyItem) => Promise<TypeHierarchyItem[]>;
+  provideSubtypes: (item: TypeHierarchyItem) => ProviderResult<TypeHierarchyItem[]>;
 }
 
-export const ITypeHierarchyService = Symbol('ICallHierarchyService');
+export const ITypeHierarchyService = Symbol('ITypeHierarchyService');
 
 export const TypeHierarchyProviderRegistry = new LanguageFeatureRegistry<TypeHierarchyProvider>();

--- a/packages/types/vscode/typings/vscode.language.d.ts
+++ b/packages/types/vscode/typings/vscode.language.d.ts
@@ -262,6 +262,15 @@ declare module 'vscode' {
     export function registerCallHierarchyProvider(selector: DocumentSelector, provider: CallHierarchyProvider): Disposable;
 
     /**
+		 * Register a type hierarchy provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A type hierarchy provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerTypeHierarchyProvider(selector: DocumentSelector, provider: TypeHierarchyProvider): Disposable;
+
+    /**
      * Register a linked editing range provider.
      *
      * Multiple providers can be registered for a language. In that case providers are sorted
@@ -2625,4 +2634,103 @@ declare module 'vscode' {
      */
     provideCallHierarchyOutgoingCalls(item: CallHierarchyItem, token: CancellationToken): ProviderResult<CallHierarchyOutgoingCall[]>;
   }
+
+  /**
+	 * Represents an item of a type hierarchy, like a class or an interface.
+	 */
+	export class TypeHierarchyItem {
+		/**
+		 * The name of this item.
+		 */
+		name: string;
+
+		/**
+		 * The kind of this item.
+		 */
+		kind: SymbolKind;
+
+		/**
+		 * Tags for this item.
+		 */
+		tags?: ReadonlyArray<SymbolTag>;
+
+		/**
+		 * More detail for this item, e.g. the signature of a function.
+		 */
+		detail?: string;
+
+		/**
+		 * The resource identifier of this item.
+		 */
+		uri: Uri;
+
+		/**
+		 * The range enclosing this symbol not including leading/trailing whitespace
+		 * but everything else, e.g. comments and code.
+		 */
+		range: Range;
+
+		/**
+		 * The range that should be selected and revealed when this symbol is being
+		 * picked, e.g. the name of a class. Must be contained by the {@link TypeHierarchyItem.range range}-property.
+		 */
+		selectionRange: Range;
+
+		/**
+		 * Creates a new type hierarchy item.
+		 *
+		 * @param kind The kind of the item.
+		 * @param name The name of the item.
+		 * @param detail The details of the item.
+		 * @param uri The Uri of the item.
+		 * @param range The whole range of the item.
+		 * @param selectionRange The selection range of the item.
+		 */
+		constructor(kind: SymbolKind, name: string, detail: string, uri: Uri, range: Range, selectionRange: Range);
+	}
+
+
+	/**
+	 * The type hierarchy provider interface describes the contract between extensions
+	 * and the type hierarchy feature.
+	 */
+	export interface TypeHierarchyProvider {
+
+		/**
+		 * Bootstraps type hierarchy by returning the item that is denoted by the given document
+		 * and position. This item will be used as entry into the type graph. Providers should
+		 * return `undefined` or `null` when there is no item at the given location.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @returns One or multiple type hierarchy items or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined`, `null`, or an empty array.
+		 */
+		prepareTypeHierarchy(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<TypeHierarchyItem | TypeHierarchyItem[]>;
+
+		/**
+		 * Provide all supertypes for an item, e.g all types from which a type is derived/inherited. In graph terms this describes directed
+		 * and annotated edges inside the type graph, e.g the given item is the starting node and the result is the nodes
+		 * that can be reached.
+		 *
+		 * @param item The hierarchy item for which super types should be computed.
+		 * @param token A cancellation token.
+		 * @returns A set of direct supertypes or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideTypeHierarchySupertypes(item: TypeHierarchyItem, token: CancellationToken): ProviderResult<TypeHierarchyItem[]>;
+
+		/**
+		 * Provide all subtypes for an item, e.g all types which are derived/inherited from the given item. In
+		 * graph terms this describes directed and annotated edges inside the type graph, e.g the given item is the starting
+		 * node and the result is the nodes that can be reached.
+		 *
+		 * @param item The hierarchy item for which subtypes should be computed.
+		 * @param token A cancellation token.
+		 * @returns A set of direct subtypes or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideTypeHierarchySubtypes(item: TypeHierarchyItem, token: CancellationToken): ProviderResult<TypeHierarchyItem[]>;
+	}
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
support vscode 1.63.2 type hierarchy api

### Test

#### 1:
sample: https://github.com/Eskibear/type-hierarchy-sample/blob/main/src/extension.ts

![image](https://user-images.githubusercontent.com/12130901/165011546-be786288-225a-4fe0-bc75-595f13865f41.png)

#### 2:
sample: ESLint extension (version 2.2.2)

![image](https://user-images.githubusercontent.com/12130901/165058956-eddcbc0e-0f2f-4d61-a53f-45701214a1d6.png)


### Changelog
* support vscode 1.63.2 type hierarchy api