### PR TITLE
fix: wrong import in tools/electron

### DIFF
--- a/tools/electron/src/node/server.ts
+++ b/tools/electron/src/node/server.ts
@@ -3,7 +3,8 @@ import net from 'net';
 
 import yargs from 'yargs';
 
-import { Deferred, DEFAULT_OPENVSX_REGISTRY } from '@opensumi/ide-core-common';
+import { Deferred } from '@opensumi/ide-core-common';
+import { DEFAULT_OPENVSX_REGISTRY } from '@opensumi/ide-core-common/lib/const';
 import { IServerAppOpts, ServerApp, NodeModule } from '@opensumi/ide-core-node';
 
 export async function startServer(arg1: NodeModule[] | Partial<IServerAppOpts>) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

fix an error `TS2305: Module '"@opensumi/ide-core-common"' has no exported member 'DEFAULT_OPENVSX_REGISTRY'.`

Original terminal output

```powershell
ERROR in C:\Users\situ\github\opensumi\core\tools\electron\src\node\server.ts     
[tsl] ERROR in C:\Users\situ\github\opensumi\core\tools\electron\src\node\server.ts(6,20)
      TS2305: Module '"@opensumi/ide-core-common"' has no exported member 'DEFAULT_OPENVSX_REGISTRY'.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @opensumi/ide-electron@1.1.0 build:main: `webpack --config ./build/webpack.main.config.js `
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the @opensumi/ide-electron@1.1.0 build:main script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\situ\AppData\Roaming\npm-cache\_logs\2022-05-31T12_26_09_502Z-debug.log
npm ERR! errno 1
npm ERR! @opensumi/ide-electron@1.1.0 build: `rimraf -rf ./out && run-p build:node build:browser build:main build:extension build:webview`
npm ERR! Exit status 1npm ERR!
npm ERR! Failed at the @opensumi/ide-electron@1.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\situ\AppData\Roaming\npm-cache\_logs\2022-05-31T12_26_11_119Z-debug.log
```
