### PR TITLE
refactor: refactor register language configuration

### DIFF
--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -703,6 +703,7 @@ export class EditorContribution
               });
             }
           }
+
         }
       },
     });

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -39,6 +39,7 @@ import {
   LanguageConfiguration,
   OnEnterRule,
 } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
+import { IIndentationRule, IndentAction, IndentationRuleDto, IRegExp, LanguageConfigurationDto, LanguagesContribution } from '@opensumi/ide-monaco/lib/common';
 import { IThemeData } from '@opensumi/ide-theme';
 import { ThemeChangedEvent } from '@opensumi/ide-theme/lib/common/event';
 import type { ILanguageExtensionPoint } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
@@ -48,7 +49,6 @@ import { IEditorDocumentModelService } from '../../doc-model/types';
 
 import { TextmateRegistry } from './textmate-registry';
 import { createTextmateTokenizer, TokenizerOption } from './textmate-tokenizer';
-import { IIndentationRule, IndentAction, IndentationRuleDto, IRegExp, LanguageConfigurationDto, LanguagesContribution } from '@opensumi/ide-monaco/lib/common';
 
 let wasmLoaded = false;
 
@@ -564,7 +564,7 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 			return undefined;
 		}
 
-		let result: OnEnterRule[] | undefined = undefined;
+		let result: OnEnterRule[] | undefined;
 		for (let i = 0, len = source.length; i < len; i++) {
 			const onEnterRule = source[i];
 			if (!isObject(onEnterRule)) {

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -537,7 +537,7 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 			return undefined;
 		}
 		if (!Array.isArray(source)) {
-			console.warn(`[${languageId}]: language configuration: expected \`colorizedBracketPairs\` to be an array.`);
+			this.logger.warn(`[${languageId}]: language configuration: expected \`colorizedBracketPairs\` to be an array.`);
 			return undefined;
 		}
 
@@ -545,7 +545,7 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 		for (let i = 0, len = source.length; i < len; i++) {
 			const pair = source[i];
 			if (!isCharacterPair(pair)) {
-				console.warn(`[${languageId}]: language configuration: expected \`colorizedBracketPairs[${i}]\` to be an array of two strings.`);
+				this.logger.warn(`[${languageId}]: language configuration: expected \`colorizedBracketPairs[${i}]\` to be an array of two strings.`);
 				continue;
 			}
 			result.push([pair[0], pair[1]]);
@@ -560,7 +560,7 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 			return undefined;
 		}
 		if (!Array.isArray(source)) {
-			console.warn(`[${languageId}]: language configuration: expected \`onEnterRules\` to be an array.`);
+			this.logger.warn(`[${languageId}]: language configuration: expected \`onEnterRules\` to be an array.`);
 			return undefined;
 		}
 
@@ -568,11 +568,11 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 		for (let i = 0, len = source.length; i < len; i++) {
 			const onEnterRule = source[i];
 			if (!isObject(onEnterRule)) {
-				console.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}]\` to be an object.`);
+				this.logger.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}]\` to be an object.`);
 				continue;
 			}
 			if (!isObject(onEnterRule.action)) {
-				console.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action\` to be an object.`);
+				this.logger.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action\` to be an object.`);
 				continue;
 			}
 			let indentAction: IndentAction;
@@ -585,7 +585,7 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 			} else if (onEnterRule.action.indent === 'outdent') {
 				indentAction = IndentAction.Outdent;
 			} else {
-				console.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action.indent\` to be 'none', 'indent', 'indentOutdent' or 'outdent'.`);
+				this.logger.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action.indent\` to be 'none', 'indent', 'indentOutdent' or 'outdent'.`);
 				continue;
 			}
 			const action: EnterAction = { indentAction };
@@ -593,14 +593,14 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 				if (typeof onEnterRule.action.appendText === 'string') {
 					action.appendText = onEnterRule.action.appendText;
 				} else {
-					console.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action.appendText\` to be undefined or a string.`);
+					this.logger.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action.appendText\` to be undefined or a string.`);
 				}
 			}
 			if (onEnterRule.action.removeText) {
 				if (typeof onEnterRule.action.removeText === 'number') {
 					action.removeText = onEnterRule.action.removeText;
 				} else {
-					console.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action.removeText\` to be undefined or a number.`);
+					this.logger.warn(`[${languageId}]: language configuration: expected \`onEnterRules[${i}].action.removeText\` to be undefined or a number.`);
 				}
 			}
 			const beforeText = this.createRegex(onEnterRule.beforeText);

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1552,6 +1552,16 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     default: EDITOR_DEFAULTS.showUnused,
     description: localize('showUnused', 'Controls fading out of unused code.'),
   },
