### PR TITLE
fix: the AppConfig.staticServicePath supports domain with path

### DIFF
--- a/packages/express-file-server/src/browser/file-server.contribution.ts
+++ b/packages/express-file-server/src/browser/file-server.contribution.ts
@@ -23,7 +23,7 @@ export class ExpressFileServerContribution implements StaticResourceContribution
          * uri.path 在 Windows 下会被解析为 /c:/Path/to/file
          * fsPath C:\\Path\\to\\file
          */
-        return assetsUri.withPath(`assets${decodeURIComponent(uri.codeUri.path)}`);
+        return assetsUri.resolve(`assets${decodeURIComponent(uri.codeUri.path)}`);
       },
       roots: [this.appConfig.staticServicePath || EXPRESS_SERVER_PATH],
     });


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close https://github.com/opensumi/ide-startup/issues/25.

### Changelog

the AppConfig.staticServicePath config supports domain with path