### PR TITLE
style: close button hover

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -235,14 +235,14 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        width: 13px;
+        width: 16px;
         flex-shrink: 0;
         flex-grow: 0;
-        height: 13px;
-        line-height: 13px;
-        font-size: 13px;
+        height: 16px;
+        line-height: 16px;
+        font-size: 16px;
         border-radius: 4px;
-
+        padding: 1px;
         &:hover {
           transform: scale(1.2);
           background-color: var(--kt-defaultButton-hoverBackground);

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -239,6 +239,14 @@
         flex-shrink: 0;
         flex-grow: 0;
         height: 13px;
+        line-height: 13px;
+        font-size: 13px;
+        border-radius: 4px;
+
+        &:hover {
+          transform: scale(1.2);
+          background-color: var(--kt-defaultButton-hoverBackground);
+        }
       }
       .dirty {
         display: flex;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution
closes #1085 

before:
![be](https://user-images.githubusercontent.com/85668115/169863117-333d27d5-a04e-4cbb-a79a-d923fbae9625.png)

after:
![af](https://user-images.githubusercontent.com/85668115/170027342-ccc616a3-56ec-472c-83a3-7464323caf85.png)

### Changelog

improve editor tab close button style