### PR TITLE
fix: get wrong code platform key

### DIFF
--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -138,8 +138,16 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
   }
 
   async getCodePlatformKey(): Promise<'osx' | 'windows' | 'linux'> {
-    // follow vscode
-    return this.getOS() === OperatingSystem.Macintosh ? 'osx' : OperatingSystem.Windows ? 'windows' : 'linux';
+    switch (this.getOS()) {
+      case OperatingSystem.Macintosh:
+        return 'osx';
+      case OperatingSystem.Windows:
+        return 'windows';
+      case OperatingSystem.Linux:
+        return 'linux';
+      default:
+        return 'linux';
+    }
   }
 
   async getDefaultSystemShell(os: OperatingSystem) {


### PR DESCRIPTION
### Types

修复getCodePlatformKey方法的错误，该错误会导致Linux环境在该方法会被返回为windows。
致使前端判断错误，导致ISSUE #1110 

- [x] 🐛 Bug Fixes

### Background or solution
修复 BUG ISSUE #1110 
点击终端新增旁边下拉按钮无反应，修复了该case

### Changelog
- 修复getCodePlatformKey方法的错误
