### PR TITLE
style: improve the file tree outer activate style

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.module.less
+++ b/packages/file-tree-next/src/browser/file-tree.module.less
@@ -24,8 +24,18 @@
 }
 
 .outer_active {
-  outline: 1px solid var(--list-focusOutline) !important;
-  outline-offset: -1px;
+  &:before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 5;
+    content: '';
+    pointer-events: none;
+    outline: 1px solid var(--list-focusOutline) !important;
+    outline-offset: -1px;
+  }
 }
 
 .empty_view {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution

This PR fixes #1141.

So, there is a file called [`tree.module.less`](https://github.com/opensumi/core/blob/cec41477f77274d807b4378c2cb9a132dfba4b2c/packages/core-browser/src/components/tree/tree.module.less) which is similar to [`file-tree.module.less`](https://github.com/opensumi/core/blob/cec41477f77274d807b4378c2cb9a132dfba4b2c/packages/file-tree-next/src/browser/file-tree.module.less). In the file, a pseudo `:before` is adopted to add outline for tree container when mouse hovering on it. And `z-index` is also set to 5 to make sure that the inner treenode won't cover the outline. In this way, the outline works well, like this:

<img width="776" alt="image" src="https://user-images.githubusercontent.com/32434520/171341096-bbc77b0d-a4f1-48b8-96bb-875e1c668d1b.png">

So I use the same way to prevent the outline of file-tree from being covered by its inner elements. Now it works well:

<img width="770" alt="image" src="https://user-images.githubusercontent.com/32434520/171341341-e816e07f-1403-4836-8172-e618902b2989.png">

### Changelog

improve the file tree outer activate style