### PR TITLE
feat: shortcut adaptation of ctrl+alt+s

### DIFF
--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -457,6 +457,7 @@ export class ExtensionCommandContribution implements CommandContribution {
       // others
       VSCodeBuiltinCommands.RELOAD_WINDOW,
       VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_SETTINGS,
+      VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_GLOBAL_SETTINGS,
       VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_SETTINGS_JSON,
     ].forEach((command) => {
       registry.registerCommand(command);

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -1,4 +1,4 @@
-import { FILE_COMMANDS, Command, EDITOR_COMMANDS } from '@opensumi/ide-core-browser';
+import { FILE_COMMANDS, Command, EDITOR_COMMANDS, COMMON_COMMANDS } from '@opensumi/ide-core-browser';
 import { DEBUG_COMMANDS } from '@opensumi/ide-debug/lib/browser/debug-contribution';
 import { TERMINAL_COMMANDS } from '@opensumi/ide-terminal-next';
 
@@ -232,6 +232,11 @@ export const COPY_RELATIVE_FILE_PATH: Command = {
 export const SETTINGS_COMMAND_OPEN_SETTINGS: Command = {
   id: 'workbench.action.openSettings',
   delegate: 'core.openpreference',
+};
+
+export const SETTINGS_COMMAND_OPEN_GLOBAL_SETTINGS: Command = {
+  id: 'workbench.action.openGlobalSettings',
+  delegate: COMMON_COMMANDS.OPEN_PREFERENCES.id,
 };
 
 export const SETTINGS_COMMAND_OPEN_SETTINGS_JSON: Command = {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution
#1105 的相关问题
<html>
<body>
<!--StartFragment--><!DOCTYPE html>

Linux, Windows | macOS | Feature | 插件自身是否支持 | 对应的command | OpenSumi 是否有实现对应插件命令
-- | -- | -- | -- | -- | --
ctrl+alt+s | cmd+, | Open Settings dialog | ✅ | workbench.action.openGlobalSettings | N/A
ctrl+alt+s | cmd+numpad_separator | Open Settings dialog | ✅ | workbench.action.openGlobalSettings | N/A

<!--EndFragment-->
</body>
</html>

### Changelog
通过命令代理，借助现有的 `OPEN_PREFERENCES` 适配插件的 `ctrl+alt+s` 快捷键打开设置页面功能。
before:
![before](https://user-images.githubusercontent.com/85668115/184871900-fae53397-a6af-410d-b8c4-322a742d7c50.jpg)

after:
![Dingtalk_20220816192017](https://user-images.githubusercontent.com/85668115/184871670-99346fa9-938f-4908-9d86-19f69f1dd9da.jpg)
感觉命令注册部分可能存在重复注册的问题。
