### PR TITLE
fix: replace got with node-fetch

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra');
 const yauzl = require('yauzl');
 const log = require('debug')('InstallExtension');
 const os = require('os');
-const got = require('got');
 const nodeFetch = require('node-fetch');
 const awaitEvent = require('await-event');
 const { v4 } = require('uuid');
@@ -56,10 +55,10 @@ async function downloadExtension(url, namespace, extensionName) {
   await fs.mkdirp(tmpPath);
 
   const tmpStream = fs.createWriteStream(tmpZipFile);
-  const data = await got.default.stream(url, { timeout: 100000 });
+  const res = await nodeFetch(url, { timeout: 100000 });
 
-  data.pipe(tmpStream);
-  await Promise.race([awaitEvent(data, 'end'), awaitEvent(data, 'error')]);
+  res.body.pipe(tmpStream);
+  await Promise.race([awaitEvent(res.body, 'end'), awaitEvent(res.body, 'error')]);
   tmpStream.close();
 
   const targetDirName = path.basename(`${namespace}.${extensionName}`);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🐛 Bug Fixes

### Background or solution
之前升级 got 是为了 stream 的问题 
#1208

但 got 最新版本使用了 esm，导致下载插件异常，当前替换 got 为 node-fetch。


### Changelog
replace got with node-fetch
