### PR TITLE
chore: remove registry constant in fe

### DIFF
--- a/packages/core-node/src/bootstrap/app.ts
+++ b/packages/core-node/src/bootstrap/app.ts
@@ -184,7 +184,7 @@ export class ServerApp implements IServerApp {
       LogServiceClass: opts.LogServiceClass,
       marketplace: Object.assign(
         {
-          endpoint: `${DEFAULT_OPENVSX_REGISTRY}/api`,
+          endpoint: DEFAULT_OPENVSX_REGISTRY,
           extensionDir: path.join(
             os.homedir(),
             ...(isWindows ? [StoragePaths.WINDOWS_APP_DATA_DIR, StoragePaths.WINDOWS_ROAMING_DIR] : ['']),

--- a/packages/extension-manager/src/browser/extension-overview/index.tsx
+++ b/packages/extension-manager/src/browser/extension-overview/index.tsx
@@ -4,7 +4,6 @@ import { Icon, getIcon, Button, Tabs } from '@opensumi/ide-components';
 import { ProgressBar } from '@opensumi/ide-core-browser/lib/components/progressbar';
 import { useInjectable } from '@opensumi/ide-core-browser/lib/react-hooks/injectable-hooks';
 import { localize, replaceLocalizePlaceholder } from '@opensumi/ide-core-common';
-import { DEFAULT_OPENVSX_REGISTRY } from '@opensumi/ide-core-common/lib/const';
 import { ReactEditorComponent } from '@opensumi/ide-editor/lib/browser';
 import { Markdown } from '@opensumi/ide-markdown';
 
@@ -30,7 +29,7 @@ interface IExtensionMetadata {
 }
 
 export const ExtensionOverview: ReactEditorComponent<
-  VSXExtensionRaw & VSXExtension & { state: string; extensionId: string }
+  VSXExtensionRaw & VSXExtension & { state: string; extensionId: string; openVSXRegistry: string }
 > = ({ resource }) => {
   const vsxExtensionService = useInjectable<IVSXExtensionService>(VSXExtensionServiceToken);
   const [loading, setLoading] = useState(true);
@@ -87,14 +86,16 @@ export const ExtensionOverview: ReactEditorComponent<
       <ProgressBar loading={loading} />
       <div className={styles.extension_overview_header}>
         <img
-          src={resource.metadata?.iconUrl || `${DEFAULT_OPENVSX_REGISTRY}/default-icon.png`}
+          src={resource.metadata?.iconUrl || `${resource.metadata?.openVSXRegistry}/default-icon.png`}
           alt={replaceLocalizePlaceholder(resource.metadata?.displayName, resource.metadata?.extensionId)}
         />
         <div className={styles.extension_detail}>
           <div className={styles.extension_name}>
             <h1>
               <a
-                href={`${DEFAULT_OPENVSX_REGISTRY}/extension/${resource.metadata?.namespace.toLowerCase()}/${resource.metadata?.name.toLowerCase()}`}
+                href={`${
+                  resource.metadata?.openVSXRegistry
+                }/extension/${resource.metadata?.namespace.toLowerCase()}/${resource.metadata?.name.toLowerCase()}`}
                 target='_blank'
                 rel='noopener noreferrer'
               >

--- a/packages/extension-manager/src/browser/extension/index.tsx
+++ b/packages/extension-manager/src/browser/extension/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react';
 
 import { Button, Icon, getIcon } from '@opensumi/ide-components';
 import { localize, replaceLocalizePlaceholder } from '@opensumi/ide-core-common';
-import { DEFAULT_OPENVSX_REGISTRY } from '@opensumi/ide-core-common/lib/const';
 
 import { InstallState, VSXExtension } from '../../common';
 
@@ -19,10 +18,11 @@ interface IExtensionViewProps {
   onClick(extension: VSXExtension, state: InstallState): void;
   type: ExtensionViewType;
   installedExtensions?: VSXExtension[];
+  openVSXRegistry: string;
 }
 
 export const Extension = React.memo(
-  ({ extension: extension, onInstall, onClick, type, installedExtensions }: IExtensionViewProps) => {
+  ({ extension: extension, onInstall, onClick, type, installedExtensions, openVSXRegistry }: IExtensionViewProps) => {
     const [installing, setInstalling] = useState<boolean>();
     const installedExtension = installedExtensions?.find(
       (installed) => installed.namespace === extension.namespace && installed.name === extension.name,
@@ -59,7 +59,7 @@ export const Extension = React.memo(
       <div className={styles.extension_item} onClick={onClickCallback}>
         <img
           className={styles.icon}
-          src={extension.iconUrl || `${DEFAULT_OPENVSX_REGISTRY}/default-icon.png`}
+          src={extension.iconUrl || `${openVSXRegistry}/default-icon.png`}
           alt={replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`)}
         />
         <div className={styles.extension_detail}>

--- a/packages/extension-manager/src/browser/vsx-extension.contribution.ts
+++ b/packages/extension-manager/src/browser/vsx-extension.contribution.ts
@@ -36,7 +36,7 @@ export class VSXExtensionContribution
     if (handler) {
       // 在激活的时候获取数据
       handler.onActivate(async () => {
-        await this.vsxExtensionService.getOpenVSXRegistry();
+        !this.vsxExtensionService.openVSXRegistry && (await this.vsxExtensionService.getOpenVSXRegistry());
         this.vsxExtensionService.search('');
       });
     }

--- a/packages/extension-manager/src/browser/vsx-extension.contribution.ts
+++ b/packages/extension-manager/src/browser/vsx-extension.contribution.ts
@@ -35,7 +35,8 @@ export class VSXExtensionContribution
     const handler = this.mainLayoutService.getTabbarHandler(OPEN_VSX_EXTENSION_MANAGER_CONTAINER_ID);
     if (handler) {
       // 在激活的时候获取数据
-      handler.onActivate(() => {
+      handler.onActivate(async () => {
+        await this.vsxExtensionService.getOpenVSXRegistry();
         this.vsxExtensionService.search('');
       });
     }
@@ -54,6 +55,7 @@ export class VSXExtensionContribution
             ...extension,
             extensionId,
             state,
+            openVSXRegistry: this.vsxExtensionService.openVSXRegistry,
           },
           icon: iconClass || getIcon('extension'),
           name: replaceLocalizePlaceholder(extension?.displayName, extensionId) || '',

--- a/packages/extension-manager/src/browser/vsx-extension.service.ts
+++ b/packages/extension-manager/src/browser/vsx-extension.service.ts
@@ -38,6 +38,9 @@ export class VSXExtensionService implements IVSXExtensionService {
   @observable
   public extensions: VSXExtension[] = [];
 
+  @observable
+  public openVSXRegistry: string;
+
   @Autowired(IStatusBarService)
   protected readonly statusBarService: IStatusBarService;
 
@@ -109,7 +112,12 @@ export class VSXExtensionService implements IVSXExtensionService {
     }
   }
 
+  async getOpenVSXRegistry() {
+    this.openVSXRegistry = await this.backService.getOpenVSXRegistry();
+  }
+
   async openExtensionEditor(extensionId: string, state: InstallState) {
+    await this.getOpenVSXRegistry();
     this.workbenchEditorService.open(new URI(`extension://?extensionId=${extensionId}&state=${state}`), {
       preview: true,
     });

--- a/packages/extension-manager/src/browser/vsx-extension.service.ts
+++ b/packages/extension-manager/src/browser/vsx-extension.service.ts
@@ -117,7 +117,6 @@ export class VSXExtensionService implements IVSXExtensionService {
   }
 
   async openExtensionEditor(extensionId: string, state: InstallState) {
-    await this.getOpenVSXRegistry();
     this.workbenchEditorService.open(new URI(`extension://?extensionId=${extensionId}&state=${state}`), {
       preview: true,
     });

--- a/packages/extension-manager/src/browser/vsx-extension.view.tsx
+++ b/packages/extension-manager/src/browser/vsx-extension.view.tsx
@@ -74,6 +74,7 @@ export const VSXExtensionView = observer(() => {
               extension={e}
               type={ExtensionViewType.MARKETPLACE}
               installedExtensions={vsxExtensionService.installedExtensions}
+              openVSXRegistry={vsxExtensionService.openVSXRegistry}
             />
           ))}
         </div>
@@ -87,6 +88,7 @@ export const VSXExtensionView = observer(() => {
               key={`${e.namespace}-${e.name}`}
               extension={e}
               type={ExtensionViewType.INSTALLED}
+              openVSXRegistry={vsxExtensionService.openVSXRegistry}
             />
           ))}
         </div>

--- a/packages/extension-manager/src/common/index.ts
+++ b/packages/extension-manager/src/common/index.ts
@@ -74,10 +74,12 @@ export interface IVSXExtensionService {
   install(extension: VSXExtension): Promise<void>;
   getLocalExtension(extensionId: string): Promise<VSXExtension | undefined>;
   getRemoteRawExtension(extensionId: string): Promise<VSXExtensionRaw | undefined>;
+  getOpenVSXRegistry(): Promise<void>;
   openExtensionEditor(extensionId: string, state: InstallState): Promise<void>;
 
   extensions: VSXExtension[];
   installedExtensions: VSXExtension[];
+  openVSXRegistry: string;
 }
 
 export const VSXExtensionBackSerivceToken = Symbol('VSXExtensionBackSerivceToken');
@@ -94,4 +96,5 @@ export interface IVSXExtensionBackService {
   search(param?: VSXSearchParam): Promise<VSXSearchResult>;
   install(param: IExtensionInstallParam): Promise<string>;
   getExtension(param: QueryParam): Promise<QueryResult | undefined>;
+  getOpenVSXRegistry(): Promise<string>;
 }

--- a/packages/extension-manager/src/node/vsx-extension.service.ts
+++ b/packages/extension-manager/src/node/vsx-extension.service.ts
@@ -80,7 +80,7 @@ export class VSXExtensionService implements IVSXExtensionBackService {
   }
 
   async getOpenVSXRegistry(): Promise<string> {
-    return this.appConfig.marketplace.endpoint + '/api';
+    return this.appConfig.marketplace.endpoint;
   }
 
   private async uncompressFile(distPath: string, downloadPath: string) {

--- a/packages/extension-manager/src/node/vsx-extension.service.ts
+++ b/packages/extension-manager/src/node/vsx-extension.service.ts
@@ -60,7 +60,7 @@ export class VSXExtensionService implements IVSXExtensionBackService {
   private appConfig: AppConfig;
 
   async getExtension(param: QueryParam): Promise<QueryResult | undefined> {
-    const uri = `${this.appConfig.marketplace.endpoint}/-/query`;
+    const uri = `${this.appConfig.marketplace.endpoint}/api/-/query`;
     const res = await nodeFetch(uri, {
       headers: {
         ...commonHeaders,
@@ -77,6 +77,10 @@ export class VSXExtensionService implements IVSXExtensionBackService {
     const targetPath = await this.uncompressFile(distPath, downloadPath);
     cleanup([downloadPath]);
     return targetPath;
+  }
+
+  async getOpenVSXRegistry(): Promise<string> {
+    return this.appConfig.marketplace.endpoint + '/api';
   }
 
   private async uncompressFile(distPath: string, downloadPath: string) {
@@ -179,7 +183,7 @@ export class VSXExtensionService implements IVSXExtensionBackService {
   }
 
   async search(param?: VSXSearchParam): Promise<VSXSearchResult> {
-    const uri = `${this.appConfig.marketplace.endpoint}/-/search?${
+    const uri = `${this.appConfig.marketplace.endpoint}/api/-/search?${
       param && new URLSearchParams(param as any).toString()
     }`;
     const res = await nodeFetch(uri, {

--- a/tools/dev-tool/src/server.ts
+++ b/tools/dev-tool/src/server.ts
@@ -55,7 +55,7 @@ export async function startServer(arg1: NodeModule[] | Partial<IServerAppOpts>) 
     injector,
     use: app.use.bind(app),
     marketplace: {
-      endpoint: `${DEFAULT_OPENVSX_REGISTRY}/api`,
+      endpoint: DEFAULT_OPENVSX_REGISTRY,
       showBuiltinExtensions: true,
     },
     processCloseExitThreshold: 5 * 60 * 1000,

--- a/tools/electron/src/node/server.ts
+++ b/tools/electron/src/node/server.ts
@@ -11,7 +11,7 @@ export async function startServer(arg1: NodeModule[] | Partial<IServerAppOpts>) 
   let opts: IServerAppOpts = {
     webSocketHandler: [],
     marketplace: {
-      endpoint: `${DEFAULT_OPENVSX_REGISTRY}/api`,
+      endpoint: DEFAULT_OPENVSX_REGISTRY,
       showBuiltinExtensions: true,
     },
   };


### PR DESCRIPTION
### Types
- [x] 🧹 Chores

### Background or solution
closes #1049 

1. 去掉 [app.ts](https://github.com/opensumi/core/pull/1064/files#diff-3b0a46e1b06590eb974b8dd6c73d012bce362456f0e1b156c448502d5dd2a892L187) 和[server.ts](https://github.com/opensumi/core/pull/1064/files#diff-cdd58a0e7b8a27dd0543bacc14c79ecdaf52845389936d3156a1e33d2c9b5e11L58) 的 `endpoint`的`/api`这一段path，让后端自主拼接，例如，[这里](https://github.com/opensumi/core/pull/1064/files#diff-bebbc315d5b07466553702f80427a0e83b6fd631b4fd50b4b9ad55d9ad79f8b1L63)。
2. 在激活的时候，通过`this.vsxExtensionService.getOpenVSXRegistry`  获取后端返回的`registry`，抹除前端硬编码的 Registry 逻辑。

### Changelog

full support for extension marketplace config 