### PR TITLE
fix: optimized tree operations and conflict handling

### DIFF
--- a/packages/components/src/recycle-tree/RecycleTree.tsx
+++ b/packages/components/src/recycle-tree/RecycleTree.tsx
@@ -283,11 +283,9 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
   private queueUpdatePromise: Promise<any> | null = null;
 
   private updateCancelToken: CancellationTokenSource = new CancellationTokenSource();
+  private expandNodeCancelToken: CancellationTokenSource = new CancellationTokenSource();
 
   private willUpdateTasks = 0;
-
-  private updateTimer;
-  private updateTime = 0;
 
   // 批量更新Tree节点
   private doBatchUpdate = (() => {
@@ -554,8 +552,11 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
       typeof pathOrCompositeTreeNode === 'string'
         ? root.getTreeNodeByPath(pathOrCompositeTreeNode)
         : pathOrCompositeTreeNode;
+    if (this.expandNodeCancelToken.token.isCancellationRequested) {
+      this.expandNodeCancelToken = new CancellationTokenSource();
+    }
     if (directory && CompositeTreeNode.is(directory) && !(directory as CompositeTreeNode).disposed) {
-      return (directory as CompositeTreeNode).setExpanded(true);
+      return (directory as CompositeTreeNode).setExpanded(false, false, true, this.expandNodeCancelToken.token);
     }
   };
 
@@ -566,6 +567,7 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
         ? root.getTreeNodeByPath(pathOrCompositeTreeNode)
         : pathOrCompositeTreeNode;
     if (directory && CompositeTreeNode.is(directory) && !(directory as CompositeTreeNode).disposed) {
+      this.expandNodeCancelToken.cancel();
       return (directory as CompositeTreeNode).setCollapsed();
     }
   };

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -533,7 +533,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
   }
 
   // 展开节点
