### PR TITLE
chore: fix typos and remove empty lines

### DIFF
--- a/packages/connection/README.md
+++ b/packages/connection/README.md
@@ -2,22 +2,22 @@
 
 基于 jsonrpc 完成多端远程调用场景，兼容 lsp 等通信方式
 
-
 ### opensumi 中使用
 
 **准备**
+
 1. 框架中服务分为运行在浏览器环境的 前端服务(frontService) 与运行在 node 环境的 后端服务(backService)，服务在两端的实现方式是一致的
 2. 目前在 `tools/dev-tool` 中的启动逻辑中完成了服务的注册和获取逻辑，在具体功能模块中无需关心具体的通信注册获取逻辑
 
-**后端服务(backService)**
-后端服务(backService) 即在 Web Server 暴露的能力，类似 web 应用框架中 controller提供的请求响应逻辑
+**后端服务(backService)** 后端服务(backService) 即在 Web Server 暴露的能力，类似 web 应用框架中 controller 提供的请求响应逻辑
 
 1. 注册服务
 
 `packages/file-service/src/node/index.ts`
+
 ```javascript
 import { FileSystemNodeOptions, FileService } from './file-service';
-import {servicePath} from '../common/index';
+import { servicePath } from '../common/index';
 
 export class FileServiceModule extends NodeModule {
   providers = [{ token: 'FileServiceOptions', useValue: FileSystemNodeOptions.DEFAULT }];
@@ -36,26 +36,25 @@ export class FileServiceModule extends NodeModule {
 2. 服务调用
 
 `packages/file-tree/src/browser/index.ts`
-```javascript
 
-import {servicePath as FileServicePath} from '@opensumi/ide-file-service';
+```javascript
+import { servicePath as FileServicePath } from '@opensumi/ide-file-service';
 
 @Injectable()
 export class FileTreeModule extends BrowserModule {
-
-  providers: Provider[] = [
-    createFileTreeAPIProvider(FileTreeAPIImpl),
+  providers: Provider[] = [createFileTreeAPIProvider(FileTreeAPIImpl)];
+  backServices = [
+    {
+      servicePath: FileServicePath,
+    },
   ];
-  backServices = [{
-    servicePath: FileServicePath,
-  }];
 }
-
 ```
 
 例如在 file-tree 模块中，首先在模块入口位置声明需要用到的 `backServices`，传入引用的服务 `servicePath`，与服务注册时的 `servicePath` 一致
 
 `packages/file-tree/src/browser/file-tree.service.ts`
+
 ```javascript
 import {servicePath as FileServicePath} from '@opensumi/ide-file-service';
 
@@ -71,13 +70,13 @@ export default class FileTreeService extends Disposable {
   @Autowired(CommandService)
   private commandService: CommandService;
 
-  constructor(@Inject(FileServicePath) protected readonly fileSevice) {
+  constructor(@Inject(FileServicePath) protected readonly fileService) {
     super();
 
     this.getFiles();
   }
    createFile = async () => {
-    const {content} = await this.fileSevice.resolveContent('/Users/franklife/work/ide/ac/ide-framework/tsconfig.json');
+    const {content} = await this.fileService.resolveContent('/Users/franklife/work/ide/ac/ide-framework/tsconfig.json');
     const file = await this.fileAPI.createFile({
       name: 'name' + Date.now() + '\n' + content,
       path: 'path' + Date.now(),
@@ -98,7 +97,7 @@ export default class FileTreeService extends Disposable {
 在 file-tree.service.ts 中通过 `servicePath` 进行注入，并直接调用在服务类上的方法
 
 ```javascript
