### PR TITLE
chore: 删除 start:remote 指定 0.0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "init:deps": "ts-node ./scripts/bootstrap",
     "init": "npm run init:deps && npm run clean && npm run build:all",
     "start": "node ./scripts/rebuild-native.js && cross-env HOST=127.0.0.1 WS_PATH=ws://127.0.0.1:8000 NODE_ENV=development ts-node ./scripts/start",
-    "start:remote": "node ./scripts/rebuild-native.js && cross-env HOST=0.0.0.0 NODE_ENV=development ts-node ./scripts/start",
+    "start:remote": "node ./scripts/rebuild-native.js && cross-env NODE_ENV=development ts-node ./scripts/start",
     "start:electron": "cross-env NODE_ENV=development ts-node ./scripts/start-electron",
     "build:components": "cd packages/components && npm run build:dist",
     "start:lite": "cross-env NODE_ENV=development ts-node ./scripts/start --script=start:lite",


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

否则在 Cloud IDE 运行 WS 的地址是 0.0.0.0，这个需要在容器内指定

### Changelog

删除 start:remote 指定 0.0.0.0