### PR TITLE
fix: toolbar action button not middle

### DIFF
--- a/packages/core-browser/src/style/toolbar.less
+++ b/packages/core-browser/src/style/toolbar.less
@@ -34,6 +34,10 @@
     }
   }
 
+  .kt-toolbar-action-btn-wrapper .kt-button {
+    vertical-align: middle;
+  }
+
   // button
   .kt-toolbar-action-btn {
     display: flex;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复 toolbar 的按钮不居中的问题
