### PR TITLE
fix: multiple debug session toolbar select show options label

### DIFF
--- a/packages/components/src/select/index.tsx
+++ b/packages/components/src/select/index.tsx
@@ -143,7 +143,7 @@ function getLabelWithChildrenProps<T = string>(
   value: T | undefined,
   children: React.ReactNode[] | React.ReactNode,
   equals: (v1, v2) => boolean = (v1, v2) => v1 === v2,
-) {
+): MaybeOption | undefined {
   const nodes = React.Children.toArray(children).filter((v) =>
     React.isValidElement<MaybeOption>(v),
   ) as React.ReactElement[];
@@ -156,7 +156,8 @@ function getLabelWithChildrenProps<T = string>(
     }
     return null;
   });
-  return currentOption?.props?.label || currentOption?.props?.value;
+
+  return currentOption?.props;
 }
 
 export function isDataOptions<T = any>(
@@ -305,11 +306,11 @@ export function Select<T = string>({
         value: options[0]?.options[0]?.value,
       };
     } else {
-      const text = children && getLabelWithChildrenProps<T>(value, children);
-      if (text) {
+      const nodeOption: IDataOption<T> = children && getLabelWithChildrenProps<T>(value, children);
+      if (nodeOption) {
         return {
-          label: text,
-          value: text,
+          label: nodeOption.label,
+          value: nodeOption.value,
         };
       }
     }

--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -173,6 +173,7 @@ export const DebugToolbarView = observer((props: DebugToolbarViewProps) => {
               className={cls(styles.debug_selection, styles.special_radius)}
               size={props.float ? 'small' : 'default'}
               value={currentSessionId}
+              options={sessions.map((s) => ({ label: s.label, value: s.id }))}
               onChange={setCurrentSession}
             >
               {renderSessionOptions(sessions)}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

![image](https://user-images.githubusercontent.com/20262815/185579753-6ef1dff3-d462-4794-a2e7-68103cb518f8.png)


### Changelog
修复开启多调试 session 时 select 组件的显示问题