### PR TITLE
chore: add extension api to exemptLabels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,7 @@ exemptLabels:
   - feature
   - help wanted
   - good first issue
+  - extension api
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

add extension api to exemptLabels

### Changelog
