### PR TITLE
chore: use equal hostname to start server

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "init:deps": "ts-node ./scripts/bootstrap",
     "init": "npm run init:deps && npm run clean && npm run build:all",
     "start": "node ./scripts/rebuild-native.js && cross-env HOST=127.0.0.1 WS_PATH=ws://127.0.0.1:8000 NODE_ENV=development ts-node ./scripts/start",
-    "start:remote": "node ./scripts/rebuild-native.js && cross-env NODE_ENV=development ts-node ./scripts/start",
+    "start:remote": "node ./scripts/rebuild-native.js && cross-env HOST=0.0.0.0 NODE_ENV=development ts-node ./scripts/start",
     "start:electron": "cross-env NODE_ENV=development ts-node ./scripts/start-electron",
     "build:components": "cd packages/components && npm run build:dist",
     "start:lite": "cross-env NODE_ENV=development ts-node ./scripts/start --script=start:lite",

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -180,7 +180,7 @@ export class ClientApp implements IClientApp, IDisposable {
       extensionDir:
         opts.extensionDir || (opts.isElectronRenderer || isDesktop ? electronEnv.metadata?.extensionDir : ''),
       injector: this.injector,
-      wsPath: opts.wsPath || 'ws://0.0.0.0:8000',
+      wsPath: opts.wsPath || `ws://${window.location.hostname}:8000`,
       layoutConfig: opts.layoutConfig as LayoutConfig,
       editorBackgroundImage: opts.editorBackgroundImage || editorBackgroundImage,
       allowSetDocumentTitleFollowWorkspaceDir,

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -116,7 +116,7 @@ export interface AppConfig {
   extensionCandidate?: ExtensionCandidate[];
   /**
    * 定义静态资源的加载路径
-   * 默认值为：http://0.0.0.0:8000/assets/${path}
+   * 默认值为：`http://${HOST}:8000/assets/${path}`
    */
   staticServicePath?: string;
   /**

--- a/packages/core-common/src/node/port.ts
+++ b/packages/core-common/src/node/port.ts
@@ -15,6 +15,8 @@ export function randomPort(): number {
   return min + Math.floor((max - min) * Math.random());
 }
 
+const defaultHost = process.env.HOST || '127.0.0.1';
+
 /**
  * Given a start point and a max number of retries, will find a port that
  * is openable. Will return 0 in case no free port can be found.
@@ -70,7 +72,7 @@ function doFindFreePort(startPort: number, giveUpAfter: number, clb: (port: numb
     return clb(startPort);
   });
 
-  client.connect(startPort, '127.0.0.1');
+  client.connect(startPort, defaultHost);
 }
 
 /**
@@ -106,7 +108,7 @@ export function findFreePortFaster(startPort: number, giveUpAfter: number, timeo
       if (err && ((err as any).code === 'EADDRINUSE' || (err as any).code === 'EACCES') && countTried < giveUpAfter) {
         startPort++;
         countTried++;
-        server.listen(startPort, '127.0.0.1');
+        server.listen(startPort, defaultHost);
       } else {
         doResolve(0, resolve);
       }
@@ -114,7 +116,7 @@ export function findFreePortFaster(startPort: number, giveUpAfter: number, timeo
     server.on('close', () => {
       doResolve(0, resolve);
     });
-    server.listen(startPort, '127.0.0.1');
+    server.listen(startPort, defaultHost);
   });
 }
 

--- a/packages/core-common/src/node/port.ts
+++ b/packages/core-common/src/node/port.ts
@@ -70,11 +70,11 @@ function doFindFreePort(startPort: number, giveUpAfter: number, clb: (port: numb
     return clb(startPort);
   });
 
-  client.connect(startPort, '0.0.0.0');
+  client.connect(startPort, '127.0.0.1');
 }
 
 /**
- * Uses listen instead of connect. Is faster, but if there is another listener on 0.0.0.0 then this will take 0.0.0.0 from that listener.
+ * Uses listen instead of connect. Is faster, but if there is another listener on 127.0.0.1 then this will take 127.0.0.1 from that listener.
  */
 export function findFreePortFaster(startPort: number, giveUpAfter: number, timeout: number): Promise<number> {
   let resolved = false;
@@ -106,7 +106,7 @@ export function findFreePortFaster(startPort: number, giveUpAfter: number, timeo
       if (err && ((err as any).code === 'EADDRINUSE' || (err as any).code === 'EACCES') && countTried < giveUpAfter) {
         startPort++;
         countTried++;
-        server.listen(startPort, '0.0.0.0');
+        server.listen(startPort, '127.0.0.1');
       } else {
         doResolve(0, resolve);
       }
@@ -114,7 +114,7 @@ export function findFreePortFaster(startPort: number, giveUpAfter: number, timeo
     server.on('close', () => {
       doResolve(0, resolve);
     });
-    server.listen(startPort, '0.0.0.0');
+    server.listen(startPort, '127.0.0.1');
   });
 }
 

--- a/packages/debug/src/browser/debugUtils.ts
+++ b/packages/debug/src/browser/debugUtils.ts
@@ -44,7 +44,7 @@ export function isRemoteAttach(config: DebugConfiguration): boolean {
     const host = config[map[type]];
 
     if (host) {
-      return !['localhost', '0.0.0.0', '::1'].includes(host);
+      return !['localhost', '0.0.0.0', '127.0.0.1', '::1'].includes(host);
     }
 
     return true;

--- a/packages/express-file-server/__tests__/browser/index.test.ts
+++ b/packages/express-file-server/__tests__/browser/index.test.ts
@@ -23,6 +23,6 @@ describe('packages/express-file-server/__tests__/browser/index.test.ts', () => {
   staticResourceClientAppContribution.initialize();
   it('express 模块提供 file schema 的 uri 转换', () => {
     const uri = staticResourceService.resolveStaticResource(URI.file('test'));
-    expect(uri.toString()).toEqual('http://0.0.0.0:8000/assets/test');
+    expect(uri.toString()).toEqual('http://127.0.0.1:8000/assets/test');
   });
 });

--- a/packages/express-file-server/src/browser/file-server.contribution.ts
+++ b/packages/express-file-server/src/browser/file-server.contribution.ts
@@ -17,7 +17,7 @@ export class ExpressFileServerContribution implements StaticResourceContribution
       scheme: Schemes.file,
       resolveStaticResource: (uri: URI) => {
         // file 协议统一走静态服务
-        // http://0.0.0.0:8000/assets/${path}
+        // http://${HOST}:8000/assets/${path}
         const assetsUri = new URI(this.appConfig.staticServicePath || EXPRESS_SERVER_PATH);
         /**
          * uri.path 在 Windows 下会被解析为 /c:/Path/to/file

--- a/packages/express-file-server/src/common/index.ts
+++ b/packages/express-file-server/src/common/index.ts
@@ -1,5 +1,5 @@
 export const EXPRESS_SERVER_PORT = 8000;
-export const EXPRESS_SERVER_PATH = process.env.STATIC_SERVER_PATH || 'http://0.0.0.0:' + EXPRESS_SERVER_PORT + '/';
+export const EXPRESS_SERVER_PATH = process.env.STATIC_SERVER_PATH || `http://127.0.0.1:${EXPRESS_SERVER_PORT}/`;
 // 静态服务资源白名单
 export const ALLOW_MIME = {
   gif: 'image/gif',

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -127,7 +127,7 @@ export class WorkerExtProcessService
   }
 
   public async $getStaticServicePath() {
-    return this.appConfig.staticServicePath || 'http://0.0.0.0:8000';
+    return this.appConfig.staticServicePath || `http://${window.location.hostname}:8000`;
   }
 
   private async createExtProcess(ignoreCors?: boolean) {

--- a/packages/remote-cli/src/index.ts
+++ b/packages/remote-cli/src/index.ts
@@ -1,11 +1,10 @@
 import { statSync, existsSync } from 'fs';
 import { join } from 'path';
 
-import { green, yellow, red } from 'chalk';
+import { green, red } from 'chalk';
 import got from 'got';
 import yargs from 'yargs';
 
-const CLI_NAME = process.env.CLI_NAME || 'sumi';
 const PRODUCTION_NAME = process.env.PRODUCTION_NAME || 'OpenSumi';
 const CLIENT_ID = process.env.CLIENT_ID;
 const SUMI_SERVER_HOST = process.env.SUMI_SERVER_HOST || 'http://0.0.0.0:8000';

--- a/packages/remote-opener/__tests__/browser/remote.opener.service.test.ts
+++ b/packages/remote-opener/__tests__/browser/remote.opener.service.test.ts
@@ -55,7 +55,7 @@ describe('packages/remote-opener/src/browser/remote.opener.service.ts', () => {
     };
     const spyOnConverter = jest.spyOn(converter, 'convert');
 
-    disposes.addDispose(remoteOpenerService.registerSupportHosts(['localhost', '0.0.0.0', '0.0.0.0']));
+    disposes.addDispose(remoteOpenerService.registerSupportHosts(['localhost', '0.0.0.0', '127.0.0.1']));
     disposes.addDispose(remoteOpenerService.registerConverter(converter));
 
     const spyOnOpen = jest.spyOn(openerService, 'open');

--- a/packages/remote-opener/src/browser/remote.opener.service.ts
+++ b/packages/remote-opener/src/browser/remote.opener.service.ts
@@ -8,7 +8,7 @@ import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { IRemoteHostConverter, IRemoteOpenerBrowserService } from '../common';
 
 // 不预置SUPPORT_HOSTS，改为用户注册，默认走openerService来处理这部分逻辑
-// const SUPPORT_HOSTS = ['localhost', '0.0.0.0', '0.0.0.0'];
+// const SUPPORT_HOSTS = ['localhost', '0.0.0.0', '127.0.0.1'];
 
 @Injectable()
 export class RemoteOpenerBrowserServiceImpl extends RPCService implements IRemoteOpenerBrowserService {

--- a/packages/startup/entry/web-lite/lite-module/file-provider/index.contribution.ts
+++ b/packages/startup/entry/web-lite/lite-module/file-provider/index.contribution.ts
@@ -48,7 +48,7 @@ export class FileProviderContribution implements StaticResourceContribution, FsP
       scheme: Schemes.file,
       resolveStaticResource: (uri: URI) => {
         // file 协议统一走 scm raw 服务
-        // https://0.0.0.0:8080/asset-service/v3/project/$repo/repository/blobs/$ref
+        // https://${HOST}:8080/asset-service/v3/project/$repo/repository/blobs/$ref
         // GET /api/v3/projects/{id}/repository/blobs/{sha}
         const assetsUri = new URI(this.appConfig.staticServicePath || EXPRESS_SERVER_PATH);
         const rootUri = new URI(this.workspaceService.workspace?.uri!);

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -8,16 +8,16 @@ import { uuid } from '@opensumi/ide-core-common';
 
 const CLIENT_ID = 'W_' + uuid();
 export async function renderApp(opts: IClientAppOpts) {
+  const defaultHost = process.env.HOST || window.location.hostname;
   const injector = new Injector();
   opts.workspaceDir = opts.workspaceDir || process.env.WORKSPACE_DIR;
 
   opts.injector = injector;
   opts.extensionDir = opts.extensionDir || process.env.EXTENSION_DIR;
-  opts.wsPath = process.env.WS_PATH || 'ws://0.0.0.0:8000';
+  opts.wsPath = process.env.WS_PATH || `ws://${defaultHost}:8000`;
 
   opts.extWorkerHost = opts.extWorkerHost || process.env.EXTENSION_WORKER_HOST;
-  const anotherHostName =
-    process.env.WEBVIEW_HOST || (window.location.hostname === 'localhost' ? '0.0.0.0' : 'localhost');
+  const anotherHostName = process.env.WEBVIEW_HOST || defaultHost;
   opts.webviewEndpoint = `http://${anotherHostName}:8899`;
   opts.editorBackgroundImage =
     'https://img.alicdn.com/imgextra/i2/O1CN01dqjQei1tpbj9z9VPH_!!6000000005951-55-tps-87-78.svg';

--- a/tools/dev-tool/src/webpack.js
+++ b/tools/dev-tool/src/webpack.js
@@ -18,7 +18,7 @@ const utils = require('./utils');
 const reactPath = path.resolve(path.join(__dirname, '../../../node_modules/react'));
 const reactDOMPath = path.resolve(path.join(__dirname, '../../../node_modules/react-dom'));
 const tsConfigPath = path.join(__dirname, '../../../tsconfig.json');
-const HOST = process.env.HOST || '0.0.0.0';
+const HOST = process.env.HOST || '127.0.0.1';
 const PORT = process.env.IDE_FRONT_PORT || 8080;
 
 const defaultWorkspace = path.join(__dirname, '../../workspace');
@@ -202,6 +202,7 @@ exports.createWebpackConfig = function (dir, entry, extraConfig) {
           'process.env.WS_PATH': JSON.stringify(process.env.WS_PATH || `ws://${HOST}:8000`),
           'process.env.WEBVIEW_HOST': JSON.stringify(process.env.WEBVIEW_HOST || HOST),
           'process.env.STATIC_SERVER_PATH': JSON.stringify(process.env.STATIC_SERVER_PATH || `http://${HOST}:8000/`),
+          'process.env.HOST': JSON.stringify(process.env.HOST),
         }),
         new FriendlyErrorsWebpackPlugin({
           compilationSuccessInfo: {
@@ -227,23 +228,23 @@ exports.createWebpackConfig = function (dir, entry, extraConfig) {
         contentBase: dir + '/dist',
         port: PORT,
         disableHostCheck: true,
-        host: process.env.HOST,
+        host: HOST,
         proxy: {
           '/api': {
-            target: 'http://localhost:8000',
+            target: `http://${HOST}:8000`,
           },
           '/extension': {
-            target: 'http://localhost:8000',
+            target: `http://${HOST}:8000`,
           },
           '/assets': {
-            target: 'http://localhost:8000',
+            target: `http://${HOST}:8000`,
           },
           '/kaitian': {
-            target: 'http://localhost:8000',
+            target: `http://${HOST}:8000`,
           },
           '/socket.io': {
             ws: true,
-            target: 'ws://localhost:8000',
+            target: `ws://${HOST}:8000`,
           },
         },
         stats: 'errors-only',


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

统一框架内启动时获取到的 HOSTNAME，减少跨域报错及问题

### Changelog
