### PR TITLE
fix: incorrect keybinding format in title of InlineActionWidget

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -181,7 +181,7 @@ const InlineActionWidget: React.FC<
   const title = React.useMemo(() => {
     const title = data.tooltip || data.label;
     if (data.keybinding) {
-      return `${title} (${data.keybinding.split('').join('+')})`;
+      return `${title} (${data.keybinding})`;
     }
     return title;
   }, [data]);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background

OS: **Windows**11 22000.708

incorrect title (Before)
<img width="754" alt="1e9e2fe268d9bf196a0c757fa54fdf9" src="https://user-images.githubusercontent.com/28241963/171452173-14ac381a-98db-4009-ab0c-0f77dcc4e265.png">


After fixing it
<img width="694" alt="f9e503c85a7ffc7db5cf439f619f541" src="https://user-images.githubusercontent.com/28241963/171452077-4ae0fcbb-11d8-4f2b-b68c-36caf4d04169.png">



