### PR TITLE
feat: add unregister item

### DIFF
--- a/packages/core-browser/src/layout/accordion/tab-bar-toolbar.tsx
+++ b/packages/core-browser/src/layout/accordion/tab-bar-toolbar.tsx
@@ -36,6 +36,14 @@ export class ToolbarRegistry {
       group: item.group || 'navigation',
     } as IMenuItem);
   }
+
+  /**
+   * 取消已注册的菜单项
+   * @param menuItemId
+   */
+  unRegisterItem(menuItemId: string) {
+    this.menuRegistry.unregisterMenuItem(MenuId.ViewTitle, menuItemId);
+  }
 }
 
 export interface TabBarToolbarItem extends IMenuItem {

--- a/packages/core-browser/src/layout/accordion/tab-bar-toolbar.tsx
+++ b/packages/core-browser/src/layout/accordion/tab-bar-toolbar.tsx
@@ -41,7 +41,7 @@ export class ToolbarRegistry {
    * 取消已注册的菜单项
    * @param menuItemId
    */
-  unRegisterItem(menuItemId: string) {
+  unregisterItem(menuItemId: string) {
     this.menuRegistry.unregisterMenuItem(MenuId.ViewTitle, menuItemId);
   }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
related: #1042 

### Changelog
注册工具菜单项用的是`registerMenuItem`函数，取消注册使用`unRegisterMenuItem`函数，所以我在 [tab-bar-toolbar.tsx](https://github.com/opensumi/core/pull/1058/files) 中补充了一下，不确定能不能解决问题。