### PR TITLE
feat: support quick-open buttons and keepScrollPosition plugin api

### DIFF
--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -2,7 +2,7 @@ import { observable } from 'mobx';
 import React from 'react';
 
 import { VALIDATE_TYPE } from '@opensumi/ide-components';
-import { URI, MaybePromise, IDisposable, Event } from '@opensumi/ide-core-common';
+import { URI, Uri, MaybePromise, IDisposable, Event } from '@opensumi/ide-core-common';
 
 import { Keybinding } from '../keybinding';
 
@@ -43,6 +43,21 @@ export interface QuickTitleButton {
   tooltip?: string;
   // undefined 在 QuickTitleBar 中视为为右侧
   side?: QuickTitleButtonSide;
+}
+
+/**
+ * Button for an action in a {@link QuickPick} or {@link InputBox}.
+ */
+export interface QuickInputButton {
+  /**
+   * Icon for the button.
+   */
+  readonly iconPath: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+
+  /**
+   * An optional tooltip.
+   */
+  readonly tooltip?: string | undefined;
 }
 
 /**
@@ -111,7 +126,10 @@ export interface QuickOpenItemOptions {
    * @returns 执行后是否要隐藏面板, mode 为 PREVIEW 时不判断该值
    */
   run?(mode: Mode): boolean;
+
   value?: any;
+
+  buttons?: QuickTitleButton[];
 }
 
 export class QuickOpenItem {
@@ -183,6 +201,9 @@ export class QuickOpenItem {
   }
   getValue(): any {
     return this.options.value;
+  }
+  getButtons(): QuickTitleButton[] {
+    return this.options.buttons || [];
   }
 }
 
