### PR TITLE
feat: attach backend or extension host skip node_internals

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
       "type": "node",
       "request": "attach",
       "name": "Attach to BackEnd",
+      "skipFiles": ["<node_internals>/**"],
       "port": 9999,
       "restart": true
     },
@@ -50,6 +51,7 @@
       "restart": true,
       "sourceMaps": true,
       "outFiles": ["${workspaceRoot}/tools/extension/**/*.js"],
+      "skipFiles": ["<node_internals>/**"],
       "sourceMapPathOverrides": {
         "webpack:///./~/*": "${workspaceRoot}/node_modules/*",
         "webpack:///./*": "${workspaceRoot}/*",


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

在 debug 后端或插件 host 代码时可以跳过 node 程序的内部文件，避免不必要的单步跳转

### Changelog
attach 后端或 host 时跳过  node_internals 
