### PR TITLE
style: improve extension manager scroller style

### DIFF
--- a/packages/extension-manager/src/browser/extension-overview/index.tsx
+++ b/packages/extension-manager/src/browser/extension-overview/index.tsx
@@ -161,8 +161,10 @@ export const ExtensionOverview: ReactEditorComponent<
           onChange={onDidTabChange}
           tabs={[TabActiveKey.details, TabActiveKey.changelog]}
         />
-        {activateKey === TabActiveKey.details && metadata.readme && <Markdown content={metadata.readme} />}
-        {activateKey === TabActiveKey.changelog && metadata.changelog && <Markdown content={metadata.changelog} />}
+        <div className={styles.extension_content}>
+          {activateKey === TabActiveKey.details && metadata.readme && <Markdown content={metadata.readme} />}
+          {activateKey === TabActiveKey.changelog && metadata.changelog && <Markdown content={metadata.changelog} />}
+        </div>
       </div>
     </div>
   );

--- a/packages/extension-manager/src/browser/extension-overview/overview.module.less
+++ b/packages/extension-manager/src/browser/extension-overview/overview.module.less
@@ -96,10 +96,13 @@
 
 .extension_overview_body {
   flex: 1;
-
   .tabs {
+    width: 100%;
     padding: 0px 20px;
     font-size: 14px;
     font-weight: bold;
+  }
+  .extension_content {
+    height: calc(100% - 39px);
   }
 }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

before:
![image](https://user-images.githubusercontent.com/9823838/171082124-ae2830db-da8b-4fa8-9931-1f7f04fab16e.png)

after:

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/9823838/171082078-a3e98c54-f52c-4810-9fd5-4dd495b8f301.png">

### Changelog

improve extension manager scroller style
