### PR TITLE
feat: shortcut-adaptation-of-alt+0

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -793,6 +793,11 @@ export namespace MARKER_COMMANDS {
     id: 'marker.action.showErrorsWarnings',
     category: CATEGORY,
   };
+
+  export const TOGGLE_SHOW_ERRORS_WARNINGS = {
+    id: 'marker.action.toggleShowErrorsWarnings',
+    category: CATEGORY,
+  };
 }
 
 export { TERMINAL_COMMANDS } from '@opensumi/ide-core-common/lib/commands/terminal';

--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -456,6 +456,7 @@ export class ExtensionCommandContribution implements CommandContribution {
       VSCodeBuiltinCommands.NEW_WORKBENCH_VIEW_TERMINAL,
       // marker builtin commands
       VSCodeBuiltinCommands.MARKER_COMMAND_SHOW_ERRORS_WARNINGS,
+      VSCodeBuiltinCommands.MARKER_COMMAND_TOGGLE_SHOW_ERRORS_WARNINGS,
       // others
       VSCodeBuiltinCommands.RELOAD_WINDOW,
       VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_SETTINGS,

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -322,3 +322,8 @@ export const MARKER_COMMAND_SHOW_ERRORS_WARNINGS: Command = {
   id: 'workbench.action.showErrorsWarnings',
   delegate: MARKER_COMMANDS.SHOW_ERRORS_WARNINGS.id,
 };
+
+export const MARKER_COMMAND_TOGGLE_SHOW_ERRORS_WARNINGS: Command = {
+  id: 'workbench.actions.view.problems',
+  delegate: MARKER_COMMANDS.TOGGLE_SHOW_ERRORS_WARNINGS.id,
+};

--- a/packages/markers/src/browser/markers-contribution.ts
+++ b/packages/markers/src/browser/markers-contribution.ts
@@ -65,5 +65,17 @@ export class MarkersContribution implements CommandContribution, ComponentContri
         },
       },
     );
+
+    commands.registerCommand(
+      { id: MARKER_COMMANDS.TOGGLE_SHOW_ERRORS_WARNINGS.id },
+      {
+        execute: () => {
+          const tabbarHandler = this.mainlayoutService.getTabbarHandler(MARKER_CONTAINER_ID);
+          if (tabbarHandler) {
+            tabbarHandler.isActivated() ? tabbarHandler.deactivate() : tabbarHandler.activate();
+          }
+        },
+      },
+    );
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
#1105 的相关问题

<html>
<body>
<!--StartFragment--><!DOCTYPE html>

Linux, Windows | macOS | Feature | 插件自身是否支持 | 对应的command | OpenSumi 是否有实现对应插件命令
-- | -- | -- | -- | -- | --
alt+0 | cmd+0 | Activate Messages window (Problems) | ✅ | workbench.actions.view.problems | N/A
alt+numpad0 | cmd+numpad0 | Activate Messages window (Problems) | ✅ | workbench.actions.view.problems | N/A

<!--EndFragment-->
</body>
</html>

### Changelog
新增一个 `TOGGLE_SHOW_ERRORS_WARNINGS` 命令，然后通过命令代理，适配插件的快捷键 `alt+0` 和`alt+numpand0`。
before:
![before](https://user-images.githubusercontent.com/85668115/185360035-2112d557-3f90-435b-bc31-89b44c347e35.jpg)

after:
![after](https://user-images.githubusercontent.com/85668115/185359853-85cd4ba6-db94-4511-9488-49fbbdbf9694.jpg)



