### PR TITLE
feat: decoration support `textUnderlinePosition`

### DIFF
--- a/packages/editor/src/browser/editor.decoration.service.ts
+++ b/packages/editor/src/browser/editor.decoration.service.ts
@@ -6,7 +6,6 @@ import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
 import { IThemeDecorationRenderOptions, IDecorationRenderOptions, IContentDecorationRenderOptions } from '../common';
 
-
 import {
   IEditorDecorationCollectionService,
   IBrowserTextEditorDecorationType,
@@ -164,6 +163,7 @@ export class EditorDecorationCollectionService implements IEditorDecorationColle
       fontStyle: styles.fontStyle,
       fontWeight: styles.fontWeight,
       textDecoration: styles.textDecoration,
+      textUnderlinePosition: styles.textUnderlinePosition,
       cursor: styles.cursor,
       color: this.themeService.getColorVar(styles.color),
       opacity: styles.opacity,

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -557,6 +557,10 @@ export interface IThemeDecorationRenderOptions {
   fontStyle?: string;
   fontWeight?: string;
   textDecoration?: string;
+  /**
+   * @proposal
+   */
+  textUnderlinePosition?: string;
   cursor?: string;
   color?: string | IThemeColor;
   opacity?: string;

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -770,6 +770,7 @@ export namespace ThemableDecorationRenderOptions {
       fontStyle: options.fontStyle,
       fontWeight: options.fontWeight,
       textDecoration: options.textDecoration,
+      textUnderlinePosition: options.textUnderlinePosition,
       cursor: options.cursor,
       color: options.color as string | IThemeColor,
       opacity: options.opacity,

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -738,6 +738,7 @@ export namespace DecorationRenderOptions {
       fontStyle: options.fontStyle,
       fontWeight: options.fontWeight,
       textDecoration: options.textDecoration,
+      textUnderlinePosition: options.textUnderlinePosition,
       cursor: options.cursor,
       color: options.color as string | IThemeColor,
       opacity: options.opacity,

--- a/packages/types/vscode/typings/vscode.theme.d.ts
+++ b/packages/types/vscode/typings/vscode.theme.d.ts
@@ -138,7 +138,10 @@ declare module 'vscode' {
      * CSS styling property that will be applied to text enclosed by a decoration.
      */
     textDecoration?: string;
-
+    /**
+     * @proposal
+     */
+    textUnderlinePosition?: string;
     /**
      * CSS styling property that will be applied to text enclosed by a decoration.
      */


### PR DESCRIPTION
### Types

- [x] 🎉 New Features


### Background or solution

这是一个新需求，想在 editor 上展示这个 css style 的效果，也同步给 VSCode 提了 PR:

- https://github.com/microsoft/vscode/pull/158717

### Changelog

`createTextEditorDecorationType` support `textUnderlinePosition` field