### PR TITLE
feat: quickopen add onKeyMods listener

### DIFF
--- a/packages/core-browser/src/dom/index.ts
+++ b/packages/core-browser/src/dom/index.ts
@@ -73,11 +73,16 @@ export function isAncestor(testChild: Node | null, testAncestor: Node | null): b
 
 export class DomListener implements IDisposable {
   private _handler: (e: any) => void;
-  private _node: Element | Window | Document;
+  private _node: EventTarget;
   private readonly _type: string;
-  private readonly _useCapture: boolean;
+  private readonly _useCapture: boolean | AddEventListenerOptions;
 
-  constructor(node: Element | Window | Document, type: string, handler: (e: any) => void, useCapture?: boolean) {
+  constructor(
+    node: EventTarget,
+    type: string,
+    handler: (e: any) => void,
+    useCapture?: boolean | AddEventListenerOptions,
+  ) {
     this._node = node;
     this._type = type;
     this._handler = handler;
@@ -97,6 +102,33 @@ export class DomListener implements IDisposable {
     this._node = null!;
     this._handler = null!;
   }
+}
+
+export function addDisposableListener<K extends keyof GlobalEventHandlersEventMap>(
+  node: EventTarget,
+  type: K,
+  handler: (event: GlobalEventHandlersEventMap[K]) => void,
+  useCapture?: boolean,
+): IDisposable;
+export function addDisposableListener(
+  node: EventTarget,
+  type: string,
+  handler: (event: any) => void,
+  useCapture?: boolean,
+): IDisposable;
+export function addDisposableListener(
+  node: EventTarget,
+  type: string,
+  handler: (event: any) => void,
+  options: AddEventListenerOptions,
+): IDisposable;
+export function addDisposableListener(
+  node: EventTarget,
+  type: string,
+  handler: (event: any) => void,
+  useCaptureOrOptions?: boolean | AddEventListenerOptions,
+): IDisposable {
+  return new DomListener(node, type, handler, useCaptureOrOptions);
 }
 
 export class FocusTracker extends Disposable {

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -3,7 +3,6 @@ import React from 'react';
 
 import type { VALIDATE_TYPE } from '@opensumi/ide-components';
 import type { URI, MaybePromise, IDisposable, Event } from '@opensumi/ide-core-common';
-import type { KeyMods } from '@opensumi/ide-quick-open/lib/browser/quick-open.type';
 
 import type { Keybinding } from '../keybinding';
 
@@ -36,6 +35,11 @@ export interface Highlight {
  * 该类型使用 monaco-editor-core/esm 中导入的版本
  */
 export { Mode as QuickOpenMode };
+
+export interface IKeyMods {
+  readonly ctrlCmd: boolean;
+  readonly alt: boolean;
+}
 
 export interface QuickTitleButton {
   iconPath: URI | { light: string | URI; dark: string | URI } | ThemeIcon;
@@ -297,7 +301,7 @@ export namespace QuickOpenOptions {
     /**
      * 在 quick pick 时监听是否有 modifer 按下
      */
-    onKeyMods?: (mods: KeyMods) => void;
+    onKeyMods?: (mods: IKeyMods) => void;
     /**
      * 是否模糊匹配标签
      * 使用 vscode filter matchesFuzzy 方法

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -1,10 +1,11 @@
 import { observable } from 'mobx';
 import React from 'react';
 
-import { VALIDATE_TYPE } from '@opensumi/ide-components';
-import { URI, Uri, MaybePromise, IDisposable, Event } from '@opensumi/ide-core-common';
+import type { VALIDATE_TYPE } from '@opensumi/ide-components';
+import type { URI, MaybePromise, IDisposable, Event } from '@opensumi/ide-core-common';
+import type { KeyMods } from '@opensumi/ide-quick-open/lib/browser/quick-open.type';
 
-import { Keybinding } from '../keybinding';
+import type { Keybinding } from '../keybinding';
 
 export enum Mode {
   /**
@@ -292,7 +293,11 @@ export namespace QuickOpenOptions {
      * 在输入框修改文字时触发
      * @param value
      */
-    onChangeValue(value: string): void;
+    onChangeValue: (value: string) => void;
+    /**
+     * 在 quick pick 时监听是否有 modifer 按下
+     */
+    onKeyMods?: (mods: KeyMods) => void;
     /**
      * 是否模糊匹配标签
      * 使用 vscode filter matchesFuzzy 方法

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -16,6 +16,7 @@ import { VALIDATE_TYPE } from '@opensumi/ide-core-browser/lib/components';
 import {
   HideReason,
   Highlight,
+  IKeyMods,
   QuickOpenItem,
   QuickOpenModel as IKaitianQuickOpenModel,
   QuickOpenOptions,
@@ -24,7 +25,7 @@ import {
 import { MonacoContextKeyService } from '@opensumi/ide-monaco/lib/browser/monaco.context-key.service';
 import { matchesFuzzy } from '@opensumi/monaco-editor-core/esm/vs/base/common/filters';
 
-import { IAutoFocus, IQuickOpenModel, KeyMods, QuickOpenContext } from './quick-open.type';
+import { IAutoFocus, IQuickOpenModel, QuickOpenContext } from './quick-open.type';
 import { QuickOpenView } from './quick-open.view';
 import { QuickOpenWidget } from './quick-open.widget';
 
@@ -42,7 +43,7 @@ export interface IKaitianQuickOpenControllerOpts extends QuickOpenTabOptions {
   onSelect?(item: QuickOpenItem, index: number): void;
   onConfirm?(items: QuickOpenItem[]): void;
   onChangeValue?(lookFor: string): void;
-  onKeyMods?(mods: KeyMods): void;
+  onKeyMods?(mods: IKeyMods): void;
   keepScrollPosition?: boolean | undefined;
 }
 

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -24,7 +24,7 @@ import {
 import { MonacoContextKeyService } from '@opensumi/ide-monaco/lib/browser/monaco.context-key.service';
 import { matchesFuzzy } from '@opensumi/monaco-editor-core/esm/vs/base/common/filters';
 
-import { IAutoFocus, IQuickOpenModel, QuickOpenContext } from './quick-open.type';
+import { IAutoFocus, IQuickOpenModel, KeyMods, QuickOpenContext } from './quick-open.type';
 import { QuickOpenView } from './quick-open.view';
 import { QuickOpenWidget } from './quick-open.widget';
 
@@ -42,6 +42,7 @@ export interface IKaitianQuickOpenControllerOpts extends QuickOpenTabOptions {
   onSelect?(item: QuickOpenItem, index: number): void;
   onConfirm?(items: QuickOpenItem[]): void;
   onChangeValue?(lookFor: string): void;
+  onKeyMods?(mods: KeyMods): void;
   keepScrollPosition?: boolean | undefined;
 }
 
@@ -166,6 +167,11 @@ export class MonacoQuickOpenService implements QuickOpenService {
             this.opts.onConfirm(items);
           }
         },
+        onKeyMods: (mods) => {
+          if (this.opts.onKeyMods) {
+            this.opts.onKeyMods(mods);
+          }
+        },
       },
     ]);
     this.initWidgetView(this._widget);
@@ -285,6 +291,12 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
       const result = this.toOpenModel(lookFor, items, actionProvider);
       acceptor(result);
     });
+  }
+
+  onKeyMods(keyMods: any) {
+    if (this.options.onKeyMods) {
+      this.options.onKeyMods(keyMods);
+    }
   }
 
   /**

--- a/packages/quick-open/src/browser/quick-open.type.ts
+++ b/packages/quick-open/src/browser/quick-open.type.ts
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import { QuickOpenItem, HideReason, QuickOpenActionProvider, QuickOpenTabOptions } from '@opensumi/ide-core-browser';
+import {
+  QuickOpenItem,
+  HideReason,
+  QuickOpenActionProvider,
+  QuickOpenTabOptions,
+  IKeyMods,
+} from '@opensumi/ide-core-browser';
 import { VALIDATE_TYPE } from '@opensumi/ide-core-browser/lib/components';
 
 export const QuickOpenContext = React.createContext<{
@@ -41,7 +47,7 @@ export interface IQuickOpenCallbacks {
   /**
    * 获取用户是否按了 modifier 按键
    */
-  onKeyMods: (mods: KeyMods) => void;
+  onKeyMods: (mods: IKeyMods) => void;
 }
 
 export interface IQuickOpenModel {
@@ -105,9 +111,4 @@ export interface IQuickOpenWidget extends QuickOpenTabOptions {
   show(prefix: string, options: QuickOpenInputOptions): void;
   hide(reason?: HideReason): void;
   blur(): void;
-}
-
-export interface KeyMods {
-  ctrlCmd: boolean;
-  alt: boolean;
 }

--- a/packages/quick-open/src/browser/quick-open.type.ts
+++ b/packages/quick-open/src/browser/quick-open.type.ts
@@ -38,6 +38,10 @@ export interface IQuickOpenCallbacks {
    * 多选确定后的回调
    */
   onConfirm: (items: QuickOpenItem[]) => void;
+  /**
+   * 获取用户是否按了 modifier 按键
+   */
+  onKeyMods: (mods: KeyMods) => void;
 }
 
 export interface IQuickOpenModel {
@@ -101,4 +105,9 @@ export interface IQuickOpenWidget extends QuickOpenTabOptions {
   show(prefix: string, options: QuickOpenInputOptions): void;
   hide(reason?: HideReason): void;
   blur(): void;
+}
+
+export interface KeyMods {
+  ctrlCmd: boolean;
+  alt: boolean;
 }

--- a/packages/quick-open/src/browser/quick-open.widget.tsx
+++ b/packages/quick-open/src/browser/quick-open.widget.tsx
@@ -8,6 +8,7 @@ import {
   addDisposableListener,
   EventType,
   DisposableCollection,
+  IKeyMods,
 } from '@opensumi/ide-core-browser';
 import { VALIDATE_TYPE } from '@opensumi/ide-core-browser/lib/components';
 
@@ -17,7 +18,6 @@ import {
   IQuickOpenModel,
   IQuickOpenWidget,
   QuickOpenInputOptions,
-  KeyMods,
 } from './quick-open.type';
 
 @Injectable({ multiple: true })
@@ -118,10 +118,10 @@ export class QuickOpenWidget implements IQuickOpenWidget {
     return this._keepScrollPosition;
   }
 
+  private modifierListeners: DisposableCollection = new DisposableCollection();
+
   public renderTab?: () => React.ReactNode;
   public toggleTab?: () => void;
-
-  private modifierListeners: DisposableCollection = new DisposableCollection();
 
   constructor(public callbacks: IQuickOpenCallbacks) {}
 
@@ -186,7 +186,7 @@ export class QuickOpenWidget implements IQuickOpenWidget {
 
   private registerKeyModsListeners() {
     const listener = (e: KeyboardEvent | MouseEvent) => {
-      const keyMods: KeyMods = {
+      const keyMods: IKeyMods = {
         ctrlCmd: e.ctrlKey || e.metaKey,
         alt: e.altKey,
       };

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -1,7 +1,7 @@
 import type { IBufferRange, ILink, ILinkDecorations, IViewportRange, Terminal } from 'xterm';
 
 import { Injectable, Autowired } from '@opensumi/di';
-import { PreferenceService } from '@opensumi/ide-core-browser';
+import { addDisposableListener, PreferenceService } from '@opensumi/ide-core-browser';
 import {
   Disposable,
   IDisposable,
@@ -74,25 +74,18 @@ export class TerminalLink extends Disposable implements ILink {
     this._activateCallback(event, text);
   }
 
-  private _addDisposableListener(node: Node, type: string, handler: EventListener) {
-    node.addEventListener(type, handler);
-    return Disposable.create(() => {
-      node.removeEventListener(type, handler);
-    });
-  }
-
   hover(event: MouseEvent, text: string): void {
     // Listen for modifier before handing it off to the hover to handle so it gets disposed correctly
     this._hoverListeners = new DisposableCollection();
     this._hoverListeners.push(
-      this._addDisposableListener(document, 'keydown', (e) => {
+      addDisposableListener(document, 'keydown', (e) => {
         if (!e.repeat && this._isModifierDown(e)) {
           this._enableDecorations();
         }
       }),
     );
     this._hoverListeners.push(
-      this._addDisposableListener(document, 'keyup', (e) => {
+      addDisposableListener(document, 'keyup', (e) => {
         if (!e.repeat && !this._isModifierDown(e)) {
           this._disableDecorations();
         }
@@ -128,7 +121,7 @@ export class TerminalLink extends Disposable implements ILink {
 
     const origin = { x: event.pageX, y: event.pageY };
     this._hoverListeners.push(
-      this._addDisposableListener(document, 'mousemove', (e) => {
+      addDisposableListener(document, 'mousemove', (e) => {
         // Update decorations
         if (this._isModifierDown(e)) {
           this._enableDecorations();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
提供 quickOpen 通用的 modifier 按键监听方法，常用于 quickOpen 上监听用户是否按了 Cmd 或者 Ctrl 或者 Alt。

使用方法：
```
quickPickService.show(items, {
  onKeyMods: (mods: KeyMods) => console.log('mods:', mods),
});
```


### Changelog
提供 quickOpen 通用的 modifier 按键监听方法