### PR TITLE
chore: limit default xterm scrollback lines

### DIFF
--- a/packages/terminal-next/src/common/preference.ts
+++ b/packages/terminal-next/src/common/preference.ts
@@ -184,7 +184,7 @@ export const terminalPreferenceSchema: PreferenceSchema = {
     },
     [TerminalSettingsId.Scrollback]: {
       type: 'number',
-      default: 5000,
+      default: 1000,
     },
     [CodeTerminalSettingId.ShellArgsLinux]: {
       type: 'array',


### PR DESCRIPTION
### Types

限制默认的Xterm终端显示行数到1000行，之前的5000行内容太多，会导致一些关联处理逻辑的CPU占用太高甚至在极端情况下造成某些ANR。
对于正常情况的用户而言1000行是完全足够的，不够的话也可以在设置中自定义配置。
> 后续需要看看具体是哪条流程导致IDE整体的卡死

![image](https://user-images.githubusercontent.com/12879047/177459293-a2dbfa19-1898-4fb1-a2d3-7de8c4857efb.png)


- [x] 🧹 Chores

### Background or solution
- 某些极端场景下（程序巨量输出链接）终端buffer内链接太多的时候会导致IDE卡死
- 目前默认的xterm buffer的行数由5000太多了
- 因此决定默认设置到1000

### Changelog
- chore: limit default xterm scrollback lines
