### PR TITLE
feat: shortcut adaptation of alt+1

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -795,4 +795,13 @@ export namespace MARKER_COMMANDS {
   };
 }
 
+export namespace EXPLORER_COMMANDS {
+  const CATEGORY = 'explorer';
+
+  export const TOGGLE_VISIBILITY = {
+    id: 'explorer.action.toggleVisibility',
+    category: CATEGORY,
+  };
+}
+
 export { TERMINAL_COMMANDS } from '@opensumi/ide-core-common/lib/commands/terminal';

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "2.19.8",
-    "@opensumi/ide-dev-tool": "^1.3.1"
+    "@opensumi/ide-dev-tool": "^1.3.1",
+    "@opensumi/ide-main-layout": "2.19.8"
   }
 }

--- a/packages/explorer/src/browser/explorer-contribution.ts
+++ b/packages/explorer/src/browser/explorer-contribution.ts
@@ -1,17 +1,28 @@
-
 import { Autowired } from '@opensumi/di';
-import { localize, Domain, IExtensionsPointService, formatLocalize, ClientAppContribution } from '@opensumi/ide-core-browser';
+import {
+  localize,
+  Domain,
+  IExtensionsPointService,
+  formatLocalize,
+  ClientAppContribution,
+  CommandContribution,
+  CommandRegistry,
+  EXPLORER_COMMANDS,
+} from '@opensumi/ide-core-browser';
 import { getIcon } from '@opensumi/ide-core-browser';
 import { browserViews } from '@opensumi/ide-core-browser/lib/extensions/schema/browserViews';
 import { ComponentContribution, ComponentRegistry } from '@opensumi/ide-core-browser/lib/layout';
+import { IMainLayoutService } from '@opensumi/ide-main-layout';
 
 export const EXPLORER_CONTAINER_ID = 'explorer';
 
-@Domain(ClientAppContribution, ComponentContribution)
-export class ExplorerContribution implements ComponentContribution {
-
+@Domain(ClientAppContribution, CommandContribution, ComponentContribution)
+export class ExplorerContribution implements CommandContribution, ComponentContribution {
   @Autowired(IExtensionsPointService)
   protected readonly extensionsPointService: IExtensionsPointService;
+
+  @Autowired(IMainLayoutService)
+  protected readonly mainlayoutService: IMainLayoutService;
 
   // Explorer 只注册容器
   registerComponent(registry: ComponentRegistry) {
@@ -20,6 +31,17 @@ export class ExplorerContribution implements ComponentContribution {
       title: localize('explorer.title'),
       priority: 10,
       containerId: EXPLORER_CONTAINER_ID,
+    });
+  }
+
+  registerCommands(commands: CommandRegistry): void {
+    commands.registerCommand(EXPLORER_COMMANDS.TOGGLE_VISIBILITY, {
+      execute: () => {
+        const tabbarHandler = this.mainlayoutService.getTabbarHandler(EXPLORER_CONTAINER_ID);
+        if (tabbarHandler) {
+          tabbarHandler.isActivated() ? tabbarHandler.deactivate() : tabbarHandler.activate();
+        }
+      },
     });
   }
 
@@ -33,5 +55,4 @@ export class ExplorerContribution implements ComponentContribution {
       },
     });
   }
-
 }

--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -450,6 +450,7 @@ export class ExtensionCommandContribution implements CommandContribution {
       // explorer builtin commands
       VSCodeBuiltinCommands.REVEAL_IN_EXPLORER,
       VSCodeBuiltinCommands.OPEN_FOLDER,
+      VSCodeBuiltinCommands.EXPLORER_COMMAND_TOGGLE_VISIBILITY,
       // terminal builtin commands
       VSCodeBuiltinCommands.CLEAR_TERMINAL,
       VSCodeBuiltinCommands.TOGGLE_WORKBENCH_VIEW_TERMINAL,

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -1,4 +1,11 @@
-import { FILE_COMMANDS, Command, EDITOR_COMMANDS, COMMON_COMMANDS, MARKER_COMMANDS } from '@opensumi/ide-core-browser';
+import {
+  FILE_COMMANDS,
+  Command,
+  EDITOR_COMMANDS,
+  COMMON_COMMANDS,
+  MARKER_COMMANDS,
+  EXPLORER_COMMANDS,
+} from '@opensumi/ide-core-browser';
 import { DEBUG_COMMANDS } from '@opensumi/ide-debug/lib/browser/debug-contribution';
 import { TERMINAL_COMMANDS } from '@opensumi/ide-terminal-next';
 
@@ -312,6 +319,11 @@ export const EDITOR_SHOW_ALL_SYMBOLS: Command = {
 export const REVEAL_IN_EXPLORER: Command = {
   id: 'revealInExplorer',
   delegate: FILE_COMMANDS.REVEAL_IN_EXPLORER.id,
+};
+
+export const EXPLORER_COMMAND_TOGGLE_VISIBILITY: Command = {
+  id: 'workbench.action.toggleSidebarVisibility',
+  delegate: EXPLORER_COMMANDS.TOGGLE_VISIBILITY.id,
 };
 
 export const GET_EXTENSION: Command = {


### PR DESCRIPTION
### Types
- [x] 🎉 New Features

### Background or solution
#1105 的相关问题
<html>
<body>
<!--StartFragment--><!DOCTYPE html>

Linux, Windows | macOS | Feature | 插件自身是否支持 | 对应的command | OpenSumi 是否有实现对应插件命令
-- | -- | -- | -- | -- | --
alt+1 | cmd+1 | Close corresponding tool window (Explorer) | ✅ | workbench.action.toggleSidebarVisibility | N/A
alt+numpad1 | cmd+numpad1 | Close corresponding tool window (Explorer) | ✅ | workbench.action.toggleSidebarVisibility | N/A

<!--EndFragment-->
</body>
</html>


### Changelog
在 `EXPLORER_COMMANDS` 命名空间内新增 `TOGGLE_VISIBILITY` 命令，通过命令代理适配插件的 `alt+1` 和 `alt+numpad1`快捷键。

before：
![before](https://user-images.githubusercontent.com/85668115/185433674-e432f3cf-68e7-4aef-9d61-fc4d9ea6e64c.jpg)

after：
![after](https://user-images.githubusercontent.com/85668115/185433698-5470575b-c96c-4546-ae7e-4ac4bdbd9e7b.jpg)


