### PR TITLE
fix: lock nsfw version

### DIFF
--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -23,7 +23,7 @@
     "file-type": "^12.0.0",
     "iconv-lite": "^0.6.3",
     "jschardet": "3.0.0",
-    "nsfw": "^2.2.0",
+    "nsfw": "2.2.0",
     "trash": "^5.2.0",
     "vscode-languageserver-types": "^3.16.0",
     "write-file-atomic": "^3.0.0"


### PR DESCRIPTION
### NSFW版本锁定问题

锁定NSFW版本，在2022年6月初 NSFW发布的2.2.1版本中，存在着Linux系统上watch巨大项目时无限循环/递归的问题。
导致await watcher.start() 的操作无限等待，进而造成IDE启动一直失败。

因此把版本锁定到测试无问题的2.2.0上。

- [x] 🐛 Bug Fixes


### Background or solution
- nsfw 2.2.1版本出现致命bug

### Changelog
- lock nsfw version
