### PR TITLE
chore: remove @opensumi/ide-core-common dependency from utils

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,6 @@
     "url": "git@github.com:opensumi/core.git"
   },
   "dependencies": {
-    "@opensumi/ide-core-common": "2.17.2",
     "iconv-lite": "^0.6.0",
     "nanoid": "^3.3.3",
     "vscode-uri": "^3.0.2"


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution
![image](https://user-images.githubusercontent.com/9823838/167148418-1f9cd072-7d04-404f-854b-a3cd6a63f90f.png)

### Changelog

- remove @opensumi/ide-core-common dependence from utils