### PR TITLE
fix: update some editor commands description

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -328,7 +328,6 @@ export namespace EDITOR_COMMANDS {
   export const SAVE_URI: Command = {
     id: 'editor.saveUri',
     category: CATEGORY,
-    label: '%editor.saveUri%',
   };
 
   export const SAVE_CURRENT: Command = {

--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -622,6 +622,7 @@ export namespace EDITOR_COMMANDS {
 
   export const TOGGLE_WORD_WRAP: Command = {
     id: 'editor.toggleWordWrap',
+    label: '%editor.toggleWordWrap%',
     category: CATEGORY,
   };
 

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -607,6 +607,8 @@ export const localizationBundle = {
     'validate.tree.fileNameExistsError': 'File or folder **{0}** already exists. Please use a different name.',
     'validate.tree.invalidFileNameError': 'The name **{0}** is not available. Please use a different name.',
 
+    'editor.close.all': 'Close All Editors',
+
     'opened.editors.title': 'OPENED EDITORS',
     'opened.editors.save.all': 'Save All',
     'opened.editors.close.all': 'Close All',

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -954,6 +954,8 @@ export const localizationBundle = {
     'keyboard.autoDetect.description': "(Current: '{0} ')",
     'keyboard.autoDetect.detail': 'Try to detect the keyboard layout from browser information and pressed keys.',
 
+    'editor.toggleWordWrap': 'Toggle Word Wrap',
+
     'editor.suggest.details.visible': 'Controls whether editor code completion expands details by default',
 
     'view.component.renderedError': 'View Component Rendering Exception',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -641,6 +641,8 @@ export const localizationBundle = {
     'validate.tree.fileNameExistsError': '文件或文件夹 **{0}** 已存在. 请使用另外的名称.',
     'validate.tree.invalidFileNameError': '名称 **{0}** 不可用. 请使用另外的名称.',
 
+    'editor.close.all': '关闭全部编辑器',
+
     'opened.editors.title': '打开的编辑器',
     'opened.editors.save.all': '保存全部',
     'opened.editors.close.all': '关闭全部',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -859,6 +859,8 @@ export const localizationBundle = {
     'toolbar-customize.complete': '完成',
     'toolbar.customize.menu': '自定义工具栏...',
 
+    'editor.toggleWordWrap': '切换自动换行',
+
     'workbench.uploadingFiles': '{0} 个文件上传中 {1}/s',
     'workspace.development.title': '插件开发宿主模式',
     'workbench.testViewContainer': '测试',

--- a/packages/quick-open/src/browser/quick-open.command.service.ts
+++ b/packages/quick-open/src/browser/quick-open.command.service.ts
@@ -12,6 +12,7 @@ import {
   IReporterService,
   REPORT_NAME,
 } from '@opensumi/ide-core-common';
+import { uppercaseFirstLetter } from '@opensumi/ide-utils/lib/strings';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
 import { QuickOpenHandler } from './prefix-quick-open.service';
@@ -224,7 +225,9 @@ export class CommandQuickOpenItem extends QuickOpenItem {
   }
 
   getLabel(): string {
-    return this.command.category ? `${this.command.category}: ` + this.command.label! : this.command.label!;
+    return this.command.category
+      ? `${uppercaseFirstLetter(this.command.category)}: ` + this.command.label!
+      : this.command.label!;
   }
 
   isHidden(): boolean {
@@ -239,7 +242,7 @@ export class CommandQuickOpenItem extends QuickOpenItem {
     if (this.command.alias) {
       const category = this.command.aliasCategory ?? this.command.category;
       if (category) {
-        detail = `${category}: ${this.command.alias}`;
+        detail = `${uppercaseFirstLetter(category)}: ${this.command.alias}`;
       } else {
         detail = this.command.alias;
       }


### PR DESCRIPTION
### Types

- [x]  🐛 Bug Fixes


### Background or solution

this close: #1457 

- Support `Toggle Word Wrap` command
- Support `Close All Editor` command
- Update command display descriptions

### Changelog

- update some editor commands description
