### PR TITLE
fix: add missing data when use ApplicationError

### DIFF
--- a/packages/connection/src/common/proxy.ts
+++ b/packages/connection/src/common/proxy.ts
@@ -37,7 +37,7 @@ export class ProxyClient {
 }
 
 interface IRPCResult {
-  error: ApplicationError<number, any> | null;
+  error?: ApplicationError<number, any>;
   data: any;
 }
 export class RPCProxy {
@@ -175,7 +175,6 @@ export class RPCProxy {
       connection.onRequest((method) => {
         if (!this.proxyService[method]) {
           return {
-            error: null,
             data: NOTREGISTERMETHOD,
           };
         }
@@ -212,7 +211,6 @@ export class RPCProxy {
       const result = await this.proxyService[prop](...this.serializeArguments(args));
 
       return {
-        error: null,
         data: result,
       };
     } catch (e) {

--- a/packages/connection/src/common/proxy.ts
+++ b/packages/connection/src/common/proxy.ts
@@ -121,11 +121,11 @@ export class RPCProxy {
                     if (result.data.stack) {
                       error.stack = result.data.stack;
                     }
-                    if (result.data.errorType) {
-                      // using ApplicationError
+                    if (result.data.applicationError) {
+                      // 经过通信，applicationError 实例的构造类信息丢失了，使用 fromJson 恢复
                       const applicationError = ApplicationError.fromJson(
-                        result.data.errorType.code,
-                        result.data.errorType.data,
+                        result.data.applicationError.code,
+                        result.data.applicationError.data,
                       );
                       error.cause = applicationError;
                     }
@@ -224,6 +224,7 @@ export class RPCProxy {
         data: {
           message: e.message,
           stack: e.stack,
+          applicationError: ApplicationError.is(e) ? e : null,
         },
       };
     }

--- a/packages/connection/src/common/proxy.ts
+++ b/packages/connection/src/common/proxy.ts
@@ -1,3 +1,4 @@
+import { ApplicationError } from '@opensumi/ide-core-common';
 import type { MessageConnection } from '@opensumi/vscode-jsonrpc/lib/common/connection';
 
 export abstract class RPCService<T = any> {
@@ -119,6 +120,14 @@ export class RPCProxy {
                     const error = new Error(result.data.message);
                     if (result.data.stack) {
                       error.stack = result.data.stack;
+                    }
+                    if (result.data.errorType) {
+                      // using ApplicationError
+                      const applicationError = ApplicationError.fromJson(
+                        result.data.errorType.code,
+                        result.data.errorType.data,
+                      );
+                      error.cause = applicationError;
                     }
                     reject(error);
                   } else {

--- a/packages/core-common/src/application-error.ts
+++ b/packages/core-common/src/application-error.ts
@@ -40,6 +40,12 @@ export namespace ApplicationError {
     const constructorOpt = Object.assign((...args: any[]) => new Impl(code, factory(...args), constructorOpt), {
       code,
       is(arg: object | undefined): arg is ApplicationError<C, D> {
+        // JSON RPC通信后，错误的构造信息丢失，通过 Error 类的 cause 属性保存 ApplicationError 实例来修复。
+        // 需要加上第一个判断，否则过不了语法检查。
+        if (arg instanceof Error && arg.cause) {
+          const cause = arg.cause;
+          return cause instanceof Impl && cause.code === code;
+        }
         return arg instanceof Impl && arg.code === code;
       },
     });

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -389,7 +389,7 @@ export class DebugConfigurationManager {
       try {
         await this.filesystem.setContent(fileStat, content);
       } catch (e) {
-        if (!e.cause || !FileSystemError.FileExists.is(e.cause)) {
+        if (!FileSystemError.FileExists.is(e.cause)) {
           throw e;
         }
       }

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -27,7 +27,6 @@ import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { WorkspaceVariableContribution } from '@opensumi/ide-workspace/lib/browser/workspace-variable-contribution';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
-
 import { DebugServer, IDebugServer, IDebuggerContribution, launchSchemaUri } from '../common';
 import { DebugSessionOptions } from '../common';
 import { DebugConfiguration } from '../common';
@@ -35,7 +34,6 @@ import { DebugConfiguration } from '../common';
 import { CONTEXT_DEBUGGERS_AVAILABLE } from './../common/constants';
 import { DebugConfigurationModel } from './debug-configuration-model';
 import { DebugPreferences } from './debug-preferences';
-
 
 export type WillProvideDebugConfiguration = WaitUntilEvent;
 export type WillInitialConfiguration = WaitUntilEvent;
@@ -391,7 +389,7 @@ export class DebugConfigurationManager {
       try {
         await this.filesystem.setContent(fileStat, content);
       } catch (e) {
-        if (!FileSystemError.FileExists.is(e)) {
+        if (!e.cause || !FileSystemError.FileExists.is(e)) {
           throw e;
         }
       }

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -389,7 +389,7 @@ export class DebugConfigurationManager {
       try {
         await this.filesystem.setContent(fileStat, content);
       } catch (e) {
-        if (!e.cause || !FileSystemError.FileExists.is(e)) {
+        if (!e.cause || !FileSystemError.FileExists.is(e.cause)) {
           throw e;
         }
       }

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -389,7 +389,7 @@ export class DebugConfigurationManager {
       try {
         await this.filesystem.setContent(fileStat, content);
       } catch (e) {
-        if (!FileSystemError.FileExists.is(e.cause)) {
+        if (!FileSystemError.FileExists.is(e)) {
           throw e;
         }
       }

--- a/packages/workspace-edit/src/browser/workspace-edit.service.ts
+++ b/packages/workspace-edit/src/browser/workspace-edit.service.ts
@@ -304,7 +304,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
         await editorService.close(this.oldResource, true);
         eventBus.fire(new WorkspaceEditDidDeleteFileEvent({ oldUri: this.oldResource }));
       } catch (err) {
-        if (FileSystemError.FileNotFound.is(err) && options.ignoreIfNotExists) {
+        if (err.cause && FileSystemError.FileNotFound.is(err) && options.ignoreIfNotExists) {
           // 不抛出错误
         } else {
           throw err;
@@ -319,8 +319,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
           await workspaceFS.create(this.newResource, '', { overwrite: options.overwrite });
         }
       } catch (err) {
-        // FIXME: 不知道为什么这里错误不是 FileSystemError 了，所以换个实现兼容一下
-        if (this.isFileExistError(err) && options.ignoreIfExists) {
+        if (err.cause && FileSystemError.FileExists.is(err.cause) && options.ignoreIfExists) {
           // 不抛出错误
         } else {
           throw err;
@@ -330,10 +329,6 @@ export class ResourceFileEdit implements IResourceFileEdit {
         editorService.open(this.newResource);
       }
     }
-  }
-
-  private isFileExistError(err: Error): boolean {
-    return err.message.includes('already exists.');
   }
 
   async revert(): Promise<void> {}

--- a/packages/workspace-edit/src/browser/workspace-edit.service.ts
+++ b/packages/workspace-edit/src/browser/workspace-edit.service.ts
@@ -304,7 +304,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
         await editorService.close(this.oldResource, true);
         eventBus.fire(new WorkspaceEditDidDeleteFileEvent({ oldUri: this.oldResource }));
       } catch (err) {
-        if (FileSystemError.FileNotFound.is(err.cause) && options.ignoreIfNotExists) {
+        if (FileSystemError.FileNotFound.is(err) && options.ignoreIfNotExists) {
           // 不抛出错误
         } else {
           throw err;
@@ -319,7 +319,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
           await workspaceFS.create(this.newResource, '', { overwrite: options.overwrite });
         }
       } catch (err) {
-        if (FileSystemError.FileExists.is(err.cause) && options.ignoreIfExists) {
+        if (FileSystemError.FileExists.is(err) && options.ignoreIfExists) {
           // 不抛出错误
         } else {
           throw err;

--- a/packages/workspace-edit/src/browser/workspace-edit.service.ts
+++ b/packages/workspace-edit/src/browser/workspace-edit.service.ts
@@ -304,7 +304,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
         await editorService.close(this.oldResource, true);
         eventBus.fire(new WorkspaceEditDidDeleteFileEvent({ oldUri: this.oldResource }));
       } catch (err) {
-        if (err.cause && FileSystemError.FileNotFound.is(err) && options.ignoreIfNotExists) {
+        if (err.cause && FileSystemError.FileNotFound.is(err.cause) && options.ignoreIfNotExists) {
           // 不抛出错误
         } else {
           throw err;

--- a/packages/workspace-edit/src/browser/workspace-edit.service.ts
+++ b/packages/workspace-edit/src/browser/workspace-edit.service.ts
@@ -304,7 +304,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
         await editorService.close(this.oldResource, true);
         eventBus.fire(new WorkspaceEditDidDeleteFileEvent({ oldUri: this.oldResource }));
       } catch (err) {
-        if (err.cause && FileSystemError.FileNotFound.is(err.cause) && options.ignoreIfNotExists) {
+        if (FileSystemError.FileNotFound.is(err.cause) && options.ignoreIfNotExists) {
           // 不抛出错误
         } else {
           throw err;
@@ -319,7 +319,7 @@ export class ResourceFileEdit implements IResourceFileEdit {
           await workspaceFS.create(this.newResource, '', { overwrite: options.overwrite });
         }
       } catch (err) {
-        if (err.cause && FileSystemError.FileExists.is(err.cause) && options.ignoreIfExists) {
+        if (FileSystemError.FileExists.is(err.cause) && options.ignoreIfExists) {
           // 不抛出错误
         } else {
           throw err;


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution
closes #779 
### Changelog
原来后端报错的时候，返回给前端的只有message和stack，所以前端不具有使用`FileSystemError`进行错误信息判断的能力。
在使用了`FileSystemError`的时候，补充了相关属性。