### PR TITLE
fix: extension-management state & detail page styles

### DIFF
--- a/packages/extension-manager/src/browser/extension-overview/index.tsx
+++ b/packages/extension-manager/src/browser/extension-overview/index.tsx
@@ -135,7 +135,7 @@ export const ExtensionOverview: ReactEditorComponent<
           <div className={styles.description}>
             {replaceLocalizePlaceholder(resource.metadata?.description, resource.metadata?.extensionId)}
           </div>
-          <div>
+          <div className={styles.button}>
             {resource.metadata?.state === InstallState.NOT_INSTALLED && (
               <Button size='small' onClick={onInstallCallback} disabled={installing}>
                 {localize(installing ? 'marketplace.extension.installing' : 'marketplace.extension.install')}

--- a/packages/extension-manager/src/browser/extension-overview/index.tsx
+++ b/packages/extension-manager/src/browser/extension-overview/index.tsx
@@ -141,6 +141,11 @@ export const ExtensionOverview: ReactEditorComponent<
                 {localize(installing ? 'marketplace.extension.installing' : 'marketplace.extension.install')}
               </Button>
             )}
+            {resource.metadata?.state === InstallState.SHOULD_UPDATE && (
+              <Button size='small' onClick={onInstallCallback} disabled={installing}>
+                {localize(installing ? 'marketplace.extension.updating' : 'marketplace.extension.update')}
+              </Button>
+            )}
             {resource.metadata?.state === InstallState.INSTALLED && (
               <span>{localize('marketplace.extension.installed')}</span>
             )}

--- a/packages/extension-manager/src/browser/extension-overview/overview.module.less
+++ b/packages/extension-manager/src/browser/extension-overview/overview.module.less
@@ -87,6 +87,10 @@
       font-size: 14px;
       color: var(--descriptionForeground);
     }
+
+    .button {
+      margin-top: 8px;
+    }
   }
 }
 

--- a/packages/extension-manager/src/browser/extension/extension.module.less
+++ b/packages/extension-manager/src/browser/extension/extension.module.less
@@ -80,5 +80,9 @@
         line-height: 19px;
       }
     }
+
+    .state_text {
+      margin-right: 8px;
+    }
   }
 }

--- a/packages/extension-manager/src/browser/extension/index.tsx
+++ b/packages/extension-manager/src/browser/extension/index.tsx
@@ -87,7 +87,7 @@ export const Extension = React.memo(
                     {localize(installing ? 'marketplace.extension.updating' : 'marketplace.extension.update')}
                   </Button>
                 ) : (
-                  <span>{localize('marketplace.extension.installed')}</span>
+                  <span className={styles.state_text}>{localize('marketplace.extension.installed')}</span>
                 )
               ) : (
                 <>
@@ -96,7 +96,9 @@ export const Extension = React.memo(
                   </Button>
                 </>
               ))}
-            {type === ExtensionViewType.INSTALLED && <span>{localize('marketplace.extension.installed')}</span>}
+            {type === ExtensionViewType.INSTALLED && (
+              <span className={styles.state_text}>{localize('marketplace.extension.installed')}</span>
+            )}
           </div>
         </div>
       </div>

--- a/packages/extension-manager/src/browser/extension/index.tsx
+++ b/packages/extension-manager/src/browser/extension/index.tsx
@@ -7,69 +7,99 @@ import { InstallState, VSXExtension } from '../../common';
 
 import styles from './extension.module.less';
 
+export enum ExtensionViewType {
+  MARKETPLACE,
+  INSTALLED,
+}
+
 interface IExtensionViewProps {
   extension: VSXExtension;
   onInstall(extension: VSXExtension): Promise<void>;
   onClick(extension: VSXExtension, state: InstallState): void;
-  installed: boolean;
+  type: ExtensionViewType;
+  installedExtensions?: VSXExtension[];
 }
 
-export const Extension = React.memo(({ extension, onInstall, onClick, installed }: IExtensionViewProps) => {
-  const [installing, setInstalling] = useState<boolean>();
-  const [installedState, setInstalled] = useState<boolean>(installed);
+export const Extension = React.memo(
+  ({ extension: extension, onInstall, onClick, type, installedExtensions }: IExtensionViewProps) => {
+    const [installing, setInstalling] = useState<boolean>();
+    const installedExtension = installedExtensions?.find(
+      (installed) => installed.namespace === extension.namespace && installed.name === extension.name,
+    );
+    const isInstalled = Boolean(type === ExtensionViewType.INSTALLED || installedExtension);
+    const shouldUpdate =
+      isInstalled && type === ExtensionViewType.MARKETPLACE && installedExtension?.version !== extension.version;
+    const [installedState, setInstalled] = useState<boolean>(isInstalled);
 
-  const onInstallCallback = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      setInstalling(true);
-      onInstall(extension).then(() => {
-        setInstalling(false);
-        setInstalled(true);
-      });
-    },
-    [extension],
-  );
+    const onInstallCallback = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setInstalling(true);
+        onInstall(extension).then(() => {
+          setInstalling(false);
+          setInstalled(true);
+        });
+      },
+      [extension],
+    );
 
