### PR TITLE
fix: cancel long time save operator

### DIFF
--- a/packages/core-common/src/types/editor.ts
+++ b/packages/core-common/src/types/editor.ts
@@ -218,8 +218,10 @@ export function isEditChange(change: IEditorDocumentChange): change is IEditorDo
   return !!(change as IEditorDocumentEditChange).changes;
 }
 
+export type EditorDocumentModelSaveResultState = 'success' | 'error' | 'diff';
+
 export interface IEditorDocumentModelSaveResult {
-  state: 'success' | 'error' | 'diff';
+  state: EditorDocumentModelSaveResultState;
 
   errorMessage?: string;
 }

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -350,7 +350,9 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
     const versionId = this.monacoModel.getVersionId();
     const lastSavingTask = this.savingTasks[this.savingTasks.length - 1];
     if (lastSavingTask && lastSavingTask.versionId === versionId) {
-      return false;
+      lastSavingTask.cancel();
+      const task = this.savingTasks.pop();
+      task?.dispose();
     }
     const task = new SaveTask(this.uri, versionId, this.monacoModel.getAlternativeVersionId(), this.getText(), force);
     this.savingTasks.push(task);

--- a/packages/file-scheme/src/browser/file-doc.ts
+++ b/packages/file-scheme/src/browser/file-doc.ts
@@ -12,6 +12,7 @@ import {
   replaceLocalizePlaceholder,
   PreferenceService,
   Schemes,
+  CancellationToken,
 } from '@opensumi/ide-core-browser';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
 import { IEditorDocumentModelContentProvider } from '@opensumi/ide-editor/lib/browser';
@@ -58,6 +59,7 @@ export class FileSchemeDocumentProvider
     encoding: string,
     ignoreDiff = false,
     eol: EOL = EOL.LF,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult> {
     const baseMd5 = this.hashCalculateService.calculate(baseContent);
     if (content.length > FILE_SAVE_BY_CHANGE_THRESHOLD) {
@@ -70,6 +72,7 @@ export class FileSchemeDocumentProvider
         },
         encoding,
         ignoreDiff,
+        token,
       );
     } else {
       return await this.fileSchemeDocClient.saveByContent(
@@ -80,6 +83,7 @@ export class FileSchemeDocumentProvider
         },
         encoding,
         ignoreDiff,
+        token,
       );
     }
   }

--- a/packages/file-scheme/src/browser/file-scheme-doc.client.ts
+++ b/packages/file-scheme/src/browser/file-scheme-doc.client.ts
@@ -1,6 +1,7 @@
 import { Injectable, Autowired } from '@opensumi/di';
-import { IEditorDocumentModelSaveResult } from '@opensumi/ide-core-browser';
+import { CancellationToken, IEditorDocumentModelSaveResult } from '@opensumi/ide-core-browser';
 
+import { CancellationTokenSource } from '../../../utils/lib';
 import {
   IFileSchemeDocNodeService,
   FileSchemeDocNodeServicePath,
@@ -19,8 +20,9 @@ export class FileSchemeDocClientService implements IFileSchemeDocClient {
     change: IContentChange,
     encoding?: string | undefined,
     force?: boolean | undefined,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult> {
-    return this.fileDocBackendService.$saveByChange(uri, change, encoding, force);
+    return this.fileDocBackendService.$saveByChange(uri, change, encoding, force, token);
   }
 
   saveByContent(
@@ -28,8 +30,9 @@ export class FileSchemeDocClientService implements IFileSchemeDocClient {
     content: ISavingContent,
     encoding?: string | undefined,
     force?: boolean | undefined,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult> {
-    return this.fileDocBackendService.$saveByContent(uri, content, encoding, force);
+    return this.fileDocBackendService.$saveByContent(uri, content, encoding, force, token);
   }
 
   getMd5(uri: string, encoding?: string | undefined): Promise<string | undefined> {

--- a/packages/file-scheme/src/common/index.ts
+++ b/packages/file-scheme/src/common/index.ts
@@ -1,4 +1,4 @@
-import { IEditorDocumentChange, IEditorDocumentModelSaveResult } from '@opensumi/ide-core-common';
+import { CancellationToken, IEditorDocumentChange, IEditorDocumentModelSaveResult } from '@opensumi/ide-core-common';
 
 export const FILE_ON_DISK_SCHEME = 'fileOnDisk';
 
@@ -18,6 +18,7 @@ export interface IFileSchemeDocClient {
     change: IContentChange,
     encoding?: string,
     force?: boolean,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult>;
   /**
    * 直接使用文件内容进行保存，适用于较小的文件
@@ -31,6 +32,7 @@ export interface IFileSchemeDocClient {
     content: ISavingContent,
     encoding?: string,
     force?: boolean,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult>;
   getMd5(uri: string, encoding?: string): Promise<string | undefined>;
 }
@@ -48,6 +50,7 @@ export interface IFileSchemeDocNodeService {
     change: IContentChange,
     encoding?: string,
     force?: boolean,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult>;
 
   /**
@@ -62,6 +65,7 @@ export interface IFileSchemeDocNodeService {
     content: ISavingContent,
     encoding?: string,
     force?: boolean,
+    token?: CancellationToken,
   ): Promise<IEditorDocumentModelSaveResult>;
 
   $getMd5(uri: string, encoding?: string): Promise<string | undefined>;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

修改原有一旦存在进行中的保存任务就退出的保存逻辑，防止因为用户网络/波动，文件大等原因出现的保存失败后无法进一步保存的问题，有效避免保存假死情况

### Changelog

cancel long time save operator