### PR TITLE
fix: improve treenode path check logic

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -736,7 +736,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
         }
       }
       while ((forceLoadPath = expandedPaths.shift())) {
-        const isRelative = forceLoadPath.indexOf(this.path) > -1;
+        const isRelative = forceLoadPath.indexOf(`${this.path}${Path.separator}`) > -1;
         if (!isRelative) {
           break;
         }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

问题定位：

这里的路径判断出现问题导致同名目录被忽略处理了

### Changelog

improve treenode path check logic