### PR TITLE
fix: go to line not work

### DIFF
--- a/packages/quick-open/src/browser/quick-open.type.ts
+++ b/packages/quick-open/src/browser/quick-open.type.ts
@@ -29,7 +29,7 @@ export interface IQuickOpenCallbacks {
   /**
    * 关闭 QuickOpen 时发送的事件
    */
-  onHide: (reason: HideReason) => void;
+  onHide: (reason?: HideReason) => void;
   /**
    * select 状态时触发
    */

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -145,7 +145,7 @@ export const QuickOpenInput = observer(() => {
   }, []);
 
   return (
-    <div className={styles.input}>
+    <div tabIndex={0} className={styles.input}>
       {widget.canSelectMany && <CheckBox checked={widget.selectAll} wrapTabIndex={0} onChange={handleSelectAll} />}
       <ValidateInput
         validateMessage={validateMessage}
@@ -328,6 +328,10 @@ export const QuickOpenView = observer(() => {
     return false;
   }, []);
 
+  /**
+   * 当你修改这里的 onblur 事件之后，请确认一下几件事情
+   * 1. 按 ctrl+g，按回车，看它是否激活的 onClose 事件
+   */
   const onBlur = React.useCallback(
     (event: React.FocusEvent) => {
       if (focusInCurrentTarget(event)) {
@@ -469,7 +473,7 @@ export const QuickOpenView = observer(() => {
   }, []);
 
   return widget.isShow ? (
-    <div className={styles.container} onKeyDown={onKeydown} onBlur={onBlur}>
+    <div tabIndex={0} className={styles.container} onKeyDown={onKeydown} onBlur={onBlur}>
       <QuickOpenHeader />
       <QuickOpenInput />
       {widget.renderTab?.()}

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -330,7 +330,12 @@ export const QuickOpenView = observer(() => {
 
   /**
    * 当你修改这里的 onblur 事件之后，请确认一下几件事情
-   * 1. 按 ctrl+g，按回车，看它是否激活的 onClose 事件
+   * - 按 ctrl+g，输入行号，按回车，看是否转到了对应的行
+   * - 按 ctrl+g，输入行号，按 esc，行号没有跳转
+   * - 按 ctrl+g，输入行号，鼠标点击 quickOpen 的第一项，看是否转到了对应的行
+   * - 按 ctrl+shift+p，输入命令，按回车，看它的功能是否正常
+   * - 按 ctrl+shift+p，按 esc，看该框是否取消
+   * - 按 ctrl+shift+p，鼠标点击编辑器区域，看该框是否取消
    */
   const onBlur = React.useCallback(
     (event: React.FocusEvent) => {

--- a/packages/quick-open/src/browser/quick-open.widget.tsx
+++ b/packages/quick-open/src/browser/quick-open.widget.tsx
@@ -138,7 +138,7 @@ export class QuickOpenWidget implements IQuickOpenWidget {
       this.callbacks.onCancel();
     }
 
-    this.callbacks.onHide(reason!);
+    this.callbacks.onHide(reason);
   }
 
   @action


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

当前的 "转到行" 功能无法使用，我们在输入完行号之后，按下回车，此时由于 editor 是 focus 状态，导致会触发 quickInput 的 onBlur 事件，导致其实行为是取消的。

### Changelog

fix "Go To Line" not work
