### PR TITLE
fix: remove expandAll before filtering

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -254,11 +254,6 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
     };
   }, [model, outerActive]);
 
-  const beforeFilterValueChange = useCallback(async () => {
-    const { expandAll } = fileTreeModelService;
-    await expandAll();
-  }, [fileTreeModelService]);
-
   const ensureIsReady = useCallback(async () => {
     await fileTreeModelService.whenReady;
     if (fileTreeModelService.treeModel) {
@@ -362,7 +357,6 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
         treeIndent={treeIndent}
         filterMode={filterMode}
         locationToCurrentFile={locationToCurrentFile}
-        beforeFilterValueChange={beforeFilterValueChange}
         onTreeReady={handleTreeReady}
         onContextMenu={handleContextMenu}
         onItemClick={handleItemClicked}
@@ -386,7 +380,7 @@ interface FileTreeViewProps {
     hidesExplorerArrows: boolean;
   };
   onTreeReady: (handle: IRecycleTreeFilterHandle) => void;
-  beforeFilterValueChange: () => Promise<void>;
+  beforeFilterValueChange?: () => Promise<void>;
   locationToCurrentFile: (location: string) => void;
   onItemClick(event: MouseEvent, item: File | Directory, type: TreeNodeType, activeUri?: URI): void;
   onItemDoubleClick(event: MouseEvent, item: File | Directory, type: TreeNodeType, activeUri?: URI): void;

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1001,11 +1001,6 @@ export class FileTreeModelService {
     }
   }
 
-  // 展开所有缓存目录
-  public expandAll = async () => {
-    await this.treeModel.root.expandedAll();
-  };
-
   async deleteFileByUris(uris: URI[]) {
     if (uris.length === 0) {
       return;

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -10,7 +10,7 @@ export const localizationBundle = {
     'common.no': '否',
     extension: '插件',
 
-    'tree.filter.placeholder': '输入关键字或路径查找',
+    'tree.filter.placeholder': '输入关键字或路径筛选',
 
     'file.new': '新建文件',
     'file.folder.new': '新建文件夹',
@@ -56,7 +56,7 @@ export const localizationBundle = {
     'file.refresh': '刷新',
     'file.search.folder': '在文件夹中查找',
     'file.focus.files': '在资源管理器中聚焦文件',
-    'file.filetree.filter': '在展开文件中查找',
+    'file.filetree.filter': '基于当前文件树筛选文件',
     'file.filetree.openTerminalWithPath': '在终端中打开',
     'file.tooltip.symbolicLink': '符号链接',
     'file.resource-deleted': '（已删除）',


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

cherry-pick #1137

移除非期望的 expandAll 行为

### Changelog

remove expandAll before the filtering
