### PR TITLE
chore: search panel automatically sets selected text

### DIFF
--- a/packages/search/src/browser/search.contribution.ts
+++ b/packages/search/src/browser/search.contribution.ts
@@ -280,7 +280,6 @@ export class SearchContribution
     const handler = this.mainLayoutService.getTabbarHandler(SEARCH_CONTAINER_ID);
     if (handler) {
       handler.onActivate(() => {
-        this.searchBrowserService.setSearchValueFromActivatedEditor();
         this.searchBrowserService.searchHistory.initSearchHistory();
         this.searchBrowserService.focus();
       });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🧹 Chores

### Background or solution
- 编辑器选中文本，在点击搜索面板后停止自动赋值。这会导致用户之前的搜索结果变了，然后重新搜索，这里优化一下交互，点击搜索面板，不会重新赋值。
- 其它情况，比如通过快捷键，通过 quickpick 等行为去触发全局搜索，就会自动赋值。


上面这两种行为和其它编辑器一致。

### Changelog
取消搜索面板自动设置来自编辑器的选中文本
