### PR TITLE
fix(file-tree): multi roots `getNodeByPathOrUri`

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -597,10 +597,11 @@ export class FileTreeService extends Tree implements IFileTreeService {
       if (this.root && rootStr) {
         const rootUri = new URI(rootStr);
         if (rootUri.isEqualOrParent(pathURI)) {
-          path = new Path(this.root.path)
-            .join(rootUri.displayName)
-            .join(rootUri.relative(pathURI)!.toString())
-            .toString();
+          let basePath = new Path(this.root.path);
+          if (this.isMultipleWorkspace) {
+            basePath = basePath.join(rootUri.displayName);
+          }
+          path = basePath.join(rootUri.relative(pathURI)!.toString()).toString();
         }
       }
     }

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -597,7 +597,10 @@ export class FileTreeService extends Tree implements IFileTreeService {
       if (this.root && rootStr) {
         const rootUri = new URI(rootStr);
         if (rootUri.isEqualOrParent(pathURI)) {
-          path = new Path(this.root.path).join(rootUri.relative(pathURI)!.toString()).toString();
+          path = new Path(this.root.path)
+            .join(rootUri.displayName)
+            .join(rootUri.relative(pathURI)!.toString())
+            .toString();
         }
       }
     }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
close https://github.com/opensumi/core/issues/1556

不过现在这种 display name 的处理，不同 root 下是相同的 displayName，那 FileMap 应该还是会获取到错误的结果

> 两个 workspace 的根文件夹同名或者多窗口情况下工作区同名的情况

### Changelog
- fix file-tree multiple workspaces getNodes action