### PR TITLE
chore: check node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "changelog-old": "node scripts/changelog/index.js",
     "changelog": "ts-node -P scripts/tsconfig.scripts.json scripts/changelog/index.ts"
   },
+  "engines": {
+    "node": ">=12 <=14"
+  },
   "dependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^7.1.2",


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🧹 Chores

### Background or solution
增加对 engine 的限制，按照文档限制在了 v12 - 14

背景是在其他项目中 nvm 切到 17 后返回 opensumi 安装依赖出错