### PR TITLE
feat: wait for color theme applied

### DIFF
--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -55,11 +55,12 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
   @Autowired(ISemanticTokenRegistry)
   protected readonly semanticTokenRegistry: ISemanticTokenRegistry;
 
-  initialize() {
+  async initialize() {
     this.registerDefaultColorTheme();
     this.registerDefaultTokenStyles();
     this.registerDefaultTokenType();
     this.registerDefaultTokenModifier();
+    await this.themeService.themeLoaded.promise;
   }
 
   private registerDefaultColorTheme() {

--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -60,7 +60,10 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
     this.registerDefaultTokenStyles();
     this.registerDefaultTokenType();
     this.registerDefaultTokenModifier();
-    await this.themeService.themeLoaded.promise;
+    await Promise.all([
+      await this.iconService.iconThemeLoaded.promise,
+      await this.themeService.colorThemeLoaded.promise,
+    ]);
   }
 
   private registerDefaultColorTheme() {

--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -69,7 +69,7 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
 
   private colorClassNameMap = new Map<string, string>();
 
-  themeLoaded: Deferred<void> = new Deferred();
+  colorThemeLoaded: Deferred<void> = new Deferred();
 
   public currentThemeId: string;
   private currentTheme?: Theme;
@@ -117,7 +117,7 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
     }, new Map());
 
     this.preferenceSettings.setEnumLabels(COLOR_THEME_SETTING, Object.fromEntries(themeMap.entries()));
