### PR TITLE
fix: get the default value correctly on preference view

### DIFF
--- a/packages/core-browser/src/preferences/preference-service.ts
+++ b/packages/core-browser/src/preferences/preference-service.ts
@@ -595,7 +595,7 @@ export class PreferenceServiceImpl implements PreferenceService {
     language?: string,
   ): PreferenceResolveResult<T> {
     const result: PreferenceResolveResult<T> = { scope: PreferenceScope.Default };
-    const scopes = untilScope
+    const scopes = !isUndefined(untilScope)
       ? PreferenceScope.getScopes().filter((s) => s <= untilScope)
       : PreferenceScope.getScopes();
     for (const scope of scopes) {
@@ -642,5 +642,8 @@ export class PreferenceServiceImpl implements PreferenceService {
 }
 
 function cacheHash(language?: string, untilScope?: PreferenceScope, resourceUri?: string) {
-  return `${language ? `${language}:::` : ''}${untilScope ? `${untilScope}:::` : ''}${resourceUri}` || 'default';
+  return (
+    `${language ? `${language}:::` : ''}${!isUndefined(untilScope) ? `${untilScope}:::` : ''}${resourceUri || ''}` ||
+    'default'
+  );
 }

--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -356,7 +356,9 @@ function SelectPreferenceItem({
   hasValueInScope,
 }: IPreferenceItemProps) {
   const preferenceService: PreferenceService = useInjectable(PreferenceService);
-  const defaultValue = preferenceService.get(preferenceName, PreferenceScope.Default) || schema.default;
+  const defaultValue =
+    preferenceService.resolve(preferenceName, undefined, undefined, undefined, PreferenceScope.Default) ||
+    schema.default;
   const settingsService: PreferenceSettingsService = useInjectable(IPreferenceSettingsService);
   const [value, setValue] = useState<string>(isUndefined(currentValue) ? defaultValue : currentValue);
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

`preferenceService.get` 不支持指定作用域获取，需要通过 `resolve` 方法获取，同时需要兼容 Scope === 0 的情况

### Changelog

get the default value correctly on preference view