### PR TITLE
feat: toolbar support when clause contexts

### DIFF
--- a/packages/core-browser/src/toolbar/toolbar.registry.ts
+++ b/packages/core-browser/src/toolbar/toolbar.registry.ts
@@ -1,7 +1,8 @@
 import { Injectable, Autowired } from '@opensumi/di';
-import { IDisposable, Emitter, WithEventBus, ContributionProvider, Domain } from '@opensumi/ide-core-common';
+import { IDisposable, Emitter, WithEventBus, ContributionProvider, Domain, Event } from '@opensumi/ide-core-common';
 
 import { ClientAppContribution } from '../common';
+import { ContextKeyChangeEvent, IContextKeyService } from '../context-key';
 
 import {
   IToolbarRegistry,
@@ -13,6 +14,7 @@ import {
   ToolBarActionContribution,
   ToolbarActionGroupsChangedEvent,
   ToolbarRegistryReadyEvent,
+  ToolbarActionsWhenChangeEvent,
 } from './types';
 
 type LocationName = string;
@@ -44,6 +46,11 @@ export class NextToolbarRegistryImpl extends WithEventBus implements IToolbarReg
   private _onActionDisposed: Emitter<IToolbarAction> = new Emitter();
 
   private _onActionAdded: Emitter<IToolbarAction> = new Emitter();
+
+  private _contextKeys: Set<string> = new Set<string>();
+
+  @Autowired(IContextKeyService)
+  private readonly globalContextKeyService: IContextKeyService;
 
   @Autowired(ToolBarActionContribution)
   private readonly contributions: ContributionProvider<ToolBarActionContribution>;
@@ -106,6 +113,14 @@ export class NextToolbarRegistryImpl extends WithEventBus implements IToolbarReg
     this._onActionAdded.event((action) => {
       this.calculateActionPosition(action);
     });
+    // when context keys change we need to check if the toolbar also has changed
+    this.addDispose(
+      Event.debounce<ContextKeyChangeEvent, boolean>(
+        this.globalContextKeyService.onDidChangeContext,
+        (last, event) => last || event.payload.affectsSome(this._contextKeys),
+        50,
+      )((e) => e && this.eventBus.fire(new ToolbarActionsWhenChangeEvent()), this),
+    );
     this.eventBus.fire(new ToolbarRegistryReadyEvent());
   }
 
@@ -122,6 +137,13 @@ export class NextToolbarRegistryImpl extends WithEventBus implements IToolbarReg
 
   setDefaultLocation(locationName: string) {
     this._preferredDefaultLocation = locationName;
+  }
+
+  private fillKeysInWhenExpr(when?: string) {
+    const keys = this.globalContextKeyService.getKeysInWhen(when);
+    keys.forEach((key) => {
+      this._contextKeys.add(key);
+    });
   }
 
   registerToolbarActionGroup(group: IToolbarActionGroup): IDisposable {
@@ -275,6 +297,9 @@ export class NextToolbarRegistryImpl extends WithEventBus implements IToolbarReg
   registerToolbarAction(action: IToolbarAction): IDisposable {
     this.actions.set(action.id, action);
     this._onActionAdded.fire(action);
+    if (action.when) {
+      this.fillKeysInWhenExpr(action.when);
+    }
     return {
       dispose: () => {
         this.actions.delete(action.id);
@@ -288,7 +313,10 @@ export class NextToolbarRegistryImpl extends WithEventBus implements IToolbarReg
     if (!groups || !this.isValidGroup(position.group)) {
       return;
     }
-    const actions = groups.get(position.group);
+    const actions = groups
+      .get(position.group)
+      ?.filter((action) => (action.when ? this.globalContextKeyService.match(action.when) : true));
+
     if (!actions) {
       return;
     }

--- a/packages/core-browser/src/toolbar/toolbar.tsx
+++ b/packages/core-browser/src/toolbar/toolbar.tsx
@@ -22,6 +22,7 @@ import {
   IToolbarLocationPreference,
   IToolbarActionElementProps,
   ToolbarRegistryReadyEvent,
+  ToolbarActionsWhenChangeEvent,
 } from './types';
 
 export const DEFAULT_TOOLBAR_ACTION_MARGIN = 5;
@@ -79,6 +80,11 @@ export const ToolbarLocation = (props: IToolbarLocationProps & React.HTMLAttribu
           }),
         );
       }
+      disposer.addDispose(
+        eventBus.on(ToolbarActionsWhenChangeEvent, () => {
+          updateNow();
+        }),
+      );
       disposer.addDispose(
         eventBus.on(ToolbarActionGroupsChangedEvent, (e) => {
           if (e.payload.location === location) {

--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -171,10 +171,13 @@ export interface IToolbarAction {
    * 是否永远不被收起
    */
   neverCollapse?: boolean;
+  when?: string;
 }
 
 // events
 export class ToolbarRegistryReadyEvent extends BasicEvent<void> {}
+
+export class ToolbarActionsWhenChangeEvent extends BasicEvent<void> {}
 
 export class ToolbarActionsChangedEvent extends BasicEvent<{ position: IToolbarActionPosition }> {}
 

--- a/packages/extension/src/browser/sumi/main.thread.toolbar.ts
+++ b/packages/extension/src/browser/sumi/main.thread.toolbar.ts
@@ -224,6 +224,7 @@ export class KaitianExtensionToolbarService {
       strictPosition: contribution.strictPosition,
       description: contribution.description || contribution.title || id,
       weight: contribution.weight,
+      when: contribution.when,
       component: createToolbarActionBtn({
         id,
         popoverId: `${extensionId}:${contribution.popoverComponent}`,

--- a/packages/extension/src/browser/sumi/types.ts
+++ b/packages/extension/src/browser/sumi/types.ts
@@ -32,6 +32,7 @@ export interface IToolbarButtonContribution extends IToolbarActionBasicContribut
   popoverComponent?: string;
 
   popoverStyle?: IToolbarPopoverStyle;
+  when?: string;
 }
 
 export interface IToolbarSelectContribution<T = any> extends IToolbarActionBasicContribution {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

fix: #1192

```json
"kaitianContributes": {
    "workerMain": "./index.js",
    "toolbar": {
      "actions": [
        {
          "type": "button",
          "title": "运行",
          "id": "common-start",
          "when": "showMe == 1",
          "states": {
            "default": {
              "titleForeground": "#FF004F"
            },
            "clicked": {
              "titleForeground": "#CCC"
            }
          }
        }
      ]
    }
  },
```

### Changelog
toolbar support when clause contexts
