### PR TITLE
style: background mode icon should on position 0 0

### DIFF
--- a/packages/theme/src/browser/icon.service.ts
+++ b/packages/theme/src/browser/icon.service.ts
@@ -185,7 +185,7 @@ export class IconService extends WithEventBus implements IIconService {
   protected getBackgroundStyleSheet(iconUrl: string, className: string, baseTheme?: string): string {
     const cssRule = `${
       baseTheme || ''
-    } .${className} {background: url("${iconUrl}") no-repeat 50% 50%;background-size:cover;}`;
+    } .${className} {background: url("${iconUrl}") no-repeat 0 0;background-size:cover;}`;
     return cssRule;
   }
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

fix:

![image](https://user-images.githubusercontent.com/9823838/185022408-8d445b84-2ecc-4305-8d68-4a5be0c612f9.png)

### Changelog

the background mode icon should on position 0 0
