### PR TITLE
style: improve dialog and notification style

### DIFF
--- a/packages/components/src/badge/styles.less
+++ b/packages/components/src/badge/styles.less
@@ -1,4 +1,6 @@
-.kt-badge {
+@import '../style/variable.less';
+
+.@{prefix}-badge {
   background-color: var(--badge-background);
   color: var(--badge-foreground);
   border: 1px solid var(--kt-badge-border);

--- a/packages/components/src/button/style.less
+++ b/packages/components/src/button/style.less
@@ -1,4 +1,6 @@
-.kt-clickable-icon {
+@import '../style/variable.less';
+
+.@{prefix}-clickable-icon {
   &:hover {
     transform: scale(1.2);
   }
@@ -8,7 +10,7 @@
   }
 }
 
-.kt-icon-resource::before {
+.@{prefix}-icon-resource::before {
   display: inherit;
   background-size: 16px;
   background-position: center;
@@ -19,7 +21,7 @@
   flex-shrink: 0;
 }
 
-.kt-button {
+.@{prefix}-button {
   border: none;
   outline: none;
   cursor: pointer;
@@ -41,7 +43,7 @@
     width: 100%;
   }
 
-  & > .kt-button-secondary-more {
+  & > .@{prefix}-button-secondary-more {
     color: inherit;
     margin-left: 5px;
   }
@@ -63,7 +65,7 @@
   }
 }
 
-.kt-button-anticon-spin {
+.@{prefix}-button-anticon-spin {
   animation: loadingCircle 1s infinite linear;
   margin-right: 5px;
 }
@@ -170,16 +172,16 @@
 .secondary-button:disabled,
 .primary-button:disabled,
 .ghost-danger-button:disabled,
-.kt-danger-button-loading,
-.kt-primary-button-loading,
-.kt-secondary-button-loading {
+.@{prefix}-danger-button-loading,
+.@{prefix}-primary-button-loading,
+.@{prefix}-secondary-button-loading {
   color: var(--kt-button-disableForeground) !important;
   border-color: var(--kt-button-disableBorder) !important;
   background-color: var(--kt-button-disableBackground) !important;
   border-style: solid;
   border-width: 1px;
 
-  & > .kt-button-secondary-more {
+  & > .@{prefix}-button-secondary-more {
     color: var(--kt-button-disableForeground);
   }
 }

--- a/packages/components/src/checkbox/style.less
+++ b/packages/components/src/checkbox/style.less
@@ -1,7 +1,6 @@
-@checkbox-default-size: 12px;
-@checkbox-large-size: 14px;
+@import '../style/variable.less';
 
-.kt-checkbox {
+.@{prefix}-checkbox {
   font-size: @checkbox-default-size;
   display: inline-flex;
   align-items: center;
@@ -22,7 +21,7 @@
       opacity: 0;
     }
 
-    input:checked + .kt-checkbox-icon {
+    input:checked + .@{prefix}-checkbox-icon {
       border-color: var(--kt-checkbox-selectionBackground);
       background-color: var(--kt-checkbox-selectionBackground);
       color: var(--kt-checkbox-selectionForeground);
@@ -67,11 +66,11 @@
     }
   }
 
-  &.kt-checkbox-disabled {
+  &.@{prefix}-checkbox-disabled {
     // disabled
     color: var(--kt-checkbox-disableForeground);
 
-    input:checked + .kt-checkbox-icon {
+    input:checked + .@{prefix}-checkbox-icon {
       background-color: var(--kt-checkbox-disableBackground);
       color: var(--kt-checkbox-disableForeground);
       border-color: transparent;

--- a/packages/components/src/dialog/styles.less
+++ b/packages/components/src/dialog/styles.less
@@ -1,10 +1,12 @@
+@import '../style/variable.less';
+
 .wrapper {
-  .kt-modal-body {
+  .@{prefix}-modal-body {
     background: var(--kt-modal-background);
     border-color: var(--notifications-border);
   }
 
-  .kt-modal-footer {
+  .@{prefix}-modal-footer {
     align-items: center;
     justify-content: flex-end;
     display: flex;
@@ -14,7 +16,7 @@
     color: var(--kt-modalInfoIcon-foreground);
   }
 
-  .kt-modal-close-x {
+  .@{prefix}-modal-close-x {
     margin: 50% 50% 0 0;
     width: 20px;
     height: 20px;
@@ -23,16 +25,16 @@
   }
 }
 
-.kt-dialog-content {
+.@{prefix}-dialog-content {
   display: flex;
 
-  .kt-dialog-content_area {
+  .@{prefix}-dialog-content_area {
     display: flex;
     flex-direction: column;
     flex: 1;
     overflow: hidden;
 
-    .kt-dialog-content_title {
+    .@{prefix}-dialog-content_title {
       line-height: 22px;
       font-size: 14px;
       margin: 0px 0px 8px 0px;
@@ -44,7 +46,7 @@
   border-top: 1px solid var(--notifications-border);
 }
 
-.kt-dialog-icon {
+.@{prefix}-dialog-icon {
   margin-right: 12px;
 
   &:before {
@@ -52,7 +54,7 @@
   }
 }
 
-.kt-dialog-closex {
+.@{prefix}-dialog-closex {
   background-color: transparent;
   border: none;
   outline: none;
@@ -62,7 +64,7 @@
   cursor: pointer;
 }
 
-.kt-dialog-buttonWrap {
+.@{prefix}-dialog-buttonWrap {
   display: flex;
   flex-wrap: wrap;
   margin-top: 14px;
@@ -73,7 +75,7 @@
   }
 }
 
-.kt-dialog-message {
+.@{prefix}-dialog-message {
   color: var(--kt-modal-foreground);
   line-height: 22px;
   font-size: 14px;

--- a/packages/components/src/dialog/styles.less
+++ b/packages/components/src/dialog/styles.less
@@ -47,7 +47,12 @@
 }
 
 .@{prefix}-dialog-icon {
-  margin-right: 12px;
+  margin-right: 10px;
+  border: none;
+  outline: none;
+  display: flex;
+  flex-direction: column;
+  padding: 0px;
 
   &:before {
     font-size: 20px;
@@ -62,6 +67,14 @@
   flex-direction: column;
   padding: 0px;
   cursor: pointer;
+  margin-left: 6px;
+  height: 20px;
+  width: 20px;
+  align-items: center;
+  line-height: 20px;
+  &:hover {
+    transform: scale(1.2);
+  }
 }
 
 .@{prefix}-dialog-buttonWrap {

--- a/packages/components/src/dropdown/style.less
+++ b/packages/components/src/dropdown/style.less
@@ -1,7 +1,7 @@
 @import '../style/variable.less';
 @import '../style/mixins.less';
 
-@dropdown-prefix-cls: ~'@{kt-prefix}-dropdown';
+@dropdown-prefix-cls: ~'@{prefix}-dropdown';
 
 .@{dropdown-prefix-cls} {
   .reset-component;
@@ -26,7 +26,7 @@
   &-wrap {
     position: relative;
 
-    .@{kt-prefix}-btn > .@{iconfont-css-prefix}-down {
+    .@{prefix}-btn > .@{iconfont-css-prefix}-down {
       .iconfont-size-under-12px(10px);
     }
 
@@ -244,7 +244,7 @@
 .@{dropdown-prefix-cls}-button {
   white-space: nowrap;
 
-  &.@{kt-prefix}-btn-group > .@{kt-prefix}-btn:last-child:not(:first-child) {
+  &.@{prefix}-btn-group > .@{prefix}-btn:last-child:not(:first-child) {
     padding-right: @padding-xs;
     padding-left: @padding-xs;
   }

--- a/packages/components/src/icon/styles.less
+++ b/packages/components/src/icon/styles.less
@@ -1,4 +1,6 @@
-.kt-icon {
+@import '../style/variable.less';
+
+.@{prefix}-icon {
   display: inline-block;
   background-repeat: no-repeat;
   cursor: pointer;

--- a/packages/components/src/input/input.less
+++ b/packages/components/src/input/input.less
@@ -1,4 +1,6 @@
-.kt-input {
+@import '../style/variable.less';
+
+.@{prefix}-input {
   width: 100%;
   display: flex;
   align-items: center;

--- a/packages/components/src/input/validate-input.less
+++ b/packages/components/src/input/validate-input.less
@@ -6,7 +6,7 @@
   height: 100%;
   position: relative;
 
-  .kt-input {
+  .@{prefix}-input {
     &.validate-error {
       border: 1px solid var(--inputValidation-errorBorder);
       background-color: var(--inputValidation-errorBackground);
@@ -24,7 +24,7 @@
   }
 
   &.popup {
-    .kt-input {
+    .@{prefix}-input {
       background-color: var(--input-background);
     }
   }

--- a/packages/components/src/menu/style.less
+++ b/packages/components/src/menu/style.less
@@ -1,7 +1,7 @@
 @import '../style/variable.less';
 @import '../style/mixins.less';
 
-@menu-prefix-cls: ~'@{kt-prefix}-inner-menu';
+@menu-prefix-cls: ~'@{prefix}-inner-menu';
 
 // default theme
 .@{menu-prefix-cls} {
@@ -70,7 +70,7 @@
   }
 
   // https://github.com/ant-design/ant-design/issues/19809
-  &-item > .@{kt-prefix}-badge > a {
+  &-item > .@{prefix}-badge > a {
     color: @menu-item-color;
     &:hover {
       color: @menu-highlight-color;

--- a/packages/components/src/message/style.less
+++ b/packages/components/src/message/style.less
@@ -1,7 +1,7 @@
 @import '../style/variable.less';
 @import '../style/mixins.less';
 
-@message-prefix-cls: ~'@{kt-prefix}-message';
+@message-prefix-cls: ~'@{prefix}-message';
 
 .@{message-prefix-cls} {
   .reset-component;

--- a/packages/components/src/modal/style.less
+++ b/packages/components/src/modal/style.less
@@ -1,8 +1,8 @@
 @import '../style/variable.less';
 @import '../style/mixins.less';
 
-@dialog-prefix-cls: ~'@{kt-prefix}-modal';
-@table-prefix-cls: ~'@{kt-prefix}-table';
+@dialog-prefix-cls: ~'@{prefix}-modal';
+@table-prefix-cls: ~'@{prefix}-table';
 @modal-footer-padding-vertical: 10px;
 @modal-footer-padding-horizontal: 16px;
 

--- a/packages/components/src/notification/notification.less
+++ b/packages/components/src/notification/notification.less
@@ -94,6 +94,7 @@
     }
 
     .@{iconfont-css-prefix}&-icon {
+      height: 20px;
       &-success {
         color: @success-color;
       }
@@ -112,6 +113,7 @@
       position: absolute;
       top: 16px;
       right: 22px;
+      height: 20px;
       color: @text-color-secondary;
       outline: none;
 
@@ -210,7 +212,7 @@
 
   .@{iconfont-css-prefix} {
     font-size: 12px;
-    margin-top: 5px;
+    margin-top: 1px;
   }
 
   .@{notification-prefix-cls}-notice {

--- a/packages/components/src/notification/notification.less
+++ b/packages/components/src/notification/notification.less
@@ -121,7 +121,10 @@
     }
 
     &-btn {
-      float: right;
+      display: flex;
+      flex-flow: wrap;
+      align-items: center;
+      justify-content: flex-start;
       margin-top: 16px;
     }
   }
@@ -226,7 +229,8 @@
     }
 
     &-btn button {
-      margin: 0 0 0 10px;
+      flex: 1;
+      margin: 0 0 5px 10px;
     }
   }
 }

--- a/packages/components/src/notification/notification.less
+++ b/packages/components/src/notification/notification.less
@@ -1,7 +1,7 @@
 @import '../style/variable.less';
 @import '../style/mixins.less';
 
-@notification-prefix-cls: ~'@{kt-prefix}-notification';
+@notification-prefix-cls: ~'@{prefix}-notification';
 @notification-width: 384px;
 @notification-padding-vertical: 16px;
 @notification-padding-horizontal: 24px;

--- a/packages/components/src/overlay/styles.less
+++ b/packages/components/src/overlay/styles.less
@@ -1,6 +1,6 @@
 @import '../style/variable.less';
 
-@dialog-prefix-cls: ~'@{kt-prefix}-modal';
+@dialog-prefix-cls: ~'@{prefix}-modal';
 
 .kt-overlay {
   &.@{dialog-prefix-cls} {

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -1,4 +1,5 @@
 @import '../style/mixins.less';
+@import '../style/variable.less';
 
 .arrow(@position) {
   & when (@position = 'top'), (@position = 'bottom') {
@@ -86,7 +87,7 @@
   }
 }
 
-.kt-popover {
+.@{prefix}-popover {
   position: relative;
   display: flex;
   justify-content: center;
@@ -102,7 +103,7 @@
     justify-content: space-between;
     margin-bottom: 4px;
 
-    &.kt-button,
+    &.@{prefix}-button,
     .small-button-size {
       padding: 0px;
     }

--- a/packages/components/src/scrollbars/styles.less
+++ b/packages/components/src/scrollbars/styles.less
@@ -1,4 +1,6 @@
-.kt-scrollbar {
+@import '../style/variable.less';
+
+.@{prefix}-scrollbar {
   .scrollbar-thumb-vertical,
   .scrollbar-thumb-horizontal {
     opacity: 0;

--- a/packages/components/src/style/variable.less
+++ b/packages/components/src/style/variable.less
@@ -1,4 +1,4 @@
-@kt-prefix: kt;
+@prefix: kt;
 
 // An override for the html selector for theme prefixes
 @html-selector: html;
@@ -201,3 +201,7 @@
 // Motion
 // ---
 @wave-animation-width: 6px;
+
+// Checkbox
+@checkbox-default-size: 12px;
+@checkbox-large-size: 14px;

--- a/packages/components/src/tabs/style.less
+++ b/packages/components/src/tabs/style.less
@@ -1,34 +1,36 @@
-.kt-tabs {
+@import '../style/variable.less';
+
+.@{prefix}-tabs {
   display: flex;
   align-items: center;
   border-bottom: 1px solid var(--kt-tab-borderDown);
 
-  .kt-tab,
-  .kt-custom-tab {
+  .@{prefix}-tab,
+  .@{prefix}-custom-tab {
     padding: 8px 0 8px;
     line-height: 20px;
     border-bottom: 2px solid transparent;
     color: var(--kt-tab-inactiveForeground);
     cursor: pointer;
 
-    &.kt-mini-tab {
+    &.@{prefix}-mini-tab {
       padding: 2px 0 2px;
     }
 
-    &.kt-tab-selected {
+    &.@{prefix}-tab-selected {
       color: var(--kt-tab-activeForeground);
       border-bottom-color: var(--kt-tab-activeBorder);
     }
   }
 
-  &.kt-tabs-mini {
+  &.@{prefix}-tabs-mini {
     border-bottom: none;
   }
 
-  .kt-tab + .kt-tab,
-  .kt-custom-tab + .kt-custom-tab,
-  .kt-tab + .kt-custom-tab,
-  .kt-custom-tab + .kt-tab {
+  .@{prefix}-tab + .@{prefix}-tab,
+  .@{prefix}-custom-tab + .@{prefix}-custom-tab,
+  .@{prefix}-tab + .@{prefix}-custom-tab,
+  .@{prefix}-custom-tab + .@{prefix}-tab {
     margin-left: 24px;
   }
 }

--- a/packages/components/src/tooltip/style.less
+++ b/packages/components/src/tooltip/style.less
@@ -1,10 +1,12 @@
-.kt-tooltip-wrapper {
+@import '../style/variable.less';
+
+.@{prefix}-tooltip-wrapper {
   position: relative;
   margin: 0px;
   padding: 0px;
   display: inline-block;
 
-  .kt-tooltip-content {
+  .@{prefix}-tooltip-content {
     display: inline-block;
     position: fixed;
     font-size: 12px;
@@ -19,7 +21,7 @@
     box-shadow: 0px 6px 16px -8px rgba(0, 0, 0, 0.24), 0px 9px 28px 0px rgba(0, 0, 0, 0.15),
       0px 12px 48px 16px rgba(0, 0, 0, 0.09);
 
-    .kt-tooltip-arrow-placeholder {
+    .@{prefix}-tooltip-arrow-placeholder {
       position: absolute;
       top: 100%;
       width: 0;
@@ -28,7 +30,7 @@
       border-width: 7px 7px 0 7px;
       border-color: var(--kt-tooltip-background) transparent transparent transparent;
 
-      &.kt-tooltip-reverse-arrow {
+      &.@{prefix}-tooltip-reverse-arrow {
         top: auto !important;
         bottom: 100% !important;
         border-width: 0px 7px 7px 7px !important;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

close #1538.

重构 Component 模块内样式前缀，统一使用 `@prefix` 变量。

优化 Dialog 样式

before:
![image](https://user-images.githubusercontent.com/9823838/187349969-02a23770-6dc3-48a3-b6fd-766f79739965.png)

after:
![image](https://user-images.githubusercontent.com/9823838/187349980-04184822-fcd7-4d35-b5aa-0087e21a87eb.png)

优化消息弹窗按钮样式

before:
![image](https://user-images.githubusercontent.com/9823838/187350038-f021212d-96a6-4194-827e-78b590bb3609.png)

after:

![image](https://user-images.githubusercontent.com/9823838/187350063-e8b2868a-0114-4e96-94f7-c22b4c981282.png)

### Changelog

improve dialog and notification style
