### PR TITLE
feat: release 时生成 manifest 文件

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           npm i
           npm run init
+          npm run manifest -- -v=${{github.event.inputs.version}}
 
       # 发布正式版本
       # 当 main 分支进行首次版本发布时不推送 Lerna 更改到 Git

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "update:iconfont": "ts-node ./scripts/download-iconfont.ts",
     "changelog-old": "node scripts/changelog/index.js",
     "changelog": "ts-node -P scripts/tsconfig.scripts.json scripts/changelog/index.ts",
-    "iteration": "ts-node -P scripts/tsconfig.scripts.json scripts/iteration-plan.ts"
+    "iteration": "ts-node -P scripts/tsconfig.scripts.json scripts/iteration-plan.ts",
+    "manifest": "ts-node ./scripts/generate-manifest-json"
   },
   "engines": {
     "node": ">=12 <=14"

--- a/scripts/generate-manifest-json.ts
+++ b/scripts/generate-manifest-json.ts
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync, ensureFileSync } from 'fs-extra';
+import { generateManifest } from './manifest';
+import Package, { readAllMainPackages } from './pkg';
+import { argv } from 'yargs';
+import { join } from 'path';
+
+// npm run manifest -- -v=2.19.0
+const version = argv.v as string;
+const localManifest = join(__dirname, '../packages/types/manifest.json');
+if (!version) {
+  throw new Error('version is required');
+}
+
+const packages: Package[] = readAllMainPackages();
+generateManifest(packages, version).then((manifest) => updateFileWithDispose(localManifest, manifest));
+
+function updateFileWithDispose(filePath: string, content: any | ((original: string) => any)) {
+  ensureFileSync(filePath);
+  const original = readFileSync(filePath, { encoding: 'utf8' });
+  let newContent = content;
+  if (typeof content === 'function') {
+    newContent = content(original);
+  }
+  writeFileSync(filePath, `${JSON.stringify(newContent, null, 2)}\n`);
+}


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

manifest.json 存放了 OpenSumi 包的元信息，供插件安装引擎、自动更新版本插件这些地方消费，这些数据在 2.14 后没有生成了

### Changelog
release 时生成 manifest 文件