### PR TITLE
fix: showCollapseAll prop invalid

### DIFF
--- a/packages/extension/__tests__/browser/main.thread.treeview.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.treeview.test.ts
@@ -81,7 +81,7 @@ describe('MainThreadTreeView API Test Suite', () => {
       ]),
     );
 
-    mainThreadTreeView = injector.get(MainThreadTreeView, [mockProxy as any]);
+    mainThreadTreeView = injector.get(MainThreadTreeView, [mockProxy as any, 'node']);
     mainThreadTreeView.$registerTreeDataProvider(testTreeViewId, {});
   });
 

--- a/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
@@ -91,7 +91,7 @@ export async function createApiFactory(
   const MainThreadWebviewAPI = injector.get(MainThreadWebview, [rpcProtocol]);
   const MainThreadWebviewViewAPI = injector.get(MainThreadWebviewView, [rpcProtocol, MainThreadWebviewAPI]);
   const MainThreadSCMAPI = injector.get(MainThreadSCM, [rpcProtocol]);
-  const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [rpcProtocol]);
+  const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [rpcProtocol, 'node']);
   const MainThreadDecorationsAPI = injector.get(MainThreadDecorations, [rpcProtocol]);
   const MainThreadWindowStateAPI = injector.get(MainThreadWindowState, [rpcProtocol]);
   const MainThreadWindowAPI = injector.get(MainThreadWindow, [rpcProtocol]);
@@ -223,7 +223,7 @@ export async function initWorkerThreadAPIProxy(workerProtocol: IRPCProtocol, inj
   const MainThreadAuthenticationAPI = injector.get(MainThreadAuthentication, [workerProtocol]);
   const MainThreadSecretAPI = injector.get(MainThreadSecret, [workerProtocol]);
   const MainThreadSCMAPI = injector.get(MainThreadSCM, [workerProtocol]);
-  const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [workerProtocol]);
+  const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [workerProtocol, 'worker']);
   const MainThreadDecorationsAPI = injector.get(MainThreadDecorations, [workerProtocol]);
 
   workerProtocol.set<IMainThreadLanguages>(MainThreadAPIIdentifier.MainThreadLanguages, MainThreadLanguagesAPI);

--- a/packages/extension/src/hosted/api/sumi/ext.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/sumi/ext.host.api.impl.ts
@@ -57,7 +57,7 @@ export function createAPIFactory(
     const reporter = new ReporterService(reporterEmitter, {
       extensionId: extension.extensionId,
       extensionVersion: extension.packageJSON.version,
-      host: REPORT_HOST.EXTENSION,
+      host: type === 'worker' ? REPORT_HOST.WORKER : REPORT_HOST.EXTENSION,
     });
     return {
       layout: createLayoutAPIFactory(extHostCommands, extHostLayout, extension),

--- a/packages/extension/src/hosted/worker.host.ts
+++ b/packages/extension/src/hosted/worker.host.ts
@@ -84,7 +84,7 @@ export class ExtensionWorkerHost implements IExtensionWorkerHost {
     rpcProtocol.set(ExtHostAPIIdentifier.ExtHostStorage, this.storage);
 
     this.reporterService = new ReporterService(reporter, {
-      host: REPORT_HOST.EXTENSION,
+      host: REPORT_HOST.WORKER,
     });
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
修复类似[ json 插件](https://github.com/ZainChen/vscode-json) 不能使用收拢所有节点的问题。

在 main.thread.xxx.tx 中会被 WorkerExtProcessService 和 NodeExtProcessService 各实例化一次，导致在点收拢的时候，很可能会调用到 worker 的 command。

![image](https://user-images.githubusercontent.com/2226423/190541121-42d5c550-c252-49e1-afbe-3873fead2225.png)


### Changelog
fix: showCollapseAll prop invalid