### PR TITLE
fix: improve file tree new or rename files speed

### DIFF
--- a/packages/components/__tests__/recycle-tree/tree/TreeNode.test.ts
+++ b/packages/components/__tests__/recycle-tree/tree/TreeNode.test.ts
@@ -214,4 +214,23 @@ describe('Tree', () => {
     await root.refresh();
     expect(root.branchSize).toBe(3);
   });
+
+  it('move/remove/add node should be work', async () => {
+    const tree = new TreeA();
+    const root = new Root(tree, undefined, undefined);
+    tree.setPresetChildren([new Folder(tree, root, undefined, { name: 'a' }), new File(tree, root, { name: 'b' })]);
+    await root.ensureLoaded();
+    const a = root.getTreeNodeAtIndex(0);
+    // move node
+    root.moveNode((a as TreeNode).path, (a as TreeNode).path.replace('a', 'c'));
+    expect((a as TreeNode).name).toBe('c');
+    // remove node
+    expect(root.branchSize).toBe(2);
+    root.removeNode((a as TreeNode).path);
+    expect(root.branchSize).toBe(1);
+    // add node
+    const d = new File(tree, root, { name: 'd' });
+    root.addNode(d);
+    expect(root.branchSize).toBe(2);
+  });
 });

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -561,9 +561,9 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     }
     this.isExpanded = true;
     if (this._children === null) {
-      !quiet && this._watcher.notifyWillResolveChildren(this, this.isExpanded);
+      this._watcher.notifyWillResolveChildren(this, this.isExpanded);
       await this.hardReloadChildren(token);
-      !quiet && this._watcher.notifyDidResolveChildren(this, this.isExpanded);
+      this._watcher.notifyDidResolveChildren(this, this.isExpanded);
       // 检查其是否展开；可能同时执行了 setCollapsed 方法
       if (!this.isExpanded || token?.isCancellationRequested) {
         if (isOwner) {
@@ -594,10 +594,10 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     }
 
     if (this.isExpanded) {
-      !quiet && this._watcher.notifyWillChangeExpansionState(this, true);
+      this._watcher.notifyWillChangeExpansionState(this, true);
       // 与根节点合并分支
       this.expandBranch(this, quiet);
-      !quiet && this._watcher.notifyDidChangeExpansionState(this, true);
+      this._watcher.notifyDidChangeExpansionState(this, true);
     }
     if (isOwner) {
       TreeNode.setGlobalTreeState(this.path, {
@@ -1030,13 +1030,13 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     const state = TreeNode.getGlobalTreeState(this.path);
     state.loadPathCancelToken.cancel();
     state.refreshCancelToken.cancel();
-    !quiet && this._watcher.notifyWillChangeExpansionState(this, false);
+    this._watcher.notifyWillChangeExpansionState(this, false);
     if (this._children && this.parent) {
       // 从根节点裁剪分支
       this.shrinkBranch(this, quiet);
     }
     this.isExpanded = false;
-    !quiet && this._watcher.notifyDidChangeExpansionState(this, false);
+    this._watcher.notifyDidChangeExpansionState(this, false);
   }
 
   public mv(to: ICompositeTreeNode, name: string = this.name) {

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -1121,6 +1121,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     }
     master.setFlattenedBranch(spliceArray(master._flattenedBranch, absInsertionIndex, 0, branch));
     TreeNode.setTreeNode(item.id, item.path, item as TreeNode);
+    return item;
   }
 
   /**
@@ -1191,6 +1192,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       return;
     }
     item.mv(destDir, newP.base.toString());
+    return item;
   }
 
   public dispose() {
@@ -1369,6 +1371,41 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     }
     this.watchTerminator = this.watcher.onWatchEvent(this.path, this.handleWatchEvent);
     return true;
+  }
+
+  public moveNode(oldPath: string, newPath: string) {
+    if (typeof oldPath !== 'string') {
+      throw new TypeError('Expected oldPath to be a string');
+    }
+    if (typeof newPath !== 'string') {
+      throw new TypeError('Expected newPath to be a string');
+    }
+    if (Path.isRelative(oldPath)) {
+      throw new TypeError('oldPath must be absolute');
+    }
+    if (Path.isRelative(newPath)) {
+      throw new TypeError('newPath must be absolute');
+    }
+    return this.transferItem(oldPath, newPath);
+  }
+
+  public addNode(node: TreeNode) {
+    if (!TreeNode.is(node)) {
+      throw new TypeError('Expected node to be a TreeNode');
+    }
+    return this.insertItem(node);
+  }
+
+  public removeNode(path: string) {
+    const pathObject = new Path(path);
+    const dirName = pathObject.dir.toString();
+    const name = pathObject.base.toString();
+    if (dirName === this.path && !!this.children) {
+      const item = this.children.find((c) => c.name === name);
+      if (item) {
+        this.unlinkItem(item);
+      }
+    }
   }
 
   /**

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -177,6 +177,7 @@ export class FileTreeContribution
         this.fileTreeModelService.performLocationOnHandleShow();
       });
       handler.onInActivate(() => {
+        this.fileTreeModelService.handleTreeBlur();
         this.fileTreeModelService.contextKey.explorerViewletVisibleContext.set(false);
       });
     }

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -110,9 +110,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
 
   private _fileServiceWatchers: Map<string, IFileServiceWatcher> = new Map();
 
-  private _cacheIgnoreFileEvent: Map<string, FileChangeType> = new Map();
-  private _cacheIgnoreFileEventOnce: URI | null;
-
   // 文件系统Change事件队列
   private _changeEventDispatchQueue = new Set<string>();
 
@@ -293,7 +290,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
             const rootName = this.workspaceService.getWorkspaceName(child.uri);
             if (rootName && rootName !== child.name) {
               (child as Directory).updateMetaData({
-                displayName: rootName,
+                name: rootName,
               });
             }
           });
@@ -404,31 +401,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
   }
 
   private async onFilesChanged(changes: FileChange[]) {
-    // 过滤掉内置触发的事件
-    if (this._cacheIgnoreFileEventOnce) {
-      let filtered = false;
-      changes = changes.filter((change) => {
-        if (this._cacheIgnoreFileEventOnce!.isEqualOrParent(new URI(change.uri))) {
-          filtered = true;
-          return false;
-        }
-        return true;
-      });
-      if (filtered) {
-        this._cacheIgnoreFileEventOnce = null;
-      }
-    }
-    changes = changes.filter((change) => {
-      if (!this._cacheIgnoreFileEvent.has(change.uri)) {
-        return true;
-      } else {
-        if (this._cacheIgnoreFileEvent.get(change.uri) === change.type) {
-          this._cacheIgnoreFileEvent.delete(change.uri);
-          return false;
-        }
-        return true;
-      }
-    });
     const nodes = await this.getAffectedNodes(this.getAffectedChanges(changes));
     if (nodes.length > 0) {
       this.effectedNodes = this.effectedNodes.concat(nodes);
@@ -495,48 +467,31 @@ export class FileTreeService extends Tree implements IFileTreeService {
     }
   }
 
-  public async moveNode(node: File | Directory, source: string, target: string) {
-    const sourceUri = new URI(source);
-    const targetUri = new URI(target);
-    const oldPath = await this.getFileTreeNodePathByUri(sourceUri);
-    const newPath = await this.getFileTreeNodePathByUri(targetUri);
-    // 判断是否为重命名场景，如果是重命名，则不需要刷新父目录
-    const shouldReloadParent = sourceUri.parent.isEqual(targetUri.parent) ? false : this.isCompactMode;
-    await this.moveNodeByPath(node, oldPath, newPath, shouldReloadParent);
-  }
-
   // 软链接目录下，文件节点路径不能通过uri去获取，存在偏差
-  public async moveNodeByPath(node: File | Directory, oldPath?: string, newPath?: string, refreshParent?: boolean) {
+  public async moveNodeByPath(
+    from: Directory,
+    to: Directory,
+    oldName: string,
+    newName: string,
+    type: TreeNodeType = TreeNodeType.TreeNode,
+  ) {
+    const oldPath = new Path(from.path).join(oldName).toString();
+    const newPath = new Path(to.path).join(newName).toString();
     if (oldPath && newPath && newPath !== oldPath) {
-      if (!this.isMultipleWorkspace) {
-        this._cacheIgnoreFileEvent.set(
-          (this.root as Directory).uri.parent.resolve(oldPath.slice(1)).toString(),
-          FileChangeType.DELETED,
-        );
-        this._cacheIgnoreFileEvent.set(
-          (this.root as Directory).uri.parent.resolve(newPath.slice(1)).toString(),
-          FileChangeType.ADDED,
-        );
+      const movedNode = from.moveNode(oldPath, newPath);
+      // 更新节点除了 name 以外的其他属性，如 fileStat，tooltip 等，否则节点数据可能会异常
+      if (movedNode) {
+        (movedNode as File).updateMetaData({
+          uri: to.uri.resolve(newName),
+          fileStat: {
+            ...to.filestat,
+            uri: to.uri.resolve(newName).toString(),
+            isDirectory: type === TreeNodeType.TreeNode ? false : true,
+          },
+          tooltip: this.fileTreeAPI.getReadableTooltip(to.uri.resolve(newName)),
+        });
       }
-      this.dispatchWatchEvent(node!.path, { type: WatchEvent.Moved, oldPath, newPath });
-      // 压缩模式下，需要尝试更新移动的源节点的父节点及目标节点的目标节点折叠状态
-      if (this.isCompactMode) {
-        const oldParentPath = new Path(oldPath).dir.toString();
-        const newParentPath = new Path(newPath).dir.toString();
-        if (oldParentPath) {
-          const oldParentNode = this.getNodeByPathOrUri(oldParentPath);
-          if (!!oldParentNode && refreshParent) {
-            this.refresh(oldParentNode as Directory);
-          }
-        }
-        if (newParentPath) {
-          const newParentNode = this.getNodeByPathOrUri(newParentPath);
-          const isCompressedFocused = this.contextKeyService.getContextValue('explorerViewletCompressedFocus');
-          if (!!newParentNode && isCompressedFocused) {
-            this.refresh(newParentNode as Directory);
-          }
-        }
-      }
+      return movedNode;
     }
   }
 
@@ -547,13 +502,8 @@ export class FileTreeService extends Tree implements IFileTreeService {
     // 处理a/b/c/d这类目录
     if (namePaths.length > 1) {
       let tempUri = node.uri;
-      if ((await this.appService.backendOS) === OperatingSystem.Windows) {
-        // Windows环境下会多触发一个UPDATED事件
-        this._cacheIgnoreFileEvent.set(tempUri.toString(), FileChangeType.UPDATED);
-      }
       for (const path of namePaths) {
         tempUri = tempUri.resolve(path);
-        this._cacheIgnoreFileEvent.set(tempUri.toString(), FileChangeType.ADDED);
       }
       if (!this.isCompactMode || Directory.isRoot(node)) {
         tempName = namePaths[0];
@@ -566,11 +516,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
       }
     } else {
       tempName = newName;
-      if ((await this.appService.backendOS) === OperatingSystem.Windows) {
-        // Windows环境下会多触发一个UPDATED事件
-        this._cacheIgnoreFileEvent.set(node.uri.toString(), FileChangeType.UPDATED);
-      }
-      this._cacheIgnoreFileEvent.set(node.uri.resolve(newName).toString(), FileChangeType.ADDED);
     }
     tempFileStat = {
       uri: node.uri.resolve(tempName).toString(),
@@ -581,10 +526,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
     const addNode = await this.fileTreeAPI.toNode(this as ITree, tempFileStat, node as Directory, tempName);
     if (addNode) {
       // 节点创建失败时，不需要添加
-      this.dispatchWatchEvent(node.path, { type: WatchEvent.Added, node: addNode, id: node.id });
-    } else {
-      // 新建失败时移除该缓存
-      this._cacheIgnoreFileEvent.delete(tempFileStat.uri);
+      node.addNode(addNode);
     }
     return addNode;
   }
@@ -597,8 +539,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
       if (node.displayName.indexOf(Path.separator) > 0 && !notRefresh) {
         this.refresh(node.parent as Directory);
       } else {
-        this._cacheIgnoreFileEvent.set(node.uri.toString(), FileChangeType.DELETED);
-        this.dispatchWatchEvent(node.parent.path, { type: WatchEvent.Removed, path: node.path });
+        (node.parent as Directory).removeNode(node.path);
       }
     }
   }
@@ -621,13 +562,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
     return changes.filter((change) => change.type !== FileChangeType.DELETED);
   }
 
-  private dispatchWatchEvent(path: string, event: IWatcherEvent) {
-    const watcher = this.root?.watchEvents.get(path);
-    if (watcher && watcher.callback) {
-      watcher.callback(event);
-    }
-  }
-
   private async getAffectedNodes(changes: FileChange[]): Promise<Directory[]> {
     const nodes: Directory[] = [];
     for (const change of changes) {
@@ -638,14 +572,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
       }
     }
     return nodes;
-  }
-
-  ignoreFileEvent(uri: URI, type: FileChangeType) {
-    this._cacheIgnoreFileEvent.set(uri.toString(), type);
-  }
-
-  ignoreFileEventOnce(uri: URI | null) {
-    this._cacheIgnoreFileEventOnce = uri;
   }
 
   private isFileURI(str: string) {
@@ -762,10 +688,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
     }
     if (!Directory.is(node) && node.parent) {
       node = node.parent as Directory;
-    }
-    if (Directory.isRoot(node)) {
-      // 根目录刷新时情况忽略队列
-      this._cacheIgnoreFileEvent.clear();
     }
 
     // 队列化刷新动作减少更新成本

--- a/packages/file-tree-next/src/browser/services/file-tree-api.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-api.service.ts
@@ -52,7 +52,6 @@ export class FileTreeAPI implements IFileTreeAPI {
           if (parentName && parentName !== parent.name) {
             parent.updateMetaData({
               name: parentName,
-              displayName: parentName,
               uri: parentURI,
               fileStat: file.children[0],
               tooltip: this.getReadableTooltip(parentURI),

--- a/packages/file-tree-next/src/browser/services/file-tree-dnd.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-dnd.service.ts
@@ -269,8 +269,10 @@ export class DragAndDropService extends WithEventBus {
                   const to = containing.uri.resolve(target.name);
                   this.fileTreeService.moveNodeByPath(
                     target.parent as Directory,
-                    target.path,
-                    new Path(containing.path).join(target.name).toString(),
+                    containing,
+                    target.name,
+                    target.name,
+                    target.type,
                   );
                   // 由于节点移动时默认仅更新节点路径
                   // 我们需要自己更新额外的参数，如uri, filestat等

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1337,7 +1337,6 @@ export class FileTreeModelService {
               const parentUri = parent.uri.resolve(parentAddonPath);
               const newNodeName = [parent.name].concat(parentAddonPath).join(Path.separator);
               parent.updateMetaData({
-                displayName: newNodeName,
                 name: newNodeName,
                 uri: parentUri,
                 fileStat: {

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1228,10 +1228,8 @@ export class FileTreeModelService {
           to = (target.parent as Directory).uri.resolve(newNameFragments.concat().join(Path.separator));
         }
         // 屏蔽重命名文件事件
-        this.fileTreeService.ignoreFileEventOnce((target.parent as Directory).uri);
         const error = await this.fileTreeAPI.mv(from, to, target.type === TreeNodeType.CompositeTreeNode);
         if (error) {
-          this.fileTreeService.ignoreFileEventOnce(null);
           this.validateMessage = {
             type: PROMPT_VALIDATE_TYPE.ERROR,
             message: error,
@@ -1240,17 +1238,23 @@ export class FileTreeModelService {
           promptHandle.addValidateMessage(this.validateMessage);
           return false;
         }
-        if (!isCompactNode) {
+        if (!isCompactNode && target.parent) {
           // 重命名节点的情况，直接刷新一下父节点即可
-          const newPath = new Path(target.parent!.path).join(newName).toString();
-          await this.fileTreeService.refresh(target.parent as Directory);
-          this.willSelectedNodePath = newPath;
+          const node = await this.fileTreeService.moveNodeByPath(
+            target.parent as Directory,
+            target.parent as Directory,
+            target.name,
+            newName,
+            target.type,
+          );
+          if (node) {
+            this.selectFileDecoration(node as File, false);
+          }
         } else {
           // 更新压缩目录展示名称
           // 由于节点移动时默认仅更新节点路径
           // 我们需要自己更新额外的参数，如uri, filestat等
           (target as Directory).updateMetaData({
-            displayName: newNameFragments.concat(nameFragments.slice(index + 1)).join(Path.separator),
             name: newNameFragments.concat(nameFragments.slice(index + 1)).join(Path.separator),
             uri: to,
             fileStat: {
@@ -1261,7 +1265,7 @@ export class FileTreeModelService {
           });
           this.treeModel.dispatchChange();
           if ((target.parent as Directory).children?.find((child) => target.path.indexOf(child.path) >= 0)) {
-            // 当重命名后的压缩节点在父节点中存在子集节点时，刷新父节点
+            // 当重命名后的压缩节点在父节点中存在子节点时，刷新父节点
             // 如：
             // 压缩节点 001/002 修改为 003/002 时
             // 同时父节点下存在 003 空节点
@@ -1279,14 +1283,6 @@ export class FileTreeModelService {
         const isEmptyDirectory = !parent.children || parent.children.length === 0;
         promptHandle.addAddonAfter('loading_indicator');
         if (promptHandle.type === TreeNodeType.CompositeTreeNode) {
-          if (this.fileTreeService.isCompactMode && isEmptyDirectory && !Directory.isRoot(parent)) {
-            this.fileTreeService.ignoreFileEvent(parent.uri, FileChangeType.UPDATED);
-            if ((await this.appService.backendOS) === OperatingSystem.Windows) {
-              // Windows环境下会多触发一个UPDATED事件
-              this.fileTreeService.ignoreFileEvent(parent.uri.resolve(newName), FileChangeType.UPDATED);
-            }
-            this.fileTreeService.ignoreFileEvent(parent.uri.resolve(newName), FileChangeType.ADDED);
-          }
           error = await this.fileTreeAPI.createDirectory(newUri);
         } else {
           error = await this.fileTreeAPI.createFile(newUri);
@@ -1321,7 +1317,6 @@ export class FileTreeModelService {
                 const newNodeName = [parent.name].concat(newName).join(Path.separator);
                 parent.updateMetaData({
                   name: newNodeName,
-                  displayName: newNodeName,
                   uri: parent.uri.resolve(newName),
                   fileStat: {
                     ...parent.filestat,
@@ -1365,7 +1360,6 @@ export class FileTreeModelService {
             const parentUri = parent.uri.resolve(newName);
             const newNodeName = [parent.name].concat(newName).join(Path.separator);
             parent.updateMetaData({
-              displayName: newNodeName,
               name: newNodeName,
               uri: parentUri,
               fileStat: {
@@ -1524,7 +1518,6 @@ export class FileTreeModelService {
       // 更新目标节点信息
       (targetNode as Directory).updateMetaData({
         name: relativeName?.toString(),
-        displayName: relativeName?.toString(),
         uri: newTargetUri,
         tooltip: this.fileTreeAPI.getReadableTooltip(newTargetUri),
         fileStat: {
@@ -1682,10 +1675,6 @@ export class FileTreeModelService {
     await this.whenReady;
     // 筛选模式下，禁止使用定位功能
     if (this.fileTreeService.filterMode) {
-      return;
-    }
-    // 当存在等待选中的节点路径时，跳过定位
-    if (this.willSelectedNodePath) {
       return;
     }
     this._fileToLocation = pathOrUri;

--- a/packages/file-tree-next/src/common/file-tree-node.define.ts
+++ b/packages/file-tree-next/src/common/file-tree-node.define.ts
@@ -3,8 +3,6 @@ import { URI } from '@opensumi/ide-core-browser';
 import { FileStat } from '@opensumi/ide-file-service';
 
 export class Directory extends CompositeTreeNode {
-  private _displayName: string;
-
   constructor(
     tree: ITree,
     parent: ICompositeTreeNode | undefined,
@@ -21,17 +19,13 @@ export class Directory extends CompositeTreeNode {
   }
 
   get displayName() {
-    return this._displayName || this.name;
+    return this.name;
   }
 
   private updateName(name: string) {
     if (this.name !== name) {
-      this.name = name;
+      this.addMetadata('name', name);
     }
-  }
-
-  private updateDisplayName(name: string) {
-    this._displayName = name;
   }
 
   private updateURI(uri: URI) {
@@ -46,23 +40,16 @@ export class Directory extends CompositeTreeNode {
     this.tooltip = tooltip;
   }
 
-  updateMetaData(meta: { fileStat?: FileStat; tooltip?: string; name?: string; displayName?: string; uri?: URI }) {
-    const { fileStat, tooltip, name, displayName, uri } = meta;
-    displayName && this.updateDisplayName(displayName);
+  updateMetaData(meta: { fileStat?: FileStat; tooltip?: string; name?: string; uri?: URI }) {
+    const { fileStat, tooltip, name, uri } = meta;
     name && this.updateName(name);
     fileStat && this.updateFileStat(fileStat);
     uri && this.updateURI(uri);
     tooltip && this.updateToolTip(tooltip);
   }
-
-  dispose() {
-    super.dispose();
-  }
 }
 
 export class File extends TreeNode {
-  private _displayName: string;
-
   constructor(
     tree: ITree,
     parent: CompositeTreeNode | undefined,
@@ -75,10 +62,32 @@ export class File extends TreeNode {
   }
 
   get displayName() {
-    return this._displayName || this.name;
+    return this.name;
   }
 
-  dispose() {
-    super.dispose();
+  private updateName(name: string) {
+    if (this.name !== name) {
+      this.addMetadata('name', name);
+    }
+  }
+
+  private updateURI(uri: URI) {
+    this.uri = uri;
+  }
+
+  private updateFileStat(filestat: FileStat) {
+    this.filestat = filestat;
+  }
+
+  private updateToolTip(tooltip: string) {
+    this.tooltip = tooltip;
+  }
+
+  updateMetaData(meta: { fileStat?: FileStat; tooltip?: string; name?: string; uri?: URI }) {
+    const { fileStat, tooltip, name, uri } = meta;
+    name && this.updateName(name);
+    fileStat && this.updateFileStat(fileStat);
+    uri && this.updateURI(uri);
+    tooltip && this.updateToolTip(tooltip);
   }
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1084.
close #1077.

通过移除掉多余的文件事件处理逻辑以及加入临时节点的创建过程，让文件树内的文件操作可以在脱离文件服务的情况下也可以正常响应用户操作。

同时在切换 Tabbar 时移除文件树焦点，修复 collapsedAll 后文件树快照没有及时更新问题

以下为屏蔽了文件事件响应情况下的操作效果，在文件事件正常运作时，文件树的状态更新将会更加准确：

https://user-images.githubusercontent.com/9823838/169974759-406cba6d-9357-4746-8215-24a9424a05b6.mp4

### Changelog

弱化文件树对于文件事件依赖，优化文件树操作响应速度