### PR TITLE
chore: show node on the center while revealing filetree node

### DIFF
--- a/packages/file-tree-next/__tests__/browser/file-tree.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.test.ts
@@ -389,7 +389,7 @@ describe('FileTree should be work while on single workspace model', () => {
       await location(fileNode.uri);
       expect(mockTreeHandle.ensureVisible).toBeCalledWith(
         await fileTreeService.getFileTreeNodePathByUri(fileNode.uri),
-        'smart',
+        'center',
         true,
       );
       const fileDecoration = decorations.getDecorations(fileNode);
@@ -406,7 +406,7 @@ describe('FileTree should be work while on single workspace model', () => {
       await performLocationOnHandleShow();
       expect(mockTreeHandle.ensureVisible).toBeCalledWith(
         await fileTreeService.getFileTreeNodePathByUri(fileNode.uri),
-        'smart',
+        'center',
         true,
       );
       const fileDecoration = decorations.getDecorations(fileNode);

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1691,7 +1691,7 @@ export class FileTreeModelService {
       if (!this.fileTreeHandle) {
         return;
       }
-      const node = (await this.fileTreeHandle.ensureVisible(path, 'smart', true)) as File;
+      const node = (await this.fileTreeHandle.ensureVisible(path, 'center', true)) as File;
       if (node) {
         this.selectFileDecoration(node);
       }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原有的 `smart` 交互在文件树下很奇怪，不可见节点会默认在顶部会底部出现

### Changelog

show node on the center while revealing filetree node