### PR TITLE
fix: terminal contextmenu prevent default

### DIFF
--- a/packages/terminal-next/src/browser/terminal.context-menu.ts
+++ b/packages/terminal-next/src/browser/terminal.context-menu.ts
@@ -78,6 +78,9 @@ export class TerminalContextMenuService extends Disposable {
   }
 
   onTabContextMenu(event: React.MouseEvent<HTMLElement>, index: number) {
+    event.stopPropagation();
+    event.preventDefault();
+
     const { x, y } = event.nativeEvent;
     const menus = this.tabContextMenu;
     const menuNodes = generateMergedCtxMenu({ menus });


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

### Changelog
修复终端 tab 右键菜单的浏览器默认行为