### PR TITLE
fix: the height of electron windows header bar

### DIFF
--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -89,6 +89,8 @@ export class CodeWindow extends Disposable implements ICodeWindow {
       titleBarStyle: 'hidden',
       height: DEFAULT_WINDOW_HEIGHT,
       width: DEFAULT_WINDOW_WIDTH,
+      // trafficLight position: Center vertically
+      trafficLightPosition: { x: 10, y: 10 },
       ...this.appConfig.overrideBrowserOptions,
       ...options,
     });

--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -1,28 +1,24 @@
-:global(.mac) {
-  --header-height: 22px;
-}
-:global(.windows) {
-  --header-height: 27px;
-}
-
 .header {
-  height: var(--header-height);
+  height: var(--tabBar-height);
   background: var(--menu-background);
   color: var(--titlebar-activeForeground);
   display: flex;
   align-items: center;
   text-align: center;
-  line-height: var(--header-height);
+  line-height: var(--tabBar-height);
   font-size: 12px;
   user-select: none;
+
   .title_info {
     -webkit-app-region: drag;
     flex-grow: 1;
     text-align: left;
   }
+
   :global .menu-bar {
     flex-shrink: 0;
   }
+
   :global .menubarWrapper {
     background-color: var(--menu-background);
   }
@@ -34,15 +30,18 @@
 
 .windowActions {
   display: flex;
-  height: var(--header-height);
+  height: var(--tabBar-height);
   -webkit-app-region: no-drag;
   user-select: none;
+
   > div {
     font-size: 16px;
     padding: 0 15px;
+
     &:hover {
       background-color: hsla(0, 0%, 100%, 0.1);
     }
+
     &:hover:last-child {
       background-color: rgba(232, 17, 35, 0.9);
       color: white;

--- a/tools/electron/src/node/server.ts
+++ b/tools/electron/src/node/server.ts
@@ -28,7 +28,7 @@ export async function startServer(arg1: NodeModule[] | Partial<IServerAppOpts>) 
   }
 
   const server = net.createServer();
-  const listenPath = yargs.argv.listenPath;
+  const listenPath = (await yargs.argv).listenPath;
 
   const serverApp = new ServerApp(opts);
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes

### Background or solution
1. 修复 windows menu 和 title bar 高度不一致
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/2226423/167560680-fe1e7eff-0081-4099-990a-498f0c920471.png">

2. 修改 macOS 版本红绿灯位置
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/2226423/167560376-f79aa83c-6f5f-4c8c-b901-68c05283aa28.png">

close #989 

### Changelog
fix the height of electron windows header bar