### PR TITLE
refactor: add missing type for `file-service`

### DIFF
--- a/packages/file-service/src/browser/file-service-provider-client.ts
+++ b/packages/file-service/src/browser/file-service-provider-client.ts
@@ -122,7 +122,7 @@ export class DiskFsProviderClient extends CoreFileServiceProviderClient implemen
     return this.fileServiceProvider.copy(source, destination, options);
   }
 
-  access(uri: Uri, mode) {
+  access(uri: Uri, mode: number) {
     return this.fileServiceProvider.access(uri, mode);
   }
 

--- a/packages/file-service/src/common/file-ext.ts
+++ b/packages/file-service/src/common/file-ext.ts
@@ -1,0 +1,3 @@
+export const EXT_LIST_VIDEO = ['mp4', 'ogg', 'webm'];
+
+export const EXT_LIST_IMAGE = ['png', 'gif', 'jpg', 'jpeg', 'svg'];

--- a/packages/file-service/src/common/file-ext.ts
+++ b/packages/file-service/src/common/file-ext.ts
@@ -1,3 +1,25 @@
-export const EXT_LIST_VIDEO = ['mp4', 'ogg', 'webm'];
+export const EXT_LIST_VIDEO = ['mp4', 'webm', 'mkv', 'mov', 'mts', 'flv', 'avi', 'wmv'];
 
-export const EXT_LIST_IMAGE = ['png', 'gif', 'jpg', 'jpeg', 'svg'];
+export const EXT_LIST_IMAGE = [
+  'png',
+  'gif',
+  'jpg',
+  'jpeg',
+  'svg',
+  'bmp',
+  'avif',
+  'cr2',
+  'cr3',
+  'dng',
+  'flif',
+  'heic',
+  'icns',
+  'jxl',
+  'jpm',
+  'jpx',
+  'nef',
+  'raf',
+  'rw2',
+  'tif',
+  'orf',
+];

--- a/packages/file-service/src/common/index.ts
+++ b/packages/file-service/src/common/index.ts
@@ -1,6 +1,7 @@
 export * from './file-service-client';
 export * from './files';
 export * from './watcher';
+export * from './file-ext';
 
 export const FileServicePath = 'FileService';
 export const DiskFileServicePath = 'DiskFileService';

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -664,7 +664,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     }
   }
 
-  private _getFileType(ext) {
+  private _getFileType(ext: string) {
     let type = 'text';
 
     if (['png', 'gif', 'jpg', 'jpeg', 'svg'].indexOf(ext) !== -1) {

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -37,6 +37,8 @@ import {
   IDiskFileProvider,
   FileAccess,
   FileSystemProviderCapabilities,
+  EXT_LIST_VIDEO,
+  EXT_LIST_IMAGE,
 } from '../common/';
 
 import { ParcelWatcherServer } from './file-service-watcher';
@@ -58,8 +60,6 @@ export interface IWatcher {
 
 @Injectable({ multiple: true })
 export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvider> implements IDiskFileProvider {
-  static readonly H5VideoExtList = ['mp4', 'ogg', 'webm'];
-
   private fileChangeEmitter = new Emitter<FileChangeEvent>();
   private watcherServer: ParcelWatcherServer;
   readonly onDidChangeFile: Event<FileChangeEvent> = this.fileChangeEmitter.event;
@@ -667,9 +667,9 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   private _getFileType(ext: string) {
     let type = 'text';
 
-    if (['png', 'gif', 'jpg', 'jpeg', 'svg'].indexOf(ext) !== -1) {
+    if (EXT_LIST_IMAGE.indexOf(ext) !== -1) {
       type = 'image';
-    } else if (DiskFileSystemProvider.H5VideoExtList.indexOf(ext) !== -1) {
+    } else if (EXT_LIST_VIDEO.indexOf(ext) !== -1) {
       type = 'video';
     } else if (ext && ['xml'].indexOf(ext) === -1) {
       type = 'binary';

--- a/packages/file-service/src/node/file-service.ts
+++ b/packages/file-service/src/node/file-service.ts
@@ -589,7 +589,7 @@ export class FileService implements IFileService {
     return true;
   }
 
-  private _getFileType(ext) {
+  private _getFileType(ext: string) {
     let type = 'text';
 
     if (EXT_LIST_IMAGE.indexOf(ext) !== -1) {

--- a/packages/file-service/src/node/file-service.ts
+++ b/packages/file-service/src/node/file-service.ts
@@ -23,7 +23,7 @@ import {
   match,
 } from '@opensumi/ide-core-node';
 
-import { FileChangeEvent, TextDocumentContentChangeEvent } from '../common';
+import { FileChangeEvent, EXT_LIST_IMAGE, TextDocumentContentChangeEvent } from '../common';
 import {
   FileSystemError,
   FileStat,
@@ -592,7 +592,7 @@ export class FileService implements IFileService {
   private _getFileType(ext) {
     let type = 'text';
 
-    if (['png', 'gif', 'jpg', 'jpeg', 'svg'].indexOf(ext) !== -1) {
+    if (EXT_LIST_IMAGE.indexOf(ext) !== -1) {
       type = 'image';
     } else if (ext && ['xml'].indexOf(ext) === -1) {
       type = 'binary';

--- a/packages/startup/entry/web-lite/lite-module/file-provider/browser-fs-provider.ts
+++ b/packages/startup/entry/web-lite/lite-module/file-provider/browser-fs-provider.ts
@@ -12,6 +12,8 @@ import {
   FileSystemError,
   notEmpty,
   isErrnoException,
+  EXT_LIST_IMAGE,
+  EXT_LIST_VIDEO,
 } from '@opensumi/ide-file-service';
 
 import { HttpTreeList } from './http-file.service';
@@ -27,8 +29,6 @@ export const BROWSER_HOME_DIR = FileUri.create('/home');
 // 预览模式下，文件改动仅同步到本地；常规场景直接同步远端，本地不做文件存储
 // 利用storage来记录文件已加载的信息，dispose时记得清楚
 export class BrowserFsProvider implements IDiskFileProvider {
-  static H5VideoExtList = ['mp4', 'ogg', 'webm'];
-
   static binaryExtList = [
     'aac',
     'avi',
@@ -447,9 +447,9 @@ export class BrowserFsProvider implements IDiskFileProvider {
   private _getFileType(ext: string) {
     let type = 'text';
 
-    if (['png', 'gif', 'jpg', 'jpeg', 'svg'].indexOf(ext) > -1) {
+    if (EXT_LIST_IMAGE.indexOf(ext) > -1) {
       type = 'image';
-    } else if (BrowserFsProvider.H5VideoExtList.indexOf(ext) > -1) {
+    } else if (EXT_LIST_VIDEO.indexOf(ext) > -1) {
       type = 'video';
     } else if (BrowserFsProvider.binaryExtList.indexOf(ext) > -1) {
       type = 'binary';


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Changelog

- refactor: add missing type for method of `DiskFsProviderClient`
- refactor: add missing type for method of `DiskFileSystemProvider`
