### PR TITLE
fix: get layout maxSize property error

### DIFF
--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -240,7 +240,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
               ? element['props'].minSize + 'px'
               : '-1px',
             [Layout.getMaxSizeProperty(direction)]:
-              maxLocks[index] && getProp(element, 'minSize') ? element['props'].minSize + 'px' : 'unset',
+              maxLocks[index] && getProp(element, 'maxSize') ? element['props'].maxSize + 'px' : 'unset',
             // resize flex模式下应用flexGrow
             ...(getProp(element, 'flexGrow') !== undefined ? { flexGrow: element['props'].flexGrow } : {}),
             display: hides[index] ? 'none' : 'block',

--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -701,13 +701,11 @@ export class TabbarService extends WithEventBus {
         if (previousId && currentId !== previousId) {
           this.prevSize = getSize();
         }
-        setSize(this.prevSize || this.panelSize + this.barSize);
         const containerInfo = this.getContainer(currentId);
-        if (containerInfo && containerInfo.options!.noResize) {
-          lockSize(true);
-        } else {
-          lockSize(false);
-        }
+
+        setSize(this.prevSize || this.panelSize + this.barSize);
+        lockSize(Boolean(containerInfo?.options?.noResize));
+
         this.activatedKey.set(currentId);
       } else {
         setSize(this.barSize);


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution
SplitPanel 组件中 getMaxSizeProperty 的时候拿的是 minSize property

### Changelog
修改为 maxSize