-  const onClickCallback = useCallback(() => {
-    onClick(extension, installedState ? InstallState.INSTALLED : InstallState.NOT_INSTALLED);
-  }, [extension]);
+    const onClickCallback = useCallback(() => {
+      onClick(
+        extension,
+        installedState
+          ? shouldUpdate
+            ? InstallState.SHOULD_UPDATE
+            : InstallState.INSTALLED
+          : InstallState.NOT_INSTALLED,
+      );
+    }, [extension]);
 
-  return (
-    <div className={styles.extension_item} onClick={onClickCallback}>
-      <img
-        className={styles.icon}
-        src={extension.iconUrl || 'https://open-vsx.org/default-icon.png'}
-        alt={replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`)}
-      />
-      <div className={styles.extension_detail}>
-        <div className={styles.base_info}>
-          <span className={styles.display_name}>
-            {replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`) ||
-              extension.name}
-          </span>
-          <span className={styles.version}>{extension.version}</span>
-          {!installedState && (
-            <span className={styles.download_count}>
-              <Icon iconClass={getKaitianIcon('download')} />
-              {extension.downloadCount}
+    return (
+      <div className={styles.extension_item} onClick={onClickCallback}>
+        <img
+          className={styles.icon}
+          src={extension.iconUrl || 'https://open-vsx.org/default-icon.png'}
+          alt={replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`)}
+        />
+        <div className={styles.extension_detail}>
+          <div className={styles.base_info}>
+            <span className={styles.display_name}>
+              {replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`) ||
+                extension.name}
             </span>
-          )}
-        </div>
-        <span className={styles.description}>
-          {replaceLocalizePlaceholder(extension.description, `${extension.publisher}.${extension.name}`)}
-        </span>
-        <div className={styles.footer}>
-          <span className={styles.namespace}>{extension.namespace}</span>
-          {!installedState && (
-            <>
-              <Button type='link' size='small' onClick={onInstallCallback} disabled={installing}>
-                {localize(installing ? 'marketplace.extension.installing' : 'marketplace.extension.install')}
-              </Button>
-            </>
-          )}
-          {installedState && <span>{localize('marketplace.extension.installed')}</span>}
+            <span className={styles.version}>{extension.version}</span>
+            {!installedState && (
+              <span className={styles.download_count}>
+                <Icon iconClass={getKaitianIcon('download')} />
+                {extension.downloadCount}
+              </span>
+            )}
+          </div>
+          <span className={styles.description}>
+            {replaceLocalizePlaceholder(extension.description, `${extension.publisher}.${extension.name}`)}
+          </span>
+          <div className={styles.footer}>
+            <span className={styles.namespace}>{extension.namespace}</span>
+            {type === ExtensionViewType.MARKETPLACE &&
+              (isInstalled ? (
+                shouldUpdate ? (
+                  <Button type='link' size='small' onClick={onInstallCallback} disabled={installing}>
+                    {localize(installing ? 'marketplace.extension.updating' : 'marketplace.extension.update')}
+                  </Button>
+                ) : (
+                  <span>{localize('marketplace.extension.installed')}</span>
+                )
+              ) : (
+                <>
+                  <Button type='link' size='small' onClick={onInstallCallback} disabled={installing}>
+                    {localize(installing ? 'marketplace.extension.installing' : 'marketplace.extension.install')}
+                  </Button>
+                </>
+              ))}
+            {type === ExtensionViewType.INSTALLED && <span>{localize('marketplace.extension.installed')}</span>}
+          </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);