-  public async setExpanded(ensureVisible = true, quiet = false, isOwner = true) {
+  public async setExpanded(ensureVisible = true, quiet = false, isOwner = true, token?: CancellationToken) {
     if (this.disposed) {
       return;
     }
@@ -555,16 +555,35 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     this.isExpanded = true;
     if (this._children === null) {
       !quiet && this._watcher.notifyWillResolveChildren(this, this.isExpanded);
-      await this.hardReloadChildren();
+      await this.hardReloadChildren(token);
       !quiet && this._watcher.notifyDidResolveChildren(this, this.isExpanded);
       // 检查其是否展开；可能同时执行了 setCollapsed 方法
-      if (!this.isExpanded) {
+      if (!this.isExpanded || token?.isCancellationRequested) {
+        if (isOwner) {
+          TreeNode.setGlobalTreeState(this.path, {
+            isExpanding: false,
+          });
+        }
         return;
       }
     }
 
     if (ensureVisible && this.parent && CompositeTreeNode.is(this.parent)) {
-      await (this.parent as CompositeTreeNode).setExpanded(true, !quiet, false);
+      /**
+       * 在传入 ensureVisible = true 时，这里传入的 token 不能取消所有副作用
+       * 故在使用 ensureVisible = true 时必须保证 `setExpanded` 与 `setCollapsed` 的独立性
+       * 如需要 `await node.setExpanded(true)` 后再执行 `node.setCollapsed()`
+       */
+      await (this.parent as CompositeTreeNode).setExpanded(true, !quiet, false, token);
+    }
+
+    if (token?.isCancellationRequested) {
+      if (isOwner) {
+        TreeNode.setGlobalTreeState(this.path, {
+          isExpanding: false,
+        });
+      }
+      return;
     }
 
     if (this.isExpanded) {
@@ -1287,6 +1306,32 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       return false;
     }
 
+    const expandedChilds: CompositeTreeNode[] = [];
+    const flatTree = new Array(rawItems.length);
+    const tempChildren = new Array(rawItems.length);
+    for (let i = 0; i < rawItems.length; i++) {
+      const child = rawItems[i];
+      // 如果存在上一次缓存的节点，则使用缓存节点的 ID
+      (child as TreeNode).id = TreeNode.getIdByPath(child.path) || (child as TreeNode).id;
+      tempChildren[i] = child;
+      TreeNode.setIdByPath(child.path, child.id);
+      if (CompositeTreeNode.is(child) && child.expanded) {
+        if (!(child as CompositeTreeNode).children) {
+          await (child as CompositeTreeNode).resolveChildrens(token);
+        }
+        if (token?.isCancellationRequested) {
+          return false;
+        }
+        expandedChilds.push(child as CompositeTreeNode);
+      }
+    }
+
+    tempChildren.sort(this._tree.sortComparator || CompositeTreeNode.defaultSortComparator);
+
+    for (let i = 0; i < rawItems.length; i++) {
+      flatTree[i] = tempChildren[i].id;
+    }
+
     if (this.children) {
       // 重置节点分支
       this.shrinkBranch(this);
@@ -1297,37 +1342,12 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
         (child as any).dispose();
       }
     }
-    const expandedChilds: CompositeTreeNode[] = [];
-    const flatTree = new Array(rawItems.length);
-    this._children = new Array(rawItems.length);
-    for (let i = 0; i < rawItems.length; i++) {
-      const child = rawItems[i];
-      // 如果存在上一次缓存的节点，则使用缓存节点的 ID
-      (child as TreeNode).id = TreeNode.getIdByPath(child.path) || (child as TreeNode).id;
-      this._children[i] = child;
-      TreeNode.setIdByPath(child.path, child.id);
-      TreeNode.setTreeNode(TreeNode.getIdByPath(child.path) || child.id, child.path, child);
-      if (CompositeTreeNode.is(child) && child.expanded) {
-        await (child as CompositeTreeNode).resolveChildrens(token);
-        if (!(child as CompositeTreeNode).children) {
-          continue;
-        }
-        for (let i = 0; i < (child as CompositeTreeNode).children!.length; i++) {
-          const subChild = (child as CompositeTreeNode).children![i];
-          TreeNode.setTreeNode(TreeNode.getIdByPath(subChild.path) || subChild.id, subChild.path, subChild as TreeNode);
-        }
-        if (token?.isCancellationRequested) {
-          return false;
-        }
-        expandedChilds.push(child as CompositeTreeNode);
-      }
+
+    for (let i = 0; i < tempChildren.length; i++) {
+      this.updateTreeNodeCache(tempChildren[i]);
     }
 
-    this._children.sort(this._tree.sortComparator || CompositeTreeNode.defaultSortComparator);
-
-    for (let i = 0; i < rawItems.length; i++) {
-      flatTree[i] = this._children[i].id;
-    }
+    this._children = tempChildren;
     this._branchSize = flatTree.length;
     this.setFlattenedBranch(flatTree);
 

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -931,7 +931,11 @@ export class FileTreeModelService {
     if (Directory.is(node) && node.expanded) {
       target = node as Directory;
     } else if (node) {
-      target = node.parent as Directory;
+      if (Directory.isRoot(node.parent)) {
+        target = node as Directory;
+      } else {
+        target = node.parent as Directory;
+      }
     } else {
       return;
     }

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -915,8 +915,17 @@ export class FileTreeModelService {
     let node;
     if (this.focusedFile) {
       node = this.focusedFile;
+      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedFile = undefined;
     } else if (this.contextMenuFile) {
       node = this.contextMenuFile;
+      this.focusedDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuFile = undefined;
+    }
+    const index = this.selectedFiles.indexOf(node);
+    if (index >= 0) {
+      this.selectedFiles.splice(index, 1);
+      this.selectedDecoration.removeTarget(node);
     }
     let target: Directory;
     if (Directory.is(node) && node.expanded) {
@@ -926,6 +935,7 @@ export class FileTreeModelService {
     } else {
       return;
     }
+    this.focusedFile = target;
     if (target && target.expanded) {
       await this.fileTreeHandle.collapseNode(target as Directory);
       this.activeFileFocusedDecoration(target as Directory, true);
@@ -936,9 +946,19 @@ export class FileTreeModelService {
     let node;
     if (this.focusedFile) {
       node = this.focusedFile;
+      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedFile = undefined;
     } else if (this.contextMenuFile) {
       node = this.contextMenuFile;
+      this.focusedDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuFile = undefined;
     }
+    const index = this.selectedFiles.indexOf(node);
+    if (index >= 0) {
+      this.selectedFiles.splice(index, 1);
+      this.selectedDecoration.removeTarget(node);
+    }
+    this.focusedFile = node as Directory;
     if (Directory.is(node)) {
       if (!node.expanded) {
         await this.fileTreeHandle.expandNode(node as Directory);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

补充一种新的可能造成副作用的操作方式，即在展开节点的时候快速折叠，处理优先级如下：

<img width="775" alt="image" src="https://user-images.githubusercontent.com/9823838/165310342-b1556934-f56b-471b-b7dd-6cd86add3d5e.png">

同时优化 `←`,`→`,`↑`,`↓` 文件树操作的流畅性

https://user-images.githubusercontent.com/9823838/165311110-b1c4e6ff-4ec2-4e36-86db-f45938b1f324.mp4

### Changelog

optimized tree operations and conflict handling