### PR TITLE
fix: editor tabs wrap and debug toolbar position

### DIFF
--- a/packages/core-browser/src/common/common.contribution.ts
+++ b/packages/core-browser/src/common/common.contribution.ts
@@ -51,9 +51,7 @@ export class ClientCommonContribution
     const overridePropertiesDefault = {
       'application.supportsOpenFolder': !!this.appConfig.isElectronRenderer && !this.appConfig.isRemote,
       'application.supportsOpenWorkspace': !!this.appConfig.isElectronRenderer && !this.appConfig.isRemote,
-      'debug.toolbar.top': this.appConfig.isElectronRenderer
-        ? LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT
-        : LAYOUT_VIEW_SIZE.MENUBAR_HEIGHT + LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT,
+      'debug.toolbar.top': this.appConfig.isElectronRenderer ? 0 : LAYOUT_VIEW_SIZE.MENUBAR_HEIGHT,
     };
     const keys = Object.keys(this.schema.properties);
     for (const key of keys) {

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -261,7 +261,6 @@ export const Tabs = ({ group }: ITabsProps) => {
   const renderTabContent = () => (
     <div
       className={styles.kt_editor_tabs_content}
-      style={{ height: LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT }}
       ref={contentRef as any}
       onDragLeave={() => {
         if (contentRef.current) {
@@ -303,7 +302,11 @@ export const Tabs = ({ group }: ITabsProps) => {
               [styles.kt_editor_tab_current]: group.currentResource === resource,
               [styles.kt_editor_tab_preview]: group.previewURI && group.previewURI.isEqual(resource.uri),
             })}
-            style={wrapMode && i === group.resources.length - 1 ? { marginRight: lastMarginRight } : {}}
+            style={
+              wrapMode && i === group.resources.length - 1
+                ? { marginRight: lastMarginRight, height: LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT }
+                : { height: LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT }
+            }
             onContextMenu={(event) => {
               tabTitleMenuService.show(event.nativeEvent.x, event.nativeEvent.y, resource && resource.uri, group);
               event.preventDefault();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before:

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/9823838/183362070-0baff6ea-6d0a-4a7a-8f6a-5e909e313b89.png">

after:

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/9823838/183361925-0d37ee6c-8809-41d8-ac62-0080352b5110.png">

### Changelog

fix editor tabs wrap and debug toolbar position