### PR TITLE
feat: merge common file events to improve file watch service performance

### DIFF
--- a/packages/core-common/src/types/file-watch.ts
+++ b/packages/core-common/src/types/file-watch.ts
@@ -38,6 +38,7 @@ export interface FileChange {
   uri: string;
   type: FileChangeType;
 }
+
 export namespace FileChange {
   export function isUpdated(change: FileChange, uri: URI): boolean {
     return change.type === FileChangeType.UPDATED && uri.toString() === change.uri;

--- a/packages/core-common/src/types/file.ts
+++ b/packages/core-common/src/types/file.ts
@@ -135,7 +135,7 @@ export interface FileSystemProvider {
    * @param options Configures the watch.
    * @returns A disposable that tells the provider to stop watching the `uri`.
    */
-  watch(uri: Uri, options: { recursive: boolean; excludes?: string[] }): number | Promise<number>;
+  watch(uri: Uri, options: { excludes?: string[] }): number | Promise<number>;
 
   unwatch?(watcherId: number): void | Promise<void>;
 

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -341,7 +341,6 @@ export class FileServiceClient implements IFileServiceClient {
     const schemaWatchIdList = this.watcherWithSchemaMap.get(_uri.scheme) || [];
 
     const watcherId = await provider.watch(_uri.codeUri, {
-      recursive: true,
       excludes,
     });
 

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -349,6 +349,9 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   }
 
   protected initWatchServer(excludes?: string[]) {
+    if (!this.injector) {
+      return;
+    }
     if (this.watcherServerDisposeCollection) {
       this.watcherServerDisposeCollection.dispose();
     }

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -8,10 +8,8 @@ import writeFileAtomic from 'write-file-atomic';
 
 import { Injectable, INJECTOR_TOKEN, Autowired, Injector } from '@opensumi/di';
 import { RPCService } from '@opensumi/ide-connection';
-import { getDebugLogger } from '@opensumi/ide-core-node';
+import { Deferred, ILogService, ILogServiceManager, SupportLogNamespace } from '@opensumi/ide-core-node';
 import {
-  ParsedPattern,
-  parseGlob,
   isLinux,
   UriComponents,
   Uri,
@@ -25,6 +23,7 @@ import {
   FileUri,
   uuid,
 } from '@opensumi/ide-core-node';
+import { Path } from '@opensumi/ide-utils/lib/path';
 
 import {
   FileChangeEvent,
@@ -49,25 +48,45 @@ export interface IRPCDiskFileSystemProvider {
   onDidFilesChanged(event: DidFilesChangedParams): void;
 }
 
+export interface IWatcher {
+  id: number;
+  options?: {
+    excludes?: string[];
+  };
+  disposable: IDisposable;
+}
+
 @Injectable({ multiple: true })
 export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvider> implements IDiskFileProvider {
+  static readonly H5VideoExtList = ['mp4', 'ogg', 'webm'];
+
   private fileChangeEmitter = new Emitter<FileChangeEvent>();
   private watcherServer: ParcelWatcherServer;
   readonly onDidChangeFile: Event<FileChangeEvent> = this.fileChangeEmitter.event;
-  protected toDispose = new DisposableCollection();
+  protected watcherServerDisposeCollection: DisposableCollection;
 
-  protected readonly watcherDisposerMap = new Map<number, IDisposable>();
+  protected readonly watcherCollection = new Map<string, IWatcher>();
   protected watchFileExcludes: string[] = [];
-  protected watchFileExcludesMatcherList: ParsedPattern[] = [];
 
-  static H5VideoExtList = ['mp4', 'ogg', 'webm'];
+  private _whenReadyDeferred: Deferred<void> = new Deferred();
+  private isInitialized = false;
 
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
+  @Autowired(ILogServiceManager)
+  private readonly loggerManager: ILogServiceManager;
+
+  private logger: ILogService;
+
   constructor() {
     super();
-    this.initWatcher();
+    this.logger = this.loggerManager.getLogger(SupportLogNamespace.Node);
+    this.initWatchServer();
+  }
+
+  get whenReady() {
+    return this._whenReadyDeferred.promise;
   }
 
   onDidChangeCapabilities: Event<void> = Event.None;
@@ -91,15 +110,16 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   }
 
   dispose(): void {
-    this.toDispose.dispose();
+    this.watcherServerDisposeCollection?.dispose();
   }
 
   /**
    * @param {Uri} uri
-   * @param {{ recursive: boolean; excludes: string[] }} [options]  // 还不支持 recursive 参数
+   * @param {{ excludes: string[] }}
    * @memberof DiskFileSystemProvider
    */
-  async watch(uri: UriComponents, options?: { recursive: boolean; excludes?: string[] }): Promise<number> {
+  async watch(uri: UriComponents, options?: { excludes?: string[] }): Promise<number> {
+    await this.whenReady;
     const _uri = Uri.revive(uri);
     const id = await this.watcherServer.watchFileChanges(_uri.toString(), {
       excludes: options?.excludes ?? [],
@@ -109,16 +129,16 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
         this.watcherServer.unwatchFileChanges(id);
       },
     };
-    this.watcherDisposerMap.set(id, disposable);
+    this.watcherCollection.set(_uri.toString(), { id, options, disposable });
     return id;
   }
 
   unwatch(watcherId: number) {
-    const disposable = this.watcherDisposerMap.get(watcherId);
-    if (!disposable || !disposable.dispose) {
-      return;
+    for (const [_uri, { id, disposable }] of this.watcherCollection) {
+      if (watcherId === id) {
+        disposable.dispose();
+      }
     }
-    disposable.dispose();
   }
 
   async stat(uri: UriComponents) {
@@ -127,7 +147,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
       const stat = await this.doGetStat(_uri, 1);
       return stat;
     } catch (e) {
-      getDebugLogger().error(e);
+      this.logger.error(e);
       throw e;
     }
   }
@@ -215,7 +235,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     try {
       await writeFileAtomic(FileUri.fsPath(new URI(_uri)), buffer);
     } catch (e) {
-      getDebugLogger().warn('writeFileAtomicSync 出错，使用 fs', e);
+      this.logger.warn('writeFileAtomicSync 出错，使用 fs', e);
       await fse.writeFile(FileUri.fsPath(new URI(_uri)), buffer);
     }
   }
@@ -234,7 +254,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
       throw FileSystemError.FileNotFound(uri.path);
     }
     if (!isUndefined(options.recursive)) {
-      getDebugLogger().warn('DiskFileSystemProvider not support options.recursive!');
+      this.logger.warn('DiskFileSystemProvider not support options.recursive!');
     }
     // Windows 10.
     // Deleting an empty directory throws `EPERM error` instead of `unlinkDir`.
@@ -306,53 +326,80 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
 
   // 出于通信成本的考虑，排除文件的逻辑必须放在node层（fs provider层，不同的fs实现的exclude应该不一样）
   setWatchFileExcludes(excludes: string[]) {
-    let watcherExcludes = excludes;
+    let watchExcludes = excludes;
     // 兼容 Windows 下对 node_modules 默认排除监听的逻辑
     // 由于 files.watcherExclude 允许用户手动修改，所以只对默认值做处理
     // 在 Windows 下将 **/node_modules/**/* 替换为 **/node_modules/*/**
     if (isWindows && excludes.includes(UNIX_DEFAULT_NODE_MODULES_EXCLUDE)) {
-      const idx = watcherExcludes.findIndex((v) => v === UNIX_DEFAULT_NODE_MODULES_EXCLUDE);
-      watcherExcludes = watcherExcludes.splice(idx, 1, WINDOWS_DEFAULT_NODE_MODULES_EXCLUDE);
+      const idx = watchExcludes.findIndex((v) => v === UNIX_DEFAULT_NODE_MODULES_EXCLUDE);
+      watchExcludes = watchExcludes.splice(idx, 1, WINDOWS_DEFAULT_NODE_MODULES_EXCLUDE);
     }
-    getDebugLogger().info('set watch file exclude:', watcherExcludes);
-    this.watchFileExcludes = watcherExcludes;
-    this.watchFileExcludesMatcherList = watcherExcludes.map((pattern) => parseGlob(pattern));
+    // 每次调用之后都需要重新初始化 WatcherServer，保证最新的规则生效
+    this.logger.log('Set watcher exclude:', watchExcludes);
+    this.watchFileExcludes = watchExcludes;
+    this.initWatchServer(this.watchFileExcludes);
   }
 
   getWatchFileExcludes() {
     return this.watchFileExcludes;
   }
 
-  protected initWatcher() {
-    if (!this.injector) {
-      return;
+  getWatchExcludes(excludes?: string[]): string[] {
+    return Array.from(new Set(this.watchFileExcludes.concat(excludes || [])));
+  }
+
+  protected initWatchServer(excludes?: string[]) {
+    if (this.watcherServerDisposeCollection) {
+      this.watcherServerDisposeCollection.dispose();
     }
-    this.watcherServer = this.injector.get(ParcelWatcherServer);
+    this.watcherServerDisposeCollection = new DisposableCollection();
+    this.watcherServer = this.injector.get(ParcelWatcherServer, [excludes]);
     this.watcherServer.setClient({
       onDidFilesChanged: (events: DidFilesChangedParams) => {
-        const filteredChange = events.changes.filter((file) => {
-          const uri = new URI(file.uri);
-          const pathStr = uri.path.toString();
-          return !this.watchFileExcludesMatcherList.some((match) => match(pathStr));
-        });
-
-        if (filteredChange.length > 0) {
-          this.fileChangeEmitter.fire(filteredChange);
+        if (events.changes.length > 0) {
+          this.fileChangeEmitter.fire(events.changes);
           if (Array.isArray(this.rpcClient)) {
             this.rpcClient.forEach((client) => {
               client.onDidFilesChanged({
-                changes: filteredChange,
+                changes: events.changes,
               });
             });
           }
         }
       },
     });
-    this.toDispose.push({
+    this.watcherServerDisposeCollection.push({
       dispose: () => {
         this.watcherServer.dispose();
       },
     });
+    if (this.isInitialized) {
+      // 当服务已经初始化一次后，重新初始化时需要重新绑定原有的监听服务
+      this.rewatch();
+    } else {
+      this._whenReadyDeferred.resolve();
+    }
+    this.isInitialized = true;
+  }
+
+  private async rewatch() {
+    let tasks: {
+      id: number;
+      uri: string;
+      options?: { excludes?: string[] };
+    }[] = [];
+    for (const [uri, { id, options }] of this.watcherCollection) {
+      tasks.push({
+        id,
+        uri,
+        options,
+      });
+    }
+    // 需要针对缓存根据路径深度排序，防止过度监听
+    tasks = tasks.sort((a, b) => Path.pathDepth(a.uri) - Path.pathDepth(b.uri));
+    for (const { uri, options } of tasks) {
+      await this.watch(Uri.parse(uri), { excludes: this.getWatchExcludes(options?.excludes) });
+    }
   }
 
   protected async createFile(uri: UriComponents, options: { content: Buffer }): Promise<FileStat> {
@@ -533,12 +580,6 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   }
 
   protected async doCreateFileStat(uri: Uri, stat: fse.Stats): Promise<FileStat> {
-    // Then stat the target and return that
-    // const isLink = !!(stat && stat.isSymbolicLink());
-    // if (isLink) {
-    //   stat = await fs.stat(FileUri.fsPath(uri));
-    // }
-
     return {
       uri: uri.toString(),
       lastModification: stat.mtime.getTime(),
@@ -632,11 +673,5 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     }
 
     return type;
-  }
-}
-
-export class DiskFileSystemProviderWithoutWatcher extends DiskFileSystemProvider {
-  initWatcher() {
-    // Do nothing
   }
 }

--- a/packages/file-service/src/node/file-service.ts
+++ b/packages/file-service/src/node/file-service.ts
@@ -98,7 +98,6 @@ export class FileService implements IFileService {
     const schemaWatchIdList = this.watcherWithSchemaMap.get(_uri.scheme) || [];
 
     const watcherId = provider.watch(_uri.codeUri, {
-      recursive: true,
       excludes: (options && options.excludes) || [],
     }) as number;
     this.watcherDisposerMap.set(id, {


### PR DESCRIPTION
### Types

- [x] 🚀 Performance Improvements

### Background or solution

通过这层改造，更好的支持了不存在文件的监听逻辑：

https://user-images.githubusercontent.com/9823838/186811197-3b93c3bf-a196-43f6-8d65-3b11c09995e4.mp4

同时，经过简单在 ide-startup 中项目中测试，以 `opensumi/core` 项目为基本仓库，安装预装插件后，运行效果如下：

测试脚本：[inotify-consumers](https://github.com/fatso83/dotfiles/blob/master/utils/scripts/inotify-consumers)

#### 2.19.1 版本

![image](https://user-images.githubusercontent.com/9823838/186813409-21cf3cce-4f9a-4bb8-b89c-2d3a8709ec3e.png)

#### 优化后版本

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/9823838/186858795-983bc87c-4a9d-4165-93d7-55f5f4372b13.png">

结论：运行 Watcher 数量接近 1 倍，从接近 8w+ 减少至 4.8w+，目前测试无进一步问题，需要持续验证


### Changelog

merge common file events to improve file watch service performance