### PR TITLE
feat: support workbench.editorAssociations

### DIFF
--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1806,6 +1806,14 @@ const customEditorSchema: PreferenceSchemaProperties = {
     type: 'integer',
     default: 3000,
   },
+  'workbench.editorAssociations': {
+    type: 'object',
+    description: '%preference.workbench.editorAssociations%',
+    default: {},
+    additionalProperties: {
+      type: 'string',
+    },
+  },
   'diffEditor.renderSideBySide': {
     type: 'boolean',
     default: true,

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -632,6 +632,13 @@ export interface IDecorationApplyOptions {
 
 export type IHoverMessage = IMarkdownString | IMarkdownString[] | string;
 
+export enum IEditorPriority {
+  builtin = 'builtin',
+  option = 'option',
+  exclusive = 'exclusive',
+  default = 'default',
+}
+
 // 定义一个resource如何被打开
 export interface IEditorOpenType {
   type: 'code' | 'diff' | 'component';
@@ -641,6 +648,8 @@ export interface IEditorOpenType {
   title?: string;
 
   readonly?: boolean;
+
+  priority?: keyof typeof IEditorPriority;
 
   // 默认0， 大的排在前面
   weight?: number;

--- a/packages/extension/src/browser/vscode/contributes/customEditors.tsx
+++ b/packages/extension/src/browser/vscode/contributes/customEditors.tsx
@@ -3,7 +3,7 @@ import React = require('react');
 import { Injectable, Autowired } from '@opensumi/di';
 import { useInjectable, IEventBus } from '@opensumi/ide-core-browser';
 import { CancellationTokenSource, Disposable, ILogger, match } from '@opensumi/ide-core-common';
-import { EditorComponentRegistry, ReactEditorComponent } from '@opensumi/ide-editor/lib/browser';
+import { EditorComponentRegistry, IEditorPriority, ReactEditorComponent } from '@opensumi/ide-editor/lib/browser';
 import { IWebviewService } from '@opensumi/ide-webview';
 import { WebviewMounter } from '@opensumi/ide-webview/lib/browser/editor-webview';
 
@@ -72,7 +72,7 @@ export class CustomEditorContributionPoint extends VSCodeContributePoint<CustomE
       if (patterns.length === 0) {
         return;
       }
-      const priority: 'default' | 'option' = customEditor.priority || 'default';
+      const priority: keyof typeof IEditorPriority = customEditor.priority || IEditorPriority.default;
       this.addDispose(
         this.editorComponentRegistry.registerEditorComponentResolver(
           () => 10,
@@ -88,7 +88,8 @@ export class CustomEditorContributionPoint extends VSCodeContributePoint<CustomE
                   title: customEditor.displayName
                     ? this.getLocalizeFromNlsJSON(customEditor.displayName)
                     : customEditor.viewType,
-                  weight: priority === 'default' ? Number.MAX_SAFE_INTEGER : 0,
+                  weight: priority === IEditorPriority.default ? Number.MAX_SAFE_INTEGER : Number.MIN_SAFE_INTEGER,
+                  priority,
                   saveResource: (resource) =>
                     this.eventBus.fireAndAwait(
                       new CustomEditorShouldSaveEvent({

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -491,6 +491,8 @@ export const localizationBundle = {
     'preference.workbench.refactoringChanges.showPreviewStrategy':
       'Show preview confirm when triggering some refactoring changes',
     'preference.workbench.refactoringChanges.showPreviewStrategy.title': 'Refactor Confirm',
+    'preference.workbench.editorAssociations':
+      'Configure glob patterns to editors (e.g. `"*.hex": "hexEditor.hexEdit"`). These have precedence over the default behavior.',
 
     'preference.tab.name': 'Settings',
     'preference.noResults': "No Setting Found Containing '{0}'",

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -433,6 +433,8 @@ export const localizationBundle = {
     // workbench
     'preference.workbench.refactoringChanges.showPreviewStrategy': '触发一些重构变更时，是否需要弹窗确认',
     'preference.workbench.refactoringChanges.showPreviewStrategy.title': '重构确认方式',
+    'preference.workbench.editorAssociations':
+      '将 glob 模式配置到编辑器(例如 `"*十六进制": "hexEditor.hexEdit"`)。这些优先顺序高于默认行为。',
 
     'preference.editor.wrapTab': '编辑器 Tab 自动换行',
     'editor.configuration.previewMode': '使用预览模式打开',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -448,6 +448,8 @@ export const defaultSettingSections: {
         { id: 'editor.fontFamily', localized: 'preference.editor.fontFamily' },
         { id: 'editor.lineHeight', localized: 'preference.editor.lineHeight' },
         { id: 'editor.trimAutoWhitespace' },
+        // workbench
+        { id: 'workbench.editorAssociations' },
         // 补全
         { id: 'editor.suggest.insertMode' },
         { id: 'editor.suggest.filterGraceful' },
@@ -536,8 +538,6 @@ export const defaultSettingSections: {
         { id: 'files.exclude', localized: 'preference.files.exclude.title' },
         { id: 'files.watcherExclude', localized: 'preference.files.watcherExclude.title' },
         { id: 'files.associations', localized: 'preference.files.associations.title' },
-        { id: 'files.exclude', localized: 'preference.files.exclude.title' },
-        { id: 'files.watcherExclude', localized: 'preference.files.watcherExclude.title' },
       ],
     },
   ],


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

![image](https://user-images.githubusercontent.com/20262815/167128972-877deef0-6a8c-409e-b40a-cd0cdcda0d24.png)

同时作以下调整
1. 当 customEditors 的 priority 为 option 时，weight 的优先级降为最低，不作为默认打开方式
2. 如果 priority 为 default ，则根据 selector filenamePattern 匹配规则来作为默认打开方式

右下角的悬浮按钮需要作调整，收敛到右上角作为下拉菜单项，不在此 pr 处理
![image](https://user-images.githubusercontent.com/20262815/167130234-e689f26a-f615-4966-8038-8ac3e838364d.png)

### Changelog
支持 workbench.editorAssociations 配置项