### PR TITLE
feat: dialog support custom props for overlay

### DIFF
--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -59,6 +59,7 @@ export const Dialog: React.FC<IDialogProps> = ({
   cancelText,
   getContainer,
   keyboard,
+  ...props
 }) => {
   const { getIcon: getContextIcon } = React.useContext(IconContext);
   return (
@@ -75,6 +76,7 @@ export const Dialog: React.FC<IDialogProps> = ({
           : undefined
       }
       afterClose={afterClose}
+      {...props}
     >
       <>
         <div className={'kt-dialog-content'}>

--- a/packages/overlay/__tests__/browser/dialog.service.test.tsx
+++ b/packages/overlay/__tests__/browser/dialog.service.test.tsx
@@ -66,14 +66,16 @@ describe.skip('packages/overlay/src/browser/dialog.service.ts', () => {
 
   it('get field', () => {
     act(() => {
-      dialogService.info('hello', ['btnA', 'btnB']);
+      dialogService.info('hello', ['btnA', 'btnB'], undefined, { className: 'dialog-class-test' });
     });
 
     expect($$('.ant-modal')).toHaveLength(1);
+    expect($$('.dialog-class-test')).toHaveLength(1);
     expect(dialogService.getMessage()).toBe('hello');
     expect(dialogService.isVisible()).toBe(true);
     expect(dialogService.getIcon()!.className).toBe('info-circle');
     expect(dialogService.getButtons()).toEqual(['btnA', 'btnB']);
+    expect(dialogService.getProps()).toEqual({ className: 'dialog-class-test' });
   });
 
   it.skip('select btn', (done) => {

--- a/packages/overlay/src/browser/dialog.service.ts
+++ b/packages/overlay/src/browser/dialog.service.ts
@@ -19,19 +19,14 @@ export class DialogService extends AbstractMessageService implements IDialogServ
   @observable
   protected visible = false;
 
-  @observable
   protected message: string | React.ReactNode = '';
 
-  @observable
   protected title = '';
 
-  @observable
   public closable = true;
 
-  @observable
   protected buttons: string[] = [];
 
-  @observable
   protected props: Record<string, any> = {};
 
   @action

--- a/packages/overlay/src/browser/dialog.service.ts
+++ b/packages/overlay/src/browser/dialog.service.ts
@@ -31,12 +31,17 @@ export class DialogService extends AbstractMessageService implements IDialogServ
   @observable
   protected buttons: string[] = [];
 
+  @observable
+  protected props: Record<string, any> = {};
+
   @action
   open<T = string>(
     message: string | React.ReactNode,
     type: MessageType,
     buttons?: any[],
     closable = true,
+    _?: string,
+    props?: Record<string, any>,
   ): Promise<T | undefined> {
     this.deferred = new Deferred<string>();
     this.type = type;
@@ -44,6 +49,7 @@ export class DialogService extends AbstractMessageService implements IDialogServ
     this.visible = true;
     this.contextkeyService.dialogViewVisibleContext.set(true);
     this.closable = closable;
+    this.props = props ?? {};
     if (buttons) {
       this.buttons = buttons;
     }
@@ -62,6 +68,7 @@ export class DialogService extends AbstractMessageService implements IDialogServ
     this.type = undefined;
     this.message = '';
     this.buttons = [];
+    this.props = {};
   }
 
   isVisible(): boolean {
@@ -100,5 +107,9 @@ export class DialogService extends AbstractMessageService implements IDialogServ
 
   getButtons(): string[] {
     return this.buttons;
+  }
+
+  getProps(): Record<string, any> {
+    return this.props;
   }
 }

--- a/packages/overlay/src/browser/dialog.view.tsx
+++ b/packages/overlay/src/browser/dialog.view.tsx
@@ -1,5 +1,5 @@
 import { observer } from 'mobx-react-lite';
-import React, { useEffect, RefObject, useRef } from 'react';
+import React from 'react';
 
 import { Button, Dialog as DialogView } from '@opensumi/ide-components';
 import { useInjectable, localize } from '@opensumi/ide-core-browser';
@@ -13,7 +13,8 @@ export const Dialog = observer(() => {
   const message = dialogService.getMessage();
   const buttons = dialogService.getButtons();
   const type = dialogService.getType();
-  const wrapperRef: RefObject<HTMLDivElement> = useRef(null);
+  // props will transfer to Overlay component
+  const customProps = dialogService.getProps();
 
   function afterClose() {
     dialogService.reset();
@@ -58,6 +59,7 @@ export const Dialog = observer(() => {
           </Button>
         )
       }
+      {...customProps}
     />
   );
 });

--- a/packages/overlay/src/common/index.ts
+++ b/packages/overlay/src/common/index.ts
@@ -14,6 +14,7 @@ export interface IMessageService {
     buttons?: string[],
     closable?: boolean,
     from?: string,
+    props?: Record<string, any>,
   ): Promise<T | undefined>;
   hide<T = string>(value?: T): void;
 }
@@ -33,6 +34,7 @@ export interface IDialogService extends IMessageService {
   getIcon(): Icon | undefined;
   getButtons(): string[];
   getType(): MessageType | undefined;
+  getProps(): Record<string, any>;
   reset(): void;
 }
 
@@ -53,6 +55,8 @@ export abstract class AbstractMessageService implements IMessageService {
     type: MessageType,
     buttons?: any[],
     closable?: boolean,
+    from?: string,
+    props?: Record<string, any>,
   ): Promise<T | undefined>;
   abstract hide<T = string>(value?: T): void;
 }

--- a/packages/overlay/src/common/index.ts
+++ b/packages/overlay/src/common/index.ts
@@ -5,9 +5,24 @@ import { MessageType, URI } from '@opensumi/ide-core-common';
 export const IMessageService = Symbol('IMessageService');
 
 export interface IMessageService {
-  info(message: string | React.ReactNode, buttons?: string[], closable?: boolean): Promise<string | undefined>;
-  warning(message: string | React.ReactNode, buttons?: string[], closable?: boolean): Promise<string | undefined>;
-  error(message: string | React.ReactNode, buttons?: string[], closable?: boolean): Promise<string | undefined>;
+  info(
+    message: string | React.ReactNode,
+    buttons?: string[],
+    closable?: boolean,
+    props?: Record<string, any>,
+  ): Promise<string | undefined>;
+  warning(
+    message: string | React.ReactNode,
+    buttons?: string[],
+    closable?: boolean,
+    props?: Record<string, any>,
+  ): Promise<string | undefined>;
+  error(
+    message: string | React.ReactNode,
+    buttons?: string[],
+    closable?: boolean,
+    props?: Record<string, any>,
+  ): Promise<string | undefined>;
   open<T = string>(
     message: string | React.ReactNode,
     type: MessageType,
@@ -39,16 +54,31 @@ export interface IDialogService extends IMessageService {
 }
 
 export abstract class AbstractMessageService implements IMessageService {
-  info(message: string | React.ReactNode, buttons?: string[], closable?: boolean): Promise<string | undefined> {
-    return this.open(message, MessageType.Info, buttons, closable);
+  info(
+    message: string | React.ReactNode,
+    buttons?: string[],
+    closable?: boolean,
+    props?: Record<string, any>,
+  ): Promise<string | undefined> {
+    return this.open(message, MessageType.Info, buttons, closable, undefined, props);
   }
 
-  warning(message: string | React.ReactNode, buttons?: string[], closable?: boolean): Promise<string | undefined> {
-    return this.open(message, MessageType.Warning, buttons, closable);
+  warning(
+    message: string | React.ReactNode,
+    buttons?: string[],
+    closable?: boolean,
+    props?: Record<string, any>,
+  ): Promise<string | undefined> {
+    return this.open(message, MessageType.Warning, buttons, closable, undefined, props);
   }
 
-  error(message: string | React.ReactNode, buttons?: string[], closable?: boolean): Promise<string | undefined> {
-    return this.open(message, MessageType.Error, buttons, closable);
+  error(
+    message: string | React.ReactNode,
+    buttons?: string[],
+    closable?: boolean,
+    props?: Record<string, any>,
+  ): Promise<string | undefined> {
+    return this.open(message, MessageType.Error, buttons, closable, undefined, props);
   }
   abstract open<T = string>(
     message: string | React.ReactNode,


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

Close #1057

对于 `dialogService.open` 增加 `props` 透传给 Overlay 组件

**使用方式**

例如对 https://github.com/opensumi/core/blob/main/packages/editor/src/browser/untitled-resource.ts#L205 增加 props

<img width="600" alt="image" src="https://user-images.githubusercontent.com/47357585/174451008-43570164-119d-4db8-a6f9-e29ff02f57d0.png">

触发 dialog 增加对应 className

<img width="571" alt="image" src="https://user-images.githubusercontent.com/47357585/174451022-bbbd671a-5dd9-4f11-a89e-244b67917b02.png">


### Changelog
`dialogService.open` 增加 props 自定义 dialog 样式