### PR TITLE
fix: cancel prev tree node revealing when next revealing called

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -1521,17 +1521,13 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       return;
     }
     state.refreshCancelToken.cancel();
-    let token;
-    if (state.loadPathCancelToken.token.isCancellationRequested) {
-      const loadPathCancelToken = new CancellationTokenSource();
-      TreeNode.setGlobalTreeState(this.path, {
-        isLoadingPath: true,
-        loadPathCancelToken,
-      });
-      token = loadPathCancelToken.token;
-    } else {
-      token = state.loadPathCancelToken.token;
-    }
+    state.loadPathCancelToken.cancel();
+    const loadPathCancelToken = new CancellationTokenSource();
+    TreeNode.setGlobalTreeState(this.path, {
+      isLoadingPath: true,
+      loadPathCancelToken,
+    });
+    const token = loadPathCancelToken.token;
 
     const flattenedBranchChilds: CompositeTreeNode[] = [];
     const { splitPath, isRelative } = Path;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

Tree 节点定位时应该只受最后一次用户操作影响

### Changelog

cancel prev tree node revealing when next revealing called