### PR TITLE
fix: open file on the filetree should not focus on the editor

### DIFF
--- a/packages/file-tree-next/__tests__/browser/file-tree.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.test.ts
@@ -313,7 +313,7 @@ describe('FileTree should be work while on single workspace model', () => {
       handleItemClick(fileNode, TreeNodeType.TreeNode);
       const fileDecoration = decorations.getDecorations(fileNode);
       expect(fileDecoration?.classlist).toEqual([styles.mod_selected, styles.mod_focused]);
-      expect(openFile).toBeCalledWith(fileNode.uri, { disableNavigate: true, preview: true, focus: true });
+      expect(openFile).toBeCalledWith(fileNode.uri, { disableNavigate: true, preview: true });
     });
 
     it('Style decoration should be right while click with ctrl/cmd/shift', async () => {

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -775,7 +775,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
     this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, uri, {
       disableNavigate: true,
       preview,
-      focus: true,
     });
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

单击打开文件的情况下不应该把焦点放置到编辑器上

#1448 修改导致的问题

### Changelog

open file on the filetree should not focus on the editor