### PR TITLE
fix: search panel process bar performance

### DIFF
--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -76,11 +76,16 @@ export const Search = React.memo(
       width: viewState.width || '100%',
       height: viewState.height,
     };
+
+    const SearchProcess = React.useMemo(() => (
+        <div className={styles['loading-wrap']}>
+          <ProgressBar loading={isSearchDoing} />
+        </div>
+      ), [isSearchDoing]);
+
     return (
       <div className={styles.wrap} style={collapsePanelContainerStyle}>
-        <div className={styles['loading-wrap']}>
-          <ProgressBar loading={searchState === SEARCH_STATE.doing} />
-        </div>
+        {SearchProcess}
         <div className={styles.search_options} ref={searchOptionRef}>
           <SearchInputWidget
             isDetailOpen={UIState.isDetailOpen}
@@ -99,7 +104,7 @@ export const Search = React.memo(
             searchInputEl={searchBrowserService.searchInputEl}
             searchValue={searchBrowserService.searchValue}
             onSearchInputChange={searchBrowserService.onSearchInputChange}
-            onSearch={searchBrowserService.search}
+            onSearch={searchBrowserService.search.bind(searchBrowserService)}
           />
 
           <SearchReplaceWidget
@@ -116,7 +121,7 @@ export const Search = React.memo(
               <SearchRulesWidget
                 includeValue={searchBrowserService.includeValue}
                 excludeValue={searchBrowserService.excludeValue}
-                onSearch={searchBrowserService.search}
+                onSearch={searchBrowserService.search.bind(searchBrowserService)}
                 onChangeInclude={searchBrowserService.onSearchIncludeChange}
                 onChangeExclude={searchBrowserService.onSearchExcludeChange}
                 isOnlyOpenEditors={UIState.isOnlyOpenEditors}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
1. 修复搜索面板 processbar 进度条卡顿
2. searchBrowserService.search 调用需要加上 context
![screenshort_20220421-112007](https://user-images.githubusercontent.com/2226423/164365499-d3052262-34fd-476c-ac3d-2c98b45b27cd.gif)

close #854 

### Changelog
fix search panel process bar performance