### PR TITLE
fix: improve Gitlens 12+ welcome page style

### DIFF
--- a/packages/express-file-server/src/browser/file-server.contribution.ts
+++ b/packages/express-file-server/src/browser/file-server.contribution.ts
@@ -23,7 +23,8 @@ export class ExpressFileServerContribution implements StaticResourceContribution
          * uri.path 在 Windows 下会被解析为 /c:/Path/to/file
          * fsPath C:\\Path\\to\\file
          */
-        return assetsUri.resolve(`assets${decodeURIComponent(uri.codeUri.path)}`);
+        const [resourceUrl, query] = uri.codeUri.path.split('?');
+        return assetsUri.resolve(`assets${decodeURIComponent(resourceUrl)}`).withQuery(query);
       },
       roots: [this.appConfig.staticServicePath || EXPRESS_SERVER_PATH],
     });

--- a/packages/express-file-server/src/common/index.ts
+++ b/packages/express-file-server/src/common/index.ts
@@ -5,6 +5,7 @@ export const ALLOW_MIME = {
   gif: 'image/gif',
   jpg: 'image/jpeg',
   png: 'image/png',
+  webp: 'image/webp',
   svg: 'image/svg+xml',
   ttf: 'font/ttf',
   eot: 'font/eot',

--- a/packages/static-resource/src/browser/static.definition.ts
+++ b/packages/static-resource/src/browser/static.definition.ts
@@ -32,7 +32,7 @@ export abstract class StaticResourceService {
    * 用于webview的cspResource字段,
    * webview需要能够知道什么样的资源是可以被访问的。
    *
-   * 例: ['http://0.0.0.0:8000']
+   * 例: ['http://127.0.0.1:8000']
    */
   public readonly resourceRoots: Set<string>;
 }

--- a/packages/webview/src/webview-host/webview-manager.ts
+++ b/packages/webview/src/webview-host/webview-manager.ts
@@ -51,7 +51,7 @@ export class WebviewPanelManager {
       if (!pending) {
         const target = this.getActiveFrame();
         if (target) {
-          target.contentWindow!.postMessage(data, '*');
+          target.contentWindow?.postMessage(data, '*');
           return;
         }
       }
@@ -90,7 +90,7 @@ export class WebviewPanelManager {
         }
       };
     } else {
-      const scrollY = frame && frame.contentDocument && frame.contentDocument.body ? frame.contentWindow!.scrollY : 0;
+      const scrollY = frame && frame.contentDocument && frame.contentDocument.body ? frame.contentWindow?.scrollY : 0;
       setInitialScrollPosition = (body, window) => {
         if (window.scrollY === 0) {
           window.scroll(0, scrollY);
@@ -111,7 +111,7 @@ export class WebviewPanelManager {
     const newFrame = document.createElement('iframe');
     newFrame.setAttribute('id', 'pending-frame');
     newFrame.setAttribute('frameborder', '0');
-    newFrame.setAttribute('allow', 'autoplay');
+    newFrame.setAttribute('allow', 'autoplay; clipboard-read; clipboard-write;');
 
     const sandboxRules = new Set(['allow-same-origin', 'allow-pointer-lock']);
     if (options.allowScripts) {
@@ -132,16 +132,16 @@ export class WebviewPanelManager {
 
     if (!this.channel.fakeLoad) {
       // write new content onto iframe
-      newFrame.contentDocument!.open();
+      newFrame.contentDocument?.open();
     }
 
-    newFrame.contentWindow!.addEventListener('keydown', this.handleInnerKeydown.bind(this));
+    newFrame.contentWindow?.addEventListener('keydown', this.handleInnerKeydown.bind(this));
 
-    newFrame.contentWindow!.addEventListener('DOMContentLoaded', (e) => {
+    newFrame.contentWindow?.addEventListener('DOMContentLoaded', (e) => {
       if (this.channel.fakeLoad) {
-        newFrame.contentDocument!.open();
-        newFrame.contentDocument!.write(newDocument);
-        newFrame.contentDocument!.close();
+        newFrame.contentDocument?.open();
+        newFrame.contentDocument?.write(newDocument);
+        newFrame.contentDocument?.close();
         hookupOnLoadHandlers(newFrame);
       }
       const contentDocument: HTMLDocument | undefined = e.target ? (e.target as HTMLDocument) : undefined;
@@ -168,7 +168,7 @@ export class WebviewPanelManager {
         newFrame.setAttribute('id', 'active-frame');
         newFrame.style.visibility = 'visible';
         if (this.channel.focusIframeOnCreate) {
-          newFrame.contentWindow!.focus();
+          newFrame.contentWindow?.focus();
         }
 
         contentWindow.addEventListener('scroll', this.handleInnerScroll.bind(this));
@@ -215,8 +215,8 @@ export class WebviewPanelManager {
     }
 
     if (!this.channel.fakeLoad) {
-      newFrame.contentDocument!.write(newDocument);
-      newFrame.contentDocument!.close();
+      newFrame.contentDocument?.write(newDocument);
+      newFrame.contentDocument?.close();
     }
 
     this.channel.postMessage('did-set-content', undefined);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1450 

原因是部分资源，如字体，webp 没有被正常加载导致界面异常

<img width="721" alt="image" src="https://user-images.githubusercontent.com/9823838/182092538-32b95d6b-9a00-4c96-89f9-5429eb330d28.png">

### Changelog

improve Gitlens 12+ welcome page style