### PR TITLE
WIP: refactor: optimize node process start before browserWindow

### DIFF
--- a/packages/core-electron-main/browser-preload/index.js
+++ b/packages/core-electron-main/browser-preload/index.js
@@ -10,7 +10,7 @@ window.id = Number(urlParams.get('windowId'));
 const webContentsId = Number(urlParams.get('webContentsId'));
 
 function createRPCNetConnection() {
-  const rpcListenPath = ipcRenderer.sendSync('window-rpc-listen-path', electronEnv.currentWindowId);
+  const rpcListenPath = ipcRenderer.sendSync(`window-rpc-listen-path:${electronEnv.currentWindowId}`);
   return net.createConnection(rpcListenPath);
 }
 
@@ -31,7 +31,7 @@ electronEnv.currentWindowId = window.id;
 electronEnv.currentWebContentsId = webContentsId;
 electronEnv.onigWasmPath = require.resolve('vscode-oniguruma/release/onig.wasm');
 
-const metaData = JSON.parse(ipcRenderer.sendSync('window-metadata', electronEnv.currentWindowId));
+const metaData = JSON.parse(ipcRenderer.sendSync(`window-metadata:${electronEnv.currentWindowId}`));
 
 electronEnv.metadata = metaData;
 process.env = Object.assign({}, process.env, metaData.env, { WORKSPACE_DIR: metaData.workspace });

--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -64,6 +64,8 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
   public metadata: any;
 
+  private windowId: number;
+
   private _nodeReady = new Deferred<void>();
 
   private _options: BrowserWindowConstructorOptions & ICodeWindowOptions = {};
@@ -141,6 +143,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
       ...this.appConfig.overrideBrowserOptions,
       ...this._options,
     });
+    this.windowId = this.browser.id;
 
     this.browser.on('closed', () => {
       this.dispose();
@@ -164,17 +167,17 @@ export class CodeWindow extends Disposable implements ICodeWindow {
       });
     };
 
-    const rpcListenPathResponser = async (event: IpcMainEvent) => {
+    const rpcListenPathResponser = async () => {
       await this._nodeReady.promise;
       return this.rpcListenPath;
     };
 
-    ipcMain.on(`window-metadata:${this.browser.id}`, metadataResponser);
-    ipcMain.handle(`window-rpc-listen-path:${this.browser.id}`, rpcListenPathResponser);
+    ipcMain.on(`window-metadata:${this.windowId}`, metadataResponser);
+    ipcMain.handle(`window-rpc-listen-path:${this.windowId}`, rpcListenPathResponser);
     this.addDispose({
       dispose: () => {
-        ipcMain.removeListener(`window-metadata:${this.browser.id}`, metadataResponser);
-        ipcMain.removeListener(`window-rpc-listen-path:${this.browser.id}`, rpcListenPathResponser);
+        ipcMain.removeListener(`window-metadata:${this.windowId}`, metadataResponser);
+        ipcMain.removeHandler(`window-rpc-listen-path:${this.windowId}`);
       },
     });
 

--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -167,17 +167,17 @@ export class CodeWindow extends Disposable implements ICodeWindow {
       });
     };
 
-    const rpcListenPathResponser = async () => {
+    const rpcListenPathResponser = async (event: IpcMainEvent) => {
       await this._nodeReady.promise;
-      return this.rpcListenPath;
+      event.returnValue = this.rpcListenPath;
     };
 
     ipcMain.on(`window-metadata:${this.windowId}`, metadataResponser);
-    ipcMain.handle(`window-rpc-listen-path:${this.windowId}`, rpcListenPathResponser);
+    ipcMain.on(`window-rpc-listen-path:${this.windowId}`, rpcListenPathResponser);
     this.addDispose({
       dispose: () => {
         ipcMain.removeListener(`window-metadata:${this.windowId}`, metadataResponser);
-        ipcMain.removeHandler(`window-rpc-listen-path:${this.windowId}`);
+        ipcMain.removeListener(`window-rpc-listen-path:${this.windowId}`, rpcListenPathResponser);
       },
     });
 

--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -139,7 +139,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
       height: DEFAULT_WINDOW_HEIGHT,
       width: DEFAULT_WINDOW_WIDTH,
       // trafficLight position: Center vertically
-      trafficLightPosition: { x: 10, y: 10 },
+      trafficLightPosition: { x: 9, y: 6 },
       ...this.appConfig.overrideBrowserOptions,
       ...this._options,
     });

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -1,22 +1,9 @@
-import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser';
+import { Injectable, Autowired } from '@opensumi/di';
 import { ContributionProvider } from '@opensumi/ide-core-browser';
-import { LabelService } from '@opensumi/ide-core-browser/lib/services';
-import { WorkbenchEditorService } from '@opensumi/ide-editor';
-import { IFileServiceClient } from '@opensumi/ide-file-service';
-import { OutputChannel } from '@opensumi/ide-output/lib/browser/output.channel';
-import { OutputService } from '@opensumi/ide-output/lib/browser/output.service';
-import { IMessageService } from '@opensumi/ide-overlay';
-import { ITerminalApiService } from '@opensumi/ide-terminal-next/lib/common';
 
-import { DebugAdapterPath, DebugSessionOptions, IDebugSessionManager } from '../common';
+import { DebugSessionOptions } from '../common';
 
-import { BreakpointManager } from './breakpoint';
-import { DebugPreferences } from './debug-preferences';
 import { DebugSession } from './debug-session';
-import { DebugSessionConnection } from './debug-session-connection';
-import { DebugSessionManager } from './debug-session-manager';
-import { DebugModelManager } from './editor/debug-model-manager';
 
 export const DebugSessionContribution = Symbol('DebugSessionContribution');
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🪚 Refactors

### Background or solution
1. 在 electron 中 `new BrowserWindow` 有时候耗时 40ms 左右，可以把 Node.js 进程启动时机提前，能在 Renderer 进程与 Node.js 进程建立链接的时候加快启动的时间。
2. 使用 electron [handle](https://www.electronjs.org/docs/latest/api/ipc-main#ipcmainhandlechannel-listener) 和 invoke 让请求异步。这个优化在同时打开多个窗口的时候很有用，之前的 sendSync 在每次请求都会阻塞所有窗口 10~200 ms，导致每个窗口都来来回回阻塞。
3. 去掉 listener 的 windowId ，减少事件广播

metadata 的 sendSync 只耗时 1 ms 内，之后在去除 electronEnv 的时候处理。

breakchange:
preload 的调用方式要从 sendSync 改为 invoke。

### Changelog
- 重构 Electron Node.js 进程启动顺序
- 重构 Electron 获取 ipc 的同步方法