--- a/packages/extension-manager/src/browser/vsx-extension.contribution.ts
+++ b/packages/extension-manager/src/browser/vsx-extension.contribution.ts
@@ -10,8 +10,7 @@ import {
 import { IMainLayoutService, MainLayoutContribution } from '@opensumi/ide-main-layout';
 import { IIconService, IconType } from '@opensumi/ide-theme';
 
-import { InstallState, IVSXExtensionService, VSXExtensionServiceToken } from '../common';
-import { VSXExtensionRaw } from '../common/vsx-registry-types';
+import { IVSXExtensionService, VSXExtensionServiceToken } from '../common';
 
 import { OPEN_VSX_EXTENSION_MANAGER_CONTAINER_ID, EXTENSION_SCHEME } from './const';
 import { ExtensionOverview } from './extension-overview';
@@ -72,7 +71,7 @@ export class VSXExtensionContribution
     });
 
     editorComponentRegistry.registerEditorComponentResolver(EXTENSION_SCHEME, (_, __, resolve) => {
-      resolve!([
+      resolve?.([
         {
           type: 'component',
           componentId: EXTENSIONS_DETAIL_COMPONENT_ID,

--- a/packages/extension-manager/src/browser/vsx-extension.service.ts
+++ b/packages/extension-manager/src/browser/vsx-extension.service.ts
@@ -76,9 +76,9 @@ export class VSXExtensionService implements IVSXExtensionService {
 
     const task = this.backService.install({
       id,
-      name: extension.name!,
+      name: extension.name ?? '-',
       url: extension.downloadUrl,
-      version: extension.version!,
+      version: extension.version ?? '-',
     });
     this.tasks.set(id, task);
     this.updateStatusBar();

--- a/packages/extension-manager/src/browser/vsx-extension.view.tsx
+++ b/packages/extension-manager/src/browser/vsx-extension.view.tsx
@@ -9,11 +9,10 @@ import { ProgressBar } from '@opensumi/ide-core-browser/lib/components/progressb
 import { localize } from '@opensumi/ide-core-common';
 import { AutoFocusedInput } from '@opensumi/ide-main-layout/lib/browser/input';
 
-
-import { IVSXExtensionService, TabActiveKey, VSXExtension, VSXExtensionServiceToken } from '../common';
+import { IVSXExtensionService, TabActiveKey, VSXExtension, VSXExtensionServiceToken, InstallState } from '../common';
 
 import { OPEN_VSX_EXTENSION_MANAGER_CONTAINER_ID } from './const';
-import { Extension } from './extension';
+import { Extension, ExtensionViewType } from './extension';
 import styles from './vsx-extension.module.less';
 
 const tabMap = [TabActiveKey.MARKETPLACE, TabActiveKey.INSTALLED];
@@ -35,7 +34,7 @@ export const VSXExtensionView = observer(() => {
 
   const onInstall = useCallback((extension: VSXExtension) => vsxExtensionService.install(extension), []);
 
-  const onClick = useCallback((extension, state) => {
+  const onClick = useCallback((extension: VSXExtension, state: InstallState) => {
     const id = extension?.namespace?.toLowerCase() + '.' + extension?.name?.toLowerCase();
     vsxExtensionService.openExtensionEditor(id, state);
   }, []);
@@ -73,7 +72,8 @@ export const VSXExtensionView = observer(() => {
               onInstall={onInstall}
               key={`${e.namespace}-${e.name}`}
               extension={e}
-              installed={false}
+              type={ExtensionViewType.MARKETPLACE}
+              installedExtensions={vsxExtensionService.installedExtensions}
             />
           ))}
         </div>
@@ -86,7 +86,7 @@ export const VSXExtensionView = observer(() => {
               onInstall={onInstall}
               key={`${e.namespace}-${e.name}`}
               extension={e}
-              installed={true}
+              type={ExtensionViewType.INSTALLED}
             />
           ))}
         </div>

--- a/packages/extension-manager/src/common/index.ts
+++ b/packages/extension-manager/src/common/index.ts
@@ -13,6 +13,7 @@ export enum TabActiveKey {
 export enum InstallState {
   INSTALLED = 'INSTALLED',
   NOT_INSTALLED = 'NOT_INSTALLED',
+  SHOULD_UPDATE = 'SHOULD_UPDATE',
 }
 
 export type VSXExtensionNamespaceAccess = 'public' | 'restricted';

--- a/packages/extension-manager/src/node/vsx-extension.service.ts
+++ b/packages/extension-manager/src/node/vsx-extension.service.ts
@@ -147,7 +147,7 @@ export class VSXExtensionService implements IVSXExtensionBackService {
       }
     });
   }
-  private async downloadExtension({ url, name, id }): Promise<{ downloadPath: string }> {
+  private async downloadExtension({ url, id }): Promise<{ downloadPath: string }> {
     const extensionDir = path.join(os.tmpdir(), 'extension', uuidv4());
     await fs.mkdirp(extensionDir);
     const vsixFileName = id + '.vsix';


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

Related issues: https://github.com/opensumi/core/issues/747 https://github.com/opensumi/core/issues/750

> 目前解决的问题
>
> - 插件详情页按钮样式
> - 为 `<Extension />` 添加 type，在 init 时扩展市场可以正确判断安装、已安装与更新状态
> - 修复部分 lint warning
>
>这个改动复杂度比想象中大，所有有些疑问的点想先讨论下
>
> - 发现额外的问题
> - 搜索栏切换到 “已安装插件” 后依然搜索市场中的插件
> - 插件有部分能力没有实现，包括激活、禁用、卸载
> - browser 侧的 installedExtensions property 是通过 `getExtensionInstances` computed ，实际调用的 extensionMap 并没有在增删插件时更新，是通过 initExtensionMetaData 从 node 侧的 nodeExtensionService 初始化时读取的，要实现同步的话这块改动可能比较大
> - 对于更新来说，可能还需要增加额外的逻辑，在安装前首先卸载相同 extensionId 的插件，保持插件唯一。另外项目本身也会在 `tools/extensions` 安装插件，和 `~/.sumi/extensions` 中 extensionId 相同时，更新应该操作哪一侧

**Fix**

- 已安装与更新逻辑可正常在插件市场 tab 显示

> 提到的同步和搜索等其他问题后续拆成其他 PR，关联 issue 先不 close 了

<img width="328" alt="image" src="https://user-images.githubusercontent.com/47357585/167830555-34d00404-77de-4ec3-b70e-50abf270850d.png">
<img width="322" alt="image" src="https://user-images.githubusercontent.com/47357585/167830668-635cd610-4583-4160-8f27-4a6150552830.png">



### Changelog

improve extension-management state & detail page styles