### PR TITLE
feat: improve RelativePattern

### DIFF
--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -415,25 +415,54 @@ export enum EndOfLine {
 
 @es5ClassCompat
 export class RelativePattern {
-  base: string;
+  pattern: string;
 
-  constructor(base: vscode.WorkspaceFolder | string, public pattern: string) {
+  private _base!: string;
+  get base(): string {
+    return this._base;
+  }
+  set base(base: string) {
+    this._base = base;
+    this._baseUri = Uri.file(base);
+  }
+
+  private _baseUri!: Uri;
+  get baseUri(): Uri {
+    return this._baseUri;
+  }
+  set baseUri(baseUri: Uri) {
+    this._baseUri = baseUri;
+    this._base = baseUri.fsPath;
+  }
+
+  constructor(base: vscode.WorkspaceFolder | Uri | string, pattern: string) {
     if (typeof base !== 'string') {
-      if (!base || !Uri.isUri(base.uri)) {
-        throw new Error('illegalArgument: base');
+      if (!base || (!Uri.isUri(base) && !Uri.isUri(base.uri))) {
+        throw illegalArgument('base');
       }
     }
 
     if (typeof pattern !== 'string') {
-      throw new Error('illegalArgument: pattern');
+      throw illegalArgument('pattern');
     }
 
-    this.base = typeof base === 'string' ? base : base.uri.fsPath;
+    if (typeof base === 'string') {
+      this.baseUri = Uri.file(base);
+    } else if (Uri.isUri(base)) {
+      this.baseUri = base;
+    } else {
+      this.baseUri = base.uri;
+    }
+
+    this.pattern = pattern;
   }
 
-  pathToRelative(from: string, to: string): string {
-    // return relative(from, to);
-    return 'not implement!';
+  toJSON() {
+    return {
+      pattern: this.pattern,
+      base: this.base,
+      baseUri: this.baseUri.toJSON(),
+    };
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

在 vscode-hexeditor 插件中，使用了最新的 RelativePattern 类，且第一个参数是 Uri 类型
![image](https://user-images.githubusercontent.com/20262815/164385834-30162327-19e1-446f-b7e6-3e85c5e74cfe.png)

但在我们的旧实现当中并不支持，导致该插件运行报错

### Changelog
kaitian.RelativePattern 参数支持 Uri
