### PR TITLE
feat: remove layout state await

### DIFF
--- a/packages/main-layout/src/browser/main-layout.contribution.ts
+++ b/packages/main-layout/src/browser/main-layout.contribution.ts
@@ -129,9 +129,8 @@ export class MainLayoutModuleContribution
   @Autowired(KeybindingRegistry)
   protected keybindingRegistry: KeybindingRegistry;
 
-  async initialize() {
-    // 全局只要初始化一次
-    await this.layoutState.initStorage();
+  initialize() {
+    this.layoutState.initStorage();
 
     const componentContributions = this.contributionProvider.getContributions();
     for (const contribution of componentContributions) {


### PR DESCRIPTION
### Types

- [x] 🚀 Performance Improvements

### Background or solution

移除了 layout 初始化过程中多余的 await 逻辑，首屏加载速度加快约 200ms

before：
<img width="886" alt="截屏2022-06-13 下午2 28 30" src="https://user-images.githubusercontent.com/9823838/173293777-47affa50-7dd2-4fc0-b855-6ec13498546c.png">

after:
<img width="756" alt="image" src="https://user-images.githubusercontent.com/9823838/173293877-b2c3f6a3-5b18-499a-a9a4-5742be136b6b.png">

### Changelog

improve layout restore process
