### PR TITLE
fix: auto focus editor tab when opening a file on filetree

### DIFF
--- a/packages/components/src/scrollbars/styles.less
+++ b/packages/components/src/scrollbars/styles.less
@@ -1,6 +1,9 @@
 @import '../style/variable.less';
 
 .@{prefix}-scrollbar {
+  will-change: transform;
+  direction: ltr;
+  transform: translate3d(0px, 0px, 0px);
   .scrollbar-thumb-vertical,
   .scrollbar-thumb-horizontal {
     opacity: 0;
@@ -16,11 +19,11 @@
   }
 
   .scrollbar-thumb-vertical {
-    width: 10px;
+    z-index: 9999;
   }
 
   .scrollbar-thumb-horizontal {
-    height: 10px;
+    z-index: 9999;
   }
 
   // 设置滚动条样式
@@ -31,7 +34,7 @@
     }
   }
 
-  .scrollbar-decoration {
+  .scrollbar-decoration-vertical {
     position: fixed;
     top: 0;
     left: 0;
@@ -39,5 +42,15 @@
     height: 6px;
     z-index: 999;
     box-shadow: var(--scrollbar-shadow) 0 6px 6px -6px inset;
+  }
+
+  .scrollbar-decoration-horizontal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 6px;
+    z-index: 999;
+    box-shadow: var(--scrollbar-shadow) 6px 0 6px -6px inset;
   }
 }

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -4,7 +4,6 @@
 .kt_workbench_editor {
   height: 100%;
   background-color: var(--editor-background);
-  border-top: 1px solid var(--tab-border);
   display: flex;
 }
 .kt_editor_main_wrapper {
@@ -61,6 +60,7 @@
       padding: 0 5px 0 10px;
       background: var(--editorGroupHeader-tabsBackground);
       border-bottom: 1px solid var(--tab-border);
+      border-top: 1px solid var(--tab-border);
       .editor_action_wrapper {
         margin-left: 8px;
         position: relative;
@@ -89,27 +89,33 @@
 
   .kt_editor_tabs_scroll_wrapper {
     flex-grow: 1;
-    width: 10px;
-    :global(.thumb-vertical) {
-      opacity: 0 !important;
+    width: 100%;
+    position: relative;
+    &::before {
+      position: absolute;
+      content: '';
+      height: 1px;
+      width: 100%;
+      top: 0;
+      left: 0;
+      z-index: 10;
+      background-color: var(--tab-border);
+    }
+    &::after {
+      position: absolute;
+      content: '';
+      height: 1px;
+      width: 100%;
+      bottom: 0;
+      left: 0;
+      z-index: 10;
+      background-color: var(--tab-border);
     }
   }
 
   .kt_editor_tabs_scroll {
     overflow-y: hidden;
     background: var(--editorGroupHeader-tabsBackground);
-    &::before {
-      content: '';
-      height: 1px;
-      background: var(--tab-border);
-      bottom: 0;
-      width: 100%;
-      left: 0;
-      position: absolute;
-      display: block;
-      z-index: 0;
-    }
-
     :global(.loading_indicator) {
       width: 16px;
       height: 22px;
@@ -250,12 +256,21 @@
         }
       }
       &.kt_editor_tab_current {
+        position: relative;
         background: var(--tab-activeBackground);
         color: var(--tab-activeForeground);
         border-bottom: 1px solid var(--tab-activeBackground);
         border-bottom-color: var(--tab-activeBorder);
-        border-top: 1px solid var(--tab-activeBackground);
-        border-top-color: var(--tab-activeBorderTop);
+        &::before {
+          position: absolute;
+          content: '';
+          height: 2px;
+          width: 100%;
+          top: 0;
+          left: 0;
+          z-index: 999;
+          background-color: var(--tab-activeBorderTop);
+        }
         .dirty {
           &::before {
             background-color: var(--kt-dirtyDot-foreground);

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -124,7 +124,7 @@ export const Tabs = ({ group }: ITabsProps) => {
             '.' + styles.kt_editor_tab + "[data-uri='" + group.currentResource.uri.toString() + "']",
           );
           if (currentTab) {
-            scrollToTabEl(tabContainer.current, currentTab as HTMLDivElement);
+            currentTab.scrollIntoView();
           }
         } catch (e) {
           // noop
@@ -473,40 +473,6 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
     );
   },
 );
-
-/**
- * 获取 Tab DOM 在可视范围的位置
- * @param {HTMLElement} container
- * @param {HTMLElement} el
- * @returns {number} -1 左边，0 可见，1 右边
- */
-function getTabDOMPosition(container: HTMLElement, el: HTMLElement): number {
-  const left = container.scrollLeft;
-  const right = left + container.offsetWidth;
-  const elLeft = el.offsetLeft;
-  const elRight = el.offsetWidth + elLeft;
-  if (el.offsetWidth > container.offsetWidth) {
-    return -1;
-  }
-  if (left <= elLeft) {
-    if (right >= elRight) {
-      return 0;
-    } else {
-      return 1;
-    }
-  } else {
-    return -1;
-  }
-}
-
-function scrollToTabEl(container: HTMLElement, el: HTMLElement) {
-  const position = getTabDOMPosition(container, el);
-  if (position < 0) {
-    container.scrollLeft = el.offsetLeft;
-  } else if (position > 0) {
-    container.scrollLeft = el.offsetLeft + el.offsetWidth - container.offsetWidth;
-  }
-}
 
 function preventNavigation(this: HTMLDivElement, e: WheelEvent) {
   if (this.offsetWidth + this.scrollLeft + e.deltaX > this.scrollWidth) {

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import React, { useEffect, useState, useCallback, useRef, useContext, useMemo, forwardRef } from 'react';
 
+import { Scrollbars } from '@opensumi/ide-components';
 import {
   getIcon,
   MaybeNull,
@@ -16,7 +17,6 @@ import {
   Event,
 } from '@opensumi/ide-core-browser';
 import { InlineActionBar } from '@opensumi/ide-core-browser/lib/components/actions';
-import { Scroll } from '@opensumi/ide-core-browser/lib/components/scroll';
 import { LAYOUT_VIEW_SIZE } from '@opensumi/ide-core-browser/lib/layout/constants';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
 import { IMenuRegistry, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
@@ -131,7 +131,7 @@ export const Tabs = ({ group }: ITabsProps) => {
         }
       }
     }
-  }, [group]);
+  }, [group, tabContainer.current]);
 
   const updateTabMarginRight = useCallback(() => {
     if (editorActionUpdateTimer.current) {
@@ -388,9 +388,13 @@ export const Tabs = ({ group }: ITabsProps) => {
     <div id={VIEW_CONTAINERS.EDITOR_TABS} className={styles.kt_editor_tabs}>
       <div className={styles.kt_editor_tabs_scroll_wrapper}>
         {!wrapMode ? (
-          <Scroll ref={(el) => (el ? (tabContainer.current = el.ref) : null)} className={styles.kt_editor_tabs_scroll}>
+          <Scrollbars
+            thumbSize={5}
+            forwardedRef={(el) => (el ? (tabContainer.current = el) : null)}
+            className={styles.kt_editor_tabs_scroll}
+          >
             {renderTabContent()}
-          </Scroll>
+          </Scrollbars>
         ) : (
           <div className={styles.kt_editor_wrap_container}>{renderTabContent()}</div>
         )}
@@ -471,10 +475,10 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
 );
 
 /**
- * 获取tab DOM在可视范围的位置
+ * 获取 Tab DOM 在可视范围的位置
  * @param {HTMLElement} container
  * @param {HTMLElement} el
- * @returns {number} -1左边或骑跨，0可见，1右边
+ * @returns {number} -1 左边，0 可见，1 右边
  */
 function getTabDOMPosition(container: HTMLElement, el: HTMLElement): number {
   const left = container.scrollLeft;

--- a/packages/main-layout/src/browser/accordion/titlebar.view.tsx
+++ b/packages/main-layout/src/browser/accordion/titlebar.view.tsx
@@ -8,7 +8,7 @@ export const TitleBar: React.FC<{
   title: string;
   menubar?: React.ReactNode;
 }> = React.memo((props) => (
-  <div className={styles.titlebar} style={{ height: LAYOUT_VIEW_SIZE.PANEL_TITLEBAR_HEIGHT }}>
+  <div className={styles.titlebar} style={{ height: LAYOUT_VIEW_SIZE.PANEL_TITLEBAR_HEIGHT - 2 }}>
     <h1>{props.title}</h1>
     {props.menubar || null}
   </div>

--- a/packages/startup/entry/web/layout.tsx
+++ b/packages/startup/entry/web/layout.tsx
@@ -7,8 +7,8 @@ export function DefaultLayout() {
   const { colors, layout } = getStorageValue();
   return (
     <BoxPanel direction='top-to-bottom'>
-      <SlotRenderer backgroundColor={colors.menuBarBackground} defaultSize={34} slot='top' z-index={2} />
-      <SplitPanel id='main-horizontal' overflow='hidden' flex={1}>
+      <SlotRenderer backgroundColor={colors.menuBarBackground} defaultSize={35} slot='top' z-index={2} />
+      <SplitPanel id='main-horizontal' flex={1}>
         <SlotRenderer
           backgroundColor={colors.sideBarBackground}
           slot='left'


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

统一使用了 `@opensumi/ide-components` 内的 `Scroller` 组件，后续对于引用 [packages/core-browser/src/components/scroll/index.tsx](https://github.com/opensumi/core/blob/5bbeaa642290304f5d43693713ac26a09f645fb4/packages/core-browser/src/components/scroll/index.tsx) 的组件均可平滑替换，具备更良好的拓展性

同时移除了原有依赖 DOM 计算去定位 Tab 的逻辑（存在时序问题），由于 `Scroller` 组件依旧是基于原生 Scroller 做的拓展，故可以直接使用兼容性良好的 `Element.scrollIntoView() API`，相关兼容性见：[浏览器兼容性](https://developer.mozilla.org/zh-CN/docs/Web/API/Element/scrollIntoView#%E6%B5%8F%E8%A7%88%E5%99%A8%E5%85%BC%E5%AE%B9%E6%80%A7)
<img width="804" alt="image" src="https://user-images.githubusercontent.com/9823838/188296445-a2ccccfa-58ec-4cff-8a24-eeaea0da7697.png">

修改后效果预览（跳转丝滑许多）

https://user-images.githubusercontent.com/9823838/188296450-77c2ac72-da51-41ca-836d-879f1211d7fc.mp4

### Changelog

auto focus editor tab when opening a file on filetree