+  'editor.comments.insertSpace': {
+    type: 'boolean',
+    default: true,
+    description: localize('insertSpace', 'Insert a space after the line comment token and inside the block comments tokens.'),
+  },
+  'editor.comments.ignoreEmptyLines': {
+    type: 'boolean',
+    default: true,
+    description: localize('insertSpace', 'Ignore empty lines when inserting line comments.'),
+  },
   'editor.links': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.links,

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -2105,7 +2105,6 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
 
   componentUndo() {
     const currentOpenType = this.currentOpenType;
-    console.log('currentOpenType>', currentOpenType);
     if (currentOpenType?.undo) {
       currentOpenType.undo(this.currentResource!);
     }

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -2105,6 +2105,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
 
   componentUndo() {
     const currentOpenType = this.currentOpenType;
+    console.log('currentOpenType>', currentOpenType);
     if (currentOpenType?.undo) {
       currentOpenType.undo(this.currentResource!);
     }

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -1069,7 +1069,6 @@ export class MainThreadLanguages implements IMainThreadLanguages {
       indentationRules: reviveIndentationRule(configuration.indentationRules),
       onEnterRules: reviveOnEnterRules(configuration.onEnterRules),
     };
-    console.log('language config>', config);
     this.disposables.set(handle, monaco.languages.setLanguageConfiguration(languageId, config));
   }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -1069,7 +1069,7 @@ export class MainThreadLanguages implements IMainThreadLanguages {
       indentationRules: reviveIndentationRule(configuration.indentationRules),
       onEnterRules: reviveOnEnterRules(configuration.onEnterRules),
     };
-
+    console.log('language config>', config);
     this.disposables.set(handle, monaco.languages.setLanguageConfiguration(languageId, config));
   }
 

--- a/packages/extension/src/browser/vscode/contributes/language.ts
+++ b/packages/extension/src/browser/vscode/contributes/language.ts
@@ -5,6 +5,7 @@ import { ITextmateTokenizer, ITextmateTokenizerService } from '@opensumi/ide-mon
 
 import { VSCodeContributePoint, Contributes } from '../../../common';
 
+
 export type LanguagesSchema = Array<LanguagesContribution>;
 
 @Injectable()

--- a/packages/monaco/src/browser/contrib/tokenizer.ts
+++ b/packages/monaco/src/browser/contrib/tokenizer.ts
@@ -1,11 +1,6 @@
 import { URI } from '@opensumi/ide-core-common';
 
 import { LanguagesContribution } from '../../common';
-import {
-  FoldingRules,
-  IAutoClosingPair,
-  IAutoClosingPairConditional,
-} from '../monaco-api/types';
 
 export const ITextmateTokenizer = Symbol('ITextmateTokenizer');
 
@@ -39,54 +34,4 @@ export interface GrammarsContribution {
    * 主要解决无需多个插件即可注册多个 grammar 进来
    */
   resolvedConfiguration?: object;
-}
-
-export interface IndentationRules {
-  increaseIndentPattern: string;
-  decreaseIndentPattern: string;
-  unIndentedLinePattern?: string;
-  indentNextLinePattern?: string;
-}
-
-export interface ILanguageConfiguration {
-  comments?: CommentRule;
-  brackets?: CharacterPair[];
-  autoClosingPairs?: Array<CharacterPair | IAutoClosingPairConditional>;
-  surroundingPairs?: Array<CharacterPair | IAutoClosingPair>;
-  wordPattern?: string | IRegExp;
-  indentationRules?: IIndentationRules;
-  folding?: FoldingRules;
-  autoCloseBefore?: string;
-}
-
-/**
- * Describes how comments for a language work.
- */
-export interface CommentRule {
-  /**
-   * The line comment token, like `// this is a comment`
-   */
-  lineComment?: string | null;
-  /**
-   * The block comment character pair, like `/* block comment *&#47;`
-   */
-  blockComment?: CharacterPair | null;
-}
-
-/**
- * A tuple of two characters, like a pair of
- * opening and closing brackets.
- */
-export type CharacterPair = [string, string];
-
-interface IRegExp {
-  pattern: string;
-  flags?: string;
-}
-
-interface IIndentationRules {
-  decreaseIndentPattern: string | IRegExp;
-  increaseIndentPattern: string | IRegExp;
-  indentNextLinePattern?: string | IRegExp;
-  unIndentedLinePattern?: string | IRegExp;
 }