@@ -345,6 +366,7 @@ export interface QuickPickItem<T> {
   description?: string;
   detail?: string;
   iconClass?: string;
+  buttons?: QuickInputButton[];
 }
 
 export interface QuickPickOptions extends QuickOpenOptions {

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -341,6 +341,11 @@ export namespace QuickOpenOptions {
      * 结果为空显示的 item，应该用此方法实现空占位，不用 accept，accept 结果可能会被 fuzzy 处理导致高亮
      */
     getPlaceholderItem?: (lookFor: string, originLookFor: string) => QuickOpenItem;
+
+    /**
+     * 内容更新后保持滚动区域不变
+     */
+    keepScrollPosition?: boolean;
   }
   export const defaultOptions: Resolved = Object.freeze({
     enabled: true,
@@ -426,6 +431,11 @@ export interface QuickPickOptions extends QuickOpenOptions {
    * The prefill value.
    */
   value?: string;
+
+  /*
+   * An optional flag to maintain the scroll position of the quick pick when the quick pick items are updated. Defaults to false.
+   */
+  keepScrollPosition?: boolean;
 }
 
 export const QuickPickService = Symbol('QuickPickService');

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -38,7 +38,7 @@ export { Mode as QuickOpenMode };
 
 export interface QuickTitleButton {
   iconPath: URI | { light: string | URI; dark: string | URI } | ThemeIcon;
-  icon: string; // a background image coming from a url
+  icon?: string; // a background image coming from a url
   iconClass?: string; // a class such as one coming from font awesome
   tooltip?: string;
   // undefined 在 QuickTitleBar 中视为为右侧
@@ -52,12 +52,29 @@ export interface QuickInputButton {
   /**
    * Icon for the button.
    */
-  readonly iconPath: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+  readonly iconPath: URI | { light: URI; dark: URI } | ThemeIcon;
 
   /**
    * An optional tooltip.
    */
   readonly tooltip?: string | undefined;
+
+  /**
+   * a class such as one coming from font awesome
+   */
+  readonly iconClass?: string;
+
+  /**
+   * An optional id for the button.
+   */
+  handle?: number;
+}
+
+export interface IQuickPickItemButtonEvent {
+  button: QuickInputButton;
+  item: {
+    handle: number;
+  };
 }
 
 /**
@@ -129,7 +146,7 @@ export interface QuickOpenItemOptions {
 
   value?: any;
 
-  buttons?: QuickTitleButton[];
+  buttons?: QuickInputButton[];
 }
 
 export class QuickOpenItem {
@@ -202,7 +219,7 @@ export class QuickOpenItem {
   getValue(): any {
     return this.options.value;
   }
-  getButtons(): QuickTitleButton[] {
+  getButtons(): QuickInputButton[] {
     return this.options.buttons || [];
   }
 }

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.quickopen.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.quickopen.test.ts
@@ -2,6 +2,8 @@ import { RPCProtocol } from '@opensumi/ide-connection';
 import { Emitter, Disposable } from '@opensumi/ide-core-common';
 import { QuickPickService } from '@opensumi/ide-quick-open';
 import { QuickTitleBar } from '@opensumi/ide-quick-open/lib/browser/quick-title-bar';
+import { IconService } from '@opensumi/ide-theme/lib/browser/icon.service';
+import { IIconService, IThemeService } from '@opensumi/ide-theme/lib/common/theme.service';
 
 import { createBrowserInjector } from '../../../../../../tools/dev-tool/src/injector-helper';
 import { mockService } from '../../../../../../tools/dev-tool/src/mock-injector';
@@ -36,6 +38,16 @@ describe(__filename, () => {
         // 默认返回第一个
         show: (_, options) => (options.canPickMany ? [0] : 0),
       }),
+    },
+    {
+      token: IThemeService,
+      useValue: {
+        applyTheme: () => {},
+      },
+    },
+    {
+      token: IIconService,
+      useClass: IconService,
     },
     {
       token: QuickTitleBar,

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.quickopen.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.quickopen.test.ts
@@ -1,7 +1,9 @@
 import { RPCProtocol } from '@opensumi/ide-connection';
 import { Emitter, Disposable } from '@opensumi/ide-core-common';
-import { QuickPickService } from '@opensumi/ide-quick-open';
+import { IQuickInputService, QuickOpenService, QuickPickService } from '@opensumi/ide-quick-open';
+import { QuickInputService } from '@opensumi/ide-quick-open/lib/browser/quick-input-service';
 import { QuickTitleBar } from '@opensumi/ide-quick-open/lib/browser/quick-title-bar';
+import { MockQuickOpenService } from '@opensumi/ide-quick-open/lib/common/mocks/quick-open.service';
 import { IconService } from '@opensumi/ide-theme/lib/browser/icon.service';
 import { IIconService, IThemeService } from '@opensumi/ide-theme/lib/common/theme.service';
 
@@ -50,6 +52,16 @@ describe(__filename, () => {
       useClass: IconService,
     },
     {
+      token: IQuickInputService,
+      useClass: QuickInputService,
+    },
+    {
+      token: QuickOpenService,
+      useValue: {
+        open: () => Promise.resolve(),
+      },
+    },
+    {
       token: QuickTitleBar,
       useValue: mockService({
         onDidTriggerButton: () => Disposable.NULL,
@@ -79,5 +91,26 @@ describe(__filename, () => {
       canPickMany: true,
     });
     expect(item).toStrictEqual(['a']);
+  });
+
+  it('trigger quick open item button', async () => {
+    extHost.$onDidTriggerItemButton(0, 0);
+  });
+
+  it('invoke show input box', async () => {
+    extHost.showInputBox({
+      title: 'test input box',
+      value: '0',
+    });
+  });
+
+  it('set input box items', async () => {
+    const quickPick = extHost.createQuickPick();
+    quickPick.items = [
+      {
+        label: 'test button',
+      },
+    ];
+    expect(quickPick.items.length).toBe(1);
   });
 });

--- a/packages/extension/src/browser/vscode/api/main.thread.quickopen.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.quickopen.ts
@@ -3,6 +3,7 @@ import { IRPCProtocol } from '@opensumi/ide-connection';
 import { Disposable } from '@opensumi/ide-core-browser';
 import { IQuickInputService } from '@opensumi/ide-core-browser/lib/quick-open';
 import { QuickPickService, QuickPickItem, QuickPickOptions, QuickInputOptions } from '@opensumi/ide-quick-open';
+import { QuickOpenItemService } from '@opensumi/ide-quick-open/lib/browser/quick-open-item.service';
 import { QuickTitleBar } from '@opensumi/ide-quick-open/lib/browser/quick-title-bar';
 import { InputBoxImpl } from '@opensumi/ide-quick-open/lib/browser/quickInput.inputBox';
 
@@ -21,6 +22,9 @@ export class MainThreadQuickOpen extends Disposable implements IMainThreadQuickO
   @Autowired(QuickTitleBar)
   protected quickTitleBarService: QuickTitleBar;
 
+  @Autowired(QuickOpenItemService)
+  protected quickOpenItemService: QuickOpenItemService;
+
   @Autowired(INJECTOR_TOKEN)
   protected injector: Injector;
 
@@ -28,11 +32,16 @@ export class MainThreadQuickOpen extends Disposable implements IMainThreadQuickO
     super();
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostQuickOpen);
 
-    this.addDispose(
+    this.addDispose([
       this.quickTitleBarService.onDidTriggerButton((button) => {
         this.proxy.$onDidTriggerButton((button as unknown as { handler: number }).handler);
       }),
-    );
+      this.quickOpenItemService.onDidTriggerItemButton(({ item, button }) => {
+        if (button.handle !== undefined) {
+          this.proxy.$onDidTriggerItemButton(item.handle, button.handle);
+        }
+      }),
+    ]);
   }
 
   $showQuickPick(

--- a/packages/extension/src/common/vscode/window.ts
+++ b/packages/extension/src/common/vscode/window.ts
@@ -52,6 +52,7 @@ type VSCodeQuickPickItem = string | vscode.QuickPickItem;
 
 export interface IExtHostQuickOpen {
   $onDidTriggerButton(handler: number): void;
+  $onDidTriggerItemButton(itemHandler: number, buttonHandler: number): void;
   $onItemSelected(handler: number): void;
   showQuickPick(
     promiseOrItems: vscode.QuickPickItem[] | Promise<vscode.QuickPickItem[]>,

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -102,6 +102,7 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
         fuzzyMatchDescription: options.matchOnDescription,
         fuzzyMatchDetail: options.matchOnDetail,
         ignoreFocusOut: options.ignoreFocusOut,
+        keepScrollPosition: options.keepScrollPosition,
         title: (options as QuickPickOptions).title,
         buttons: (options as QuickPickOptions).buttons,
         step: (options as QuickPickOptions).step,
@@ -246,6 +247,7 @@ class ExtQuickPick<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
   ignoreFocusOut: boolean;
   matchOnDescription: boolean;
   matchOnDetail: boolean;
+  keepScrollPosition?: boolean | undefined;
   selectedItems: ReadonlyArray<T>;
   step: number | undefined;
   title: string | undefined;
@@ -409,6 +411,7 @@ class ExtQuickPick<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
           placeHolder: this.placeholder,
           ignoreFocusOut: this.ignoreFocusOut,
           _sessionId: this.quickPickIndex,
+          keepScrollPosition: this.keepScrollPosition,
         } as QuickPickOptions,
       )
       .then((item) => {

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -11,7 +11,13 @@ import {
   isUndefined,
   Disposable,
 } from '@opensumi/ide-core-common';
-import { QuickInputOptions, QuickPickItem, QuickPickOptions, QuickTitleButton } from '@opensumi/ide-quick-open';
+import {
+  QuickInputButton,
+  QuickInputOptions,
+  QuickPickItem,
+  QuickPickOptions,
+  QuickTitleButton,
+} from '@opensumi/ide-quick-open';
 
 import {
   MainThreadAPIIdentifier,
@@ -75,12 +81,12 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
           value: index,
         };
       } else {
-        const quickPickItem: any = {
+        const quickPickItem: QuickPickItem<number> = {
           label: item.label,
           description: item.description,
           detail: item.detail,
           value: index, // handle
-          buttons: item.buttons,
+          buttons: item.buttons as QuickInputButton[],
         };
 
         return quickPickItem;

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -75,11 +75,12 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
           value: index,
         };
       } else {
-        const quickPickItem: QuickPickItem<number> = {
+        const quickPickItem: any = {
           label: item.label,
           description: item.description,
           detail: item.detail,
           value: index, // handle
+          buttons: item.buttons,
         };
 
         return quickPickItem;
@@ -249,6 +250,7 @@ class ExtQuickPick<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
   private readonly _onDidChangeSelectionEmitter: Emitter<T[]>;
   private readonly _onDidChangeValueEmitter: Emitter<string>;
   private readonly _onDidTriggerButtonEmitter: Emitter<vscode.QuickInputButton>;
+  private readonly _onDidTriggerItemButtonEmitter: Emitter<vscode.QuickPickItemButtonEvent<T>>;
 
   private didShow = false;
 
@@ -268,6 +270,7 @@ class ExtQuickPick<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
     this.disposableCollection.push((this._onDidChangeSelectionEmitter = new Emitter()));
     this.disposableCollection.push((this._onDidChangeValueEmitter = new Emitter()));
     this.disposableCollection.push((this._onDidTriggerButtonEmitter = new Emitter()));
+    this.disposableCollection.push((this._onDidTriggerItemButtonEmitter = new Emitter()));
   }
 
   get items(): T[] {
@@ -323,6 +326,10 @@ class ExtQuickPick<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
 
   get onDidTriggerButton(): Event<vscode.QuickInputButton> {
     return this._onDidTriggerButtonEmitter.event;
+  }
+
+  get onDidTriggerItemButton(): Event<vscode.QuickPickItemButtonEvent<T>> {
+    return this._onDidTriggerItemButtonEmitter.event;
   }
 
   _fireDidChangeValue(value: string) {

--- a/packages/quick-open/__tests__/browser/quick-open.service.test.ts
+++ b/packages/quick-open/__tests__/browser/quick-open.service.test.ts
@@ -7,7 +7,8 @@ import { MonacoContextKeyService } from '@opensumi/ide-monaco/lib/browser/monaco
 import { QuickOpenItemService } from '@opensumi/ide-quick-open/lib/browser/quick-open-item.service';
 import { StaticResourceService } from '@opensumi/ide-static-resource/lib/browser';
 import { StaticResourceServiceImpl } from '@opensumi/ide-static-resource/lib/browser/static.service';
-import { IThemeService } from '@opensumi/ide-theme/lib/common';
+import { IconService } from '@opensumi/ide-theme/lib/browser/icon.service';
+import { IIconService, IThemeService } from '@opensumi/ide-theme/lib/common';
 
 import { QuickOpenModule } from '../../src/browser';
 import { IQuickOpenWidget } from '../../src/browser/quick-open.type';
@@ -44,6 +45,10 @@ describe(__filename, () => {
       {
         token: QuickOpenItemService,
         useClass: QuickOpenItemService,
+      },
+      {
+        token: IIconService,
+        useClass: IconService,
       },
       {
         token: IThemeService,

--- a/packages/quick-open/__tests__/browser/quick-open.service.test.ts
+++ b/packages/quick-open/__tests__/browser/quick-open.service.test.ts
@@ -373,4 +373,22 @@ describe(__filename, () => {
       expect($onClose).toBeCalledWith(true);
     });
   });
+
+  // 直接调用事件
+  describe('event', () => {
+    it('fire item button event', () => {
+      const quickOpenItemService = injector.get(QuickOpenItemService);
+      quickOpenItemService.onDidTriggerItemButton((event) => {
+        expect(event.item).toBe(0);
+        expect(event.button.tooltip).toBe('tooltip');
+      });
+      quickOpenItemService.fireDidTriggerItemButton(0, {
+        iconPath: {
+          dark: URI.file('resources/dark/add.svg'),
+          light: URI.file('resources/dark/add.svg'),
+        },
+        tooltip: 'tooltip',
+      });
+    });
+  });
 });

--- a/packages/quick-open/__tests__/browser/quick-open.service.test.ts
+++ b/packages/quick-open/__tests__/browser/quick-open.service.test.ts
@@ -1,9 +1,13 @@
 import { VALIDATE_TYPE } from '@opensumi/ide-components';
-import { HideReason, IContextKeyService } from '@opensumi/ide-core-browser';
+import { HideReason, IContextKeyService, URI } from '@opensumi/ide-core-browser';
 import { MockContextKeyService } from '@opensumi/ide-core-browser/__mocks__/context-key';
 import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { MockInjector, mockService } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { MonacoContextKeyService } from '@opensumi/ide-monaco/lib/browser/monaco.context-key.service';
+import { QuickOpenItemService } from '@opensumi/ide-quick-open/lib/browser/quick-open-item.service';
+import { StaticResourceService } from '@opensumi/ide-static-resource/lib/browser';
+import { StaticResourceServiceImpl } from '@opensumi/ide-static-resource/lib/browser/static.service';
+import { IThemeService } from '@opensumi/ide-theme/lib/common';
 
 import { QuickOpenModule } from '../../src/browser';
 import { IQuickOpenWidget } from '../../src/browser/quick-open.type';
@@ -36,6 +40,22 @@ describe(__filename, () => {
       {
         token: IContextKeyService,
         useClass: MockContextKeyService,
+      },
+      {
+        token: QuickOpenItemService,
+        useClass: QuickOpenItemService,
+      },
+      {
+        token: IThemeService,
+        useValue: {
+          getCurrentThemeSync: () => ({
+            type: 'dark',
+          }),
+        },
+      },
+      {
+        token: StaticResourceService,
+        useClass: StaticResourceServiceImpl,
       },
     );
     model = {
@@ -131,6 +151,19 @@ describe(__filename, () => {
     expect(widget.validateType).toBe(VALIDATE_TYPE.ERROR);
     quickOpenService.hideDecoration();
     expect(widget.validateType).toBeUndefined();
+  });
+
+  it('show quick-open item buttons', () => {
+    const quickOpenItemService = injector.get(QuickOpenItemService);
+    quickOpenItemService.getButtons([
+      {
+        iconPath: {
+          dark: URI.file('resources/dark/add.svg'),
+          light: URI.file('resources/dark/add.svg'),
+        },
+        tooltip: 'demo button',
+      },
+    ]);
   });
 
   // onType 为 quickOpen 最主要的回调方法，在这里着重测试

--- a/packages/quick-open/src/browser/quick-open-item.service.ts
+++ b/packages/quick-open/src/browser/quick-open-item.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { IQuickPickItemButtonEvent, QuickInputButton } from '@opensumi/ide-core-browser/lib/quick-open';
+import { Emitter, Event } from '@opensumi/ide-core-common';
+import { StaticResourceService } from '@opensumi/ide-static-resource/lib/browser';
+import { IconType, IIconService, IThemeService } from '@opensumi/ide-theme';
+
+import { iconPath2URI } from '../common/icon';
+
+@Injectable()
+export class QuickOpenItemService {
+  @Autowired(IThemeService)
+  private readonly themeService: IThemeService;
+
+  @Autowired()
+  private readonly staticResourceService: StaticResourceService;
+
+  @Autowired(IIconService)
+  private readonly iconService: IIconService;
+
+  private readonly onDidTriggerItemButtonEmitter: Emitter<IQuickPickItemButtonEvent> = new Emitter();
+
+  get onDidTriggerItemButton(): Event<IQuickPickItemButtonEvent> {
+    return this.onDidTriggerItemButtonEmitter.event;
+  }
+
+  fireDidTriggerItemButton(itemHandle: number, button: QuickInputButton): void {
+    this.onDidTriggerItemButtonEmitter.fire({
+      button,
+      item: { handle: itemHandle },
+    });
+  }
+
+  getButtons(buttons: QuickInputButton[]): QuickInputButton[] {
+    if (buttons.length === 0) {
+      return [];
+    }
+    return buttons.map((btn, i) => {
+      const iconUri = iconPath2URI(btn.iconPath, this.themeService.getCurrentThemeSync().type);
+      const iconPath = iconUri && this.staticResourceService.resolveStaticResource(iconUri).toString();
+      const iconClass = iconPath && this.iconService.fromIcon('', iconPath, IconType.Background);
+      return {
+        ...btn,
+        iconClass,
+        handle: i,
+      };
+    });
+  }
+}

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -42,6 +42,7 @@ export interface IKaitianQuickOpenControllerOpts extends QuickOpenTabOptions {
   onSelect?(item: QuickOpenItem, index: number): void;
   onConfirm?(items: QuickOpenItem[]): void;
   onChangeValue?(lookFor: string): void;
+  keepScrollPosition?: boolean | undefined;
 }
 
 @Injectable()
@@ -110,6 +111,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
       inputEnable: opts.enabled ?? true,
       valueSelection: opts.valueSelection,
       canSelectMany: opts.canSelectMany,
+      keepScrollPosition: opts.keepScrollPosition,
       renderTab: opts.renderTab,
       toggleTab: opts.toggleTab,
     });
@@ -247,6 +249,10 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
 
   get valueSelection(): [number, number] | undefined {
     return this.options.valueSelection;
+  }
+
+  get keepScrollPosition(): boolean | undefined {
+    return this.options.keepScrollPosition;
   }
 
   get renderTab() {

--- a/packages/quick-open/src/browser/quick-open.type.ts
+++ b/packages/quick-open/src/browser/quick-open.type.ts
@@ -77,12 +77,14 @@ export interface QuickOpenInputOptions extends QuickOpenTabOptions {
   inputEnable?: boolean;
   valueSelection?: [number, number];
   canSelectMany?: boolean;
+  keepScrollPosition?: boolean;
 }
 
 export interface IQuickOpenWidget extends QuickOpenTabOptions {
   inputValue: string;
   selectIndex: number;
   validateType?: VALIDATE_TYPE;
+  keepScrollPosition?: boolean;
   readonly MAX_HEIGHT: number;
   readonly isShow: boolean;
   readonly items: QuickOpenItem[];

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -75,7 +75,7 @@ export const QuickOpenHeader = observer(() => {
     [quickTitleBar.fireDidTriggerButton],
   );
 
-  return quickTitleBar.isAttached && titleText ? (
+  return quickTitleBar.isAttached ? (
     <div className={styles.title_bar}>
       <div className={styles.title_bar_button}>
         {quickTitleBar.leftButtons.map((button) => (
@@ -185,6 +185,8 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
 
   const [labelHighlights, descriptionHighlights, detailHighlights] = React.useMemo(() => data.getHighlights(), [data]);
 
+  const [mouseOver, setMouseOver] = React.useState(false);
+
   const actions = React.useMemo(() => {
     const provider = widget.actionProvider;
     if (provider && provider.hasActions(data)) {
@@ -232,6 +234,8 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
         [styles.item_selected]: widget.selectIndex === index,
         [styles.item_border]: showBorder,
       })}
+      onMouseEnter={() => setMouseOver(true)}
+      onMouseLeave={() => setMouseOver(false)}
     >
       {widget.canSelectMany && (
         <CheckBox
@@ -285,9 +289,10 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           className={clx(styles.item_action, action.class)}
         ></span>
       ))}
-      {buttons?.map((button) => (
-        <QuickOpenButton onMouseDown={(event) => onSelectButton(event, button)} button={button} />
-      ))}
+      {(mouseOver || widget.selectIndex === index) &&
+        buttons?.map((button) => (
+          <QuickOpenButton onMouseDown={(event) => onSelectButton(event, button)} button={button} />
+        ))}
     </div>
   );
 });
@@ -351,7 +356,7 @@ export const QuickOpenView = observer(() => {
         // 判断触发事件的元素是否在父元素内，如果在父元素内就不做处理
         return;
       }
-      // widget.blur();
+      widget.blur();
     },
     [widget],
   );

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -32,12 +32,12 @@ interface IQuickOpenItemProps {
   index: number;
 }
 
-const QuickOpenHeaderButton: React.FC<
+const QuickOpenButton: React.FC<
   {
     button: QuickTitleButton;
   } & React.ButtonHTMLAttributes<HTMLButtonElement>
 > = observer(({ button, ...props }) => (
-  <Button {...props} key={button.tooltip} type='icon' iconClass={button.iconClass} title={button.tooltip}></Button>
+  <Button {...props} key={button.tooltip} type='icon' iconClass={button.iconClass} title={button.tooltip} />
 ));
 
 export const QuickOpenHeader = observer(() => {
@@ -76,19 +76,13 @@ export const QuickOpenHeader = observer(() => {
     <div className={styles.title_bar}>
       <div className={styles.title_bar_button}>
         {quickTitleBar.leftButtons.map((button) => (
-          <QuickOpenHeaderButton
-            onMouseDown={(event) => onSelectButton(event, button)}
-            button={button}
-          ></QuickOpenHeaderButton>
+          <QuickOpenButton onMouseDown={(event) => onSelectButton(event, button)} button={button} />
         ))}
       </div>
       <div>{titleText}</div>
       <div className={styles.title_bar_button}>
         {quickTitleBar.rightButtons.map((button) => (
-          <QuickOpenHeaderButton
-            onMouseDown={(event) => onSelectButton(event, button)}
-            button={button}
-          ></QuickOpenHeaderButton>
+          <QuickOpenButton onMouseDown={(event) => onSelectButton(event, button)} button={button} />
         ))}
       </div>
     </div>
@@ -183,6 +177,8 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
 
   const showBorder = React.useMemo(() => data.showBorder(), [data]);
 
+  const buttons = React.useMemo(() => data.getButtons(), [data]);
+
   const [labelHighlights, descriptionHighlights, detailHighlights] = React.useMemo(() => data.getHighlights(), [data]);
 
   const actions = React.useMemo(() => {
@@ -213,6 +209,16 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
     (action: QuickOpenAction) => {
       action.run(data);
       widget.hide(HideReason.ELEMENT_SELECTED);
+    },
+    [data],
+  );
+
+  const onSelectButton = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, button: QuickTitleButton) => {
+      event.stopPropagation();
+      // eslint-disable-next-line no-console
+      console.log('xxxxx');
+      // quickTitleBar.fireDidTriggerButton(button);
     },
     [data],
   );
@@ -277,6 +283,9 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           className={clx(styles.item_action, action.class)}
         ></span>
       ))}
+      {buttons?.map((button) => (
+        <QuickOpenButton onMouseDown={(event) => onSelectButton(event, button)} button={button} />
+      ))}
     </div>
   );
 });
@@ -334,7 +343,7 @@ export const QuickOpenView = observer(() => {
         // 判断触发事件的元素是否在父元素内，如果在父元素内就不做处理
         return;
       }
-      widget.blur();
+      // widget.blur();
     },
     [widget],
   );

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -13,6 +13,7 @@ import {
 import { Key, KeyCode, useInjectable, localize } from '@opensumi/ide-core-browser';
 import {
   HideReason,
+  QuickInputButton,
   QuickOpenAction,
   QuickOpenItem,
   QuickOpenMode,
@@ -23,6 +24,7 @@ import { KeyCode as KeyCodeEnum } from '@opensumi/monaco-editor-core/esm/vs/base
 
 import { HighlightLabel } from './components/highlight-label';
 import { KeybindingView } from './components/keybinding';
+import { QuickOpenItemService } from './quick-open-item.service';
 import { QuickOpenContext } from './quick-open.type';
 import { QuickTitleBar } from './quick-title-bar';
 import styles from './styles.module.less';
@@ -162,6 +164,7 @@ export const QuickOpenInput = observer(() => {
 
 const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index }) => {
   const { widget } = React.useContext(QuickOpenContext);
+  const quickOpenItemService = useInjectable<QuickOpenItemService>(QuickOpenItemService);
 
   const label = React.useMemo(() => data.getLabel(), [data]);
 
@@ -177,7 +180,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
 
   const showBorder = React.useMemo(() => data.showBorder(), [data]);
 
-  const buttons = React.useMemo(() => data.getButtons(), [data]);
+  const buttons = React.useMemo(() => quickOpenItemService.getButtons(data.getButtons()), [data]);
 
   const [labelHighlights, descriptionHighlights, detailHighlights] = React.useMemo(() => data.getHighlights(), [data]);
 
@@ -214,11 +217,9 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
   );
 
   const onSelectButton = React.useCallback(
-    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, button: QuickTitleButton) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, button: QuickInputButton) => {
       event.stopPropagation();
-      // eslint-disable-next-line no-console
-      console.log('xxxxx');
-      // quickTitleBar.fireDidTriggerButton(button);
+      quickOpenItemService.fireDidTriggerItemButton(index, button);
     },
     [data],
   );
@@ -296,7 +297,7 @@ export const QuickOpenList: React.FC<{ onReady: (api: IRecycleListHandler) => vo
   const getSize = React.useCallback(
     (index) => {
       const item = widget.items[index];
-      return item?.getDetail() ? 44 : 22;
+      return item?.getDetail() ? 40 : 22;
     },
     [widget.items],
   );

--- a/packages/quick-open/src/browser/quick-open.widget.tsx
+++ b/packages/quick-open/src/browser/quick-open.widget.tsx
@@ -42,6 +42,9 @@ export class QuickOpenWidget implements IQuickOpenWidget {
   @observable
   private _isPassword?: boolean;
 
+  @observable
+  private _keepScrollPosition?: boolean;
+
   @computed
   get isPassword() {
     return this._isPassword;
@@ -102,6 +105,11 @@ export class QuickOpenWidget implements IQuickOpenWidget {
     return this._autoFocus;
   }
 
+  @computed
+  get keepScrollPosition() {
+    return this._keepScrollPosition;
+  }
+
   public renderTab?: () => React.ReactNode;
   public toggleTab?: () => void;
 
@@ -116,6 +124,7 @@ export class QuickOpenWidget implements IQuickOpenWidget {
     this._inputEnable = options.inputEnable;
     this._valueSelection = options.valueSelection;
     this._canSelectMany = options.canSelectMany;
+    this._keepScrollPosition = options.keepScrollPosition;
     this.renderTab = options.renderTab;
     this.toggleTab = options.toggleTab;
     // 获取第一次要展示的内容

--- a/packages/quick-open/src/browser/quick-pick.service.ts
+++ b/packages/quick-open/src/browser/quick-pick.service.ts
@@ -14,7 +14,6 @@ import { Emitter, Event } from '@opensumi/ide-core-common';
 
 import { QuickTitleBar } from './quick-title-bar';
 
-
 @Injectable()
 export class QuickPickServiceImpl implements QuickPickService {
   @Autowired(QuickTitleBar)
@@ -89,6 +88,7 @@ export class QuickPickServiceImpl implements QuickPickService {
     const detail = typeof element === 'string' ? undefined : element.detail;
     const groupLabel = typeof element === 'string' ? undefined : element.groupLabel;
     const showBorder = typeof element === 'string' ? undefined : element.showBorder;
+    const buttons = typeof element === 'string' ? undefined : element.buttons;
     const [icon, text] = getIconClass(label);
 
     if (icon) {
@@ -102,6 +102,7 @@ export class QuickPickServiceImpl implements QuickPickService {
       iconClass,
       groupLabel,
       showBorder,
+      buttons,
       run: (mode) => {
         if (mode !== Mode.OPEN) {
           return false;

--- a/packages/quick-open/src/browser/quick-title-bar.ts
+++ b/packages/quick-open/src/browser/quick-title-bar.ts
@@ -2,10 +2,12 @@ import { observable, computed, action } from 'mobx';
 
 import { Injectable, Autowired } from '@opensumi/di';
 import { QuickTitleButton, QuickTitleButtonSide } from '@opensumi/ide-core-browser/lib/quick-open';
-import { Emitter, Event, isUndefined, URI } from '@opensumi/ide-core-common';
+import { Emitter, Event, isUndefined } from '@opensumi/ide-core-common';
 import { StaticResourceService } from '@opensumi/ide-static-resource/lib/browser';
 import './quick-title-bar.less';
 import { IconType, IIconService, IThemeService } from '@opensumi/ide-theme';
+
+import { iconPath2URI } from '../common/icon';
 
 @Injectable()
 export class QuickTitleBar {
@@ -69,7 +71,7 @@ export class QuickTitleBar {
       return [];
     }
     return this._buttons.map((btn, i) => {
-      const iconUri = this.iconPath2URI(btn.iconPath);
+      const iconUri = iconPath2URI(btn.iconPath, this.themeService.getCurrentThemeSync().type);
       const iconPath = iconUri && this.staticResourceService.resolveStaticResource(iconUri).toString();
       const iconClass = iconPath && this.iconService.fromIcon('', iconPath, IconType.Background);
       return {
@@ -88,18 +90,6 @@ export class QuickTitleBar {
   @computed
   get rightButtons(): ReadonlyArray<QuickTitleButton> {
     return this.buttons.filter((btn) => btn.side === QuickTitleButtonSide.RIGHT || typeof btn.side === 'undefined');
-  }
-
-  private iconPath2URI(iconPath): URI | undefined {
-    if (URI.isUri(iconPath)) {
-      return iconPath;
-    }
-
-    if (iconPath.dark || iconPath.light) {
-      return this.themeService.getCurrentThemeSync().type === 'dark'
-        ? new URI(iconPath.dark.toString())
-        : new URI(iconPath.light.toString());
-    }
   }
 
   @action

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -124,7 +124,7 @@
 .item_label_container {
   flex: 1;
   width: 100%;
-  line-height: 16px;
+  line-height: 22px;
   overflow: hidden;
   user-select: none;
 }

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -124,7 +124,7 @@
 .item_label_container {
   flex: 1;
   width: 100%;
-  line-height: 22px;
+  line-height: 16px;
   overflow: hidden;
   user-select: none;
 }

--- a/packages/quick-open/src/common/icon.ts
+++ b/packages/quick-open/src/common/icon.ts
@@ -1,0 +1,11 @@
+import { URI } from '@opensumi/ide-core-common';
+
+export function iconPath2URI(iconPath: any, themeType?: string): URI | undefined {
+  if (URI.isUri(iconPath)) {
+    return iconPath;
+  }
+
+  if ((iconPath.dark || iconPath.light) && themeType) {
+    return themeType === 'dark' ? new URI(iconPath.dark.toString()) : new URI(iconPath.light.toString());
+  }
+}

--- a/packages/types/vscode/typings/vscode.quickpick.d.ts
+++ b/packages/types/vscode/typings/vscode.quickpick.d.ts
@@ -35,6 +35,14 @@ declare module 'vscode' {
      * not implemented yet
      */
     alwaysShow?: boolean;
+
+    /**
+		 * Optional buttons that will be rendered on this particular item. These buttons will trigger
+		 * an {@link QuickPickItemButtonEvent} when clicked. Buttons are only rendered when using a quickpick
+		 * created by the {@link window.createQuickPick()} API. Buttons are not rendered when using
+		 * the {@link window.showQuickPick()} API.
+		 */
+		buttons?: QuickInputButton[];
   }
 
 
@@ -80,6 +88,13 @@ declare module 'vscode' {
      * An event signaling when a button was triggered.
      */
     readonly onDidTriggerButton: Event<QuickInputButton>;
+
+
+    /**
+     * An event signaling when a button in a particular {@link QuickPickItem} was triggered.
+     * This event does not fire for buttons in the title bar.
+     */
+    readonly onDidTriggerItemButton: Event<QuickPickItemButtonEvent<T>>;
 
     /**
      * Items to pick from.
@@ -130,9 +145,9 @@ declare module 'vscode' {
    */
   export interface QuickPickOptions {
 
-		/**
-		 * An optional string that represents the title of the quick pick.
-		 */
+    /**
+     * An optional string that represents the title of the quick pick.
+     */
     title?: string;
 
     /**
@@ -265,9 +280,9 @@ declare module 'vscode' {
   export interface InputBoxOptions {
 
     /**
-		 * An optional string that represents the title of the input box.
-		 */
-		title?: string;
+     * An optional string that represents the title of the input box.
+     */
+    title?: string;
 
     /**
      * The value to prefill in the input box.
@@ -482,6 +497,21 @@ declare module 'vscode' {
      * @hidden
      */
     private constructor();
+  }
+
+  /**
+   * An event signaling when a button in a particular {@link QuickPickItem} was triggered.
+   * This event does not fire for buttons in the title bar.
+   */
+  export interface QuickPickItemButtonEvent<T extends QuickPickItem> {
+    /**
+     * The button that was clicked.
+     */
+    readonly button: QuickInputButton;
+    /**
+     * The item that the button belongs to.
+     */
+    readonly item: T;
   }
 
 }

--- a/packages/types/vscode/typings/vscode.quickpick.d.ts
+++ b/packages/types/vscode/typings/vscode.quickpick.d.ts
@@ -37,12 +37,12 @@ declare module 'vscode' {
     alwaysShow?: boolean;
 
     /**
-		 * Optional buttons that will be rendered on this particular item. These buttons will trigger
-		 * an {@link QuickPickItemButtonEvent} when clicked. Buttons are only rendered when using a quickpick
-		 * created by the {@link window.createQuickPick()} API. Buttons are not rendered when using
-		 * the {@link window.showQuickPick()} API.
-		 */
-		buttons?: QuickInputButton[];
+     * Optional buttons that will be rendered on this particular item. These buttons will trigger
+     * an {@link QuickPickItemButtonEvent} when clicked. Buttons are only rendered when using a quickpick
+     * created by the {@link window.createQuickPick()} API. Buttons are not rendered when using
+     * the {@link window.showQuickPick()} API.
+     */
+    buttons?: QuickInputButton[];
   }
 
 
@@ -117,6 +117,11 @@ declare module 'vscode' {
      */
     matchOnDetail: boolean;
 
+    /*
+     * An optional flag to maintain the scroll position of the quick pick when the quick pick items are updated. Defaults to false.
+     */
+    keepScrollPosition?: boolean;
+
     /**
      * Active items. This can be read and updated by the extension.
      * not implemented yet
@@ -159,6 +164,11 @@ declare module 'vscode' {
      * An optional flag to include the detail when filtering the picks.
      */
     matchOnDetail?: boolean;
+
+    /*
+     * An optional flag to maintain the scroll position of the quick pick when the quick pick items are updated. Defaults to false.
+     */
+    keepScrollPosition?: boolean;
 
     /**
      * An optional string to show as place holder in the input box to guide the user what to pick on.


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution
1. 支持 VSCode 插件 API 1.63.2 中的 QuickOpen 相关 API：
QuickPick
[x] onDidTriggerItemButton
[x] keepScrollPosition
QuickPickItem
[x] buttons
[x] QuickPickItemButtonEvent
2. 支持 RecycleList 新接口 onScroll，完善类型补全
3. 修复 QuickOpen 如果没有 title 内容就不显示 TitleBar 的问题

效果：
1. 支持在 QuickOpen Item 中添加 buttons 按钮
动图（gif）：
![screenshort_20220415-204211](https://user-images.githubusercontent.com/2226423/163572077-8beda36c-709b-4434-9ffa-fa81166ca4ec.gif)

2. 支持添加 keepScrollPosition 选项，在 quickOpen items 更新后，继续显示当前内容，而不是置顶

### Changelog
support quick-open buttons and keepScrollPosition plugin api