### PR TITLE
chore: always set UIState.isSearchFocus to false in recoverUIState()

### DIFF
--- a/packages/search/src/browser/search.service.ts
+++ b/packages/search/src/browser/search.service.ts
@@ -688,6 +688,11 @@ export class ContentSearchClientService implements IContentSearchClientService {
 
   private async recoverUIState() {
     const UIState = (await this.browserStorageService.getData('search.UIState')) as IUIState | undefined;
+    // 上次关闭时搜索框若处于focus状态会导致本次启动恢复现场后UI与Service不一致 (#1203)
+    // 这里一个非根本性解决方法是在updateUIState前将isSearchFocus置为false
+    if (UIState) {
+      UIState.isSearchFocus = false;
+    }
     this.updateUIState(UIState || {});
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes
- [x] 🧹 Chores

### Background or solution
fix #1203 .

在recoverUIState时，无论UIState.isSearchFocus是什么值，都置为false。这的确符合事实，因为打开时光标的确没有focus在任何地方，需要用户点击后才会focus。

这不是一个从根本上解决问题的方案，但是影响范围最小，改动最少，简单有效。麻烦 @bytemain 看看。

### Changelog
chore: always set UIState.isSearchFocus to false in recoverUIState()