### PR TITLE
chore: lock vscode-languageserver-protocol dependence version

### DIFF
--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -50,7 +50,7 @@
     "react-window": "^1.8.5",
     "reconnecting-websocket": "^4.2.0",
     "resize-observer-polyfill": "1.5.1",
-    "vscode-languageserver-protocol": "^3.14.1",
+    "vscode-languageserver-protocol": "^3.16.0",
     "vscode-textmate": "5.4.0"
   }
 }


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

ref: https://github.com/microsoft/vscode-languageserver-node/releases/tag/release%2Ftypes%2F3.17.0

### Changelog

lock vscode-languageserver-protocol dependence version