### PR TITLE
fix: file menus remove new_folder

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -24,6 +24,7 @@ export namespace FILE_COMMANDS {
   export const NEW_FOLDER: Command = {
     id: 'file.folder.new',
     category: CATEGORY,
+    label: '%file.folder.new%',
     iconClass: getIcon('new-folder'),
   };
 

--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -24,7 +24,6 @@ export namespace FILE_COMMANDS {
   export const NEW_FOLDER: Command = {
     id: 'file.folder.new',
     category: CATEGORY,
-    label: '%file.folder.new%',
     iconClass: getIcon('new-folder'),
   };
 

--- a/packages/core-browser/src/common/common.contribution.ts
+++ b/packages/core-browser/src/common/common.contribution.ts
@@ -121,10 +121,6 @@ export class ClientCommonContribution
         group: '2_new',
       },
       {
-        command: FILE_COMMANDS.NEW_FOLDER.id,
-        group: '2_new',
-      },
-      {
         command: {
           id: EDITOR_COMMANDS.SAVE_CURRENT.id,
           label: localize('file.save'),


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

~~由于 command 没有 label，new_folder 在 menu 中引用没有生效，同时命令面板中也没有注册~~

在 file menu 中移除相关逻辑

### Changelog