### PR TITLE
cherrypick: terminal task auto close issue

### DIFF
--- a/packages/task/src/browser/terminal-task-system.ts
+++ b/packages/task/src/browser/terminal-task-system.ts
@@ -214,7 +214,7 @@ export class TerminalTaskExecutor extends Disposable implements ITaskExecutor {
 
     this.disposableCollection.push(
       this.terminalClient?.onExit(async (e) => {
-        if (e.id === this.terminalClient?.id) {
+        if (e.id === this.terminalClient?.id && this.taskStatus !== TaskStatus.PROCESS_EXITED) {
           this.onTaskExit(e.code);
           this.processExited = true;
           this.taskStatus = TaskStatus.PROCESS_EXITED;
@@ -225,7 +225,7 @@ export class TerminalTaskExecutor extends Disposable implements ITaskExecutor {
 
     this.disposableCollection.push(
       this.terminalService.onExit(async (e) => {
-        if (e.sessionId === this.terminalClient?.id) {
+        if (e.sessionId === this.terminalClient?.id && this.taskStatus !== TaskStatus.PROCESS_EXITED) {
           await this.processReady.promise;
           this.onTaskExit(e.code);
           this.processExited = true;

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -212,7 +212,8 @@ export class TerminalController extends WithEventBus implements ITerminalControl
     this.logger.log(`setup client ${client.id}`);
     client.addDispose(
       client.onExit((e) => {
-        this.terminalView.removeWidget(client.id);
+        // 直接使用removeWidget会导致TerminalTask场景下任务执行完毕直接退出而不是用户手动触发onKeyDown退出
+        // this.terminalView.removeWidget(client.id);
         this.clients.delete(client.id);
         this._onDidCloseTerminal.fire({ id: client.id, code: e.code });
       }),


### PR DESCRIPTION
### Types

Terminal Task 会在任务进程结束后直接退出，不符合预期。本PR修复了这个问题。
修复CherryPick到2.18版本上 #1345

- [x] 🐛 Bug Fixes

### Background or solution
- Terminal Task 会在任务进程结束后直接退出，不符合预期
### Changelog
- cherrypick: #1345 terminal task auto close issue
