### PR TITLE
fix: windows-compatible static resource URIs

### DIFF
--- a/packages/core-electron-main/src/bootstrap/types.ts
+++ b/packages/core-electron-main/src/bootstrap/types.ts
@@ -125,11 +125,11 @@ export interface ICodeWindow {
 
   metadata: any;
 
-  setWorkspace(workspace: string, fsPath?: boolean);
+  setWorkspace(workspace: string, fsPath?: boolean): void;
 
-  setExtensionDir(extensionDir: string);
+  setExtensionDir(extensionDir: string): void;
 
-  setExtensionCandidate(extensionCandidate: ExtensionCandidate[]);
+  setExtensionCandidate(extensionCandidate: ExtensionCandidate[]): void;
 }
 
 export interface ICodeWindowOptions {

--- a/packages/express-file-server/package.json
+++ b/packages/express-file-server/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@opensumi/ide-core-browser": "2.17.4",
     "@opensumi/ide-dev-tool": "^1.3.1",
+    "@types/koa-mount": "^4.0.1",
     "superagent": "^5.1.0"
   }
 }

--- a/packages/express-file-server/src/browser/file-server.contribution.ts
+++ b/packages/express-file-server/src/browser/file-server.contribution.ts
@@ -20,10 +20,10 @@ export class ExpressFileServerContribution implements StaticResourceContribution
         // http://0.0.0.0:8000/assets/${path}
         const assetsUri = new URI(this.appConfig.staticServicePath || EXPRESS_SERVER_PATH);
         /**
-         * uri.path 在 Windows 下会被解析为  \c:\\Path\\to\file
+         * uri.path 在 Windows 下会被解析为 /c:/Path/to/file
          * fsPath C:\\Path\\to\\file
          */
-        return assetsUri.withPath(`assets${decodeURIComponent(uri.codeUri.fsPath)}`);
+        return assetsUri.withPath(`assets${decodeURIComponent(uri.codeUri.path)}`);
       },
       roots: [this.appConfig.staticServicePath || EXPRESS_SERVER_PATH],
     });

--- a/tools/dev-tool/src/server.ts
+++ b/tools/dev-tool/src/server.ts
@@ -60,7 +60,11 @@ export async function startServer(arg1: NodeModule[] | Partial<IServerAppOpts>) 
     processCloseExitThreshold: 5 * 60 * 1000,
     terminalPtyCloseThreshold: 5 * 60 * 1000,
     staticAllowOrigin: '*',
-    staticAllowPath: [path.join(__dirname, '../../../packages/extension'), '/'],
+    staticAllowPath: [
+      path.join(__dirname, '../../../packages/extension'),
+      path.join(__dirname, '../../../tools/extensions'),
+      '/',
+    ],
     extLogServiceClassPath: path.join(__dirname, './mock-log-service.js'),
     /**
      * 集成时可使用自定义的 extHost 入口传入内置 command


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
修复 Windows 启动 core 后，IDE 不能正常加载资源比如图标主题或者 worker 资源
close #1015 

1. 静态资源拼接用 path 而不是 fsPath
```js
// windows
assetsUri.toString()
'http://127.0.0.1:8000/'
uri.toString()
'file:///c%3A/Users/Administrator/repo/core/tools/extensions/vscode-icons-team.vscode-icons/icons/folder_type_kubernetes.svg'

// 组合
assetsUri.withPath(`assets${decodeURIComponent(uri.codeUri.fsPath)}`).toString();
'http://127.0.0.1:8000/assetsc%3A/Users/Administrator/repo/core/tools/extensions/vscode-icons-team.vscode-icons/icons/folder_type_kubernetes.svg'
```

标准的 uri windows 路径是：`file:///d:/some/path/to/repos/on/d/drive`

所以如果用 assets 拼接，应该是 http://127.0.0.1:8000/assets/d:/some/path/to/repos/on/d/drive 而不是现在的
http://127.0.0.1:8000/assetsd:/some/path/to/repos/on/d/drive

2. 解析使用 uri 解析，而不是截断
从 http://127.0.0.1:8000/assets 截断后面的 path 后，应该用 file:// 包裹，通过 URI 去正确的解析 不同操作系统的路径。

3. Windows 启动的 Web 容器能在 macOS  和 Linux 系统中打开？
目前可以了，统一了当前静态资源，但可能其它地方还需要检查一下。

---

Before:
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/2226423/168056688-ea1803a3-b2fe-48ca-85f8-237ec2299911.png">

After:
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/2226423/168055961-41c8ac1a-758f-42bc-864e-ca923585c052.png">

---
Browser 里面有两个 Uri，之后可能要注意一下， vscode-uri 因为一些编译处理，导致 isWindows 判断异常
1. webpack:///C:/Users/Administrator/repo/core/node_modules/@opensumi/monaco-editor-core/esm/vs/base/common/uri.js
2. webpack:///C:/Users/Administrator/repo/core/node_modules/vscode-uri/lib/esm/index.js

### Changelog
windows-compatible static resource URIs