### PR TITLE
fix: shellLaunchConfig isTransient not keepalive

### DIFF
--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -288,7 +288,7 @@ export class TerminalClient extends Disposable implements ITerminalClient {
       // location:
       // internalOptions?.location ||
       // this._serializeParentTerminal(options.location, internalOptions?.resolvedExtHostIdentifier),
-      // disablePersistence: withNullAsUndefined(options.disablePersistence),
+      disablePersistence: withNullAsUndefined(options.isTransient),
     };
 
     if (options.isExtensionTerminal) {

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -463,7 +463,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
           return;
         }
 
-        if (client.options.isExtensionTerminal || client.options.isTransient) {
+        if (client?.options?.isExtensionTerminal || client?.options?.isTransient) {
           return;
         }
 

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -259,6 +259,9 @@ export interface TerminalOptions {
    */
   beforeCreate?: (terminalId: string) => void;
 
+  /**
+   * 终端是否保活
+   */
   isTransient?: boolean;
 }
 

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -57,7 +57,7 @@ export class PtyService extends Disposable {
     return this._ptyProcess;
   }
 
-  constructor(public id: string, private readonly shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number) {
+  constructor(public id: string, public readonly shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number) {
     super();
     let name: string;
     if (isWindows) {

--- a/packages/terminal-next/src/node/terminal.service.ts
+++ b/packages/terminal-next/src/node/terminal.service.ts
@@ -88,7 +88,10 @@ export class TerminalServiceImpl implements ITerminalNodeService {
     if (terminalMap) {
       terminalMap.forEach((t, id) => {
         this.terminalProcessMap.delete(id);
-        // t.kill(); // 这个是窗口关闭时候触发，在这个场景下终端要保活，不能Kill
+        if (t.shellLaunchConfig.disablePersistence || t.shellLaunchConfig.isExtensionOwnedTerminal) {
+          t.kill(); // terminalProfile有isTransient的参数化，要Kill，不保活
+        }
+        // t.kill(); // 这个是窗口关闭时候触发，终端默认在这种场景下保活, 不kill
         // TOOD 后续看看有没有更加优雅的方案
       });
       this.clientTerminalMap.delete(clientId);


### PR DESCRIPTION
## Types
在TerminalProfile中有 isTransient 或者 检测到Terminal是 Extension创建 的时候，不纳入保活逻辑，窗口关闭自动杀

 - [x] 🐛 Bug Fixes


## Background or solution
JSDebugger 插件适配因为终端恢复逻辑导致生命周期异常。