### PR TITLE
fix: use unequal name on opened editor

### DIFF
--- a/packages/opened-editor/src/browser/opened-editor-node.define.ts
+++ b/packages/opened-editor/src/browser/opened-editor-node.define.ts
@@ -70,7 +70,7 @@ export class EditorFile extends TreeNode {
     public tooltip: string,
     parent: EditorFileGroup | undefined,
   ) {
-    super(tree as ITree, parent, undefined, { name: `${resource.uri.path.toString()}` });
+    super(tree as ITree, parent, undefined, { name: `${resource.uri.toString()}` });
   }
 
   get displayName() {

--- a/packages/opened-editor/src/browser/services/opened-editor-tree.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-tree.service.ts
@@ -104,16 +104,16 @@ export class OpenedEditorService extends Tree {
           .join(groupName)
           .join(
             resource && (resource as IResource).uri
-              ? (resource as IResource).uri.path.toString()
-              : (resource as URI).path.toString(),
+              ? (resource as IResource).uri.toString()
+              : (resource as URI).toString(),
           )
           .toString();
       } else {
         path = new Path(path)
           .join(
             resource && (resource as IResource).uri
-              ? (resource as IResource).uri.path.toString()
-              : (resource as URI).path.toString(),
+              ? (resource as IResource).uri.toString()
+              : (resource as URI).toString(),
           )
           .toString();
       }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1579.

after:

![image](https://user-images.githubusercontent.com/9823838/187180281-91c4365c-54b8-4298-b47a-900101ed19b5.png)

### Changelog