### PR TITLE
fix: saving untitled file on Windows will occur crash

### DIFF
--- a/packages/editor/src/browser/untitled-resource.ts
+++ b/packages/editor/src/browser/untitled-resource.ts
@@ -17,6 +17,7 @@ import {
   formatLocalize,
   MessageType,
   path,
+  isWindows,
 } from '@opensumi/ide-core-browser';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import { IDialogService } from '@opensumi/ide-overlay';
@@ -122,7 +123,7 @@ export class UntitledSchemeDocumentProvider implements IEditorDocumentModelConte
     const saveUri = await this.commandService.tryExecuteCommand<URI>('file.save', {
       showNameInput: true,
       defaultFileName: name || uri.displayName,
-      defaultUri: URI.file(defaultPath),
+      defaultUri: URI.file(isWindows ? defaultPath.replaceAll('\\', '/') : defaultPath),
     });
     if (saveUri) {
       await this.editorDocumentModelService.saveEditorDocumentModel(

--- a/packages/file-tree-next/__tests__/browser/dialog/file-dialog.service.test.ts
+++ b/packages/file-tree-next/__tests__/browser/dialog/file-dialog.service.test.ts
@@ -116,7 +116,7 @@ describe('FileDialogService should be work', () => {
   it('getDirectoryList method should be work', async () => {
     await fileTreeDialogService.resolveRoot(rootUri.toString());
     const directory = fileTreeDialogService.getDirectoryList();
-    expect(directory.length === 1).toBeTruthy();
+    expect(directory.length === 2).toBeTruthy();
   });
 
   it('sortComparator method should be work', () => {

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
@@ -81,9 +81,13 @@ export class FileTreeDialogService extends Tree {
       return directory;
     }
     let root = new URI(this.workspaceRoot.uri);
-    if (root.path.toString() !== '/') {
-      while (root.path.toString() !== '/') {
-        directory.push(root.path.toString());
+    if (root && root.parent) {
+      while (root.parent) {
+        const folder = root.codeUri.fsPath;
+        if (directory.indexOf(folder) >= 0) {
+          break;
+        }
+        directory.push(folder);
         root = root.parent;
       }
     } else {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1511.
close #1358.

### Changelog

fix saving untitled file on Windows will occur crash