### PR TITLE
fix: disable node collapse while node is expanding

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -1027,6 +1027,10 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       return;
     }
     const state = TreeNode.getGlobalTreeState(this.path);
+    if (state.isExpanding) {
+      // 当节点处于加载子节点过程时，尽管为展开状态，但此时不应该支持折叠节点
+      return;
+    }
     state.loadPathCancelToken.cancel();
     state.refreshCancelToken.cancel();
     this._watcher.notifyWillChangeExpansionState(this, false);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

当节点处于加载子节点过程时，尽管为展开状态，但此时不应该支持折叠节点，否则后续节点计算可能存在问题

### Changelog

 disable node collapse while node is expanding