### PR TITLE
chore: upgrade opensumi-theme to v2.5.6

### DIFF
--- a/configs/vscode-extensions.json
+++ b/configs/vscode-extensions.json
@@ -158,7 +158,7 @@
     "opensumi": [
       {
         "name": "opensumi-default-themes",
-        "version": "2.5.5"
+        "version": "2.5.6"
       }
     ]
   }

--- a/packages/core-common/src/const/application.ts
+++ b/packages/core-common/src/const/application.ts
@@ -2,5 +2,5 @@ export const DEFAULT_APPLICATION_NAME = 'OpenSumi';
 export const DEFAULT_APPLICATION_DESKTOP_HOST = 'desktop';
 export const DEFAULT_APPLICATION_WEB_HOST = 'web';
 export const DEFAULT_URI_SCHEME = 'sumi';
-export const DEFAULT_OPENVSX_REGISTRY = 'https://marketplace.smartide.cn'; // China Mirror
-// export const DEFAULT_OPENVSX_REGISTRY = 'https://open-vsx.org'; // Official Registry
+// export const DEFAULT_OPENVSX_REGISTRY = 'https://marketplace.smartide.cn'; // China Mirror
+export const DEFAULT_OPENVSX_REGISTRY = 'https://open-vsx.org'; // Official Registry

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -46,8 +46,8 @@ const parallelRunPromise = (lazyPromises, n) => {
   return new Promise(addWorking);
 };
 
-// const api = 'https://open-vsx.org/api/';
-const api = 'https://marketplace.smartide.cn/api/'; // China Mirror
+const api = 'https://open-vsx.org/api/';
+// const api = 'https://marketplace.smartide.cn/api/'; // China Mirror
 
 async function downloadExtension(url, namespace, extensionName) {
   const tmpPath = path.join(os.tmpdir(), 'extension', v4());

--- a/tools/electron/config/vscode-extensions.json
+++ b/tools/electron/config/vscode-extensions.json
@@ -158,7 +158,7 @@
     "opensumi": [
       {
         "name": "opensumi-default-themes",
-        "version": "2.5.5"
+        "version": "2.5.6"
       }
     ]
   }


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

升级主题插件，解决两个问题：

- https://github.com/opensumi/Default-Themes/issues/4
- https://github.com/opensumi/Default-Themes/issues/3

同时修改框架默认插件市场镜像，目前国内镜像存在同步问题，有些滞后，后续仅在启动案例中使用

### Changelog
