### PR TITLE
fix: last view attached to bottom or right

### DIFF
--- a/packages/main-layout/src/browser/accordion/accordion.service.ts
+++ b/packages/main-layout/src/browser/accordion/accordion.service.ts
@@ -526,6 +526,11 @@ export class AccordionService extends WithEventBus {
   protected setSize(index: number, targetSize: number, isIncrement?: boolean, noAnimation?: boolean): number {
     const fullHeight = this.splitPanelService.rootNode!.clientHeight;
     const panel = this.splitPanelService.panels[index];
+    if (targetSize) {
+      panel.style.flexGrow = '1';
+    } else {
+      panel.style.flexGrow = '';
+    }
     if (!noAnimation) {
       panel.classList.add('resize-ease');
     }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
closes #857 

### Changelog
看了VS Code的交互，窗口变化时，每个已展开视图均摊变化的size，所以给每个已展开视图添加flexGrow属性。
