### PR TITLE
feat: shortcut adaptation of alt+9

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -800,4 +800,13 @@ export namespace MARKER_COMMANDS {
   };
 }
 
+export namespace SCM_COMMANDS {
+  const CATEGORY = 'scm';
+
+  export const TOGGLE_VISIBILITY = {
+    id: 'scm.action.toggleVisibility',
+    category: CATEGORY,
+  };
+}
+
 export { TERMINAL_COMMANDS } from '@opensumi/ide-core-common/lib/commands/terminal';

--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -450,6 +450,8 @@ export class ExtensionCommandContribution implements CommandContribution {
       // explorer builtin commands
       VSCodeBuiltinCommands.REVEAL_IN_EXPLORER,
       VSCodeBuiltinCommands.OPEN_FOLDER,
+      // scm builtin commands
+      VSCodeBuiltinCommands.SCM_COMMAND_TOGGLE_VISIBILITY,
       // terminal builtin commands
       VSCodeBuiltinCommands.CLEAR_TERMINAL,
       VSCodeBuiltinCommands.TOGGLE_WORKBENCH_VIEW_TERMINAL,

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -1,4 +1,11 @@
-import { FILE_COMMANDS, Command, EDITOR_COMMANDS, COMMON_COMMANDS, MARKER_COMMANDS } from '@opensumi/ide-core-browser';
+import {
+  FILE_COMMANDS,
+  Command,
+  EDITOR_COMMANDS,
+  COMMON_COMMANDS,
+  MARKER_COMMANDS,
+  SCM_COMMANDS,
+} from '@opensumi/ide-core-browser';
 import { DEBUG_COMMANDS } from '@opensumi/ide-debug/lib/browser/debug-contribution';
 import { TERMINAL_COMMANDS } from '@opensumi/ide-terminal-next';
 
@@ -326,4 +333,9 @@ export const MARKER_COMMAND_SHOW_ERRORS_WARNINGS: Command = {
 export const MARKER_COMMAND_TOGGLE_SHOW_ERRORS_WARNINGS: Command = {
   id: 'workbench.actions.view.problems',
   delegate: MARKER_COMMANDS.TOGGLE_SHOW_ERRORS_WARNINGS.id,
+};
+
+export const SCM_COMMAND_TOGGLE_VISIBILITY: Command = {
+  id: 'workbench.action.toggleSidebarVisibility',
+  delegate: SCM_COMMANDS.TOGGLE_VISIBILITY.id,
 };

--- a/packages/scm/src/browser/scm.contribution.ts
+++ b/packages/scm/src/browser/scm.contribution.ts
@@ -5,6 +5,7 @@ import {
   PreferenceService,
   getExternalIcon,
   IExtensionsPointService,
+  SCM_COMMANDS,
 } from '@opensumi/ide-core-browser';
 import { getIcon } from '@opensumi/ide-core-browser';
 import { Disposable, URI } from '@opensumi/ide-core-browser';
@@ -22,7 +23,7 @@ import {
 } from '@opensumi/ide-core-common';
 import { Domain } from '@opensumi/ide-core-common/lib/di-helper';
 import { WorkbenchEditorService, EditorCollectionService, IEditor } from '@opensumi/ide-editor/lib/common';
-import { IViewsRegistry, MainLayoutContribution } from '@opensumi/ide-main-layout';
+import { IMainLayoutService, IViewsRegistry, MainLayoutContribution } from '@opensumi/ide-main-layout';
 
 import {
   scmContainerId,
@@ -78,6 +79,9 @@ export class SCMContribution
 
   @Autowired(EditorCollectionService)
   private readonly editorCollectionService: EditorCollectionService;
+
+  @Autowired(IMainLayoutService)
+  protected readonly mainlayoutService: IMainLayoutService;
 
   private toDispose = new Disposable();
 
@@ -173,6 +177,15 @@ export class SCMContribution
     commands.registerCommand(SET_SCM_LIST_VIEW_MODE, {
       execute: () => {
         this.scmTreeService.changeTreeMode(false);
+      },
+    });
+
+    commands.registerCommand(SCM_COMMANDS.TOGGLE_VISIBILITY, {
+      execute: () => {
+        const tabbarHandler = this.mainlayoutService.getTabbarHandler(scmContainerId);
+        if (tabbarHandler) {
+          tabbarHandler.isActivated() ? tabbarHandler.deactivate() : tabbarHandler.activate();
+        }
       },
     });
   }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
#1105 相关问题
<html>
<body>
<!--StartFragment--><!DOCTYPE html>

Linux, Windows | macOS | Feature | 插件自身是否支持 | 对应的command | OpenSumi 是否有实现对应插件命令
-- | -- | -- | -- | -- | --
alt+9 | cmd+9 | Close corresponding tool window (Git) | ✅ | workbench.action.toggleSidebarVisibility | N/A
alt+numpad9 | cmd+numpad9 | Close corresponding tool window (Git) | ✅ | workbench.action.toggleSidebarVisibility | N/A

<!--EndFragment-->
</body>
</html>

### Changelog
在 `SCM_COMMANDS`命名空间新增 `TOGGLE_VISIBILITY `命令，通过命令代理适配插件的`alt+9`和`alt+numpad9`快捷键。

before:
![before](https://user-images.githubusercontent.com/85668115/185545000-458cd551-acfc-4f7c-b5e8-f8a14463e5fc.jpg)

after:
![after](https://user-images.githubusercontent.com/85668115/185544789-24443dc5-70b4-44d4-b326-efa485d493fe.jpg)


