### PR TITLE
fix: add missing part for zoom

### DIFF
--- a/packages/core-common/src/electron.ts
+++ b/packages/core-common/src/electron.ts
@@ -26,7 +26,13 @@ export interface IElectronMainUIServiceShape {
 
   showSaveDialog(windowId: number, options: Electron.SaveDialogOptions): Promise<string | undefined>;
 
-  setZoomFactor(webContentsId: number, options: { value?: number; delta?: number }): void;
+  /**
+   * 默认最小缩放因数为 0.25，最大缩放因数为 5.0
+   */
+  setZoomFactor(
+    webContentsId: number,
+    options: { value?: number; delta?: number; minValue?: number | undefined; maxValue?: number | undefined },
+  ): void;
   getZoomFactor(webContentsId: number): number | undefined;
 
   /**

--- a/packages/core-common/src/electron.ts
+++ b/packages/core-common/src/electron.ts
@@ -32,8 +32,8 @@ export interface IElectronMainUIServiceShape {
   setZoomFactor(
     webContentsId: number,
     options: { value?: number; delta?: number; minValue?: number | undefined; maxValue?: number | undefined },
-  ): void;
-  getZoomFactor(webContentsId: number): number | undefined;
+  ): Promise<void>;
+  getZoomFactor(webContentsId: number): Promise<number | undefined>;
 
   /**
    * 在资源管理器里打开文件

--- a/packages/core-common/src/electron.ts
+++ b/packages/core-common/src/electron.ts
@@ -27,6 +27,7 @@ export interface IElectronMainUIServiceShape {
   showSaveDialog(windowId: number, options: Electron.SaveDialogOptions): Promise<string | undefined>;
 
   setZoomFactor(webContentsId: number, options: { value?: number; delta?: number }): void;
+  getZoomFactor(webContentsId: number): number | undefined;
 
   /**
    * 在资源管理器里打开文件

--- a/packages/core-common/src/electron.ts
+++ b/packages/core-common/src/electron.ts
@@ -27,7 +27,7 @@ export interface IElectronMainUIServiceShape {
   showSaveDialog(windowId: number, options: Electron.SaveDialogOptions): Promise<string | undefined>;
 
   /**
-   * 默认最小缩放因数为 0.25，最大缩放因数为 5.0
+   * 默认：最小缩放因子为 0.25，最大缩放因子为 5.0
    */
   setZoomFactor(
     webContentsId: number,

--- a/packages/core-electron-main/src/bootstrap/services/ui.ts
+++ b/packages/core-electron-main/src/bootstrap/services/ui.ts
@@ -109,14 +109,35 @@ export class ElectronMainUIService
     return contents?.getZoomFactor();
   }
 
-  setZoomFactor(webContentsId: number, options: { value?: number; delta?: number } = {}) {
+  setZoomFactor(
+    webContentsId: number,
+    options: { value?: number; delta?: number; minValue?: number; maxValue?: number } = {},
+  ) {
+    if (options.minValue === undefined) {
+      options.minValue = 0.25;
+    }
+    if (options.maxValue === undefined) {
+      options.maxValue = 5;
+    }
+
     const contents = webContents.fromId(webContentsId);
     if (contents) {
+      let factor: number | undefined;
       if (options.value) {
+        factor = options.value;
         contents.setZoomFactor(options.value);
       }
       if (options.delta) {
-        contents.setZoomFactor(contents.getZoomFactor() + options.delta);
+        factor = contents.getZoomFactor() + options.delta;
+      }
+      if (factor) {
+        if (options.minValue && factor < options.minValue) {
+          factor = options.minValue;
+        }
+        if (options.maxValue && factor > options.maxValue) {
+          factor = options.maxValue;
+        }
+        contents.setZoomFactor(factor);
       }
     }
   }

--- a/packages/core-electron-main/src/bootstrap/services/ui.ts
+++ b/packages/core-electron-main/src/bootstrap/services/ui.ts
@@ -104,12 +104,12 @@ export class ElectronMainUIService
     openInTerminal(targetPath);
   }
 
-  getZoomFactor(webContentsId: number): number | undefined {
+  async getZoomFactor(webContentsId: number): Promise<number | undefined> {
     const contents = webContents.fromId(webContentsId);
     return contents?.getZoomFactor();
   }
 
-  setZoomFactor(
+  async setZoomFactor(
     webContentsId: number,
     options: { value?: number; delta?: number; minValue?: number; maxValue?: number } = {},
   ) {

--- a/packages/electron-basic/src/browser/index.ts
+++ b/packages/electron-basic/src/browser/index.ts
@@ -334,6 +334,10 @@ export class ElectronBasicContribution
       command: 'electron.zoomOut',
       keybinding: isWindows ? 'alt+-' : 'ctrlcmd+-',
     });
+    keybindings.registerKeybinding({
+      command: 'electron.zoomReset',
+      keybinding: isWindows ? 'alt+numpad0' : 'ctrlcmd+numpad0',
+    });
   }
 
   onStart() {


### PR DESCRIPTION
### Types

- [x]  🐛 Bug Fixes

### Background or solution

this close: #1104

### Changelog

add missing  `getZoomFactor` method declaration
