### PR TITLE
fix: filetree input selection color should inherit parent node

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-node.module.less
+++ b/packages/file-tree-next/src/browser/file-tree-node.module.less
@@ -143,6 +143,9 @@
   width: 100%;
   input {
     font-size: @base-font-size;
+    &::selection {
+      color: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes


### Background or solution

![image](https://user-images.githubusercontent.com/6399899/170494563-3f7fd2b3-f967-48b0-9879-2e3bae75f57f.png)

fix: #673

### Changelog

filetree input selection color should inherit parent node
