### PR TITLE
chore: add iteration plan generate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "download-extension": "cross-env DEBUG=InstallExtension node scripts/download.js",
     "update:iconfont": "ts-node ./scripts/download-iconfont.ts",
     "changelog-old": "node scripts/changelog/index.js",
-    "changelog": "ts-node -P scripts/tsconfig.scripts.json scripts/changelog/index.ts"
+    "changelog": "ts-node -P scripts/tsconfig.scripts.json scripts/changelog/index.ts",
+    "iteration": "ts-node -P scripts/tsconfig.scripts.json scripts/iteration-plan.ts"
   },
   "engines": {
     "node": ">=12 <=14"

--- a/scripts/changelog/types.ts
+++ b/scripts/changelog/types.ts
@@ -14,3 +14,9 @@ export interface ICommitLogFields extends DefaultLogFields {
    */
   loginName?: string;
 }
+
+export enum PR_STATE {
+  CLOSED = 0,
+  OPEN,
+  ALL,
+}

--- a/scripts/changelog/util.ts
+++ b/scripts/changelog/util.ts
@@ -37,6 +37,9 @@ export function getType(message) {
 
 // 从 PR 描述中提取 changelog
 export function getChangelog(message) {
+  if (!message) {
+    return;
+  }
   const stripedMsg = message.replace(/\r?\n|\r/g, '');
   const match = /### changelog(.+)$/i.exec(stripedMsg);
   return match && match[1] && match[1] && cleanupUselessContent(match[1]);

--- a/scripts/iteration-plan.ts
+++ b/scripts/iteration-plan.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+import { getPrList } from './changelog/github';
+import { formatBytes, getChangelog } from './changelog/util';
+import { argv } from 'yargs';
+
+import chalk from 'chalk';
+
+if (!process.env.GITHUB_TOKEN) {
+  console.log(chalk.red('Please export your github persional access token as env `GITHUB_TOKEN`'));
+  console.log(chalk.green('You can access your own access token by https://github.com/settings/tokens'));
+  console.log(chalk.yellow('Please keep your github access token carefully'));
+  process.exit();
+} else if (!argv.time || !argv.version) {
+  console.log(chalk.yellow('Please process a time argv, like `npm run iteration -- --time=2022-2-2 --version=2.18`'));
+  process.exit();
+}
+
+// 当前仅会统计已合并的 PR 用于最初的迭代计划内容初始化，后续内容需要手动调整
+(async () => {
+  const time = argv.time as string;
+  const version = argv.version as string;
+  const items = await getPrList(new Date(time).getTime());
+  const draftLog: string[] = [];
+  for (const item of items) {
+    const changelog = getChangelog(item.body);
+    if (!changelog) {
+      continue;
+    }
+    draftLog.push(`- [x] ${changelog} [#${item.number}](${item.issue_url}). [@${item.user.login}](${item.user.url})`);
+  }
+
+  const plan = `<!-- This plan captures our work in February. This is a 3-week iteration. We will ship in mid-April. -->
+
+# Plan Items
+  
+Legend of annotations:
+  
+|  Mark   | Description  |
+|  ----  | ----  |
+|🏃| work in progress |
+|✋| blocked task |
+|💪| stretch goal for this iteration |
+|👨🏻‍💻| a large work item, larger than one iteration |
+|🐚| under discussion within the team |
+  
+Below is a summary of the top-level plan items.
+
+## [Draft]
+<!-- 发布前需要对 PR 进行分类, 标注 emoji 信息，同时移除多余的分类信息，下列部分仅为迭代期间合并的 PR，还有部分信息需要手动补充 -->
+${draftLog.join('\n')}
+
+## Editor
+
+## Extension Manager
+    
+## FileTree
+
+## Debug
+
+## Webview
+
+## Search
+
+## Terminal
+
+## Preference
+
+## Keymaps
+  
+## Theme
+ 
+## Webview
+
+## StatusBar
+ 
+## Extension API
+ 
+## QuickOpen
+
+## Refactor
+
+## Electron
+
+## Storage
+ 
+## Style Change
+
+## Tabbar
+
+## Others 
+
+Release Notes 见：[release-notes/v${version}.md](https://github.com/opensumi/doc/blob/main/release-notes/v${version}.md).
+`;
+
+  const logFile = path.resolve(__dirname, '../iteration-plan.md');
+  await fs.promises.writeFile(logFile, plan);
+  const bytes = Buffer.byteLength(plan, 'utf8');
+  console.log(`${formatBytes(bytes)} written to ${logFile}\n`);
+})();


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

用于按日期，按版本生成一份迭代计划模板，调用格式如下：

```bash
$ GITHUB_TOKEN=... npm run iteration -- --time=2022-2-2 --version=2.18
```

### Changelog
