### PR TITLE
fix: start electron not work on Windows

### DIFF
--- a/scripts/start-electron.ts
+++ b/scripts/start-electron.ts
@@ -6,12 +6,12 @@ import { run } from './fn/shell';
 const folderName = 'tools/electron';
 
 async function main() {
-  const semphore = path.resolve(folderName, 'node_modules/.init-done');
-  if (!fs.existsSync(semphore)) {
+  const semaphore = path.resolve(folderName, 'node_modules/.init-done');
+  if (!fs.existsSync(semaphore)) {
     await run(
       'cd tools/electron && rimraf ./node_modules && npm i && npm run link-local && npm run rebuild-native && npm run build',
     );
-    fs.closeSync(fs.openSync(semphore, 'a'));
+    fs.closeSync(fs.openSync(semaphore, 'a'));
   }
 
   startFromFolder(folderName, 'start');

--- a/scripts/start-electron.ts
+++ b/scripts/start-electron.ts
@@ -11,7 +11,7 @@ async function main() {
     await run(
       'cd tools/electron && rimraf ./node_modules && npm i && npm run link-local && npm run rebuild-native && npm run build',
     );
-    await run('touch ' + semphore);
+    fs.closeSync(fs.openSync(semphore, 'a'));
   }
 
   startFromFolder(folderName, 'start');


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
- [x] 🧹 Chores

### Background or solution

`npm run start:electron` does not work because `touch` does not exist on Windows.

Here is a solution(using fs API that is equivalent to `touch`) to this issues: https://stackoverflow.com/a/34259166/8096007