--- a/packages/monaco/src/browser/contrib/tokenizer.ts
+++ b/packages/monaco/src/browser/contrib/tokenizer.ts
@@ -5,7 +5,6 @@ import {
   FoldingRules,
   IAutoClosingPair,
   IAutoClosingPairConditional,
-  LanguageConfiguration,
 } from '../monaco-api/types';
 
 export const ITextmateTokenizer = Symbol('ITextmateTokenizer');

--- a/packages/monaco/src/browser/contrib/tokenizer.ts
+++ b/packages/monaco/src/browser/contrib/tokenizer.ts
@@ -1,4 +1,5 @@
 import { URI } from '@opensumi/ide-core-common';
+import { LanguagesContribution } from '../../common';
 
 import {
   FoldingRules,
@@ -18,29 +19,6 @@ export interface ITextmateTokenizerService {
   registerLanguage(language: LanguagesContribution, extPath: URI): Promise<void>;
   registerLanguages(language: LanguagesContribution[], extPath: URI): Promise<void>;
   testTokenize(line: string, languageId: string): void;
-}
-
-export interface LanguagesContribution {
-  id: string;
-  // 扩展名
-  extensions: string[];
-  // 语言别名
-  aliases?: string[];
-  // 正则表达式字符串 如 "^#!/.*\\bpython[0-9.-]*\\b"
-  firstLine?: string;
-  // 配置文件路径
-  configuration?: string;
-  // 如["text/css"]
-  mimetypes?: string[];
-  filenames?: string[];
-  filenamePatterns?: string[];
-
-  /**
-   * 定义统一的 resolvedConfiguration 数据
-   * 其中的值为 configuration 指向的 json 配置文件的内容
-   * 主要解决无需多个插件即可注册多个 language 进来
-   */
-  resolvedConfiguration?: LanguageConfiguration;
 }
 
 export interface ScopeMap {

--- a/packages/monaco/src/browser/contrib/tokenizer.ts
+++ b/packages/monaco/src/browser/contrib/tokenizer.ts
@@ -1,6 +1,6 @@
 import { URI } from '@opensumi/ide-core-common';
-import { LanguagesContribution } from '../../common';
 
+import { LanguagesContribution } from '../../common';
 import {
   FoldingRules,
   IAutoClosingPair,

--- a/packages/monaco/src/common/index.ts
+++ b/packages/monaco/src/common/index.ts
@@ -1,35 +1,32 @@
 import { URI } from '@opensumi/ide-core-common';
 
-import type {
-  IAutoClosingPair,
-  IAutoClosingPairConditional,
-} from './types';
+import type { IAutoClosingPair, IAutoClosingPairConditional } from './types';
 
 export * from '@opensumi/ide-core-browser/lib/monaco';
 
 export interface IRegExp {
-	pattern: string;
-	flags?: string;
+  pattern: string;
+  flags?: string;
 }
 
 export interface IEnterAction {
-	indent: 'none' | 'indent' | 'indentOutdent' | 'outdent';
-	appendText?: string;
-	removeText?: number;
+  indent: 'none' | 'indent' | 'indentOutdent' | 'outdent';
+  appendText?: string;
+  removeText?: number;
 }
 
 export interface IIndentationRule {
   decreaseIndentPattern: IRegExp;
-	increaseIndentPattern: IRegExp;
-	indentNextLinePattern?: IRegExp;
-	unIndentedLinePattern?: IRegExp;
+  increaseIndentPattern: IRegExp;
+  indentNextLinePattern?: IRegExp;
+  unIndentedLinePattern?: IRegExp;
 }
 
 export interface IOnEnterRule {
   beforeText: IRegExp;
-	afterText?: IRegExp;
-	previousLineText?: IRegExp;
-	action: IEnterAction;
+  afterText?: IRegExp;
+  previousLineText?: IRegExp;
+  action: IEnterAction;
 }
 
 export interface FoldingMarkers {
@@ -44,45 +41,45 @@ export interface IndentationRuleDto {
    * See [wikipedia](https://en.wikipedia.org/wiki/Off-side_rule) for more information.
    * If not set, `false` is used and empty lines belong to the previous block.
    */
-    offSide?: boolean;
-    /**
-    * Region markers used by the language.
-    */
-    markers?: FoldingMarkers;
+  offSide?: boolean;
+  /**
+   * Region markers used by the language.
+   */
+  markers?: FoldingMarkers;
 }
 
 export interface LanguageConfigurationDto {
-	comments?: CommentRule;
-	brackets?: CharacterPair[];
+  comments?: CommentRule;
+  brackets?: CharacterPair[];
   autoClosingPairs?: Array<CharacterPair | IAutoClosingPairConditional>;
   colorizedBracketPairs?: Array<CharacterPair>;
   surroundingPairs?: Array<CharacterPair | IAutoClosingPair>;
-	wordPattern?: IRegExp;
-	indentationRules?: IIndentationRule;
-	onEnterRules?: IOnEnterRule[];
+  wordPattern?: IRegExp;
+  indentationRules?: IIndentationRule;
+  onEnterRules?: IOnEnterRule[];
   folding?: IndentationRuleDto;
   autoCloseBefore?: string;
 }
 
 export enum IndentAction {
-	/**
-	 * Insert new line and copy the previous line's indentation.
-	 */
-	None = 0,
-	/**
-	 * Insert new line and indent once (relative to the previous line's indentation).
-	 */
-	Indent = 1,
-	/**
-	 * Insert two new lines:
-	 *  - the first one indented which will hold the cursor
-	 *  - the second one at the same indentation level
-	 */
-	IndentOutdent = 2,
-	/**
-	 * Insert new line and outdent once (relative to the previous line's indentation).
-	 */
-	Outdent = 3
+  /**
+   * Insert new line and copy the previous line's indentation.
+   */
+  None = 0,
+  /**
+   * Insert new line and indent once (relative to the previous line's indentation).
+   */
+  Indent = 1,
+  /**
+   * Insert two new lines:
+   *  - the first one indented which will hold the cursor
+   *  - the second one at the same indentation level
+   */
+  IndentOutdent = 2,
+  /**
+   * Insert new line and outdent once (relative to the previous line's indentation).
+   */
+  Outdent = 3,
 }
 
 export interface LanguagesContribution {

--- a/packages/monaco/src/common/index.ts
+++ b/packages/monaco/src/common/index.ts
@@ -3,7 +3,7 @@ import { URI } from '@opensumi/ide-core-common';
 import type {
   IAutoClosingPair,
   IAutoClosingPairConditional,
-} from '../browser/monaco-api/types';
+} from './types';
 
 export * from '@opensumi/ide-core-browser/lib/monaco';
 

--- a/packages/monaco/src/common/index.ts
+++ b/packages/monaco/src/common/index.ts
@@ -1,14 +1,89 @@
 import { URI } from '@opensumi/ide-core-common';
 
 import type {
-  FoldingRules,
   IAutoClosingPair,
   IAutoClosingPairConditional,
-  LanguageConfiguration,
-  // eslint-disable-next-line import/no-restricted-paths
 } from '../browser/monaco-api/types';
 
 export * from '@opensumi/ide-core-browser/lib/monaco';
+
+export interface IRegExp {
+	pattern: string;
+	flags?: string;
+}
+
+export interface IEnterAction {
+	indent: 'none' | 'indent' | 'indentOutdent' | 'outdent';
+	appendText?: string;
+	removeText?: number;
+}
+
+export interface IIndentationRule {
+  decreaseIndentPattern: IRegExp;
+	increaseIndentPattern: IRegExp;
+	indentNextLinePattern?: IRegExp;
+	unIndentedLinePattern?: IRegExp;
+}
+
+export interface IOnEnterRule {
+  beforeText: IRegExp;
+	afterText?: IRegExp;
+	previousLineText?: IRegExp;
+	action: IEnterAction;
+}
+
+export interface FoldingMarkers {
+  start: RegExp;
+  end: RegExp;
+}
+
+export interface IndentationRuleDto {
+  /**
+   * Used by the indentation based strategy to decide whether empty lines belong to the previous or the next block.
+   * A language adheres to the off-side rule if blocks in that language are expressed by their indentation.
+   * See [wikipedia](https://en.wikipedia.org/wiki/Off-side_rule) for more information.
+   * If not set, `false` is used and empty lines belong to the previous block.
+   */
+    offSide?: boolean;
+    /**
+    * Region markers used by the language.
+    */
+    markers?: FoldingMarkers;
+}
+
+export interface LanguageConfigurationDto {
+	comments?: CommentRule;
+	brackets?: CharacterPair[];
+  autoClosingPairs?: Array<CharacterPair | IAutoClosingPairConditional>;
+  colorizedBracketPairs?: Array<CharacterPair>;
+  surroundingPairs?: Array<CharacterPair | IAutoClosingPair>;
+	wordPattern?: IRegExp;
+	indentationRules?: IIndentationRule;
+	onEnterRules?: IOnEnterRule[];
+  folding?: IndentationRuleDto;
+  autoCloseBefore?: string;
+}
+
+export enum IndentAction {
+	/**
+	 * Insert new line and copy the previous line's indentation.
+	 */
+	None = 0,
+	/**
+	 * Insert new line and indent once (relative to the previous line's indentation).
+	 */
+	Indent = 1,
+	/**
+	 * Insert two new lines:
+	 *  - the first one indented which will hold the cursor
+	 *  - the second one at the same indentation level
+	 */
+	IndentOutdent = 2,
+	/**
+	 * Insert new line and outdent once (relative to the previous line's indentation).
+	 */
+	Outdent = 3
+}
 
 export interface LanguagesContribution {
   id: string;
@@ -30,7 +105,7 @@ export interface LanguagesContribution {
    * 其中的值为 configuration 指向的 json 配置文件的内容
    * 主要解决无需多个插件即可注册多个 language 进来
    */
-  resolvedConfiguration?: LanguageConfiguration;
+  resolvedConfiguration?: LanguageConfigurationDto;
 }
 
 export interface ScopeMap {
@@ -54,24 +129,6 @@ export interface GrammarsContribution {
   resolvedConfiguration?: object;
 }
 
-export interface IndentationRules {
-  increaseIndentPattern: string;
-  decreaseIndentPattern: string;
-  unIndentedLinePattern?: string;
-  indentNextLinePattern?: string;
-}
-
-export interface ILanguageConfiguration {
-  comments?: CommentRule;
-  brackets?: CharacterPair[];
-  autoClosingPairs?: Array<CharacterPair | IAutoClosingPairConditional>;
-  surroundingPairs?: Array<CharacterPair | IAutoClosingPair>;
-  wordPattern?: string | IRegExp;
-  indentationRules?: IIndentationRules;
-  folding?: FoldingRules;
-  autoCloseBefore?: string;
-}
-
 /**
  * Describes how comments for a language work.
  */
@@ -91,17 +148,5 @@ export interface CommentRule {
  * opening and closing brackets.
  */
 export type CharacterPair = [string, string];
-
-interface IRegExp {
-  pattern: string;
-  flags?: string;
-}
-
-interface IIndentationRules {
-  decreaseIndentPattern: string | IRegExp;
-  increaseIndentPattern: string | IRegExp;
-  indentNextLinePattern?: string | IRegExp;
-  unIndentedLinePattern?: string | IRegExp;
-}
 
 export * from './types';

--- a/packages/monaco/src/common/types.ts
+++ b/packages/monaco/src/common/types.ts
@@ -9,6 +9,8 @@ export {
   IndentationRule,
   IAutoClosingPairConditional,
   IAutoClosingPair,
+  OnEnterRule,
+  EnterAction,
 } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/languageConfiguration';
 export { CodeActionTriggerType } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages';
 


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution
 1.65 版本之前，JavaScript/TypeScript 语言注册一部分在 language basic 插件的 json 文件中声明，而另一部分(如 onEnterRules、indentationRules 等)在 typescript language features 插件中调用 API 注册。这部分恰巧在之前的版本中也没有实现。

在这个 [commit](https://github.com/microsoft/vscode/commit/2b92835853693127ba5a92e1750169b28b11a849) 之后语言注册全部都迁移到了 language basic 插件中，这会导致在使用 1.65+版本 typescript language features 插件时缺失一部分例如块注释中按下回车自动插入 `*` 以及自动缩进规则等特性

### Changelog
- 重构语言注册逻辑