### PR TITLE
fix: remove unexpected expandAll action before filtering the file tree

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -264,11 +264,6 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
     };
   }, [model, outerActive]);
 
-  const beforeFilterValueChange = useCallback(async () => {
-    const { expandAll } = fileTreeModelService;
-    await expandAll();
-  }, [fileTreeModelService]);
-
   const ensureIsReady = useCallback(
     async (token: CancellationToken) => {
       await fileTreeModelService.whenReady;
@@ -381,7 +376,6 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
         treeIndent={treeIndent}
         filterMode={filterMode}
         locationToCurrentFile={locationToCurrentFile}
-        beforeFilterValueChange={beforeFilterValueChange}
         onTreeReady={handleTreeReady}
         onContextMenu={handleContextMenu}
         onItemClick={handleItemClicked}
@@ -405,7 +399,7 @@ interface FileTreeViewProps {
     hidesExplorerArrows: boolean;
   };
   onTreeReady: (handle: IRecycleTreeFilterHandle) => void;
-  beforeFilterValueChange: () => Promise<void>;
+  beforeFilterValueChange?: () => Promise<void>;
   locationToCurrentFile: (location: string) => void;
   onItemClick(event: MouseEvent, item: File | Directory, type: TreeNodeType, activeUri?: URI): void;
   onItemDoubleClick(event: MouseEvent, item: File | Directory, type: TreeNodeType, activeUri?: URI): void;
@@ -427,7 +421,6 @@ const FileTreeView = memo(
     onItemDoubleClick,
     onContextMenu,
     onTwistierClick,
-    beforeFilterValueChange,
   }: FileTreeViewProps) => {
     const filetreeService = useInjectable<FileTreeService>(IFileTreeService);
     const { decorationService, labelService, locationToCurrentFile } = filetreeService;
@@ -472,7 +465,6 @@ const FileTreeView = memo(
             onReady={onTreeReady}
             model={model}
             filterEnabled={filterMode}
-            beforeFilterValueChange={beforeFilterValueChange}
             filterAfterClear={locationToCurrentFile}
             filterAutoFocus={true}
             leaveBottomBlank={true}

--- a/packages/file-tree-next/src/browser/services/file-tree-dnd.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-dnd.service.ts
@@ -8,7 +8,6 @@ import {
   URI,
   ThrottledDelayer,
   FileStat,
-  path,
 } from '@opensumi/ide-core-browser';
 import { FileTreeDropEvent } from '@opensumi/ide-core-common/lib/types/dnd';
 import { IMessageService } from '@opensumi/ide-overlay';
@@ -20,8 +19,6 @@ import styles from '../file-tree.module.less';
 import { FileTreeService } from '../file-tree.service';
 
 import { FileTreeModelService } from './file-tree-model.service';
-
-const { Path } = path;
 
 @Injectable()
 export class DragAndDropService extends WithEventBus {

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1003,11 +1003,6 @@ export class FileTreeModelService {
     }
   }
 
-  // 展开所有缓存目录
-  public expandAll = async () => {
-    await this.treeModel.root.expandedAll();
-  };
-
   async deleteFileByUris(uris: URI[]) {
     if (uris.length === 0) {
       return;

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -10,7 +10,7 @@ export const localizationBundle = {
     'common.no': '否',
     extension: '插件',
 
-    'tree.filter.placeholder': '输入关键字或路径查找',
+    'tree.filter.placeholder': '输入关键字或路径筛选',
 
     'file.new': '新建文件',
     'file.folder.new': '新建文件夹',
@@ -62,7 +62,7 @@ export const localizationBundle = {
     'file.refresh': '刷新',
     'file.search.folder': '在文件夹中查找',
     'file.focus.files': '在资源管理器中聚焦文件',
-    'file.filetree.filter': '在展开文件中查找',
+    'file.filetree.filter': '基于当前文件树筛选文件',
     'file.filetree.openTerminalWithPath': '在终端中打开',
     'file.tooltip.symbolicLink': '符号链接',
     'file.resource-deleted': '（已删除）',


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1131 

优化了文案展示，强调该部分功能为筛选功能，是基于当前的文件树进行筛选操作，而不是查找，这里仅会基于当前状态做筛选

### Changelog

remove unexpected expandAll action before filtering the file tree