### PR TITLE
在终端恢复时检测到sessionID不包含"|"时不启用hack clientID逻辑

### DIFF
--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -247,14 +247,14 @@ export class TerminalController extends WithEventBus implements ITerminalControl
 
     const currentClientId = this.wsChannelHandler.clientId;
     const currentRealSessionId = history.current?.split('|')?.[1];
-    if (history.current) {
+    if (history.current && history.current.includes('|')) {
       history.current = `${currentClientId}|${currentRealSessionId}`;
     }
     history.groups = history.groups.map((group) => {
       if (Array.isArray(group)) {
         // 替换clientId为当前窗口ClientID
         return group.map(({ client, ...other }) => ({
-          client: `${currentClientId}|${(client as string)?.split('|')?.[1]}`,
+          client: client.includes('|') ? `${currentClientId}|${(client as string)?.split('|')?.[1]}` : client,
           ...other,
         }));
       } else {
@@ -265,7 +265,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
     let currentWidgetId = '';
     const { groups, current } = history;
 
-    const ids: (string | { clientId: string })[] = [];
+    const ids: (string | { client: string })[] = [];
 
     groups.forEach((widgets) => ids.push(...widgets.map((widget) => widget.client)));
 


### PR DESCRIPTION
### Types

在终端恢复时检测到sessionID不包含"|"时不启用hack clientID逻辑

- [x] 🐛 Bug Fixes

### Background or solution
某集成端完成重写了Terminal前端连接逻辑以及sessionID逻辑，此时terminal.controller不应该强行做clientID的hack，这样会导致终端基础逻辑反而出bug。

因此在执行Hack逻辑判断下sessionID是否包含"|"这个字符，如果没有的话，可以认为这是被干预过的SessionID，不执行Hack逻辑。

不过本质上是集成端的覆写逻辑太过于老旧导致的，正好借此回归验证的机会对这里的hack逻辑做一个Corner Case 的处理。

### Changelog
