### PR TITLE
chore: lock typescript version to 4.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "tslib": "^2.4.0",
     "node-gyp": "^9.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.4.2",
+    "typescript": "4.6.4",
     "webpack": "^4.39.3"
   },
   "lint-staged": {

--- a/tools/dev-tool/package.json
+++ b/tools/dev-tool/package.json
@@ -41,7 +41,7 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.8.0",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
-    "typescript": "^4.4.2",
+    "typescript": "4.6.4",
     "webpack": "^4.30.0",
     "acorn": "^8.7.1",
     "webpack-cli": "^3.3.1",

--- a/tools/electron/package.json
+++ b/tools/electron/package.json
@@ -69,7 +69,7 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.8.0",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
-    "typescript": "^4.4.2",
+    "typescript": "4.6.4",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.1",
     "yargs": "^13.2.4"


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

close #1108

### Changelog
