### PR TITLE
fix: editor title menu should always be worked

### DIFF
--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -413,6 +413,11 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
     const editorService: WorkbenchEditorServiceImpl = useInjectable(WorkbenchEditorService);
     const menu = editorActionRegistry.getMenu(group);
     const [hasFocus, setHasFocus] = useState<boolean>(editorService.currentEditorGroup === group);
+    const [args, setArgs] = useState<[URI, IEditorGroup, MaybeNull<URI>] | undefined>(
+      group.currentResource
+        ? [group.currentResource.uri, group, group.currentOrPreviousFocusedEditor?.currentUri]
+        : undefined,
+    );
 
     useEffect(() => {
       const disposableCollection = new DisposableCollection();
@@ -421,14 +426,20 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
           setHasFocus(editorService.currentEditorGroup === group);
         }),
       );
+      disposableCollection.push(
+        editorService.onActiveResourceChange(() => {
+          setArgs(
+            group.currentResource
+              ? [group.currentResource.uri, group, group.currentOrPreviousFocusedEditor?.currentUri]
+              : undefined,
+          );
+        }),
+      );
       return () => {
         disposableCollection.dispose();
       };
     }, []);
 
-    const args: [URI, IEditorGroup, MaybeNull<URI>] | undefined = group.currentResource
-      ? [group.currentResource.uri, group, group.currentOrPreviousFocusedEditor?.currentUri]
-      : undefined;
     // 第三个参数是当前编辑器的URI（如果有）
     return (
       <div


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1542 

定位到原因是因为 Editor Tabs 的菜单渲染仅与 Group Change 事件关联，导致大部分情况下，Editor Title Menu 的执行参数都是错的

### Changelog

修复编辑器菜单执行参数错误问题