### PR TITLE
feat: terminal use webgl renderer

### DIFF
--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -23,9 +23,11 @@
     "event-kit": "^2.5.3",
     "node-pty": "0.11.0-beta19",
     "os-locale": "^4.0.0",
-    "xterm": "5.0.0-beta.36",
+    "xterm": "5.0.0-beta.48",
     "xterm-addon-fit": "^0.6.0-beta.17",
-    "xterm-addon-search": "0.10.0-beta.5"
+    "xterm-addon-search": "0.10.0-beta.5",
+    "xterm-addon-webgl": "0.13.0-beta.46",
+    "xterm-addon-canvas": "0.2.0-beta.17"
   },
   "devDependencies": {
     "@opensumi/ide-components": "2.19.13",

--- a/packages/terminal-next/src/browser/terminal.preference.ts
+++ b/packages/terminal-next/src/browser/terminal.preference.ts
@@ -16,13 +16,20 @@ import {
 @Injectable()
 export class TerminalPreference implements ITerminalPreference {
   static defaultOptions: SupportedOptions & ITerminalOptions = {
-    allowTransparency: true,
+    allowTransparency: false,
     macOptionIsMeta: false,
     cursorBlink: false,
     scrollback: 2500,
     tabStopWidth: 8,
     fontSize: 12,
+    customGlyphs: true,
+    drawBoldTextInBrightColors: true,
+    fastScrollModifier: 'alt',
+    fastScrollSensitivity: 5,
+    scrollSensitivity: 1,
+    overviewRulerWidth: 10,
     copyOnSelection: false,
+    fontWeightBold: 'bold',
     fontFamily: "Menlo, Monaco, 'Courier New', monospace",
     cursorStyle: 'block',
   };

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -1,10 +1,12 @@
 import { ITerminalOptions, ITheme, Terminal } from 'xterm';
+import type { CanvasAddon as CanvasAddonType } from 'xterm-addon-canvas';
 import { FitAddon } from 'xterm-addon-fit';
 import { ISearchOptions, SearchAddon } from 'xterm-addon-search';
+import type { WebglAddon as WebglAddonType } from 'xterm-addon-webgl';
 
 import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
 import { IClipboardService } from '@opensumi/ide-core-browser';
-import { Disposable } from '@opensumi/ide-core-common';
+import { Disposable, isSafari } from '@opensumi/ide-core-common';
 import { MessageService } from '@opensumi/ide-overlay/lib/browser/message.service';
 import { WorkbenchThemeService } from '@opensumi/ide-theme/lib/browser/workbench.theme.service';
 import { PANEL_BACKGROUND } from '@opensumi/ide-theme/lib/common/color-registry';
@@ -23,6 +25,20 @@ import {
   TERMINAL_OVERVIEW_RULER_CURSOR_FOREGROUND_COLOR,
   TERMINAL_OVERVIEW_RULER_FIND_MATCH_FOREGROUND_COLOR,
 } from './terminal.color';
+
+const enum Constants {
+  /**
+   * The maximum amount of milliseconds to wait for a container before starting to create the
+   * terminal process. This period helps ensure the terminal has good initial dimensions to work
+   * with if it's going to be a foreground terminal.
+   */
+  WaitForContainerThreshold = 100,
+
+  DefaultCols = 80,
+  DefaultRows = 30,
+  MaxSupportedCols = 5000,
+  MaxCanvasWidth = 8000,
+}
 
 export interface XTermOptions {
   cwd?: string;
@@ -54,11 +70,12 @@ export class XTerm extends Disposable implements IXTerm {
   /** addons */
   private _fitAddon: FitAddon;
   private _searchAddon: SearchAddon;
+  private _webglAddon?: WebglAddonType;
+  private _canvasAddon?: CanvasAddonType;
   /** end */
 
   constructor(public options: XTermOptions) {
     super();
-
     this.container = document.createElement('div');
     this.container.className = styles.terminalInstance;
 
@@ -72,9 +89,55 @@ export class XTerm extends Disposable implements IXTerm {
     this.raw.onSelectionChange(this.onSelectionChange.bind(this));
   }
 
-  private _prepareAddons() {
+  private loadWebGLAddon() {
+    return !isSafari;
+  }
+
+  private async enableCanvasRenderer() {
+    try {
+      if (!this._canvasAddon) {
+        this._canvasAddon = new (await import('xterm-addon-canvas')).CanvasAddon();
+      }
+
+      this.addDispose(this._canvasAddon);
+      this.raw.loadAddon(this._canvasAddon);
+
+      if (this._webglAddon) {
+        this._webglAddon.dispose();
+        this._webglAddon = undefined;
+      }
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  private async enableWebglRenderer() {
+    try {
+      if (!this._webglAddon) {
+        this._webglAddon = new (await import('xterm-addon-webgl')).WebglAddon();
+      }
+
+      this.addDispose(this._webglAddon);
+      this.addDispose(
+        this._webglAddon.onContextLoss(() => {
+          // @ts-ignore
+          this.raw.options.rendererType = 'dom';
+        }),
+      );
+      this.raw.loadAddon(this._webglAddon);
+      if (this._canvasAddon) {
+        this._canvasAddon.dispose();
+        this._canvasAddon = undefined;
+      }
+    } catch (err) {
+      await this.enableCanvasRenderer();
+    }
+  }
+
+  private async _prepareAddons() {
     this._searchAddon = new SearchAddon();
     this._fitAddon = new FitAddon();
+
     this.addDispose([this._searchAddon, this._fitAddon]);
 
     this.raw.loadAddon(this._searchAddon);
@@ -137,6 +200,10 @@ export class XTerm extends Disposable implements IXTerm {
 
   open() {
     this.raw.open(this.container);
+
+    if (this.loadWebGLAddon()) {
+      this.enableWebglRenderer();
+    }
   }
 
   fit() {

--- a/packages/utils/src/platform.ts
+++ b/packages/utils/src/platform.ts
@@ -187,3 +187,8 @@ export enum OperatingSystem {
   Macintosh = 2,
   Linux = 3,
 }
+
+export const userAgent = typeof navigator === 'object' ? navigator.userAgent : null;
+
+export const isChrome = userAgent?.indexOf('Chrome')! >= 0;
+export const isSafari = !isChrome && userAgent?.indexOf('Safari')! >= 0;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
终端使用 webGL 渲染器以支持更多功能，在不支持 webgl 的浏览器下 fallback 到 canvas

### Changelog
- terminal use webgl renderer