### PR TITLE
style: improve debug stack item style

### DIFF
--- a/packages/debug/src/browser/view/frames/debug-call-stack-session.view.tsx
+++ b/packages/debug/src/browser/view/frames/debug-call-stack-session.view.tsx
@@ -198,8 +198,8 @@ export const DebugStackSessionView = (props: DebugStackSessionViewProps) => {
           >
             {(supportsThreadIdCorrespond || threads.length > 0) && (
               <>
-                <div className={unfold ? getIcon('down') : getIcon('right')} onClick={() => setUnfold(!unfold)}></div>,
-                <div className={cls([getIcon('debug'), styles.debug_session_icon])}></div>,
+                <div className={unfold ? getIcon('down') : getIcon('right')} onClick={() => setUnfold(!unfold)}></div>
+                <div className={cls([getIcon('debug'), styles.debug_session_icon])}></div>
               </>
             )}
             <div className={styles.debug_stack_item_label_title}>{session.label}</div>

--- a/packages/debug/src/browser/view/frames/debug-call-stack.module.less
+++ b/packages/debug/src/browser/view/frames/debug-call-stack.module.less
@@ -59,7 +59,7 @@
 }
 
 .debug_session_icon {
-  padding: 0px 2px;
+  padding: 0px 4px;
 }
 
 .debug_stack_frames {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

before：
<img width="323" alt="截屏2022-05-16 下午8 53 38" src="https://user-images.githubusercontent.com/9823838/168599098-700a8667-8bd5-4fd4-a4ab-e7c6f60cfbb9.png">

after:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/9823838/168599399-b25f092b-9320-4b7c-89d9-1d309c23e2bb.png">

### Changelog

improve debug stack item style