### PR TITLE
fix: keymaps view cannot be closed

### DIFF
--- a/packages/keymaps/src/browser/keymaps.view.tsx
+++ b/packages/keymaps/src/browser/keymaps.view.tsx
@@ -137,13 +137,13 @@ export const KeymapsView: ReactEditorComponent<null> = () => {
     const renderPlaceholder = () => <div className={styles.keybinding_key_input_placeholder}>⏎</div>;
 
     const renderReset = (source?: string) => {
-      // 修改时固定设置页面
-      if (!isDirty) {
-        fixed();
-        setIsDirty(true);
-      }
       const reset = (event) => {
         event.preventDefault();
+        // 修改时固定设置页面
+        if (!isDirty) {
+          fixed();
+          setIsDirty(true);
+        }
         resetKeybinding({
           command: getRaw(id),
           when: getRaw(when) || '',


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原来的错误写法会在每次渲染 Reset 按钮时再次调用 Open 方法导致异常

### Changelog

keymaps view cannot be closed