### PR TITLE
fix: the quick-open title button theme

### DIFF
--- a/packages/quick-open/src/browser/quick-title-bar.ts
+++ b/packages/quick-open/src/browser/quick-title-bar.ts
@@ -96,7 +96,7 @@ export class QuickTitleBar {
     }
 
     if (iconPath.dark || iconPath.light) {
-      return this.themeService.currentThemeId === 'ide-dark'
+      return this.themeService.getCurrentThemeSync().type === 'dark'
         ? new URI(iconPath.dark.toString())
         : new URI(iconPath.light.toString());
     }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
Before:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/2226423/163305433-31f64cbc-1036-45c1-b666-db02c916ad9e.png">

After:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/2226423/163304743-17cad105-9d77-40e9-a46c-a1f36532941f.png">


### Changelog
fix the quick-open title button theme