### PR TITLE
fix: response customRequest with the body in debug session

### DIFF
--- a/packages/debug/__tests__/browser/debug-session-connection.test.ts
+++ b/packages/debug/__tests__/browser/debug-session-connection.test.ts
@@ -165,7 +165,7 @@ describe('DebugSessionConnection', () => {
         },
       }),
     );
-    expect((await requestPromise).body).toBeDefined();
+    expect(await requestPromise).toBeDefined();
   });
 
   it('handle event message', (done) => {

--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -167,7 +167,7 @@ export class DebugSessionConnection implements IDisposable {
   }
 
   async sendCustomRequest<T extends DebugProtocol.Response>(command: string, args?: any): Promise<T> {
-    return (await this.doSendRequest<T>(command, args)).body;
+    return (await this.doSendRequest<T>(command, args))?.body;
   }
 
   protected async doSendRequest<K extends DebugProtocol.Response>(

--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -166,8 +166,8 @@ export class DebugSessionConnection implements IDisposable {
     return result;
   }
 
-  sendCustomRequest<T extends DebugProtocol.Response>(command: string, args?: any): Promise<T> {
-    return this.doSendRequest<T>(command, args);
+  async sendCustomRequest<T extends DebugProtocol.Response>(command: string, args?: any): Promise<T> {
+    return (await this.doSendRequest<T>(command, args)).body;
   }
 
   protected async doSendRequest<K extends DebugProtocol.Response>(


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

#930

sendCustomRequest应该是只返回body

### Changelog

response customRequest with the body in debug session
