### PR TITLE
fix: inaccurate search results

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -388,7 +388,7 @@ export class FileTreeContribution
             }
           }
         }
-        this.commandService.executeCommand(SEARCH_COMMANDS.OPEN_SEARCH.id, { includeValue: searchPath! });
+        this.commandService.executeCommand(SEARCH_COMMANDS.OPEN_SEARCH.id, { includeValue: searchPath! + '/' });
       },
       isVisible: () =>
         !!this.fileTreeModelService.contextMenuFile && Directory.is(this.fileTreeModelService.contextMenuFile),

--- a/packages/search/src/browser/search.service.ts
+++ b/packages/search/src/browser/search.service.ts
@@ -245,7 +245,7 @@ export class ContentSearchClientService implements IContentSearchClientService {
       exclude: splitOnComma(this.excludeValue || ''),
     };
 
-    searchOptions.exclude = this.getExcludeWithSetting(searchOptions);
+    searchOptions.exclude = this.getExcludeWithSetting(searchOptions, state);
 
     // 记录搜索历史
     this.searchHistory.setSearchHistory(value);
@@ -277,7 +277,7 @@ export class ContentSearchClientService implements IContentSearchClientService {
     // FIXME: 当前无法在不同根目录内根据各自 include 搜素，因此如果多 workspaceFolders，此处可能返回比实际要多的结果
     // 同时 searchId 设计原因只能针对单服务，多个 search 服务无法对同一个 searchId 返回结果
     // 长期看需要改造，以支持 registerFileSearchProvider
-    if (this.UIState.isOnlyOpenEditors) {
+    if (state.isOnlyOpenEditors) {
       rootDirs = [];
       const openResources = arrays.coalesce(
         arrays.flatten(this.workbenchEditorService.editorGroups.map((group) => group.resources)),
@@ -285,11 +285,11 @@ export class ContentSearchClientService implements IContentSearchClientService {
       const includeMatcherList = searchOptions.include?.map((str) => parse(anchorGlob(str))) || [];
       const excludeMatcherList = searchOptions.exclude?.map((str) => parse(anchorGlob(str))) || [];
       const openResourcesInFilter = openResources.filter((resource) => {
-        const uriString = resource.uri.toString();
-        if (excludeMatcherList.length > 0 && excludeMatcherList.some((matcher) => matcher(uriString))) {
+        const fsPath = resource.uri.codeUri.fsPath.toString();
+        if (excludeMatcherList.length > 0 && excludeMatcherList.some((matcher) => matcher(fsPath))) {
           return false;
         }
-        if (includeMatcherList.length > 0 && !includeMatcherList.some((matcher) => matcher(uriString))) {
+        if (includeMatcherList.length > 0 && !includeMatcherList.some((matcher) => matcher(fsPath))) {
           return false;
         }
         return true;
@@ -311,8 +311,9 @@ export class ContentSearchClientService implements IContentSearchClientService {
           include.push(uri.codeUri.fsPath);
         }
       });
+
       searchOptions.include = include;
-      searchOptions.exclude = include.length ? undefined : ['**/*'];
+      searchOptions.exclude = include.length > 0 ? undefined : ['**/*'];
     }
 
     // 从 doc model 中搜索
@@ -689,7 +690,7 @@ export class ContentSearchClientService implements IContentSearchClientService {
     this.updateUIState(UIState || {});
   }
 
-  private getExcludeWithSetting(searchOptions: ContentSearchOptions) {
+  private getExcludeWithSetting(searchOptions: ContentSearchOptions, state: IUIState) {
     let result: string[] = [];
 
     if (searchOptions.exclude) {
@@ -697,7 +698,7 @@ export class ContentSearchClientService implements IContentSearchClientService {
     }
 
     // 启用默认排除项
-    if (!this.UIState.isIncludeIgnored) {
+    if (!state.isIncludeIgnored) {
       result = result.concat(this.getPreferenceSearchExcludes());
     }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

1. 修复了 include 条件不能和 only opened docs 一起使用
2. 修复了点击默认排除项后，从 node_modules 中的文件夹右键点击 在文件夹中搜索 不生效的 case。（解决方案就是在路径后加一个 /），但这只是暂时的修复，之后从根本上修一下。
3. 修复了当前打开的文档 & include 条件会出现多个结果

### Changelog

Fix inaccurate search results when use `include` and `isOnlyOpenEditors`
