### PR TITLE
fix: remove useless textmate theme init logic

### DIFF
--- a/packages/monaco/src/browser/monaco.contribution.ts
+++ b/packages/monaco/src/browser/monaco.contribution.ts
@@ -267,9 +267,6 @@ export class MonacoClientContribution
 
   private initTextmateService() {
     this.textmateService.init();
-    const currentTheme = this.themeService.getCurrentThemeSync();
-    const themeData = currentTheme.themeData;
-    this.textmateService.setTheme(themeData);
     this.textmateService.initialized = true;
   }
 


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes
### Background or solution

### Changelog
- 去除多余的 textmateService 主题初始化逻辑