### PR TITLE
style: change text input selection color to default

### DIFF
--- a/packages/components/src/style/base.less
+++ b/packages/components/src/style/base.less
@@ -498,7 +498,6 @@ mark {
 }
 
 ::selection {
-  color: @text-color-inverse;
   background: @text-selection-bg;
 }
 

--- a/packages/components/src/style/base.less
+++ b/packages/components/src/style/base.less
@@ -497,10 +497,6 @@ mark {
   background-color: @yellow-1;
 }
 
-::selection {
-  background: @text-selection-bg;
-}
-
 // Utility classes
 .clearfix {
   .clearfix();

--- a/packages/core-browser/src/style/normalize.less
+++ b/packages/core-browser/src/style/normalize.less
@@ -78,6 +78,11 @@ html {
   li {
     list-style: none;
   }
+
+  ::selection {
+    color: inherit;
+    background: var(--editor-selectionBackground);
+  }
 }
 
 /* ---- 该样式主要用于让带 tabindex='-1' 的元素焦点态时拥有高亮边框，以便于实现如Tree，List组件焦点态时的自动高亮边框效果  ---- */

--- a/packages/core-browser/src/style/utilities.less
+++ b/packages/core-browser/src/style/utilities.less
@@ -1,11 +1,3 @@
-.kt-text-desc {
-  color: var(--descriptionForeground);
-}
-
-.kt-text-error {
-  color: var(--errorForeground);
-}
-
 .none-pointer-event {
   pointer-events: none;
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution
在 component 中使用 less function ，所以 less 的变量是固定值，也一定会出现这种问题。现在直接使用默认值即可。

<img width="352" alt="Context Mapper 6 6 1" src="https://user-images.githubusercontent.com/2226423/183585484-bca52d37-5909-46de-8110-25669a17476a.png">

<img width="355" alt="Changes" src="https://user-images.githubusercontent.com/2226423/183585498-0028fc86-812d-4c0f-aab0-8d814f9a1459.png">

<img width="636" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/2226423/183585517-cf0fce50-8d13-4296-85df-8f30df24ca2c.png">

### Changelog
改变选中文本后的颜色为默认值