### PR TITLE
fix: windows header bar icon not a correct position

### DIFF
--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -34,6 +34,10 @@
   > div {
     font-size: 16px;
     padding: 0 15px;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
 
     &:hover {
       background-color: hsla(0, 0%, 100%, 0.1);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
- 修复 icon 位置不正确问题，最开始增加高度导致 Windows 的图标没有对齐 https://github.com/opensumi/core/pull/1342
- 修复 title bar 拖动有时候拖拽失败，因为 header bar 的高度变了后，变成很窄的一个区域
<img width="584" alt="image" src="https://user-images.githubusercontent.com/2226423/187620023-af55c406-e278-4263-a2f6-fccf5b712d28.png">


### Changelog

修复 Windows 环境下 TitleBar 区域图标对齐问题
