### PR TITLE
fix: 修复终端面板未激活情况下底部工具栏功能缺失问题

### DIFF
--- a/packages/main-layout/src/browser/main-layout.contribution.ts
+++ b/packages/main-layout/src/browser/main-layout.contribution.ts
@@ -236,11 +236,6 @@ export class MainLayoutModuleContribution
       },
     });
     commands.registerCommand(WORKBENCH_ACTION_CLOSEPANEL);
-    commands.registerCommand(TOGGLE_BOTTOM_PANEL_COMMAND, {
-      execute: (show?: boolean, size?: number) => {
-        this.mainLayoutService.toggleSlot(SlotLocation.bottom, show, size);
-      },
-    });
     commands.registerCommand(IS_VISIBLE_BOTTOM_PANEL_COMMAND, {
       execute: () => this.mainLayoutService.getTabbarService('bottom').currentContainerId !== '',
     });
@@ -255,16 +250,16 @@ export class MainLayoutModuleContribution
         this.mainLayoutService.setFloatSize(size);
       },
     });
-    commands.registerCommand(EXPAND_BOTTOM_PANEL, {
-      execute: () => {
-        this.mainLayoutService.expandBottom(true);
-      },
-    });
-    commands.registerCommand(RETRACT_BOTTOM_PANEL, {
-      execute: () => {
-        this.mainLayoutService.expandBottom(false);
-      },
-    });
+    // commands.registerCommand(EXPAND_BOTTOM_PANEL, {
+    //   execute: () => {
+    //     this.mainLayoutService.expandBottom(true);
+    //   },
+    // });
+    // commands.registerCommand(RETRACT_BOTTOM_PANEL, {
+    //   execute: () => {
+    //     this.mainLayoutService.expandBottom(false);
+    //   },
+    // });
 
     commands.registerCommand(
       {

--- a/packages/main-layout/src/browser/main-layout.contribution.ts
+++ b/packages/main-layout/src/browser/main-layout.contribution.ts
@@ -250,16 +250,6 @@ export class MainLayoutModuleContribution
         this.mainLayoutService.setFloatSize(size);
       },
     });
-    // commands.registerCommand(EXPAND_BOTTOM_PANEL, {
-    //   execute: () => {
-    //     this.mainLayoutService.expandBottom(true);
-    //   },
-    // });
-    // commands.registerCommand(RETRACT_BOTTOM_PANEL, {
-    //   execute: () => {
-    //     this.mainLayoutService.expandBottom(false);
-    //   },
-    // });
 
     commands.registerCommand(
       {

--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -149,8 +149,27 @@ export class TabbarService extends WithEventBus {
     });
     this.activatedKey = this.contextKeyService.createKey(getTabbarCtxKey(this.location), '');
     if (this.location === 'bottom') {
+      this.registerPanelCommands();
       this.registerPanelMenus();
     }
+  }
+
+  registerPanelCommands(): void {
+    this.commandRegistry.registerCommand(EXPAND_BOTTOM_PANEL, {
+      execute: () => {
+        this.layoutService.expandBottom(true);
+      },
+    });
+    this.commandRegistry.registerCommand(RETRACT_BOTTOM_PANEL, {
+      execute: () => {
+        this.layoutService.expandBottom(false);
+      },
+    });
+    this.commandRegistry.registerCommand(TOGGLE_BOTTOM_PANEL_COMMAND, {
+      execute: (show?: boolean, size?: number) => {
+        this.layoutService.toggleSlot(SlotLocation.bottom, show, size);
+      },
+    });
   }
 
   public getContainerState(containerId: string) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1517.

### Changelog

修复终端面板未激活情况下底部工具栏功能缺失问题