### PR TITLE
fix: remove embedded markdonw preview

### DIFF
--- a/packages/markdown/src/browser/index.ts
+++ b/packages/markdown/src/browser/index.ts
@@ -3,7 +3,6 @@ import { BrowserModule } from '@opensumi/ide-core-browser';
 
 import { IMarkdownService } from '../common';
 
-import { EmbeddedMarkdownEditorContribution } from './contribution';
 import { MarkdownServiceImpl } from './markdown.service';
 export { Markdown } from './markdown-widget';
 @Injectable()
@@ -13,6 +12,5 @@ export class MarkdownModule extends BrowserModule {
       token: IMarkdownService,
       useClass: MarkdownServiceImpl,
     },
-    EmbeddedMarkdownEditorContribution,
   ];
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Changelog
- [x] remove embedded markdonw preview