### PR TITLE
fix(electron): debug toolbar can't be clicked

### DIFF
--- a/packages/debug/src/browser/view/configuration/debug-configuration.module.less
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.module.less
@@ -89,6 +89,10 @@
   .modal-shadow();
 }
 
+.debug_toolbar_wrapper_electron {
+  -webkit-app-region: none;
+}
+
 .debug_toolbar_drag {
   pointer-events: all;
   cursor: pointer;

--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -5,7 +5,14 @@ import React from 'react';
 
 import { Injectable } from '@opensumi/di';
 import { Option, Select } from '@opensumi/ide-components';
-import { getIcon, isElectronRenderer, localize, PreferenceService, useInjectable } from '@opensumi/ide-core-browser';
+import {
+  AppConfig,
+  getIcon,
+  isElectronRenderer,
+  localize,
+  PreferenceService,
+  useInjectable,
+} from '@opensumi/ide-core-browser';
 import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { Select as NativeSelect } from '@opensumi/ide-core-browser/lib/components/select';
 
@@ -232,6 +239,7 @@ const DebugPreferenceHeightKey = 'debug.toolbar.height';
 const FloatDebugToolbarView = observer(() => {
   const controller = useInjectable<FloatController>(FloatController);
   const preference = useInjectable<PreferenceService>(PreferenceService);
+  const { isElectronRenderer } = useInjectable<AppConfig>(AppConfig);
   const { state } = useInjectable<DebugToolbarService>(DebugToolbarService);
 
   const customTop = preference.get<number>(DebugPreferenceTopKey) || 0;
@@ -239,7 +247,7 @@ const FloatDebugToolbarView = observer(() => {
 
   const debugToolbarWrapperClass = cls({
     [styles.debug_toolbar_wrapper]: true,
-    [styles.debug_toolbar_wrapper_electron]: isElectronRenderer(),
+    [styles.debug_toolbar_wrapper_electron]: isElectronRenderer,
   });
 
   if (state) {

--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -18,7 +18,6 @@ import styles from './debug-configuration.module.less';
 import { DebugConfigurationService } from './debug-configuration.service';
 import { DebugToolbarService } from './debug-toolbar.service';
 
-
 @Injectable()
 class FloatController {
   @observable
@@ -238,6 +237,11 @@ const FloatDebugToolbarView = observer(() => {
   const customTop = preference.get<number>(DebugPreferenceTopKey) || 0;
   const customHeight = preference.get<number>(DebugPreferenceHeightKey) || 0;
 
+  const debugToolbarWrapperClass = cls({
+    [styles.debug_toolbar_wrapper]: true,
+    [styles.debug_toolbar_wrapper_electron]: isElectronRenderer(),
+  });
+
   if (state) {
     return (
       <div
@@ -251,7 +255,7 @@ const FloatDebugToolbarView = observer(() => {
             transform: `translateX(${controller.x}px) translateY(${customTop + controller.line * customHeight}px)`,
             height: `${customHeight}px`,
           }}
-          className={styles.debug_toolbar_wrapper}
+          className={debugToolbarWrapperClass}
         >
           <div className={cls(styles.debug_toolbar_drag_wrapper)}>
             <div


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

close https://github.com/opensumi/core/issues/1009

### Changelog

- fix(electron): debug toolbar can't be clicked
