### PR TITLE
fix(terminal): close search input box

### DIFF
--- a/packages/terminal-next/src/browser/component/terminal.view.tsx
+++ b/packages/terminal-next/src/browser/component/terminal.view.tsx
@@ -103,7 +103,7 @@ export default observer(() => {
             onChange={searchInput}
             onKeyDown={searchKeyDown}
           />
-          <div className={getIcon('close')} onClick={searchService.close}></div>
+          <div className={getIcon('close')} onClick={() => searchService.close()}></div>
         </div>
       )}
       {groups.map((group, index) => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

### Changelog

Fix can not click to close the search box in the terminal