### PR TITLE
fix: ctx-menu conflict when same command id

### DIFF
--- a/packages/core-browser/src/menu/next/renderer/ctxmenu/electron.ts
+++ b/packages/core-browser/src/menu/next/renderer/ctxmenu/electron.ts
@@ -23,28 +23,28 @@ export interface IElectronMenuBarService {
 export class ElectronMenuFactory extends Disposable {
   public getTemplate(
     menuNodes: MenuNode[],
-    map: Map<string, () => void>,
+    menuMap: Map<string, () => void>,
     context?: any[],
   ): INativeMenuTemplate[] | undefined {
-    return menuNodes.map((menuNode) => {
+    return menuNodes.map((menuNode, index) => {
       if (menuNode.id === SeparatorMenuItemNode.ID) {
         return { type: 'separator' };
       }
       if (menuNode.id === SubmenuItemNode.ID) {
-        const submenuTemplate = this.getTemplate(menuNode.children, map, context);
+        const submenuTemplate = this.getTemplate(menuNode.children, menuMap, context);
         return {
           label: `${strings.mnemonicButtonLabel(menuNode.label, true)}`,
           submenu: Array.isArray(submenuTemplate) && submenuTemplate.length ? submenuTemplate : undefined,
         };
       } else {
-        this.bindAction(menuNode, map, context);
+        this.bindAction(menuNode, menuMap, index, context);
         return {
           type: menuNode.checked ? 'checkbox' : undefined,
           checked: menuNode.checked ? menuNode.checked : false,
           label: `${strings.mnemonicButtonLabel(menuNode.label, true)} ${
             menuNode.isKeyCombination ? menuNode.keybinding : ''
           }`,
-          id: menuNode.id,
+          id: `${menuNode.id}-${index}`,
           action: true,
           role: menuNode.nativeRole,
           disabled: menuNode.disabled,
@@ -57,9 +57,9 @@ export class ElectronMenuFactory extends Disposable {
     });
   }
 
-  private bindAction(menuNode: MenuNode, map: Map<string, () => void>, context?: any[]) {
+  private bindAction(menuNode: MenuNode, map: Map<string, () => void>, index: number, context?: any[]) {
     if (typeof menuNode.execute === 'function') {
-      map.set(menuNode.id, () => {
+      map.set(`${menuNode.id}-${index}`, () => {
         menuNode.execute(context);
       });
     }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
使用多个 customEditor 的 api 时，会有一个编辑器右上角会出现一个菜单，显示打开的方式。如果出现同一个 command 但不同参数的场景，会导致创建的菜单异常。

https://user-images.githubusercontent.com/2226423/180906017-c389bcb4-6a99-4068-9cc2-7e043a268a96.mov


### Changelog
ctx-menu conflict when same command id