### PR TITLE
fix: reveal file on the filetree when editor focused

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -909,6 +909,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
         this._onDidEditorFocusChange.fire();
       }),
       this.codeEditor.onFocus(() => {
+        if (this.codeEditor.currentUri) {
+          this.locateInFileTree(this.codeEditor.currentUri);
+        }
         this._currentOrPreviousFocusedEditor = this.codeEditor;
         this.setContextKeys();
         this._onDidEditorFocusChange.fire();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1626.

### Changelog

reveal file on the filetree when editor tobe focused