-constructor(@Inject(FileServicePath) protected readonly fileSevice) {
+constructor(@Inject(FileServicePath) protected readonly fileService) {
     super();
 
     this.getFiles();
@@ -108,30 +107,30 @@ constructor(@Inject(FileServicePath) protected readonly fileSevice) {
 方法调用会转换成一个远程调用进行响应，返回结果
 
 ```javascript
-const {content} = await this.fileSevice.resolveContent('/Users/franklife/work/ide/ac/ide-framework/tsconfig.json');
+const { content } = await this.fileService.resolveContent('/Users/franklife/work/ide/ac/ide-framework/tsconfig.json');
 ```
 
-
-**前端服务(frontService)**
-后端服务(backService) 即在 Browser 环境下运行的代码暴露的能力
+**前端服务(frontService)** 后端服务(backService) 即在 Browser 环境下运行的代码暴露的能力
 
 1. 注册服务
 
 `packages/file-ree/src/browser/index.ts`
+
 ```javascript
 @Injectable()
 export class FileTreeModule extends BrowserModule {
-
-  providers: Provider[] = [
-    createFileTreeAPIProvider(FileTreeAPIImpl),
+  providers: Provider[] = [createFileTreeAPIProvider(FileTreeAPIImpl)];
+  backServices = [
+    {
+      servicePath: FileServicePath,
+    },
   ];
-  backServices = [{
-    servicePath: FileServicePath,
-  }];
-  frontServices = [{
-    servicePath: FileTreeServicePath,
-    token: FileTreeService,
-  }];
+  frontServices = [
+    {
+      servicePath: FileTreeServicePath,
+      token: FileTreeService,
+    },
+  ];
 }
 ```
 
@@ -140,8 +139,9 @@ export class FileTreeModule extends BrowserModule {
 2. 服务使用
 
 `packages/file-service/src/node/index.ts`
+
 ```javascript
-import {servicePath as FileTreeServicePath} from '@opensumi/ide-file-tree';
+import { servicePath as FileTreeServicePath } from '@opensumi/ide-file-tree';
 
 @Injectable()
 export class FileServiceModule extends NodeModule {
@@ -164,6 +164,7 @@ export class FileServiceModule extends NodeModule {
 与使用后端服务一致，在模块定义中声明需要使用的前端服务 `frontServices`，传入前端服务注册时用的 `servicePath` 一致
 
 `packages/file-service/src/node/file-service.ts`
+
 ```javascript
 @Injectable()
 export class FileService implements IFileService {
@@ -192,17 +193,10 @@ export class FileService implements IFileService {
 ```
 
 方法调用会转换成一个远程调用进行响应，返回结果
+
 ```javascript
-const fileTree = await this.fileTreeService
-fileTree.fileName(uri.substr(-5))
+const fileTree = await this.fileTreeService;
+fileTree.fileName(uri.substr(-5));
 ```
 
-与后端服务调用区别的是，目前因前端代码后置执行，所以首先需要获取服务 `await thie.fileTreeService` 后进行调用
-
-
-
-
-
-
-
-
+与后端服务调用区别的是，目前因前端代码后置执行，所以首先需要获取服务 `await this.fileTreeService` 后进行调用


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🧹 Chores

### Changelog

fix typos and remove empty lines in packages/connection/README.md

fileSevice => fileService
thie => this

By the way, the doc was automatically formatted by  `prettier --write`, how to prevent it?

```shell
(base) PS C:\Users\situ\github\opensumi\core> git commit -m "fix: fix typos and remove empty lines"
[STARTED] Preparing lint-staged...
[SUCCESS] Preparing lint-staged...
[STARTED] Running tasks for staged files...
[STARTED] package.json — 1 file
[STARTED] *.{js,jsx,ts,tsx,md,html,css,less,json} — 1 file
[STARTED] *.{js,jsx,ts,tsx} — 0 file
[SKIPPED] *.{js,jsx,ts,tsx} — no files
[STARTED] prettier --write
[SUCCESS] prettier --write
[SUCCESS] *.{js,jsx,ts,tsx,md,html,css,less,json} — 1 file
[SUCCESS] package.json — 1 file
[SUCCESS] Running tasks for staged files...
[STARTED] Applying modifications from tasks...
[SUCCESS] Applying modifications from tasks...
[STARTED] Cleaning up temporary files...
[SUCCESS] Cleaning up temporary files...
[patch-connection-readme aa30e58aa] fix: fix typos and remove empty lines
 1 file changed, 36 insertions(+), 42 deletions(-)
```
