### PR TITLE
test: fix testcase

### DIFF
--- a/packages/core-browser/__mocks__/progress-service.ts
+++ b/packages/core-browser/__mocks__/progress-service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@opensumi/di';
+import {
+  IDisposable,
+  IProgressOptions,
+  IProgressNotificationOptions,
+  IProgressWindowOptions,
+  IProgressCompositeOptions,
+  IProgress,
+  IProgressStep,
+} from '@opensumi/ide-core-common';
+
+import { IProgressIndicator, IProgressService } from '../src/progress';
+
+@Injectable()
+export class MockProgressService implements IProgressService {
+  registerProgressIndicator(location: string, indicator?: IProgressIndicator): IDisposable {
+    return {
+      dispose() {},
+    };
+  }
+  getIndicator(location: string): IProgressIndicator | undefined {
+    return;
+  }
+  async withProgress<R>(
+    options: IProgressOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
+    task: (progress: IProgress<IProgressStep>) => Promise<R>,
+    onDidCancel?: (choice?: number) => void,
+  ): Promise<R> {
+    return await task({
+      report() {},
+    });
+  }
+}

--- a/packages/keymaps/__tests__/browser/keymaps.service.test.ts
+++ b/packages/keymaps/__tests__/browser/keymaps.service.test.ts
@@ -18,6 +18,8 @@ import {
   AppConfig,
 } from '@opensumi/ide-core-browser';
 import { MockLogger } from '@opensumi/ide-core-browser/__mocks__/logger';
+import { MockProgressService } from '@opensumi/ide-core-browser/__mocks__/progress-service';
+import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
 import { IDiskFileProvider, IFileServiceClient } from '@opensumi/ide-file-service';
 import { FileServiceClientModule } from '@opensumi/ide-file-service/lib/browser';
 import { FileServiceContribution } from '@opensumi/ide-file-service/lib/browser/file-service-contribution';
@@ -101,6 +103,10 @@ describe('KeymapsService should be work', () => {
       {
         token: ILogger,
         useClass: MockLogger,
+      },
+      {
+        token: IProgressService,
+        useClass: MockProgressService,
       },
       {
         token: AppConfig,
@@ -197,7 +203,7 @@ describe('KeymapsService should be work', () => {
           key: 'cmd+c',
         },
       ];
-      keymapsService.reconcile(keybindings);
+      await keymapsService.reconcile(keybindings);
       expect(mockKeybindingRegistry.getKeybindingsForCommand).toBeCalledTimes(3);
       expect(mockKeybindingRegistry.unregisterKeybinding).toBeCalledTimes(2);
       expect(mockKeybindingRegistry.registerKeybinding).toBeCalledTimes(3);
@@ -208,12 +214,13 @@ describe('KeymapsService should be work', () => {
         command: 'test.command',
         keybinding: 'cmd+c',
       };
-      keymapsService.setKeybinding(keybinding);
+      await keymapsService.setKeybinding(keybinding);
       expect(mockKeybindingRegistry.registerKeybinding).toBeCalledTimes(4);
     });
 
-    it('getKeybindings method should be work', () => {
-      keymapsService.getKeybindings();
+    it('getKeybindings method should be work', async () => {
+      const list = await keymapsService.getKeybindings();
+      expect(list?.length).toBeGreaterThan(0);
     });
 
     it('resetKeybinding method should be work', async () => {

--- a/packages/keymaps/src/browser/keymaps.service.ts
+++ b/packages/keymaps/src/browser/keymaps.service.ts
@@ -320,13 +320,13 @@ export class KeymapService implements IKeymapService {
    * @returns {Promise<void>}
    * @memberof KeymapsService
    */
-  setKeybinding = (keybinding: Keybinding) => {
+  setKeybinding = (keybinding: Keybinding) =>
     this.progressService.withProgress(
       {
         location: ProgressLocation.Notification,
       },
       (progress: IProgress<IProgressStep>) =>
-        new Promise<any>(async (resolve, reject) => {
+        new Promise<any>((resolve, reject) => {
           progress.report({ message: localize('keymaps.keybinding.loading'), increment: 0, total: 100 });
           const keybindings: KeymapItem[] = this.storeKeybindings || [];
           let updated = false;
@@ -347,9 +347,9 @@ export class KeymapService implements IKeymapService {
             }
           }
           if (!updated) {
-            const defaultBinding: KeybindingItem = this.keybindings.find(
+            const defaultBinding: KeybindingItem | undefined = this.keybindings.find(
               (kb: KeybindingItem) => kb.id === keybinding.command && this.getRaw(kb.when) === keybinding.when,
-            )!;
+            );
             if (defaultBinding && defaultBinding.keybinding) {
               this.unregisterDefaultKeybinding({
                 when: this.getRaw(defaultBinding.when),
@@ -367,7 +367,7 @@ export class KeymapService implements IKeymapService {
             this.registerUserKeybinding(keybinding);
           }
           // 后置存储流程
-          this.saveKeybinding(keybindings)
+          return this.saveKeybinding(keybindings)
             .then(() => {
               resolve(undefined);
               progress.report({ message: localize('keymaps.keybinding.success'), increment: 99 });
@@ -385,7 +385,6 @@ export class KeymapService implements IKeymapService {
         }),
       () => {},
     );
-  };
 
   private async saveKeybinding(keymaps: KeymapItem[]) {
     this.storeKeybindings = keymaps;
@@ -416,7 +415,7 @@ export class KeymapService implements IKeymapService {
     const filtered = keymaps.filter((a) => a.command !== item.command);
     this.unregisterUserKeybinding(item);
     this.restoreDefaultKeybinding(item);
-    this.saveKeybinding(filtered);
+    await this.saveKeybinding(filtered);
   };
 
   /**

--- a/packages/keymaps/src/common/keymaps.ts
+++ b/packages/keymaps/src/common/keymaps.ts
@@ -65,7 +65,7 @@ export interface IKeymapService {
    * @returns {Promise<void>}
    * @memberof KeymapsService
    */
-  setKeybinding(keybinding: Keybinding): void;
+  setKeybinding(keybinding: Keybinding): Promise<void>;
 
   /**
    * 移除给定ID的快捷键绑定


### PR DESCRIPTION
### Types

- [x] ⏱ Tests


### Background or solution

fix test case:
```
FAIL packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
  ● Workbench - TerminalWebLinkProvider › LinkComputer cases

    ENOENT: no such file or directory, open '/tmp/keymaps-service-test/.sumi/keymaps.json'
```


<img width="908" alt="image" src="https://user-images.githubusercontent.com/13938334/163701571-534c50ab-d830-4e3a-b008-46a8dd6e40f5.png">

### Changelog
