### PR TITLE
fix: custom toolbar buttons

### DIFF
--- a/packages/components/src/checkbox/index.tsx
+++ b/packages/components/src/checkbox/index.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import { isUndefined } from '@opensumi/ide-utils';
+
 import { warning } from '../utils/warning';
 
 import './style.less';
@@ -21,7 +23,7 @@ export const CheckBox: React.FC<
     // https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null
     wrapTabIndex?: number;
   }
-> = ({ insertClass, className, label, size = 'default', disabled, checked = false, wrapTabIndex, ...restProps }) => {
+> = ({ insertClass, className, label, size = 'default', disabled, checked, wrapTabIndex, ...restProps }) => {
   warning(!insertClass, '`insertClass` was deprecated, please use `className` instead');
 
   const cls = classNames('kt-checkbox', insertClass, className, {
@@ -29,10 +31,16 @@ export const CheckBox: React.FC<
     'kt-checkbox-disabled': disabled,
   });
 
+  const checkboxProps = restProps;
+
+  if (!isUndefined(checked)) {
+    checkboxProps['chcked'] = checked;
+  }
+
   return (
     <label className={cls} tabIndex={wrapTabIndex}>
       <span className='kt-checkbox-lump'>
-        <input type='checkbox' disabled={disabled} checked={checked} {...restProps} />
+        <input type='checkbox' disabled={disabled} {...checkboxProps} />
         <span className='kt-checkbox-icon'>
           <CheckIconSvg />
         </span>


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原来自定义工具栏依赖了 CheckBox 默认的开关能力，在设置 checked 默认为 false 后，该开关能力失效导致功能不可用

<img width="872" alt="image" src="https://user-images.githubusercontent.com/9823838/178962376-7a924602-5ccc-41b1-ac57-407073433cfa.png">

### Changelog

修复自定义工具栏按钮无法点击问题
