### PR TITLE
fix: lazy load mainUIService on Electron renderer

### DIFF
--- a/packages/debug/src/browser/view/configuration/debug-toolbar.service.ts
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.service.ts
@@ -1,9 +1,10 @@
 import { observable, action } from 'mobx';
 
-import { Injectable, Autowired } from '@opensumi/di';
-import { IContextKeyService, IReporterService } from '@opensumi/ide-core-browser';
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { IContextKeyService, IReporterService, memoize } from '@opensumi/ide-core-browser';
 import { AbstractContextMenuService, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { IContextMenu } from '@opensumi/ide-core-browser/lib/menu/next';
+import { IElectronMainUIService } from '@opensumi/ide-core-common/lib/electron';
 
 import { DebugState, DEBUG_REPORT_NAME } from '../../../common';
 import { DebugSession } from '../../debug-session';
@@ -22,6 +23,9 @@ export class DebugToolbarService {
 
   @Autowired(IReporterService)
   protected readonly reporterService: IReporterService;
+
+  @Autowired(INJECTOR_TOKEN)
+  private readonly injector: Injector;
 
   @observable
   state: DebugState;
@@ -42,6 +46,11 @@ export class DebugToolbarService {
       this.updateToolBarMenu();
       this.updateModel();
     });
+  }
+
+  @memoize
+  get mainUIService() {
+    return this.injector.get(IElectronMainUIService);
   }
 
   @action

--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -244,14 +244,15 @@ const FloatDebugToolbarView = observer(() => {
   const controller = useInjectable<FloatController>(FloatController);
   const preference = useInjectable<PreferenceService>(PreferenceService);
   const { isElectronRenderer } = useInjectable<AppConfig>(AppConfig);
-  const { state } = useInjectable<DebugToolbarService>(DebugToolbarService);
+  const debugToolbarService = useInjectable<DebugToolbarService>(DebugToolbarService);
   const [toolbarOffsetTop, setToolbarOffsetTop] = useState<number>(0);
+  const { state } = debugToolbarService;
 
   useEffect(() => {
     const disposableCollection = new DisposableCollection();
     const value = preference.get<number>(DebugPreferenceTopKey) || 0;
     if (isElectronRenderer) {
-      const uiService: IElectronMainUIService = useInjectable(IElectronMainUIService);
+      const uiService: IElectronMainUIService = debugToolbarService.mainUIService;
       const isNewMacHeaderBar = () => isMacintosh && parseFloat(electronEnv.osRelease) >= 20;
       // Electron 环境下需要在非全屏情况下追加 Header 高度
       uiService.isFullScreen(electronEnv.currentWindowId).then((fullScreen) => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

ref https://github.com/opensumi/core/pull/1342/files#diff-78b009ab7192cc151d4422b5c96eb8a0af9ab1f893e1e937eb1aba4278c0dab0R254

### Changelog

lazy load mainUIService on Electron renderer
