### PR TITLE
fix: await terminal context key passed

### DIFF
--- a/packages/terminal-next/src/browser/contribution/terminal.lifecycle.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.lifecycle.ts
@@ -1,6 +1,6 @@
 import { Autowired } from '@opensumi/di';
 import { Domain, ClientAppContribution } from '@opensumi/ide-core-browser';
-import { MainLayoutContribution } from '@opensumi/ide-main-layout';
+import { IMainLayoutService, MainLayoutContribution } from '@opensumi/ide-main-layout';
 
 import { ITerminalController, ITerminalRestore } from '../../common';
 import { IEnvironmentVariableService, EnvironmentVariableServiceToken } from '../../common/environmentVariable';
@@ -21,6 +21,9 @@ export class TerminalLifeCycleContribution implements ClientAppContribution, Mai
   @Autowired(EnvironmentVariableServiceToken)
   protected readonly environmentService: IEnvironmentVariableService;
 
+  @Autowired(IMainLayoutService)
+  protected readonly layoutService: IMainLayoutService;
+
   initialize() {
     registerTerminalColors();
   }
@@ -32,9 +35,9 @@ export class TerminalLifeCycleContribution implements ClientAppContribution, Mai
 
   // 必须等待这个事件返回，否则 tabHandler 无法保证获取
   onDidRender() {
-    this.store.restore().then(() => {
-      this.terminalController.firstInitialize();
-    });
+    this.layoutService.viewReady.promise.then(() =>
+      this.store.restore().then(() => this.terminalController.firstInitialize()),
+    );
   }
 
   onStop() {

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -109,7 +109,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
   @Autowired(ICtxMenuRenderer)
   private ctxMenuRenderer: ICtxMenuRenderer;
 
-  private terminalContextKey: TerminalContextKey;
+  private terminalContextKey: TerminalContextKey | undefined;
 
   @observable
   themeBackground: string;
@@ -378,7 +378,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
       }
     }
 
-    this.terminalContextKey.isTerminalViewInitialized.set(true);
+    this.terminalContextKey?.isTerminalViewInitialized.set(true);
     this._ready.resolve();
   }
 
@@ -394,12 +394,12 @@ export class TerminalController extends WithEventBus implements ITerminalControl
 
   focus() {
     this._focus = true;
-    this.terminalContextKey.isTerminalFocused.set(true);
+    this.terminalContextKey?.isTerminalFocused.set(true);
   }
 
   blur() {
     this._focus = false;
-    this.terminalContextKey.isTerminalFocused.set(false);
+    this.terminalContextKey?.isTerminalFocused.set(false);
   }
 
   onContextMenu(e: React.MouseEvent<HTMLElement>): void {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

这里的 contextKey 是在视图加载完成之后才注入进来的，所以如果视图没有加载完成，这里就加载了就会报错。

### Changelog

Fix terminal context key use before define