### PR TITLE
fix: diff editor encoding switch

### DIFF
--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -785,8 +785,11 @@ export class EditorContribution
           return;
         }
 
-        this.editorDocumentModelService.changeModelOptions(resource.uri, {
-          encoding: selectedFileEncoding,
+        const uris = resource.uri.scheme === 'diff' ? [resource.metadata.original, resource.metadata.modified] : [resource.uri];
+        uris.forEach((uri) => {
+          this.editorDocumentModelService.changeModelOptions(uri, {
+            encoding: selectedFileEncoding,
+          });
         });
       },
     });


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

Background: 浏览器中，diff 模式下，切换编码不生效。

editor.contribution 注册编码切换的命令，执行 changeModelOptions。changeModelOptions中，根据 uri 获取 docRef 进行编码切换，当 uri 为 diff uri，获取不到 docRef。

solution:  diff 模式下，分别获取  original/modify uri (git uri)，拿到 docRef 进行编码切换

### Changelog

修复编辑器 Diff 模式下切换编码失效问题