### PR TITLE
fix: removed node maybe not a child of head

### DIFF
--- a/packages/extension/src/browser/shadowRoot.tsx
+++ b/packages/extension/src/browser/shadowRoot.tsx
@@ -52,7 +52,9 @@ function useMutationObserver(from: HTMLHeadElement, target: HTMLHeadElement) {
         }
         if (mutation.removedNodes.length > 0) {
           for (const removedNode of Array.from(mutation.removedNodes)) {
-            target.removeChild(removedNode as any);
+            if (target.contains(removedNode)) {
+              target.removeChild(removedNode as any);
+            }
           }
         }
       }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

#1076

### Changelog
- fix: removed node maybe not a child of head