### PR TITLE
chore: upgrade got dependence to v12.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
     "git-rev-sync": "^3.0.1",
-    "got": "^11.8.3",
+    "got": "^12.1.0",
     "handlebars": "^4.7.3",
     "is-git-clean": "^1.1.0",
     "jest": "^28.0.3",

--- a/packages/remote-cli/package.json
+++ b/packages/remote-cli/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "got": "^11.8.3",
+    "got": "^12.1.0",
     "yargs": "^17.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

在 Electron 17 环境下使用目前存在该问题 https://github.com/sindresorhus/got/issues/1803 ，通过升级依赖的方式解决该问题

### Changelog