### PR TITLE
feat(ext-host): can set partition in plain webview

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.api.webview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.webview.ts
@@ -63,7 +63,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
   @Autowired(IActivationEventService)
   activation: IActivationEventService;
 
-  private webivewPanels: Map<string, WebviewPanel> = new Map();
+  private webviewPanels: Map<string, WebviewPanel> = new Map();
 
   private webviews: Map<string, IWebview> = new Map();
 
@@ -185,7 +185,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
         return;
       }
       let hasChange = false;
-      const webviewPanel = this.getWebivewPanel(id);
+      const webviewPanel = this.getWebviewPanel(id);
       if (state.active) {
         if (!currentResource || !this.isActive(webviewPanel, currentResource, currentOpenType)) {
           state.active = false;
@@ -221,8 +221,8 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
 
       if (hasChange) {
         this.proxy.$onDidChangeWebviewPanelViewState(id, state);
-        if (state.position !== this.getWebivewPanel(id)!.viewColumn) {
-          this.getWebivewPanel(id)!.viewColumn = state.position;
+        if (state.position !== this.getWebviewPanel(id)!.viewColumn) {
+          this.getWebviewPanel(id)!.viewColumn = state.position;
           this._persistWebviewPanelMeta(id);
         }
       }
@@ -257,13 +257,13 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
   }
 
   public async reviveWebview(id: string) {
-    const persistedWebivewPanelMeta: IWebviewPanelData | undefined = (
+    const persistedWebviewPanelMeta: IWebviewPanelData | undefined = (
       await this.extWebviewStorage
     ).get<IWebviewPanelData>(id);
-    if (!persistedWebivewPanelMeta) {
+    if (!persistedWebviewPanelMeta) {
       throw new Error('No revival info for webview ' + id);
     }
-    const { viewType, webviewOptions, extensionInfo, title } = persistedWebivewPanelMeta;
+    const { viewType, webviewOptions, extensionInfo, title } = persistedWebviewPanelMeta;
     await this.activation.fireEvent('onWebviewPanel', viewType);
     const state = await this.getPersistedWebviewState(viewType, id);
     const editorWebview = this.webviewService.createEditorWebviewComponent(
@@ -274,7 +274,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
       },
       id,
     );
-    const viewColumn = editorWebview.group ? editorWebview.group.index + 1 : persistedWebivewPanelMeta.viewColumn;
+    const viewColumn = editorWebview.group ? editorWebview.group.index + 1 : persistedWebviewPanelMeta.viewColumn;
     await this.doCreateWebviewPanel(id, viewType, title, { viewColumn }, webviewOptions, extensionInfo, state);
     await this.proxy.$deserializeWebviewPanel(
       id,
@@ -287,7 +287,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
   }
 
   private onCreateWebviewPanel(webviewPanel: WebviewPanel) {
-    this.webivewPanels.set(webviewPanel.id, webviewPanel);
+    this.webviewPanels.set(webviewPanel.id, webviewPanel);
     const webview = webviewPanel.webview;
     const id = webviewPanel.id;
     if (webviewPanel.editorWebview) {
@@ -309,8 +309,8 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
 
     this.addDispose({
       dispose: () => {
-        if (this.webivewPanels.has(id)) {
-          this.getWebivewPanel(id).dispose();
+        if (this.webviewPanels.has(id)) {
+          this.getWebviewPanel(id).dispose();
         }
       },
     });
@@ -371,32 +371,32 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
     }
   }
 
-  private getWebivewPanel(id): WebviewPanel {
-    if (!this.webivewPanels.has(id)) {
+  private getWebviewPanel(id): WebviewPanel {
+    if (!this.webviewPanels.has(id)) {
       throw new Error('拥有ID ' + id + ' 的 webview 不存在在browser进程中！');
     }
-    return this.webivewPanels.get(id)!;
+    return this.webviewPanels.get(id)!;
   }
 
   private hasWebviewPanel(id): boolean {
-    return this.webivewPanels.has(id);
+    return this.webviewPanels.has(id);
   }
 
   $disposeWebview(id: string): void {
-    const webviewPanel = this.getWebivewPanel(id);
+    const webviewPanel = this.getWebviewPanel(id);
     webviewPanel.dispose();
-    this.webivewPanels.delete(id);
+    this.webviewPanels.delete(id);
     this._persistWebviewPanelMeta(id);
   }
 
   $reveal(id: string, showOptions: WebviewPanelShowOptions = {}): void {
-    const webviewPanel = this.getWebivewPanel(id);
+    const webviewPanel = this.getWebviewPanel(id);
     const viewColumn = Object.assign({}, webviewPanel.showOptions, showOptions).viewColumn;
     webviewPanel.editorWebview?.open(viewColumnToResourceOpenOptions(viewColumn));
   }
 
   $setTitle(id: string, value: string): void {
-    const webviewPanel = this.getWebivewPanel(id);
+    const webviewPanel = this.getWebviewPanel(id);
     if (!webviewPanel.editorWebview) {
       return;
     }
@@ -406,7 +406,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
   }
 
   $setIconPath(id: string, value: { light: string; dark: string; hc: string } | undefined): void {
-    const webviewPanel = this.getWebivewPanel(id);
+    const webviewPanel = this.getWebviewPanel(id);
     if (!webviewPanel.editorWebview) {
       return;
     }
@@ -434,21 +434,21 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
     return disposable;
   }
 
-  private getWebivew(id: string): IWebview | undefined {
+  private getWebview(id: string): IWebview | undefined {
     return this.webviews.get(id);
   }
 
   $setHtml(id: string, value: string): void {
-    this.getWebivew(id)?.setContent(value);
+    this.getWebview(id)?.setContent(value);
   }
 
   $setOptions(id: string, options: IWebviewOptions): void {
-    this.getWebivew(id)?.updateOptions({ allowScripts: options.enableScripts, allowForms: options.enableForms });
+    this.getWebview(id)?.updateOptions({ allowScripts: options.enableScripts, allowForms: options.enableForms });
   }
 
   async $postMessage(id: string, value: any): Promise<boolean> {
     try {
-      await this.getWebivew(id)?.postMessage(value);
+      await this.getWebview(id)?.postMessage(value);
       return true;
     } catch (e) {
       return false;
@@ -457,7 +457,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
 
   $registerSerializer(viewType: string): void {
     this._hasSerializer.add(viewType);
-    this.webivewPanels.forEach((panel) => {
+    this.webviewPanels.forEach((panel) => {
       if (panel.viewType === viewType) {
         if (panel.editorWebview) {
           panel.editorWebview.supportsRevive = true;
@@ -472,8 +472,8 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
 
   private _persistWebviewPanelMeta(id: string) {
     return this.extWebviewStorage.then((storage) => {
-      if (this.webivewPanels.has(id)) {
-        storage.set(id, this.getWebivewPanel(id)!.toJSON());
+      if (this.webviewPanels.has(id)) {
+        storage.set(id, this.getWebviewPanel(id)!.toJSON());
       } else {
         storage.delete(id);
       }
@@ -541,6 +541,18 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
       throw new Error('No Plain Webview With id ' + id);
     }
     await this.plainWebviews.get(id)!.webview.loadURL(uri);
+  }
+  /**
+   * A string that sets the session used by the page.
+   *
+   * fallback to a generated id.
+   */
+  async $setPlainWebviewPartition(id: string, value?: string) {
+    if (!this.plainWebviews.has(id)) {
+      throw new Error('No Plain Webview With id ' + id);
+    }
+    const webview = this.plainWebviews.get(id)!.webview;
+    webview.setPartition(value ?? id);
   }
 
   async $disposePlainWebview(id: string): Promise<void> {

--- a/packages/extension/src/browser/vscode/api/main.thread.api.webview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.webview.ts
@@ -373,7 +373,7 @@ export class MainThreadWebview extends Disposable implements IMainThreadWebview 
 
   private getWebviewPanel(id): WebviewPanel {
     if (!this.webviewPanels.has(id)) {
-      throw new Error('拥有ID ' + id + ' 的 webview 不存在在browser进程中！');
+      throw new Error(`No Webview with id: ${id} was found in the browser process.`);
     }
     return this.webviewPanels.get(id)!;
   }

--- a/packages/extension/src/common/sumi/webview.ts
+++ b/packages/extension/src/common/sumi/webview.ts
@@ -8,15 +8,23 @@ export interface IPlainWebviewHandle {
   postMessage(message: any): Promise<boolean>;
 
   /**
-   *
+   * 接收到 WebView 内消息
    */
   onMessage: Event<any>;
+
+  /**
+   * A string that sets the session used by the page.
+   */
+  setPartition(value?: string): Promise<void>;
+
+  /**
+   * 加载一个 url
+   */
+  loadUrl(url: string): Promise<void>;
 }
 
 export interface IExtHostPlainWebview extends IPlainWebviewHandle {
   reveal(groupIndex: number);
-
-  loadUrl(url: string);
 }
 
 export interface ISumiExtHostWebviews {

--- a/packages/extension/src/common/sumi/webview.ts
+++ b/packages/extension/src/common/sumi/webview.ts
@@ -2,13 +2,13 @@ import { Event } from '@opensumi/ide-core-common';
 
 export interface IPlainWebviewHandle {
   /**
-   * 向webview内部发送消息
+   * Post Message to Webview
    * @param message
    */
   postMessage(message: any): Promise<boolean>;
 
   /**
-   * 接收到 WebView 内消息
+   * Receive message from Webview
    */
   onMessage: Event<any>;
 
@@ -18,7 +18,7 @@ export interface IPlainWebviewHandle {
   setPartition(value?: string): Promise<void>;
 
   /**
-   * 加载一个 url
+   * Load url
    */
   loadUrl(url: string): Promise<void>;
 }

--- a/packages/extension/src/common/vscode/webview.ts
+++ b/packages/extension/src/common/vscode/webview.ts
@@ -56,6 +56,8 @@ export interface IMainThreadWebview {
   $plainWebviewLoadUrl(id: string, uri: string): Promise<void>;
   $disposePlainWebview(id: string): Promise<void>;
   $revealPlainWebview(id: string, groupIndex: number): Promise<void>;
+
+  $setPlainWebviewPartition(id: string, value?: string): Promise<void>;
 }
 
 export interface IWebviewExtensionDescription {
@@ -107,7 +109,7 @@ export interface IExtHostWebview {
   ): Promise<void>;
 
   /**
-   * browser主动创建了一个webview，把它交给 exthost 创建 webviewPanel
+   * browser 主动创建了一个 webview，把它交给 exthost 创建 webviewPanel
    * @param id
    */
   $pipeBrowserHostedWebviewPanel(id: string, viewType: string): void;

--- a/packages/extension/src/common/vscode/webview.ts
+++ b/packages/extension/src/common/vscode/webview.ts
@@ -109,7 +109,7 @@ export interface IExtHostWebview {
   ): Promise<void>;
 
   /**
-   * browser 主动创建了一个 webview，把它交给 exthost 创建 webviewPanel
+   * browser 主动创建了一个 Webview，把它交给 exthost 创建 WebviewPanel
    * @param id
    */
   $pipeBrowserHostedWebviewPanel(id: string, viewType: string): void;

--- a/packages/extension/src/hosted/api/sumi/ext.host.webview.ts
+++ b/packages/extension/src/hosted/api/sumi/ext.host.webview.ts
@@ -58,6 +58,10 @@ export class PlainWebviewHandle extends Disposable implements IPlainWebviewHandl
     return this.proxy.$postMessageToPlainWebview(this.id, message);
   }
 
+  async setPartition(value?: string | undefined): Promise<void> {
+    await this.proxy.$setPlainWebviewPartition(this.id, value);
+  }
+
   async loadUrl(url: string) {
     this.proxy.$plainWebviewLoadUrl(this.id, url);
   }

--- a/packages/types/sumi.d.ts
+++ b/packages/types/sumi.d.ts
@@ -325,7 +325,7 @@ declare module 'sumi' {
 
   export interface ExtensionCandidate {
     path: string;
-    isBuintin: boolean;
+    isBuiltin: boolean;
   }
 
   export interface IPlainWebviewHandle {
@@ -348,9 +348,27 @@ declare module 'sumi' {
     onMessage: Event<any>;
 
     /**
-     * 加载一个url
+     * Load url
      */
     loadUrl(url: string): Promise<void>;
+
+    /**
+     * In `webview` element it will use [partition](https://www.electronjs.org/docs/latest/api/webview-tag#partition)
+     *
+     * A `String` that sets the session used by the page. If `partition` starts with
+     * `persist:`, the page will use a persistent session available to all pages in the
+     * app with the same `partition`. if there is no `persist:` prefix, the page will
+     * use an in-memory session. By assigning the same `partition`, multiple pages can
+     * share the same session. If the `partition` is unset then default session of the
+     * app will be used.
+     *
+     * This value can only be modified before the `loadUrl()` method, since the session
+     * of an active renderer process cannot change. Subsequent attempts to modify the
+     * value will fail with a DOM exception.
+     *
+     * **not work in `iframe` element.**
+     */
+    setPartition(value?: string): Promise<void>;
   }
 
   export interface IDisposable {

--- a/packages/webview/__tests__/browser/webview.service.test.ts
+++ b/packages/webview/__tests__/browser/webview.service.test.ts
@@ -1,4 +1,3 @@
-import { AppConfig } from '@opensumi/ide-core-browser';
 import { Disposable } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { EditorComponentRegistry, EditorPreferences } from '@opensumi/ide-editor/lib/browser';
@@ -8,6 +7,7 @@ import { IThemeService, ITheme } from '@opensumi/ide-theme';
 import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 import { IWebviewService } from '../../src/browser';
+import { ElectronPlainWebview } from '../../src/browser/plain-webview';
 import { WebviewServiceImpl } from '../../src/browser/webview.service';
 
 let injector: MockInjector;
@@ -124,6 +124,18 @@ describe('electron platform webview service test suite', () => {
     webview.appendTo(document.createElement('div'));
     await webview.loadURL('http://example.test.com');
     expect(webview.url).toBe('http://example.test.com');
+  });
+
+  it('can set partition in electron plain webview', async () => {
+    const service: IWebviewService = injector.get(IWebviewService);
+    const webview = service.createPlainWebview();
+    webview.setPartition('persist:test');
+    webview.appendTo(document.createElement('div'));
+    await webview.loadURL('http://example.test.com');
+    expect(webview.url).toBe('http://example.test.com');
+    const domNode = (webview as ElectronPlainWebview).getWebviewElement();
+    expect(domNode).toBeDefined();
+    expect(domNode?.partition).toBe('persist:test');
   });
 
   it('should be able to create electron webview webviewComponent', async () => {

--- a/packages/webview/src/browser/types.ts
+++ b/packages/webview/src/browser/types.ts
@@ -87,7 +87,10 @@ export interface IWebviewContentScrollPosition {
   scrollXPercentage: number;
 }
 
-// 纯粹的Webview或者Iframe元素。加载一个url
+/**
+ * 纯粹的 webview 或 iframe 元素
+ * 用以加载指定的 url
+ */
 export interface IPlainWebview extends IDisposable {
   readonly url: string | undefined;
 
@@ -100,6 +103,24 @@ export interface IPlainWebview extends IDisposable {
   onMessage: Event<any>;
 
   getDomNode(): MaybeNull<HTMLElement>;
+
+  /**
+   * In `webview` element it will use [partition](https://www.electronjs.org/docs/latest/api/webview-tag#partition)
+   *
+   * A `String` that sets the session used by the page. If `partition` starts with
+   * `persist:`, the page will use a persistent session available to all pages in the
+   * app with the same `partition`. if there is no `persist:` prefix, the page will
+   * use an in-memory session. By assigning the same `partition`, multiple pages can
+   * share the same session. If the `partition` is unset then default session of the
+   * app will be used.
+   *
+   * This value can only be modified before the first navigation, since the session
+   * of an active renderer process cannot change. Subsequent attempts to modify the
+   * value will fail with a DOM exception.
+   *
+   * **not work in `iframe` element.**
+   */
+  setPartition(value: string): void;
 
   onDispose: Event<void>;
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

我们使用 `opensumi.webview.getPlainWebviewHandle(xx)` 获取一个 webview 的时候， OpenSumi 在 Electron 上不会给这个 webview 设置 partition，导致该 webview 会同步默认的 session，导致 localStorage 和其他页面互通了。

### Changelog

Allow set partition value to webview element by PlainWebviewHandle
