### PR TITLE
fix: terminal title fallback to default name

### DIFF
--- a/packages/terminal-next/src/browser/component/tab.module.less
+++ b/packages/terminal-next/src/browser/component/tab.module.less
@@ -45,6 +45,7 @@
   border-top: 1px solid transparent;
   align-items: center;
   position: relative;
+  max-width: 200px;
   .close_icon {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;

--- a/packages/terminal-next/src/browser/terminal.view.ts
+++ b/packages/terminal-next/src/browser/terminal.view.ts
@@ -155,7 +155,7 @@ export class WidgetGroup extends Disposable implements IWidgetGroup {
 
   @computed
   get snapshot() {
-    return this.current?.processName || this.name;
+    return this.name || this.processName || this.current?.name!;
   }
 
   @computed


### PR DESCRIPTION
### Types


- [x] 💄 Style Changes


### Background or solution

![image](https://user-images.githubusercontent.com/17701805/165460716-8e3c93e5-86ee-4a80-8781-e978601e57ad.png)

### Changelog
- terminal title fallback to default name