### PR TITLE
style: use css variable as icon hover background

### DIFF
--- a/packages/core-browser/src/components/actions/styles.module.less
+++ b/packages/core-browser/src/components/actions/styles.module.less
@@ -70,7 +70,7 @@
 
   &:not(.disabled):hover {
     border-radius: 4px;
-    background-color: rgba(184, 184, 184, 0.31);
+    background-color: var(--kt-defaultButton-hoverBackground);
   }
 
   &.selected {

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -205,6 +205,7 @@
         }
       }
       .kt_editor_close_icon {
+        margin-right: 0 !important;
         &::before {
           font-size: 14px;
         }

--- a/packages/terminal-next/src/browser/component/tab.module.less
+++ b/packages/terminal-next/src/browser/component/tab.module.less
@@ -134,7 +134,7 @@
   &:hover {
     color: var(--kt-icon-hoverForeground);
     border-radius: 4px;
-    background-color: rgba(184, 184, 184, 0.31);
+    background-color: var(--kt-defaultButton-hoverBackground);
   }
 }
 
@@ -158,7 +158,7 @@
   font-size: 12px !important;
   &:hover {
     border-radius: 4px;
-    background-color: rgba(184, 184, 184, 0.31);
+    background-color: var(--kt-defaultButton-hoverBackground);
   }
 }
 

--- a/packages/theme/src/common/color-tokens/custom/button.ts
+++ b/packages/theme/src/common/color-tokens/custom/button.ts
@@ -277,7 +277,7 @@ export const ktDefaultButtonBorder = registerColor(
 );
 export const ktDefaultButtonHoverBackground = registerColor(
   'kt.defaultButton.hoverBackground',
-  { dark: '#5F656B', light: '#FFFFFF', hc: null },
+  { dark: '#b8b8b82f', light: '#b8b8b82f', hc: null },
   localize('ktDefaultButtonHoverBackground', 'Danger Ghost Button Hover Background color.'),
 );
 export const ktDefaultButtonHoverForeground = registerColor(


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

统一框架内所有按钮 Hover 默认样式

before:

<img width="508" alt="image" src="https://user-images.githubusercontent.com/9823838/184574829-94a2b711-3cf2-4e1b-a849-e867045f141d.png">

after:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/9823838/184574753-c296fc31-a8ad-46a7-b9fb-8761da74e38d.png">


### Changelog

use css variable as icon hover background