### PR TITLE
fix: terminal task system exit failed

### DIFF
--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -214,7 +214,6 @@ export class TerminalController extends WithEventBus implements ITerminalControl
       client.onExit((e) => {
         // 直接使用removeWidget会导致TerminalTask场景下任务执行完毕直接退出而不是用户手动触发onKeyDown退出
         // this.terminalView.removeWidget(client.id);
-        this.clients.delete(client.id);
         this._onDidCloseTerminal.fire({ id: client.id, code: e.code });
       }),
     );


### PR DESCRIPTION
### Types

修复某些集成端直接调用Terminal Task时遇到的关闭问题。

- [x] 🐛 Bug Fixes

### Background or solution
- 集成端Task结束后关闭生命周期有问题

### Changelog
- cherrypick fix: terminal task system exit failed