-    this.themeLoaded.resolve();
+    this.colorThemeLoaded.resolve();
   }
 
   get preferenceThemeId(): string | undefined {
@@ -138,7 +138,7 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
 
       if (this.preferenceThemeId === themeId) {
         await this.applyTheme(this.preferenceThemeId);
-        this.themeLoaded.resolve();
+        this.colorThemeLoaded.resolve();
       }
 
       disposables.push({
@@ -195,7 +195,7 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
     this.doApplyTheme(this.currentTheme);
 
     if (!this.preferenceThemeId) {
-      this.themeLoaded.resolve();
+      this.colorThemeLoaded.resolve();
     }
   }
 

--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -19,6 +19,7 @@ import {
   IThemeColor,
   OnEvent,
   ExtensionDidContributes,
+  Deferred,
 } from '@opensumi/ide-core-common';
 
 import { ICSSStyleService } from '../common';
@@ -68,6 +69,8 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
 
   private colorClassNameMap = new Map<string, string>();
 
+  themeLoaded: Deferred<void> = new Deferred();
+
   public currentThemeId: string;
   private currentTheme?: Theme;
   private latestApplyTheme: string;
@@ -105,7 +108,7 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
   }
 
   @OnEvent(ExtensionDidContributes)
-  onDidExtensionContributes() {
+  async onDidExtensionContributes() {
     const themeMap = this.getAvailableThemeInfos().reduce((pre: Map<string, string>, cur: ThemeInfo) => {
       if (!pre.has(cur.themeId)) {
         pre.set(cur.themeId, cur.name);
@@ -113,14 +116,12 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
       return pre;
     }, new Map());
 
-    const themeId = this.preferenceService.get<string>(COLOR_THEME_SETTING);
-    if (themeId && themeId !== DEFAULT_THEME_ID && themeMap.has(themeId)) {
-      this.applyTheme(themeId);
-    } else {
-      this.applyTheme(DEFAULT_THEME_ID);
-    }
-
     this.preferenceSettings.setEnumLabels(COLOR_THEME_SETTING, Object.fromEntries(themeMap.entries()));
+    this.themeLoaded.resolve();
+  }
+
+  get preferenceThemeId(): string | undefined {
+    return this.preferenceService.get<string>(COLOR_THEME_SETTING);
   }
 
   public registerThemes(themeContributions: ThemeContribution[], extPath: URI) {
@@ -128,16 +129,16 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
     disposables.push({
       dispose: () => this.doSetPreferenceSchema(),
     });
-    const preferenceThemeId = this.preferenceService.get<string>(COLOR_THEME_SETTING);
 
-    themeContributions.forEach((contribution) => {
+    themeContributions.forEach(async (contribution) => {
       const themeExtContribution = { basePath: extPath, contribution };
       const themeId = getThemeId(contribution);
 
       this.themeContributionRegistry.set(themeId, themeExtContribution);
 
-      if (preferenceThemeId === themeId) {
-        this.applyTheme(preferenceThemeId);
+      if (this.preferenceThemeId === themeId) {
+        await this.applyTheme(this.preferenceThemeId);
+        this.themeLoaded.resolve();
       }
 
       disposables.push({
@@ -192,6 +193,10 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
     this.toggleBaseThemeClass(prevThemeType, currentThemeType);
 
     this.doApplyTheme(this.currentTheme);
+
+    if (!this.preferenceThemeId) {
+      this.themeLoaded.resolve();
+    }
   }
 
   public registerColor(contribution: ExtColorContribution) {
@@ -318,7 +323,10 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
         50,
       )(async (e) => {
         if (e.preferenceName === COLOR_THEME_SETTING) {
-          await this.applyTheme(e.newValue);
+          // make sure the theme is registered
+          if (this.themeContributionRegistry.has(e.newValue)) {
+            await this.applyTheme(e.newValue);
+          }
         }
 
         if (this.currentTheme) {

--- a/packages/theme/src/common/mocks/theme.service.ts
+++ b/packages/theme/src/common/mocks/theme.service.ts
@@ -5,7 +5,7 @@ import { ThemeContribution, ExtColorContribution, IThemeService, ITheme } from '
 
 @Injectable()
 export class MockThemeService implements IThemeService {
-  themeLoaded: Deferred<void>;
+  colorThemeLoaded: Deferred<void>;
 
   public currentThemeId = 'dark';
 
@@ -21,7 +21,7 @@ export class MockThemeService implements IThemeService {
     };
   }
   async applyTheme(id: string) {
-    this.themeLoaded.resolve();
+    this.colorThemeLoaded.resolve();
     throw new Error('Method not implemented.');
   }
 

--- a/packages/theme/src/common/mocks/theme.service.ts
+++ b/packages/theme/src/common/mocks/theme.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@opensumi/di';
-import { Emitter, Event, URI, IThemeColor } from '@opensumi/ide-core-common';
+import { Emitter, Event, URI, IThemeColor, Deferred } from '@opensumi/ide-core-common';
 
 import { ThemeContribution, ExtColorContribution, IThemeService, ITheme } from '../theme.service';
 
 @Injectable()
 export class MockThemeService implements IThemeService {
+  themeLoaded: Deferred<void>;
+
   public currentThemeId = 'dark';
 
   private _onThemeChange = new Emitter<ITheme>();
@@ -19,6 +21,7 @@ export class MockThemeService implements IThemeService {
     };
   }
   async applyTheme(id: string) {
+    this.themeLoaded.resolve();
     throw new Error('Method not implemented.');
   }
 

--- a/packages/theme/src/common/theme.service.ts
+++ b/packages/theme/src/common/theme.service.ts
@@ -35,6 +35,7 @@ export enum IconShape {
 export interface IIconService {
   currentThemeId: string;
   currentTheme: IIconTheme;
+  iconThemeLoaded: Deferred<void>;
 
   onThemeChange: Event<IIconTheme>;
   /**
@@ -77,7 +78,7 @@ export interface IThemeData extends IStandaloneThemeData {
 
 export interface IThemeService {
   currentThemeId: string;
-  themeLoaded: Deferred<void>;
+  colorThemeLoaded: Deferred<void>;
   onThemeChange: Event<ITheme>;
   registerThemes(themeContributions: ThemeContribution[], extPath: URI): IDisposable;
   /**

--- a/packages/theme/src/common/theme.service.ts
+++ b/packages/theme/src/common/theme.service.ts
@@ -1,6 +1,6 @@
 import { IRawThemeSetting } from 'vscode-textmate';
 
-import { Event, URI, IDisposable, IThemeColor } from '@opensumi/ide-core-common';
+import { Event, URI, IDisposable, IThemeColor, Deferred } from '@opensumi/ide-core-common';
 
 import { Color } from './color';
 import { vs, vs_dark, hc_black } from './default-themes';
@@ -77,6 +77,7 @@ export interface IThemeData extends IStandaloneThemeData {
 
 export interface IThemeService {
   currentThemeId: string;
+  themeLoaded: Deferred<void>;
   onThemeChange: Event<ITheme>;
   registerThemes(themeContributions: ThemeContribution[], extPath: URI): IDisposable;
   /**


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

第一次加载时（无缓存），在设置了 `defaultPreferences.general.theme` 的情况下，会先应用一次内置的 baseTheme(vs-dark), 然后等主题插件加载完后再次应用设置的主题，并且之前的改造是在插件全部 contributes 结束之前就 render 了界面，因为这样看起来会快一些。于是这中间主题切换的过程会导致闪烁。有缓存的情况下，会直接从缓存中获取上一次的主题，相对等待插件 contributes 来说会快很多。

这里有几个问题

1. opensumi 并没有默认渲染时就将 baseTheme 应用上去，而是等 initialize 阶段才应用（可以优化）
2. 等待所有插件 contributes 完成太慢，不等会在配置的主题加载时闪烁
3. 较小概率会出现的是，themeService 中会监听 preferencesChange 事件，而可能在插件 contributes 未执行完（也就是设置的主题还没注册时）就调用 `applyTheme` ，而这里又因为此时主题并不存在，会走到默认 fallback 到 baseTheme 的逻辑，导致出现设置了 defaultPreferences.general.theme 且安装了主题，但并未加载成功的情况。

1、2 解决方式是在 `ThemeContribution` 中等待配置的主题加载完成

```ts
 initialize() {
  async initialize() {
    await this.themeService.themeLoaded.promise;
  }
```

由于不同集成、配置、插件安装情况不同，这里 `themeLoaded` resolve 的时机也有所不同

1. 设置了 defaultPreferences.general.theme 且对应主题已安装，会在 defaultPreferences.general.theme 应用以后 resolve
2. defaultPreferences.general.theme 但未安装对应主题，会在所有主题插件 contributes 执行结束后 resolve，也就是说会相对较慢
4. 没有设置 defaultPreferences.general.theme ，则只会在应用了 baseTheme 后立即 resolve，相对来说最快

3 的解决方式是在 preferencesChange 事件回调中添加一层判断，如果当前主题尚未注册就不应用


> iconTheme 同理，唯一一处区别在于没有 baseIconTheme 

### Changelog
