### PR TITLE
feat: using browser version jsonrpc client to connect server

### DIFF
--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -1,13 +1,6 @@
 require('./jest.setup.base');
 require('jest-canvas-mock');
 require('jest-fetch-mock').enableMocks();
-const { Buffer } = require('buffer');
-const timer = require('timers');
-
-// vscode-jsonrpc 的 node 层需要 setImmediate 函数
-global.setImmediate = timer.setImmediate;
-global.Buffer = Buffer;
-global.clearImmediate = timer.clearImmediate;
 
 // packages/extension/__tests__/browser/main.thread.env.test.ts
 // MainThreadEnvAPI Test Suites  › can read/write text via clipboard

--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -1,6 +1,9 @@
 require('./jest.setup.base');
 require('jest-canvas-mock');
 require('jest-fetch-mock').enableMocks();
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
 
 // packages/extension/__tests__/browser/main.thread.env.test.ts
 // MainThreadEnvAPI Test Suites  › can read/write text via clipboard

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@opensumi/ide-core-common": "2.20.6",
-    "@opensumi/vscode-jsonrpc": "^8.0.0-next.2",
+    "@opensumi/vscode-jsonrpc": "^8.0.0-next.6",
     "path-match": "^1.2.4",
     "ws": "^7.2.0"
   },

--- a/packages/connection/src/common/message.ts
+++ b/packages/connection/src/common/message.ts
@@ -6,12 +6,6 @@ import {
 import { Disposable } from '@opensumi/vscode-jsonrpc/lib/common/disposable';
 import { MessageReader, DataCallback } from '@opensumi/vscode-jsonrpc/lib/common/messageReader';
 import { MessageWriter } from '@opensumi/vscode-jsonrpc/lib/common/messageWriter';
-/**
- * FIXME: 由于 `createMessageConnection` 方法隐式依赖了 `@opensumi/vscode-jsonrpc/lib/browser/main` 或 `@opensumi/vscode-jsonrpc/lib/node/main`
- * 的 `RIL.install()` 初始化代码，而 `browser/main` 中仅支持浏览器使用，
- * 故需要保证提前引入或执行一次 `@opensumi/vscode-jsonrpc/lib/node/main` 代码才能保证逻辑正常执行
- */
-import '@opensumi/vscode-jsonrpc/lib/node/main';
 
 export class WebSocketMessageReader extends AbstractMessageReader implements MessageReader {
   protected state: 'initial' | 'listening' | 'closed' = 'initial';

--- a/packages/core-browser/src/utils/electron.ts
+++ b/packages/core-browser/src/utils/electron.ts
@@ -3,7 +3,7 @@ import type net from 'net';
 import { IDisposable } from '@opensumi/ide-core-common';
 import { IElectronMainApi } from '@opensumi/ide-core-common/lib/electron';
 import type { MessageConnection } from '@opensumi/vscode-jsonrpc';
-import { createMessageConnection } from '@opensumi/vscode-jsonrpc/lib/node-client/main';
+import { createMessageConnection } from '@opensumi/vscode-jsonrpc/lib/electron-renderer/main';
 
 declare const ElectronIpcRenderer: IElectronIpcRenderer;
 

--- a/packages/core-browser/src/utils/electron.ts
+++ b/packages/core-browser/src/utils/electron.ts
@@ -1,6 +1,9 @@
+import type net from 'net';
+
 import { IDisposable } from '@opensumi/ide-core-common';
 import { IElectronMainApi } from '@opensumi/ide-core-common/lib/electron';
 import type { MessageConnection } from '@opensumi/vscode-jsonrpc';
+import { createMessageConnection } from '@opensumi/vscode-jsonrpc/lib/node-client/main';
 
 declare const ElectronIpcRenderer: IElectronIpcRenderer;
 
@@ -80,13 +83,15 @@ export interface IElectronNativeDialogService {
 
 export const IElectronNativeDialogService = Symbol('IElectronNativeDialogService');
 
+/**
+ * Browser 版本客户端实现，用于连接 Node.js 服务端
+ */
 export function createElectronClientConnection(connectPath?: string): MessageConnection {
-  let socket;
+  let socket: net.Socket;
   if (connectPath) {
     socket = electronEnv.createNetConnection(connectPath);
   } else {
     socket = electronEnv.createRPCNetConnection();
   }
-  const { createSocketConnection } = require('@opensumi/ide-connection/lib/node/connect');
-  return createSocketConnection(socket);
+  return createMessageConnection(socket, socket);
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -32,7 +32,7 @@
     "@opensumi/ide-task": "2.20.6",
     "@opensumi/ide-terminal-next": "2.20.6",
     "@opensumi/ide-webview": "2.20.6",
-    "@opensumi/vscode-jsonrpc": "^8.0.0-next.2",
+    "@opensumi/vscode-jsonrpc": "^8.0.0-next.6",
     "address": "^1.1.2",
     "glob-to-regexp": "0.4.1",
     "is-running": "^2.1.0",


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🪚 Refactors

### Background or solution
由于 ide-core-browser 引用了 vscode-jsonrpc 的 node 版本，导致不管是 Web 版本还是 Electron 版本在 Browser 环境都需要 Webpack mock 一整套代码，会导致 browser 和 node 层难以分离。

通过单独对 jsonrpc 实现了一个 electron-renderer ，提供专为 electron-renderer 服务的版本，可以完全分离这块的逻辑。
https://github.com/opensumi/vscode-jsonrpc/pull/6

- [x] vscode-jsonrpc 前序完成 https://github.com/opensumi/vscode-jsonrpc/pull/6 (等 jsonrpc 合并后再合这个 pr)

---
之后处理 mock 的 setImmediate、buffer 和 TextEncoder 等都可以使用原生，另外 webpack 5 升级可以提上来了

### Changelog
electron 场景下使用 electron-renderer 版本的 jsonrpc 客户端连接后端服务