### PR TITLE
feat: add pty remote reconnection

### DIFF
--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -16,7 +16,7 @@ describe('PtyService function should be valid', () => {
   let injector: Injector;
   let shellPath = '';
   let proxyProvider: PtyServiceProxyRPCProvider;
-  let ptyManagerInstance;
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
   if (os.platform() === 'win32') {
     shellPath = 'powershell';
@@ -24,27 +24,17 @@ describe('PtyService function should be valid', () => {
     shellPath = 'sh';
   }
 
-  beforeAll(() => {
+  beforeAll(async () => {
     injector = createNodeInjector([TerminalNodePtyModule], new Injector([]));
 
     // 双容器模式下，需要以本文件作为entry单独打包出一个可执行文件，运行在DEV容器中
     proxyProvider = new PtyServiceProxyRPCProvider();
     proxyProvider.initServer();
-
     injector.overrideProviders({
       token: PtyServiceManagerToken,
-      useFactory: (injector1: Injector) => {
-        if (ptyManagerInstance) {
-          return ptyManagerInstance;
-        }
-        ptyManagerInstance = injector1.get(PtyServiceManagerRemote, [
-          {
-            port: 10111,
-          },
-        ]);
-        return ptyManagerInstance;
-      },
+      useValue: injector.get(PtyServiceManagerRemote, []),
     });
+    await delay(2000);
   });
 
   afterAll(() => {

--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -12,7 +12,7 @@ import { PtyServiceProxyRPCProvider } from '../../src/node/pty.proxy';
 
 // 使用Remote模式（非Local模式）来测试PtyService
 describe('PtyService function should be valid', () => {
-  jest.setTimeout(20000);
+  jest.setTimeout(40000);
 
   let injector: Injector;
   let shellPath = '';

--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 
 import { Injector } from '@opensumi/di';
+import { normalizedIpcHandlerPath } from '@opensumi/ide-core-common/lib/utils/ipc';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 
 import { TerminalNodePtyModule } from '../../src/node';
@@ -16,6 +17,7 @@ describe('PtyService function should be valid', () => {
   let injector: Injector;
   let shellPath = '';
   let proxyProvider: PtyServiceProxyRPCProvider;
+  const ipcPath = normalizedIpcHandlerPath('NODE-TEST-PTY', true);
   const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
   if (os.platform() === 'win32') {
@@ -28,11 +30,11 @@ describe('PtyService function should be valid', () => {
     injector = createNodeInjector([TerminalNodePtyModule], new Injector([]));
 
     // 双容器模式下，需要以本文件作为entry单独打包出一个可执行文件，运行在DEV容器中
-    proxyProvider = new PtyServiceProxyRPCProvider();
+    proxyProvider = new PtyServiceProxyRPCProvider({ path: ipcPath });
     proxyProvider.initServer();
     injector.overrideProviders({
       token: PtyServiceManagerToken,
-      useValue: injector.get(PtyServiceManagerRemote, []),
+      useValue: injector.get(PtyServiceManagerRemote, [{ path: ipcPath }]),
     });
     await delay(2000);
   });

--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -12,7 +12,7 @@ import { PtyServiceProxyRPCProvider } from '../../src/node/pty.proxy';
 
 // 使用Remote模式（非Local模式）来测试PtyService
 describe('PtyService function should be valid', () => {
-  jest.setTimeout(40000);
+  jest.setTimeout(20000);
 
   let injector: Injector;
   let shellPath = '';
@@ -69,25 +69,5 @@ describe('PtyService function should be valid', () => {
     expect(instance).toBeDefined();
     expect(instance?.pid).toBeDefined();
     expect(instance?.launchConfig).toBeDefined();
-  });
-
-  it('cwd is user home dir if not set', async () => {
-    const ptyService = injector.get(PtyService, ['0', { executable: shellPath, args: ['-c', 'pwd'] }, 200, 200]);
-    const error = await ptyService.start();
-    const instance = ptyService.pty;
-
-    expect(error).toBeUndefined();
-
-    let result = '';
-
-    if (os.platform() !== 'win32') {
-      await new Promise<void>((resolve) => {
-        instance?.onData((data) => {
-          result += data;
-          resolve(undefined);
-        });
-      });
-      expect(result).toContain(os.homedir());
-    }
   });
 });

--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -11,7 +11,7 @@ import { PtyServiceProxyRPCProvider } from '../../src/node/pty.proxy';
 
 // 使用Remote模式（非Local模式）来测试PtyService
 describe('PtyService function should be valid', () => {
-  jest.setTimeout(10000);
+  jest.setTimeout(20000);
 
   let injector: Injector;
   let shellPath = '';

--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -16,6 +16,7 @@ describe('PtyService function should be valid', () => {
   let injector: Injector;
   let shellPath = '';
   let proxyProvider: PtyServiceProxyRPCProvider;
+  let ptyManagerInstance;
 
   if (os.platform() === 'win32') {
     shellPath = 'powershell';
@@ -30,9 +31,19 @@ describe('PtyService function should be valid', () => {
     proxyProvider = new PtyServiceProxyRPCProvider();
     proxyProvider.initServer();
 
-    injector.addProviders({
+    injector.overrideProviders({
       token: PtyServiceManagerToken,
-      useValue: new PtyServiceManagerRemote(),
+      useFactory: (injector1: Injector) => {
+        if (ptyManagerInstance) {
+          return ptyManagerInstance;
+        }
+        ptyManagerInstance = injector1.get(PtyServiceManagerRemote, [
+          {
+            port: 10111,
+          },
+        ]);
+        return ptyManagerInstance;
+      },
     });
   });
 


### PR DESCRIPTION
### Types

支持了终端双容器模式的RPC Socket重连。之前的终端双容器模式只会执行一次连接，如果因为各种原因（比如说PtyService启动慢了一步）导致连接失败，整个终端功能都会失效。因此需要一个自动重连PtyService的功能，在Socket连接失败后自动轮询，自动连接的逻辑。

目前还有一个未知的疑惑，为什么在我调用了RPCServiceCenter.removeConnection之后，之前的方法调用依然会被执行，导致注册的方法被重复多次调用，目前使用了标志位做规避，背后的原因暂时没有调查出来。

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution
终端双容器偶现的连接失败。

### Changelog
