### PR TITLE
fix: handle socket uncaught error

### DIFF
--- a/packages/terminal-next/src/node/pty.manager.remote.ts
+++ b/packages/terminal-next/src/node/pty.manager.remote.ts
@@ -82,6 +82,11 @@ export class PtyServiceManagerRemote extends PtyServiceManager {
       }, 2000);
     });
 
+    // 处理 Socket 异常
+    socket.on('error', (e) => {
+      this.logger.warn(e);
+    });
+
     try {
       socket.connect(connectOpts);
     } catch (e) {


### PR DESCRIPTION
### Types

对于 Pty Remote 模式重连的优化，之前的Error Catch有些漏洞，只在socket.connect 方法做了try catch。
而实际上还需要对socket.on('error')里面的问题做处理，来避免异常直接抛出影响IDE进程的正常运行。

- [x] 🐛 Bug Fixes
### Background or solution

### Changelog
- 增加 Error 处理
