### PR TITLE
fix: auto focus when created new file

### DIFF
--- a/packages/file-tree-next/src/browser/services/file-tree-api.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-api.service.ts
@@ -195,7 +195,7 @@ export class FileTreeAPI implements IFileTreeAPI {
     } catch (e) {
       return e.message;
     }
-    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, uri, { disableNavigate: true });
+    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, uri, { disableNavigate: true, focus: true });
     return;
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
- 通过文件树新建文件后自动聚焦