### PR TITLE
fix: use background image type on extension menu

### DIFF
--- a/packages/core-browser/src/style/icon/fileicons.less
+++ b/packages/core-browser/src/style/icon/fileicons.less
@@ -2,14 +2,14 @@
   .folder-icon::before,
   .rootfolder-icon::before {
     content: ' ';
-    -webkit-mask: data-uri('./fileicons/folder-default.svg') no-repeat 50% 50%;
-    -webkit-mask-size: 14px;
+    mask: data-uri('./fileicons/folder-default.svg') no-repeat 0 0;
+    mask-size: 14px;
     background-color: var(--foreground);
   }
   .file-icon::before {
     content: ' ';
-    -webkit-mask: data-uri('./fileicons/file-default.svg') no-repeat 50% 50%;
-    -webkit-mask-size: 14px;
+    mask: data-uri('./fileicons/file-default.svg') no-repeat 0 0;
+    mask-size: 14px;
     background-color: var(--foreground);
   }
 }

--- a/packages/extension/src/browser/vscode/contributes/menu.ts
+++ b/packages/extension/src/browser/vscode/contributes/menu.ts
@@ -13,7 +13,7 @@ import { ToolbarRegistry } from '@opensumi/ide-core-browser/lib/layout';
 import { IMenuRegistry, MenuId, IMenuItem, ISubmenuItem } from '@opensumi/ide-core-browser/lib/menu/next';
 import { IEditorGroup } from '@opensumi/ide-editor';
 import { IEditorActionRegistry } from '@opensumi/ide-editor/lib/browser';
-import { ThemeType } from '@opensumi/ide-theme';
+import { ThemeType, IconType } from '@opensumi/ide-theme';
 import { IIconService } from '@opensumi/ide-theme/lib/common/theme.service';
 
 import { VSCodeContributePoint, Contributes } from '../../../common';
@@ -267,7 +267,7 @@ export class MenusContributionPoint extends VSCodeContributePoint<MenusSchema> {
               when: item.when,
               group,
               order,
-              iconClass: submenuDesc.icon && this.toIconClass(submenuDesc.icon),
+              iconClass: submenuDesc.icon && this.toIconClass(submenuDesc.icon, IconType.Background),
             } as ISubmenuItem),
           );
         }

--- a/packages/extension/src/common/index.ts
+++ b/packages/extension/src/common/index.ts
@@ -263,11 +263,14 @@ export abstract class VSCodeContributePoint<T extends JSONType = JSONType> exten
 
   abstract contribute(): void;
 
-  protected toIconClass(iconContrib: { [index in ThemeType]: string } | string): string | undefined {
+  protected toIconClass(
+    iconContrib: { [index in ThemeType]: string } | string,
+    type: IconType = IconType.Mask,
+  ): string | undefined {
     if (typeof iconContrib === 'string' && VAR_REGEXP.test(iconContrib)) {
       return this.iconService?.fromString(iconContrib);
     }
-    return this.iconService?.fromIcon(this.extension.path, iconContrib, IconType.Background);
+    return this.iconService?.fromIcon(this.extension.path, iconContrib, type);
   }
 
   protected getLocalizeFromNlsJSON(title: string): string {

--- a/packages/theme/src/browser/icon.service.ts
+++ b/packages/theme/src/browser/icon.service.ts
@@ -155,7 +155,7 @@ export class IconService extends WithEventBus implements IIconService {
   }
 
   protected getMaskStyleSheet(iconUrl: string, className: string, baseTheme?: string): string {
-    const cssRule = `${baseTheme || ''} .${className} {-webkit-mask: url("${iconUrl}") no-repeat 50% 50% / 24px;}`;
+    const cssRule = `${baseTheme || ''} .${className} {-webkit-mask: url("${iconUrl}") no-repeat 0 0;}`;
     return cssRule;
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fix #1378

before:

![image](https://user-images.githubusercontent.com/9823838/179930419-cf527d34-5dd0-46b4-8a63-7e679d219f5a.png)

after:

![image](https://user-images.githubusercontent.com/9823838/179926446-1b07f50b-9c4e-4ee6-b734-3987d740e4fe.png)


### Changelog

use background image type on extension menu