### PR TITLE
feat: support markdown description of preference item

### DIFF
--- a/packages/core-common/src/preferences/preference-schema.ts
+++ b/packages/core-common/src/preferences/preference-schema.ts
@@ -78,6 +78,9 @@ export interface PreferenceItem {
   [name: string]: any;
   overridable?: boolean;
 
+  description?: string;
+  markdownDescription?: string;
+
   deprecationMessage?: string;
   markdownDeprecationMessage?: string;
 }

--- a/packages/extension/src/browser/vscode/contributes/configuration.ts
+++ b/packages/extension/src/browser/vscode/contributes/configuration.ts
@@ -31,22 +31,30 @@ export class ConfigurationContributionPoint extends VSCodeContributePoint<Prefer
 
   contribute() {
     let configurations = this.json;
-    let properties = {};
+    // 当前函数里只创建声明这一次变量，然后后面给这个函数赋值
+    let tmpProperties = {};
     if (!Array.isArray(configurations)) {
       configurations = [configurations];
     }
     for (const configuration of configurations) {
       if (configuration && configuration.properties) {
         for (const prop of Object.keys(configuration.properties)) {
-          properties[prop] = configuration.properties[prop];
-          if (configuration.properties[prop].description) {
-            properties[prop].description = replaceLocalizePlaceholder(
-              configuration.properties[prop].description,
+          const originalConfiguration = configuration.properties[prop];
+          tmpProperties[prop] = originalConfiguration;
+          if (originalConfiguration.description) {
+            tmpProperties[prop].description = replaceLocalizePlaceholder(
+              originalConfiguration.description,
+              this.extension.id,
+            );
+          }
+          if (originalConfiguration.markdownDescription) {
+            tmpProperties[prop].markdownDescription = replaceLocalizePlaceholder(
+              originalConfiguration.markdownDescription,
               this.extension.id,
             );
           }
         }
-        configuration.properties = properties;
+        configuration.properties = tmpProperties;
         configuration.title =
           replaceLocalizePlaceholder(configuration.title, this.extension.id) || this.extension.packageJSON.name;
         this.updateConfigurationSchema(configuration);
@@ -56,7 +64,7 @@ export class ConfigurationContributionPoint extends VSCodeContributePoint<Prefer
             preferences: Object.keys(configuration.properties),
           }),
         );
-        properties = {};
+        tmpProperties = {};
       }
     }
   }

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -257,10 +257,12 @@ export class PreferenceSettingsService implements IPreferenceSettingsService {
           const schema = this.schemaProvider.getPreferenceProperty(prefId);
           const prefLabel = typeof pref === 'string' ? toPreferenceReadableName(pref) : getPreferenceItemLabel(pref);
           const description = schema && replaceLocalizePlaceholder(schema.description);
+          const markdownDescription = schema && replaceLocalizePlaceholder(schema.markdownDescription);
           return (
             this.isContainSearchValue(prefId, search) ||
             this.isContainSearchValue(prefLabel, search) ||
-            (description && this.isContainSearchValue(description, search))
+            (description && this.isContainSearchValue(description, search)) ||
+            (markdownDescription && this.isContainSearchValue(markdownDescription, search))
           );
         });
         if (sec.preferences.length > 0) {

--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -16,6 +16,8 @@ import {
   useInjectable,
   formatLocalize,
   ILogger,
+  IOpenerService,
+  toMarkdown,
 } from '@opensumi/ide-core-browser';
 
 import { toPreferenceReadableName, getPreferenceItemLabel } from '../common';
@@ -218,6 +220,22 @@ const renderDescriptionExpression = (des: string) => {
   }
 };
 
+const renderDescription = (data: { description?: string; markdownDescription?: string }) => {
+  const description = data.description ?? data.markdownDescription;
+  if (!description) {
+    return null;
+  }
+  const openerService: IOpenerService = useInjectable(IOpenerService);
+
+  return (
+    <div className={styles.desc}>
+      {data.markdownDescription
+        ? toMarkdown(data.markdownDescription, openerService)
+        : renderDescriptionExpression(description)}
+    </div>
+  );
+};
+
 const SettingStatus = ({
   preferenceName,
   scope,
@@ -299,9 +317,7 @@ function InputPreferenceItem({
           showReset={isModified}
         />
       </div>
-      {schema && schema.description && (
-        <div className={styles.desc}>{renderDescriptionExpression(schema.description)}</div>
-      )}
+      {renderDescription(schema)}
       <div className={styles.control_wrap}>
         <div className={styles.text_control}>
           <ValidateInput
@@ -361,11 +377,7 @@ function CheckboxPreferenceItem({
           showReset={isModified}
         />
       </div>
-      {description ? (
-        <div>
-          <div className={styles.desc}>{renderDescriptionExpression(description)}</div>
-        </div>
-      ) : undefined}
+      {renderDescription(schema)}
     </div>
   );
 }
@@ -469,9 +481,7 @@ function SelectPreferenceItem({
           showReset={isModified}
         />
       </div>
-      {schema && schema.description && (
-        <div className={styles.desc}>{renderDescriptionExpression(schema.description)}</div>
-      )}
+      {renderDescription(schema)}
       <div className={styles.control_wrap}>
         <Select
           dropdownRenderType='absolute'
@@ -515,9 +525,7 @@ function EditInSettingsJsonPreferenceItem({
           showReset={hasValueInScope}
         />
       </div>
-      {schema && schema.description && (
-        <div className={styles.desc}>{renderDescriptionExpression(schema.description)}</div>
-      )}
+      {renderDescription(schema)}
       <div className={styles.control_wrap}>
         <a onClick={editSettingsJson}>{localize('preference.editSettingsJson')}</a>
       </div>
@@ -668,9 +676,7 @@ function StringArrayPreferenceItem({
           showReset={isModified}
         />
       </div>
-      {schema && schema.description && (
-        <div className={styles.desc}>{renderDescriptionExpression(schema.description)}</div>
-      )}
+      {renderDescription(schema)}
       <div className={styles.control_wrap}>
         <ul className={styles.array_items_wrapper}>
           {items}

--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -156,6 +156,19 @@
         opacity: 0.75;
         color: var(--descriptionForeground);
         margin-bottom: 5px;
+        ul {
+          list-style: none;
+        }
+        code {
+          color: var(--editor-foreground);
+        }
+        ul li::before {
+          content: '\2022'; /* content: \2022 is the CSS Code/unicode for a bullet */
+          font-weight: bold;
+          display: inline-block;
+          width: 1em;
+          margin-left: -1em;
+        }
       }
       .control_wrap {
         input[type='number']::-webkit-outer-spin-button,


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

Previous：

<img width="1021" alt="CleanShot 2022-08-16 at 15 49 42@2x" src="https://user-images.githubusercontent.com/13938334/184843429-0a8bb538-7999-46a0-80bb-c47e87da478a.png">

Now:
<img width="431" alt="CleanShot 2022-08-16 at 16 59 33@2x" src="https://user-images.githubusercontent.com/13938334/184846101-78bd16a8-1cdc-4812-a649-a6c693857009.png">
<img width="414" alt="CleanShot 2022-08-16 at 17 27 01@2x" src="https://user-images.githubusercontent.com/13938334/184846230-0717a7e7-911b-4cff-b7ac-04616b3c91a1.png">


### Changelog

support display configuration markdown description
