### PR TITLE
fix: import appConfig types form ide-core-node/lib/types

### DIFF
--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -5,9 +5,10 @@ import type https from 'https';
 import type Koa from 'koa';
 import type ws from 'ws';
 
-import { Injector } from '@opensumi/di';
-import { WebSocketHandler } from '@opensumi/ide-connection/lib/node';
-import { ConstructorOf, ILogService, LogLevel, MaybePromise, BasicModule } from '@opensumi/ide-core-common';
+import type { Injector } from '@opensumi/di';
+import type { WebSocketHandler } from '@opensumi/ide-connection/lib/node';
+import type { ConstructorOf, ILogService, LogLevel, MaybePromise } from '@opensumi/ide-core-common';
+import { BasicModule } from '@opensumi/ide-core-common';
 
 export abstract class NodeModule extends BasicModule {}
 

--- a/packages/debug/__tests__/browser/launch-preferences.test.ts
+++ b/packages/debug/__tests__/browser/launch-preferences.test.ts
@@ -16,7 +16,7 @@ import {
   IContextKeyService,
 } from '@opensumi/ide-core-browser';
 import { MockLogger } from '@opensumi/ide-core-browser/__mocks__/logger';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { DebugContribution, DebugModule } from '@opensumi/ide-debug/lib/browser';
 import { EditorCollectionService } from '@opensumi/ide-editor/lib/browser';
 import { IFileServiceClient, IDiskFileProvider } from '@opensumi/ide-file-service';

--- a/packages/extension-manager/src/node/vsx-extension.service.ts
+++ b/packages/extension-manager/src/node/vsx-extension.service.ts
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import yauzl from 'yauzl';
 
 import { Injectable, Autowired } from '@opensumi/di';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 
 import { IVSXExtensionBackService, IExtensionInstallParam } from '../common';
 import { QueryParam, QueryResult, VSXSearchParam, VSXSearchResult } from '../common/vsx-registry-types';

--- a/packages/extension-storage/__tests__/browser/storage.test.ts
+++ b/packages/extension-storage/__tests__/browser/storage.test.ts
@@ -6,7 +6,7 @@ import temp from 'temp';
 import { MockLoggerManageClient } from '@opensumi/ide-core-browser/__mocks__/logger';
 import { URI, StoragePaths, FileUri, IFileServiceClient, ILoggerManagerClient } from '@opensumi/ide-core-common';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { IExtensionStorageServer, IExtensionStoragePathServer } from '@opensumi/ide-extension-storage';
 import { FileStat, IDiskFileProvider } from '@opensumi/ide-file-service';
 import { FileServiceClient } from '@opensumi/ide-file-service/lib/browser/file-service-client';

--- a/packages/extension/__tests__/browser/main.thread.workspace.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.workspace.test.ts
@@ -31,8 +31,7 @@ import {
   Deferred,
 } from '@opensumi/ide-core-common';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
-import { AppConfig } from '@opensumi/ide-core-node';
-import { addEditorProviders } from '@opensumi/ide-dev-tool/src/injector-editor';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import {
   IEditorDocumentModelContentRegistry,

--- a/packages/extension/src/hosted/ext.host.ts
+++ b/packages/extension/src/hosted/ext.host.ts
@@ -16,7 +16,7 @@ import {
   IExtensionLogger,
   arrays,
 } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 
 import { EXTENSION_EXTEND_SERVICE_PREFIX, IExtensionHostService, IExtendProxy, getExtensionId } from '../common';
 import { ActivatedExtension, ExtensionsActivator, ActivatedExtensionJSON } from '../common/activator';

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -14,7 +14,7 @@ import {
   ILogService,
 } from '@opensumi/ide-core-common';
 import { isPromiseCanceledError, locale } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 
 import { ProcessMessageType, IExtensionHostService, KT_PROCESS_SOCK_OPTION_KEY, KT_APP_CONFIG_KEY } from '../common';
 import { CommandHandler } from '../common/vscode';

--- a/packages/extension/src/hosted/extension-log2.ts
+++ b/packages/extension/src/hosted/extension-log2.ts
@@ -6,7 +6,7 @@ import {
   LogLevel,
   IExtensionLogger,
 } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { LogServiceManager } from '@opensumi/ide-logs/lib/node/log-manager';
 
 export class ExtensionLogger2 implements IExtensionLogger {

--- a/packages/logs-core/__tests__/node/log-manager.test.ts
+++ b/packages/logs-core/__tests__/node/log-manager.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import * as fs from 'fs-extra';
 
 import { toLocalISOString } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 
 import { LogLevel, SupportLogNamespace, ILogServiceManager } from '../../src/common';

--- a/packages/logs-core/__tests__/node/log.service.test.ts
+++ b/packages/logs-core/__tests__/node/log.service.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import * as fs from 'fs-extra';
 
 import { toLocalISOString, ILogService } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 
 import { LogServiceManager } from '../../lib/node/log-manager';

--- a/packages/logs-core/src/node/log-manager.ts
+++ b/packages/logs-core/src/node/log-manager.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { Injectable, Autowired, ConstructorOf } from '@opensumi/di';
 import { Emitter } from '@opensumi/ide-core-common';
-import { AppConfig } from '@opensumi/ide-core-node';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 
 import {
   ILogService,


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

fix keytar in exthost

### Changelog

 import appConfig types form ide-core-node/lib/types