### PR TITLE
fix: matchLanguage logic

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -337,6 +337,10 @@ export class MainThreadLanguages implements IMainThreadLanguages {
     }
 
     if (DocumentFilter.is(selector)) {
+      if (!selector.language && (selector.pattern || selector.scheme)) {
+        return true;
+      }
+
       return selector?.language === languageId;
     }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

兼容没有指定 language 但包含 pattern 和 scheme 的 languagefeature

![image](https://user-images.githubusercontent.com/17701805/175020537-cd5bfcc0-f5b9-417e-bbfd-78af8b3aed98.png)

### Changelog
- 兼容没有指定 language 但包含 pattern 和 scheme 的 languagefeature
