### PR TITLE
fix: improve file tree re-render progress

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -355,8 +355,8 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       notifyDidChangeMetadata: (target: ITreeNode | ICompositeTreeNode, change: IMetadataChange) => {
         emitter.fire({ type: TreeNodeEvent.DidChangeMetadata, args: [target, change] });
       },
-      notifyDidUpdateBranch: () => {
-        emitter.fire({ type: TreeNodeEvent.BranchDidUpdate, args: [] });
+      notifyDidUpdateBranch: (force = true) => {
+        emitter.fire({ type: TreeNodeEvent.BranchDidUpdate, args: [force] });
       },
       notifyWillResolveChildren: (target: ICompositeTreeNode, nowExpanded: boolean) => {
         emitter.fire({ type: TreeNodeEvent.WillResolveChildren, args: [target, nowExpanded] });
@@ -632,10 +632,11 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       } else if (CompositeTreeNode.isRoot(this)) {
         TreeNode.updateBranchStatus(this.path, BranchOperatorStatus.EXPANDED);
         // 通知分支树已更新
-        this.watcher.notifyDidUpdateBranch();
+        this.watcher.notifyDidUpdateBranch(false);
       } else {
         // 这种情况一般为非根节点刷新后需同步到父节点，更新分支树
-        this.expandBranch(this);
+        this.expandBranch(this, true);
+        this.watcher.notifyDidUpdateBranch(false);
       }
     } else {
       // 仅需处理存在子节点的情况，否则将会影响刷新后的节点长度

--- a/packages/components/src/recycle-tree/tree/model/TreeModel.ts
+++ b/packages/components/src/recycle-tree/tree/model/TreeModel.ts
@@ -8,9 +8,9 @@ export class TreeModel {
   private _state: TreeStateManager;
   private _root: CompositeTreeNode;
 
-  private onChangeEmitter: Emitter<void> = new Emitter();
+  private onChangeEmitter: Emitter<boolean> = new Emitter();
 
-  get onChange(): Event<void> {
+  get onChange(): Event<boolean> {
     return this.onChangeEmitter.event;
   }
 
@@ -41,8 +41,8 @@ export class TreeModel {
     this.state = new TreeStateManager(root as CompositeTreeNode);
   }
 
-  dispatchChange = () => {
-    this.onChangeEmitter.fire();
+  dispatchChange = (force = true) => {
+    this.onChangeEmitter.fire(force);
   };
 
   /**

--- a/packages/components/src/recycle-tree/types/watcher.ts
+++ b/packages/components/src/recycle-tree/types/watcher.ts
@@ -141,7 +141,7 @@ export interface ITreeWatcher {
   notifyDidChangePath(target: ITreeNodeOrCompositeTreeNode);
   notifyDidChangeMetadata(target: ITreeNodeOrCompositeTreeNode, change: IMetadataChange);
 
-  notifyDidUpdateBranch();
+  notifyDidUpdateBranch(force?: boolean);
 
   dispose: IDisposable;
 }

--- a/packages/file-tree-next/src/browser/file-tree-model.ts
+++ b/packages/file-tree-next/src/browser/file-tree-model.ts
@@ -36,18 +36,20 @@ export class FileTreeModel extends TreeModel {
     // 分支更新时通知树刷新, 不是立即更新，而是延迟更新，待树稳定后再更新
     // 100ms的延迟并不能保证树稳定，特别是在node_modules展开的情况下
     // 但在普通使用上已经足够可用，即不会有渲染闪烁问题
-    this.root.watcher.on(TreeNodeEvent.BranchDidUpdate, this.doDispatchChange.bind(this));
+    this.root.watcher.on(TreeNodeEvent.BranchDidUpdate, (force) => {
+      this.doDispatchChange(force);
+    });
     // 主题或装饰器更新时，更新树
-    this.decorationService.onDidChange(this.doDispatchChange.bind(this));
+    this.decorationService.onDidChange(() => this.doDispatchChange());
   }
 
-  doDispatchChange() {
+  doDispatchChange(force = true) {
     if (!this.flushDispatchChangeDelayer.isTriggered()) {
       this.flushDispatchChangeDelayer.cancel();
     }
     this.flushDispatchChangeDelayer.trigger(async () => {
       await this.onWillUpdateEmitter.fireAndAwait();
-      this.dispatchChange();
+      this.dispatchChange(force);
     });
   }
 }

--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-model.ts
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-model.ts
@@ -41,6 +41,6 @@ export class SCMTreeModel extends TreeModel {
     });
     // this.root.watcher.on(TreeNodeEvent.BranchDidUpdate, this.dispatchChange);
     // 主题或装饰器更新时，更新树
-    this.decorationService.onDidChange(this.dispatchChange);
+    this.decorationService.onDidChange(() => this.dispatchChange());
   }
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

优化文件树的界面绘制过程，以文件编辑场景并同时启动编译服务的程序为例：

之前（一次编辑操作，触发 3 次文件树重绘操作）：

https://user-images.githubusercontent.com/9823838/163801620-110c4324-4e31-4ace-a80c-eda67860bd88.mp4

之后（对于文件树无变化的更新场景，过滤掉该重绘操作）：

https://user-images.githubusercontent.com/9823838/163801442-16a22037-9629-4ca1-8a0b-a8909319f730.mp4

### Changelog

improve file tree re-render progress
