### PR TITLE
feat: support move editor tabs over the tabbar

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -83,6 +83,13 @@
         }
       }
     }
+  }
+
+  .kt_editor_tabs_scroll_wrapper {
+    flex-grow: 1;
+    width: 100%;
+    position: relative;
+    background-color: var(--editorGroupHeader-tabsBackground);
     &::before {
       position: absolute;
       content: '';
@@ -103,6 +110,9 @@
       z-index: 10;
       background-color: var(--tab-border);
     }
+    &.kt_on_drag_over {
+      background-color: var(--editorGroup-dropBackground);
+    }
   }
 
   .kt_editor_tabs_scroll_wrapper {
@@ -113,7 +123,6 @@
 
   .kt_editor_tabs_scroll {
     overflow-y: hidden;
-    background: var(--editorGroupHeader-tabsBackground);
     :global(.loading_indicator) {
       width: 16px;
       height: 22px;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

通过将拖拽作用范围扩大来支持 Editor Tab 在 Tabbar 上的拖拽能力

https://user-images.githubusercontent.com/9823838/190940715-8f2b1781-8d85-498e-b6f3-14c2e3ad61d9.mp4


### Changelog

- support move editor tabs over the tabbar