### PR TITLE
chore: add missing type declaration

### DIFF
--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -7,6 +7,7 @@ import './style.less';
 export const Tooltip: React.FC<{
   title: string;
   delay?: number;
+  children?: React.ReactNode;
 }> = ({ title, children, delay }) => {
   const [visible, setVisible] = useState(false);
   const targetRef = useRef<HTMLParagraphElement | null>(null);

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -27,18 +27,20 @@ export const Tooltip: React.FC<{
       if (tooltipRef.current && targetRef.current && arrowRef.current) {
         const { x, y, width, height } = targetRef.current.getBoundingClientRect();
         const tooltipRect = tooltipRef.current.getBoundingClientRect();
-
-        if (y < tooltipRect.height) {
+        if (y < tooltipRect.height * 1.5) {
           arrowRef.current.className += ' kt-tooltip-reverse-arrow';
           tooltipRef.current.style.top = `${y + height + tooltipRect.height / 2}px`;
         } else {
-          tooltipRef.current.style.top = `${y - height / 2 - tooltipRect.height / 2}px`;
+          tooltipRef.current.style.top = `${y - tooltipRect.height * 1.5}px`;
         }
-
-        if (x + tooltipRect.width >= document.body.offsetWidth) {
-          arrowRef.current.style.left = `${x + tooltipRect.width - document.body.offsetWidth + width / 2}px`;
-          tooltipRef.current.style.left = `${document.body.offsetWidth - tooltipRect.width}px`;
+        if (x + tooltipRect.width / 2 >= document.body.offsetWidth) {
+          arrowRef.current.style.right = `${width / 2 - 7}px`;
+          tooltipRef.current.style.left = `${x + width - tooltipRect.width}px`;
+        } else if (x - tooltipRect.width / 2 <= 0) {
+          arrowRef.current.style.left = `${width / 2 - 7}px`;
+          tooltipRef.current.style.left = `${x}px`;
         } else {
+          arrowRef.current.style.left = `${tooltipRect.width / 2 - 7}px`;
           tooltipRef.current.style.left = `${x + width / 2 - tooltipRect.width / 2}px`;
         }
       }

--- a/packages/components/src/tooltip/style.less
+++ b/packages/components/src/tooltip/style.less
@@ -2,6 +2,7 @@
   position: relative;
   margin: 0px;
   padding: 0px;
+  display: inline-block;
 
   .kt-tooltip-content {
     display: inline-block;
@@ -20,8 +21,6 @@
 
     .kt-tooltip-arrow-placeholder {
       position: absolute;
-      left: 50%;
-      margin-left: -7px;
       top: 100%;
       width: 0;
       height: 0;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->
- [x] 🐛 Bug Fixes
### Background or solution
closes #1356 
closes #1359 

issue1 解决截图:
![ok](https://user-images.githubusercontent.com/85668115/179264928-8fb94de2-f2eb-4571-a45e-d3e699a17175.png)

issue2 解决截图:
解决箭头问题
![QQ截图20220716161722](https://user-images.githubusercontent.com/85668115/179346870-d46d3b4f-67bd-4a9c-bfc7-f610153ed716.png)

解决当左边空间不足，tip意外显示到页面中部的问题
![2](https://user-images.githubusercontent.com/85668115/179346917-a1fee9f0-734d-47b4-afd0-aa75b349b262.png)

解决鼠标未enter目标，在同一行时，也会显示tip的问题。
![动画](https://user-images.githubusercontent.com/85668115/179346919-015dd8b7-e767-42a9-8676-f05739a652b7.gif)

### Changelog
1. 增加children 声明
2. 样式文件补充target容器的display解决鼠标未enter目标，在同一行时，也会显示tip的问题。
3. 新增一个else if 判断 解决当左边空间不足，tip意外显示到页面中部的问题
