### PR TITLE
fix: detect language mode id

### DIFF
--- a/packages/core-browser/src/services/label-service.ts
+++ b/packages/core-browser/src/services/label-service.ts
@@ -369,7 +369,9 @@ export function detectModeId(
 
   // otherwise fallback to path based detection
   // return modeService.getModeIdByFilepathOrFirstLine(resource);
-  return languageService.guessLanguageIdByFilepathOrFirstLine(resource);
+  const guessLanguageId = languageService.guessLanguageIdByFilepathOrFirstLine(resource);
+  // 相关 issue: https://github.com/microsoft/vscode/commit/2959fcde6aa9ff2058ad13cef8a5265ddb5f58a4#diff-7dd3b615572806b4d2210a9e7b32e1ae3714bc7b5fb201e437edaa8b372ce1aaR188
+  return guessLanguageId === 'unknown' ? null : guessLanguageId;
 }
 
 export function getLanguageIdFromMonaco(uri: URI) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

由于 monaco 0.3x 版本的 guessLanguageIdByFilepathOrFirstLine 函数返回值发生了变化，由原来匹配不到就返回 null 的行为调整成了返回 unknown 字符串，进而影响了后续的文件类型操作

### Changelog
修复文件类型检测错误的问题
