### PR TITLE
fix: remove treeview cached data

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -729,6 +729,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
         } catch (e) {
           childrens = [];
         }
+
         if (token?.isCancellationRequested) {
           return;
         }

--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -448,6 +448,7 @@ export class TreeViewDataProvider extends Tree {
       if (children && Array.isArray(children)) {
         for (const child of children) {
           const node = await this.createTreeNode(child, parent);
+          this.treeItemId2TreeNode.set(child.id, node);
           nodes.push(node);
         }
       }

--- a/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
@@ -461,11 +461,6 @@ class ExtHostTreeView<T> implements IDisposable {
     // 如果存在缓存数据，优先从缓存中获取子节点
     if (!cachedElement && this.roots) {
       return this.roots;
-    } else if (cachedElement) {
-      const cache = this.nodes.get(cachedElement);
-      if (cache) {
-        return cache;
-      }
     }
     let children: TreeViewItem[] | undefined;
     this.isFetchingChildren = true;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
- 去除可能导致加载异常的 treeview 缓存