### PR TITLE
refactor: use languages associations replace mime service

### DIFF
--- a/packages/monaco/src/browser/monaco-mime.ts
+++ b/packages/monaco/src/browser/monaco-mime.ts
@@ -1,6 +1,6 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import { IMimeService, CorePreferences, MimeAssociation } from '@opensumi/ide-core-browser';
-import * as mime from '@opensumi/monaco-editor-core/esm/vs/base/common/mime';
+import { registerPlatformLanguageAssociation } from '@opensumi/monaco-editor-core/esm/vs/editor/common/services/languagesAssociations';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
 @Injectable()
@@ -11,8 +11,8 @@ export class MonacoMimeService implements IMimeService {
   updateMime(): void {
     for (const association of this.getPreferenceFileAssociations()) {
       const mimetype = this.getMimeForMode(association.id) || `text/x-${association.id}`;
-      mime.registerTextMime(
-        { id: association.id, mime: mimetype, filepattern: association.filePattern, userConfigured: true },
+      registerPlatformLanguageAssociation(
+        { id: association.id, mime: mimetype, filepattern: association.filePattern },
         true,
       );
     }


### PR DESCRIPTION
### Types


### Background or solution

### Changelog
- use languages associations replace mime service