### PR TITLE
feat: 新增 websocket 鉴权机制

### DIFF
--- a/packages/connection/src/browser/ws-channel-handler.ts
+++ b/packages/connection/src/browser/ws-channel-handler.ts
@@ -1,15 +1,10 @@
+import ReconnectingWebSocket from 'reconnecting-websocket';
+
 import { uuid } from '@opensumi/ide-core-common';
-import { IReporterService, REPORT_NAME } from '@opensumi/ide-core-common';
+import { IReporterService, REPORT_NAME, UrlProvider } from '@opensumi/ide-core-common';
 
 import { stringify, parse } from '../common/utils';
 import { WSChannel, MessageString } from '../common/ws-channel';
-
-let ReconnectingWebSocket = require('reconnecting-websocket');
-
-if (ReconnectingWebSocket.default) {
-  /* istanbul ignore next */
-  ReconnectingWebSocket = ReconnectingWebSocket.default;
-}
 
 // 前台链接管理类
 export class WSChannelHandler {
@@ -20,10 +15,10 @@ export class WSChannelHandler {
   private heartbeatMessageTimer: NodeJS.Timer | null;
   private reporterService: IReporterService;
 
-  constructor(public wsPath: string, logger: any, public protocols?: string[], clientId?: string) {
+  constructor(public wsPath: UrlProvider, logger: any, public protocols?: string[], clientId?: string) {
     this.logger = logger || this.logger;
     this.clientId = clientId || `CLIENT_ID_${uuid()}`;
-    this.connection = new ReconnectingWebSocket(wsPath, protocols, {}); // new WebSocket(wsPath, protocols);
+    this.connection = new ReconnectingWebSocket(wsPath, protocols, {}) as WebSocket; // new WebSocket(wsPath, protocols);
   }
   // 为解决建立连接之后，替换成可落盘的 logger
   replaceLogger(logger: any) {

--- a/packages/connection/src/node/common-channel-handler.ts
+++ b/packages/connection/src/node/common-channel-handler.ts
@@ -4,8 +4,7 @@ import ws from 'ws';
 import { stringify, parse } from '../common/utils';
 import { WSChannel, ChannelMessage } from '../common/ws-channel';
 
-import { WebSocketHandler } from './ws';
-const route = pathMatch();
+import { WebSocketHandler, CommonChannelHandlerOptions } from './ws';
 
 export interface IPathHander {
   dispose: (connection: any, connectionId: string) => void;
@@ -91,8 +90,9 @@ export class CommonChannelHandler extends WebSocketHandler {
   private connectionMap: Map<string, ws> = new Map();
   private heartbeatMap: Map<string, NodeJS.Timeout> = new Map();
 
-  constructor(routePath: string, private logger: any = console, private serverOptions: ws.ServerOptions) {
+  constructor(routePath: string, private logger: any = console, private options: CommonChannelHandlerOptions = {}) {
     super();
+    const route = pathMatch(options);
     this.handlerRoute = route(`${routePath}`);
     this.initWSServer();
   }
@@ -108,7 +108,7 @@ export class CommonChannelHandler extends WebSocketHandler {
 
   private initWSServer() {
     this.logger.log('init Common Channel Handler');
-    this.wsServer = new ws.Server({ noServer: true, ...this.serverOptions });
+    this.wsServer = new ws.Server({ noServer: true, ...this.options.wsServerOptions });
     this.wsServer.on('connection', (connection: ws) => {
       let connectionId;
       connection.on('message', (msg: string) => {

--- a/packages/connection/src/node/common-channel-handler.ts
+++ b/packages/connection/src/node/common-channel-handler.ts
@@ -92,7 +92,7 @@ export class CommonChannelHandler extends WebSocketHandler {
 
   constructor(routePath: string, private logger: any = console, private options: CommonChannelHandlerOptions = {}) {
     super();
-    const route = pathMatch(options);
+    const route = pathMatch(options.pathMatchOptions);
     this.handlerRoute = route(`${routePath}`);
     this.initWSServer();
   }

--- a/packages/connection/src/node/common-channel-handler.ts
+++ b/packages/connection/src/node/common-channel-handler.ts
@@ -86,12 +86,12 @@ export class CommonChannelHandler extends WebSocketHandler {
 
   public handlerId = 'common-channel';
   private wsServer: ws.Server;
-  private handlerRoute: (wsPathname: string) => any;
+  protected handlerRoute: (wsPathname: string) => any;
   private channelMap: Map<string | number, WSChannel> = new Map();
   private connectionMap: Map<string, ws> = new Map();
   private heartbeatMap: Map<string, NodeJS.Timeout> = new Map();
 
-  constructor(routePath: string, private logger: any = console) {
+  constructor(routePath: string, private logger: any = console, private serverOptions: ws.ServerOptions) {
     super();
     this.handlerRoute = route(`${routePath}`);
     this.initWSServer();
@@ -108,7 +108,7 @@ export class CommonChannelHandler extends WebSocketHandler {
 
   private initWSServer() {
     this.logger.log('init Common Channel Handler');
-    this.wsServer = new ws.Server({ noServer: true });
+    this.wsServer = new ws.Server({ noServer: true, ...this.serverOptions });
     this.wsServer.on('connection', (connection: ws) => {
       let connectionId;
       connection.on('message', (msg: string) => {

--- a/packages/connection/src/node/ws.ts
+++ b/packages/connection/src/node/ws.ts
@@ -11,7 +11,7 @@ export abstract class WebSocketHandler {
 
 export interface CommonChannelHandlerOptions {
   wsServerOptions?: ws.ServerOptions;
-  pathMatcheOptions?: {
+  pathMatchOptions?: {
     // When true the regexp will match to the end of the string.
     end?: boolean;
   };

--- a/packages/connection/src/node/ws.ts
+++ b/packages/connection/src/node/ws.ts
@@ -1,19 +1,29 @@
 import http from 'http';
 import url from 'url';
 
+import ws from 'ws';
+
 export abstract class WebSocketHandler {
   abstract handlerId: string;
   abstract handleUpgrade(wsPathname: string, request: any, socket: any, head: any): boolean;
   init?(): void;
 }
 
+export interface CommonChannelHandlerOptions {
+  wsServerOptions?: ws.ServerOptions;
+  pathMatcheOptions?: {
+    // When true the regexp will match to the end of the string.
+    end?: boolean;
+  };
+}
+
 export class WebSocketServerRoute {
-  public port?: number;
   public server: http.Server;
+  public port?: number;
   private wsServerHandlerArr: WebSocketHandler[];
 
   constructor(
-    server?: http.Server,
+    server: http.Server,
     private logger: any = console,
     port = 8729,
     wsServerHandlerArr: WebSocketHandler[] = [],

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -32,6 +32,7 @@ import {
   Deferred,
   isUndefined,
   GeneralSettingsId,
+  UrlProvider,
 } from '@opensumi/ide-core-common';
 import {
   DEFAULT_APPLICATION_DESKTOP_HOST,
@@ -87,7 +88,7 @@ export interface IClientAppOpts extends Partial<AppConfig> {
   modules: ModuleConstructor[];
   contributions?: ContributionConstructor[];
   modulesInstances?: BrowserModule[];
-  connectionPath?: string;
+  connectionPath?: UrlProvider;
   connectionProtocols?: string[];
   iconStyleSheets?: IconInfo[];
   useCdnIcon?: boolean;
@@ -125,7 +126,7 @@ export class ClientApp implements IClientApp, IDisposable {
 
   logger: ILogServiceClient;
 
-  connectionPath: string;
+  connectionPath: UrlProvider;
 
   connectionProtocols?: string[];
 

--- a/packages/core-browser/src/bootstrap/connection.ts
+++ b/packages/core-browser/src/bootstrap/connection.ts
@@ -10,6 +10,7 @@ import {
   BrowserConnectionOpenEvent,
   BrowserConnectionErrorEvent,
   IEventBus,
+  UrlProvider,
 } from '@opensumi/ide-core-common';
 import { BackService } from '@opensumi/ide-core-common/lib/module';
 
@@ -24,7 +25,7 @@ const initialLogger = getDebugLogger();
 export async function createClientConnection2(
   injector: Injector,
   modules: ModuleConstructor[],
-  wsPath: string,
+  wsPath: UrlProvider,
   onReconnect: () => void,
   protocols?: string[],
   clientId?: string,

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { Injector } from '@opensumi/di';
-import type { ExtensionCandidate, ExtensionConnectOption } from '@opensumi/ide-core-common';
+import type { ExtensionCandidate, ExtensionConnectOption, UrlProvider } from '@opensumi/ide-core-common';
 
 import type { IPreferences, LayoutConfig } from '../bootstrap';
 
@@ -78,7 +78,7 @@ export interface AppConfig {
   /**
    * 定义 WebScoket 通信路径
    */
-  wsPath: string;
+  wsPath: UrlProvider;
   /**
    * 定义 IDE 各个布局区块默认加载的模块，可针对性对模块进行增删改
    * 默认值可参考：https://github.com/opensumi/core/tree/58b998d9e1f721928f576579f16ded46b7505e84/packages/main-layout/src/browser/default-config.ts

--- a/packages/core-common/src/types/common.ts
+++ b/packages/core-common/src/types/common.ts
@@ -10,3 +10,5 @@ export interface ICommonServer {
    */
   getBackendOS(): Promise<OperatingSystem>;
 }
+
+export type UrlProvider = string | (() => string) | (() => Promise<string>);

--- a/packages/core-node/src/bootstrap/app.ts
+++ b/packages/core-node/src/bootstrap/app.ts
@@ -1,4 +1,3 @@
-import cp from 'child_process';
 import http from 'http';
 import https from 'https';
 import net from 'net';
@@ -6,150 +5,18 @@ import os from 'os';
 import path from 'path';
 
 import Koa from 'koa';
-import ws from 'ws';
 
-import { Injector, ConstructorOf } from '@opensumi/di';
+import { Injector } from '@opensumi/di';
 import { WebSocketHandler } from '@opensumi/ide-connection/lib/node';
-import { MaybePromise, ContributionProvider, createContributionProvider, isWindows } from '@opensumi/ide-core-common';
-import {
-  LogLevel,
-  ILogServiceManager,
-  ILogService,
-  SupportLogNamespace,
-  StoragePaths,
-} from '@opensumi/ide-core-common';
+import { ContributionProvider, createContributionProvider, isWindows } from '@opensumi/ide-core-common';
+import { ILogServiceManager, ILogService, SupportLogNamespace, StoragePaths } from '@opensumi/ide-core-common';
 import { DEFAULT_OPENVSX_REGISTRY } from '@opensumi/ide-core-common/lib/const';
 
 import { createServerConnection2, createNetServerConnection, RPCServiceCenter } from '../connection';
 import { NodeModule } from '../node-module';
+import { AppConfig, IServerApp, IServerAppOpts, ModuleConstructor, ServerAppContribution } from '../types';
 
 import { injectInnerProviders } from './inner-providers';
-
-export type ModuleConstructor = ConstructorOf<NodeModule>;
-export type ContributionConstructor = ConstructorOf<ServerAppContribution>;
-
-export const AppConfig = Symbol('AppConfig');
-
-export interface MarketplaceRequest {
-  path?: string;
-  headers?: {
-    [header: string]: string | string[] | undefined;
-  };
-}
-
-export interface MarketplaceConfig {
-  endpoint: string;
-  // 插件市场下载到本地的位置，默认 ~/.sumi/extensions
-  extensionDir: string;
-  // 是否显示内置插件，默认隐藏
-  showBuiltinExtensions: boolean;
-  // 插件市场中申请到的客户端的 accountId
-  accountId: string;
-  // 插件市场中申请到的客户端的 masterKey
-  masterKey: string;
-  // 插件市场参数转换函数
-  transformRequest?: (request: MarketplaceRequest) => MarketplaceRequest;
-  // 在热门插件、搜索插件时忽略的插件 id
-  ignoreId: string[];
-}
-
-interface Config {
-  /**
-   * 初始化的 DI 实例，一般可在外部进行 DI 初始化之后传入，便于提前进行一些依赖的初始化
-   */
-  injector: Injector;
-  /**
-   * 设置落盘日志级别，默认为 Info 级别的log落盘
-   */
-  logLevel?: LogLevel;
-  /**
-   * 设置日志的目录，默认：~/.sumi/logs
-   */
-  logDir?: string;
-  /**
-   * @deprecated 可通过在传入的 `injector` 初始化 `ILogService` 进行实现替换
-   * 外部设置的 ILogService，替换默认的 logService
-   */
-  LogServiceClass?: ConstructorOf<ILogService>;
-  /**
-   * 启用插件进程的最大个数
-   */
-  maxExtProcessCount?: number;
-  /**
-   * 插件日志自定义实现路径
-   */
-  extLogServiceClassPath?: string;
-  /**
-   * 插件进程关闭时间
-   */
-  processCloseExitThreshold?: number;
-  /**
-   * 终端 pty 进程退出时间
-   */
-  terminalPtyCloseThreshold?: number;
-  /**
-   * 访问静态资源允许的 origin
-   */
-  staticAllowOrigin?: string;
-  /**
-   * 访问静态资源允许的路径，用于配置静态资源的白名单规则
-   */
-  staticAllowPath?: string[];
-  /**
-   * 文件服务禁止访问的路径，使用 glob 匹配
-   */
-  blockPatterns?: string[];
-  /**
-   * 获取插件进程句柄方法
-   * @deprecated 自测 1.30.0 后，不在提供给 IDE 后端发送插件进程的方法
-   */
-  onDidCreateExtensionHostProcess?: (cp: cp.ChildProcess) => void;
-  /**
-   * 插件 Node 进程入口文件
-   */
-  extHost?: string;
-  /**
-   * 插件进程存放用于通信的 sock 地址
-   * 默认为 /tmp
-   */
-  extHostIPCSockPath?: string;
-  /**
-   * 插件进程 fork 配置
-   */
-  extHostForkOptions?: Partial<cp.ForkOptions>;
-  /**
-   * 配置关闭 keytar 校验能力，默认开启
-   */
-  disableKeytar?: boolean;
-}
-
-export interface AppConfig extends Partial<Config> {
-  marketplace: MarketplaceConfig;
-}
-
-export interface IServerAppOpts extends Partial<Config> {
-  modules?: ModuleConstructor[];
-  contributions?: ContributionConstructor[];
-  modulesInstances?: NodeModule[];
-  webSocketHandler?: WebSocketHandler[];
-  wsServerOptions?: ws.ServerOptions;
-  marketplace?: Partial<MarketplaceConfig>;
-  use?(middleware: Koa.Middleware<Koa.ParameterizedContext<any, any>>): void;
-}
-
-export const ServerAppContribution = Symbol('ServerAppContribution');
-
-export interface ServerAppContribution {
-  initialize?(app: IServerApp): MaybePromise<void>;
-  onStart?(app: IServerApp): MaybePromise<void>;
-  onStop?(app: IServerApp): MaybePromise<void>;
-  onWillUseElectronMain?(): void;
-}
-
-export interface IServerApp {
-  use(middleware: Koa.Middleware<Koa.ParameterizedContext<any, any>>): void;
-  start(server: http.Server | https.Server): Promise<void>;
-}
 
 export class ServerApp implements IServerApp {
   private injector: Injector;
@@ -291,7 +158,7 @@ export class ServerApp implements IServerApp {
           this.injector,
           this.modulesInstances,
           this.webSocketHandler,
-          this.opts.wsServerOptions,
+          this.opts,
         );
       } else if (server instanceof net.Server) {
         serviceCenter = createNetServerConnection(server, this.injector, this.modulesInstances);

--- a/packages/core-node/src/common-module/credential.server.ts
+++ b/packages/core-node/src/common-module/credential.server.ts
@@ -1,7 +1,7 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import { IChunkedPassword, INativeCredentialService, isWindows } from '@opensumi/ide-core-common';
 
-import { AppConfig } from '../bootstrap';
+import { AppConfig } from '../types';
 
 @Injectable()
 export class CredentialService implements INativeCredentialService {

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -16,6 +16,7 @@ import {
 
 import { INodeLogger } from './logger/node-logger';
 import { NodeModule } from './node-module';
+import { IServerAppOpts } from './types';
 
 export { RPCServiceCenter };
 
@@ -24,11 +25,14 @@ export function createServerConnection2(
   injector,
   modulesInstances,
   handlerArr: WebSocketHandler[],
-  wsServerOptions: ws.ServerOptions = {},
+  serverAppOpts: IServerAppOpts,
 ) {
   const logger = injector.get(INodeLogger);
   const socketRoute = new WebSocketServerRoute(server, logger);
-  const channelHandler = new CommonChannelHandler('/service', logger, wsServerOptions);
+  const channelHandler = new CommonChannelHandler('/service', logger, {
+    pathMatcheOptions: serverAppOpts.pathMatcheOptions,
+    wsServerOptions: serverAppOpts.wsServerOptions,
+  });
 
   // 事件由 connection 的时机来触发
   commonChannelPathHandler.register('RPCService', {

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -30,7 +30,7 @@ export function createServerConnection2(
   const logger = injector.get(INodeLogger);
   const socketRoute = new WebSocketServerRoute(server, logger);
   const channelHandler = new CommonChannelHandler('/service', logger, {
-    pathMatcheOptions: serverAppOpts.pathMatcheOptions,
+    pathMatchOptions: serverAppOpts.pathMatchOptions,
     wsServerOptions: serverAppOpts.wsServerOptions,
   });
 

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -14,7 +14,6 @@ import {
   createSocketConnection,
 } from '@opensumi/ide-connection/lib/node';
 
-
 import { INodeLogger } from './logger/node-logger';
 import { NodeModule } from './node-module';
 
@@ -24,11 +23,12 @@ export function createServerConnection2(
   server: http.Server,
   injector,
   modulesInstances,
-  handlerArr?: WebSocketHandler[],
+  handlerArr: WebSocketHandler[],
+  wsServerOptions: ws.ServerOptions = {},
 ) {
   const logger = injector.get(INodeLogger);
   const socketRoute = new WebSocketServerRoute(server, logger);
-  const channelHandler = new CommonChannelHandler('/service', logger);
+  const channelHandler = new CommonChannelHandler('/service', logger, wsServerOptions);
 
   // 事件由 connection 的时机来触发
   commonChannelPathHandler.register('RPCService', {

--- a/packages/core-node/src/hash-calculate/hash-calculate.contribution.ts
+++ b/packages/core-node/src/hash-calculate/hash-calculate.contribution.ts
@@ -2,7 +2,7 @@ import { Autowired } from '@opensumi/di';
 import { Domain } from '@opensumi/ide-core-common/lib/di-helper';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
 
-import { ServerAppContribution } from '../bootstrap';
+import { ServerAppContribution } from '../types';
 
 @Domain(ServerAppContribution)
 export class HashCalculateContribution implements ServerAppContribution {

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -1,9 +1,6 @@
 // 输出所有 common 里面会有的内容
 export * from '@opensumi/ide-core-common';
 
-// 输出 node 中特有的内容
-export * from './node-module';
-
 export * from './connection';
 
 export * from './bootstrap';
@@ -11,3 +8,5 @@ export * from './bootstrap';
 export * from './logger/node-logger';
 
 export * from './common-module';
+
+export * from './types';

--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -1,0 +1,143 @@
+import type cp from 'child_process';
+import type http from 'http';
+import type https from 'https';
+
+import type Koa from 'koa';
+import type ws from 'ws';
+
+import { Injector } from '@opensumi/di';
+import { WebSocketHandler } from '@opensumi/ide-connection/lib/node';
+import { ConstructorOf, ILogService, LogLevel, MaybePromise, BasicModule } from '@opensumi/ide-core-common';
+
+
+export abstract class NodeModule extends BasicModule {}
+
+export type ModuleConstructor = ConstructorOf<NodeModule>;
+export type ContributionConstructor = ConstructorOf<ServerAppContribution>;
+
+export const AppConfig = Symbol('AppConfig');
+
+export interface MarketplaceRequest {
+  path?: string;
+  headers?: {
+    [header: string]: string | string[] | undefined;
+  };
+}
+
+export interface MarketplaceConfig {
+  endpoint: string;
+  // 插件市场下载到本地的位置，默认 ~/.sumi/extensions
+  extensionDir: string;
+  // 是否显示内置插件，默认隐藏
+  showBuiltinExtensions: boolean;
+  // 插件市场中申请到的客户端的 accountId
+  accountId: string;
+  // 插件市场中申请到的客户端的 masterKey
+  masterKey: string;
+  // 插件市场参数转换函数
+  transformRequest?: (request: MarketplaceRequest) => MarketplaceRequest;
+  // 在热门插件、搜索插件时忽略的插件 id
+  ignoreId: string[];
+}
+
+interface Config {
+  /**
+   * 初始化的 DI 实例，一般可在外部进行 DI 初始化之后传入，便于提前进行一些依赖的初始化
+   */
+  injector: Injector;
+  /**
+   * 设置落盘日志级别，默认为 Info 级别的log落盘
+   */
+  logLevel?: LogLevel;
+  /**
+   * 设置日志的目录，默认：~/.sumi/logs
+   */
+  logDir?: string;
+  /**
+   * @deprecated 可通过在传入的 `injector` 初始化 `ILogService` 进行实现替换
+   * 外部设置的 ILogService，替换默认的 logService
+   */
+  LogServiceClass?: ConstructorOf<ILogService>;
+  /**
+   * 启用插件进程的最大个数
+   */
+  maxExtProcessCount?: number;
+  /**
+   * 插件日志自定义实现路径
+   */
+  extLogServiceClassPath?: string;
+  /**
+   * 插件进程关闭时间
+   */
+  processCloseExitThreshold?: number;
+  /**
+   * 终端 pty 进程退出时间
+   */
+  terminalPtyCloseThreshold?: number;
+  /**
+   * 访问静态资源允许的 origin
+   */
+  staticAllowOrigin?: string;
+  /**
+   * 访问静态资源允许的路径，用于配置静态资源的白名单规则
+   */
+  staticAllowPath?: string[];
+  /**
+   * 文件服务禁止访问的路径，使用 glob 匹配
+   */
+  blockPatterns?: string[];
+  /**
+   * 获取插件进程句柄方法
+   * @deprecated 自测 1.30.0 后，不在提供给 IDE 后端发送插件进程的方法
+   */
+  onDidCreateExtensionHostProcess?: (cp: cp.ChildProcess) => void;
+  /**
+   * 插件 Node 进程入口文件
+   */
+  extHost?: string;
+  /**
+   * 插件进程存放用于通信的 sock 地址
+   * 默认为 /tmp
+   */
+  extHostIPCSockPath?: string;
+  /**
+   * 插件进程 fork 配置
+   */
+  extHostForkOptions?: Partial<cp.ForkOptions>;
+  /**
+   * 配置关闭 keytar 校验能力，默认开启
+   */
+  disableKeytar?: boolean;
+}
+
+export interface AppConfig extends Partial<Config> {
+  marketplace: MarketplaceConfig;
+}
+
+export interface IServerAppOpts extends Partial<Config> {
+  modules?: ModuleConstructor[];
+  contributions?: ContributionConstructor[];
+  modulesInstances?: NodeModule[];
+  webSocketHandler?: WebSocketHandler[];
+  wsServerOptions?: ws.ServerOptions;
+  pathMatcheOptions?: {
+    // When true the regexp will match to the end of the string.
+    end?: boolean;
+  };
+  marketplace?: Partial<MarketplaceConfig>;
+  use?(middleware: Koa.Middleware<Koa.ParameterizedContext<any, any>>): void;
+}
+
+export const ServerAppContribution = Symbol('ServerAppContribution');
+
+export interface ServerAppContribution {
+  initialize?(app: IServerApp): MaybePromise<void>;
+  onStart?(app: IServerApp): MaybePromise<void>;
+  onStop?(app: IServerApp): MaybePromise<void>;
+  onWillUseElectronMain?(): void;
+}
+
+export interface IServerApp {
+  use(middleware: Koa.Middleware<Koa.ParameterizedContext<any, any>>): void;
+  start(server: http.Server | https.Server): Promise<void>;
+}

--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -9,7 +9,6 @@ import { Injector } from '@opensumi/di';
 import { WebSocketHandler } from '@opensumi/ide-connection/lib/node';
 import { ConstructorOf, ILogService, LogLevel, MaybePromise, BasicModule } from '@opensumi/ide-core-common';
 
-
 export abstract class NodeModule extends BasicModule {}
 
 export type ModuleConstructor = ConstructorOf<NodeModule>;
@@ -120,7 +119,7 @@ export interface IServerAppOpts extends Partial<Config> {
   modulesInstances?: NodeModule[];
   webSocketHandler?: WebSocketHandler[];
   wsServerOptions?: ws.ServerOptions;
-  pathMatcheOptions?: {
+  pathMatchOptions?: {
     // When true the regexp will match to the end of the string.
     end?: boolean;
   };

--- a/packages/extension/src/hosted/ext.host.ts
+++ b/packages/extension/src/hosted/ext.host.ts
@@ -16,7 +16,7 @@ import {
   IExtensionLogger,
   arrays,
 } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node/lib/bootstrap/app';
+import { AppConfig } from '@opensumi/ide-core-node';
 
 import { EXTENSION_EXTEND_SERVICE_PREFIX, IExtensionHostService, IExtendProxy, getExtensionId } from '../common';
 import { ActivatedExtension, ExtensionsActivator, ActivatedExtensionJSON } from '../common/activator';

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -14,7 +14,7 @@ import {
   ILogService,
 } from '@opensumi/ide-core-common';
 import { isPromiseCanceledError, locale } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node/lib/bootstrap/app';
+import { AppConfig } from '@opensumi/ide-core-node';
 
 import { ProcessMessageType, IExtensionHostService, KT_PROCESS_SOCK_OPTION_KEY, KT_APP_CONFIG_KEY } from '../common';
 import { CommandHandler } from '../common/vscode';

--- a/packages/extension/src/hosted/extension-log2.ts
+++ b/packages/extension/src/hosted/extension-log2.ts
@@ -6,7 +6,7 @@ import {
   LogLevel,
   IExtensionLogger,
 } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node/lib/bootstrap/app';
+import { AppConfig } from '@opensumi/ide-core-node';
 import { LogServiceManager } from '@opensumi/ide-logs/lib/node/log-manager';
 
 export class ExtensionLogger2 implements IExtensionLogger {

--- a/packages/logs-core/src/node/log-manager.ts
+++ b/packages/logs-core/src/node/log-manager.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { Injectable, Autowired, ConstructorOf } from '@opensumi/di';
 import { Emitter } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node/lib/bootstrap/app';
+import { AppConfig } from '@opensumi/ide-core-node';
 
 import {
   ILogService,


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

fix: #1222

之后鉴权方式：

前端：

```ts
new ClientApp({
  connectionPath: async () => {
       return `${wsPath}/service?token=${await getAuthToken()}`;
  }
})
```

后端

```ts
new ServerApp({
   wsServerOptions: {
       verifyClient: (info, done) => {
           const url = URL.parse(info.req.url, true);
           const { query } = url;
           if (!query.token) {
             done(false);
           }
           // 在这里实现鉴权逻辑
           const authed = await ctx.service.cloudideWsGateway.verifyAuthToken(query.token);
           done(authed);
        }
   }
})
```

### Changelog
新增 websocket 鉴权机制