### PR TITLE
fix: worker url use blob url

### DIFF
--- a/packages/extension/src/browser/loader.ts
+++ b/packages/extension/src/browser/loader.ts
@@ -11,8 +11,8 @@ export function getWorkerBootstrapUrl(scriptPath: string, label: string, ignoreC
     );
     if (scriptPath.substring(0, currentOrigin.length) !== currentOrigin) {
       const js = `/*${label}*/importScripts('${scriptPath}');/*${label}*/`;
-      const url = `data:text/javascript;charset=utf-8,${encodeURIComponent(js)}`;
-      return url;
+      const blob = new Blob([js], { type: 'application/javascript' });
+      return URL.createObjectURL(blob);
     }
   }
   return scriptPath;

--- a/packages/extension/src/hosted/worker.host-preload.ts
+++ b/packages/extension/src/hosted/worker.host-preload.ts
@@ -15,7 +15,8 @@ if (self.Worker) {
     const js = `importScripts('${stringUrl}');`;
     options = options || {};
     options.name = options.name || path.basename(stringUrl.toString());
-    return new _Worker(`data:text/javascript;charset=utf-8,${encodeURIComponent(js)}`, options);
+    const blob = new Blob([js], { type: 'application/javascript' });
+    return new _Worker(URL.createObjectURL(blob));
   } as any;
 }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

`data:text/javascript;` 的方式在某些浏览器下会因为操作不安全而被阻止抛出 `The operation is insecure` 异常

### Changelog
- 使用 Blob url 加载 Worker Host