### PR TITLE
fix: worker entry file load error

### DIFF
--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -213,17 +213,19 @@ export class WorkerExtProcessService
   }
 
   private getWorkerExtensionProps(extension: IExtension, workerMain: string) {
-    // 这里路径遵循 posix 方式，fsPath 会自动根据平台转换
-    let workerScriptPath = new URI(
-      extension.extensionLocation.with({
-        path: posix.join(extension.extensionLocation.path, workerMain),
-      }),
-    ).toString();
+    let entryScript = workerMain;
 
     // 有部分 web extension 在申明 browser 入口字段的时候，不会带上文件后缀，导致 fetch 获取文件 404
-    if (!workerScriptPath.endsWith('.js')) {
-      workerScriptPath += '.js';
+    if (!entryScript.endsWith('.js')) {
+      entryScript += '.js';
     }
+
+    // 这里路径遵循 posix 方式，fsPath 会自动根据平台转换
+    const workerScriptPath = new URI(
+      extension.extensionLocation.with({
+        path: posix.join(extension.extensionLocation.path, entryScript),
+      }),
+    ).toString();
 
     return Object.assign({}, extension.toJSON(), { workerScriptPath });
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
部分插件申明 worker 入口文件时不会写明文件.js后缀，在补全后缀时候因补全逻辑比较靠后，导致部分集成场景下出现地址错误的问题

### Changelog
提前进行后缀补全
