### PR TITLE
fix: resolve correct default value on preference view

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -417,7 +417,7 @@ export const localizationBundle = {
     'preference.stringArray.none': 'None',
 
     // Default value prompt message for enumerated options in settings
-    'preference.enum.default': 'default',
+    'preference.enum.default': 'Default',
 
     // Terminal
     'preference.terminal.type': 'Default Shell Type',
@@ -449,8 +449,8 @@ export const localizationBundle = {
     'component.modal.cancelText': 'Cancel',
     'component.modal.justOkText': 'OK',
 
-    'preference.tab.user': 'Global Settings',
-    'preference.tab.workspace': 'Workspace Settings',
+    'preference.tab.user': 'User',
+    'preference.tab.workspace': 'Workspace',
 
     'settings.group.general': 'General',
     'settings.group.shortcut': 'Shortcut',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -541,7 +541,7 @@ export const localizationBundle = {
     'preference.editSettingsJson': '在 settings.json 中编辑',
     'preference.overwritten': '（已被下一级设置覆盖）',
     'preference.overwrittenInUser': '（已在全局设置中设置）',
-    'preference.overwrittenInWorkspace': '（已在工作区设置中设置）',
+    'preference.overwrittenInWorkspace': '（已在工作区设置中被覆盖）',
     'preference.searchPlaceholder': '搜索设置...',
     'keymaps.tab.name': '快捷键设置',
 

--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -15,6 +15,7 @@ import {
   replaceLocalizePlaceholder,
   useInjectable,
   formatLocalize,
+  isUndefined,
 } from '@opensumi/ide-core-browser';
 
 import { toPreferenceReadableName, getPreferenceItemLabel } from '../common';
@@ -355,8 +356,9 @@ function SelectPreferenceItem({
   hasValueInScope,
 }: IPreferenceItemProps) {
   const preferenceService: PreferenceService = useInjectable(PreferenceService);
+  const defaultValue = preferenceService.get(preferenceName, PreferenceScope.Default) || schema.default;
   const settingsService: PreferenceSettingsService = useInjectable(IPreferenceSettingsService);
-  const [value, setValue] = useState<string>(currentValue);
+  const [value, setValue] = useState<string>(isUndefined(currentValue) ? defaultValue : currentValue);
 
   // 鼠标还没有划过来的时候，需要一个默认的描述信息
   const defaultDescription = useMemo((): string => {
@@ -366,10 +368,6 @@ function SelectPreferenceItem({
     return '';
   }, [schema]);
   const [description, setDescription] = useState<string>(defaultDescription);
-
-  useEffect(() => {
-    setValue(currentValue);
-  }, [currentValue]);
 
   const handleValueChange = useCallback(
     (val) => {
@@ -381,7 +379,6 @@ function SelectPreferenceItem({
 
   // enum 本身为 string[] | number[]
   const labels = settingsService.getEnumLabels(preferenceName);
-  const defaultValue = preferenceService.get(preferenceName, PreferenceScope.Default) || schema.default;
   const renderEnumOptions = useCallback(
     () =>
       schema.enum?.map((item, idx) => {

--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -381,7 +381,7 @@ function SelectPreferenceItem({
 
   // enum 本身为 string[] | number[]
   const labels = settingsService.getEnumLabels(preferenceName);
-
+  const defaultValue = preferenceService.get(preferenceName, PreferenceScope.Default) || schema.default;
   const renderEnumOptions = useCallback(
     () =>
       schema.enum?.map((item, idx) => {
@@ -397,7 +397,7 @@ function SelectPreferenceItem({
             className={styles.select_option}
           >
             {replaceLocalizePlaceholder((labels[item] || item).toString())}
-            {item === schema.default && (
+            {item === String(defaultValue) && (
               <div className={styles.select_default_option_tips}>{localize('preference.enum.default')}</div>
             )}
           </Option>

--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -26,6 +26,7 @@
       flex-grow: 1;
       align-self: flex-end;
       max-width: 400px;
+      margin-left: 50px;
       input {
         width: 100%;
       }

--- a/packages/preferences/src/browser/preferences.view.tsx
+++ b/packages/preferences/src/browser/preferences.view.tsx
@@ -89,14 +89,6 @@ export const PreferenceView: ReactEditorComponent<null> = observer(() => {
     const toDispose = preferenceService.onDidSettingsChange(() => {
       doGetGroups();
     });
-
-    // 如果当前工作区有设置文件，则先展示工作区设置
-    (async () => {
-      const hasWorkspaceSettings = await preferenceService.hasThisScopeSetting(PreferenceScope.Workspace);
-      if (hasWorkspaceSettings) {
-        setTabList([WorkspaceScope, UserScope]);
-      }
-    })();
     return () => {
       toDispose?.dispose();
     };


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

通过默认配置传入配置项时可能会与配置项 Scheme 定义冲突，此时应该优先使用默认配置作为默认值
<img width="878" alt="image" src="https://user-images.githubusercontent.com/9823838/168208713-865b74b5-035b-4efe-a19a-4f1e07461060.png">

优化部分文案，移除了有工作区设置情况下自动跳转工作区设置的交互

### Changelog

resolve correct default value on preference view
