### PR TITLE
fix: windows file event filter

### DIFF
--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -26,7 +26,7 @@
     "nsfw": "2.2.0",
     "trash": "^5.2.0",
     "vscode-languageserver-types": "^3.16.0",
-    "write-file-atomic": "^3.0.0"
+    "write-file-atomic": "^4.0.1"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "2.18.15",


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原来的 Windows 下事件处理逻辑存在问题，依赖了事件执行顺序
![image](https://user-images.githubusercontent.com/9823838/181222930-c900ad92-678b-4512-a265-b28b4b135a55.png)

实际执行顺序可能与预期不一致
![image](https://user-images.githubusercontent.com/9823838/181222912-305a5679-7dbc-45b7-ac39-5406773b7cea.png)

### Changelog

fix windows file event filter