### PR TITLE
style: improve select component and global color tokens style

### DIFF
--- a/packages/components/src/input/input.less
+++ b/packages/components/src/input/input.less
@@ -45,10 +45,6 @@
       &::placeholder {
         color: var(--input-placeholderForeground);
       }
-
-      &::selection {
-        background-color: var(--kt-input-selectionBackground);
-      }
     }
   }
 

--- a/packages/components/src/select/style.less
+++ b/packages/components/src/select/style.less
@@ -40,6 +40,7 @@
     box-sizing: border-box;
 
     & > span {
+      color: var(--kt-select-foreground);
       cursor: pointer;
     }
 
@@ -66,12 +67,12 @@
       color: var(--kt-select-disableForeground);
     }
     &.kt-select-warning {
-      border-color: var(--kt-select-warningColor);
+      border-color: var(--kt-select-warningForeground);
     }
   }
 
   .kt-select-warning-text {
-    background-color: var(--kt-select-warningColor);
+    background-color: var(--kt-select-warningForeground);
     padding: 4px 8px;
     color: @white;
   }
@@ -131,7 +132,12 @@
   .kt-select-option-select {
     span {
       display: inline-block;
-      width: 100%;
+      margin: 0 2px;
+      width: calc(100% - 4px);
+      box-sizing: border-box;
+      outline: 1px solid var(--list-focusOutline);
+      outline-offset: -1px;
+      color: var(--kt-selectDropdown-selectionForeground);
       background-color: var(--kt-selectDropdown-selectionBackground);
       &:hover {
         background-color: var(--kt-selectDropdown-selectionBackground);
@@ -155,9 +161,13 @@
     white-space: nowrap;
     line-height: 26px;
     display: inline-block;
-    width: 100%;
+    margin: 0 2px;
+    width: calc(100% - 4px);
     box-sizing: border-box;
     &:hover {
+      box-sizing: border-box;
+      outline: 1px solid var(--list-focusOutline);
+      outline-offset: -1px;
       background-color: var(--kt-selectDropdown-hoverBackground);
     }
   }

--- a/packages/core-browser/src/components/actions/styles.module.less
+++ b/packages/core-browser/src/components/actions/styles.module.less
@@ -71,6 +71,7 @@
   &:not(.disabled):hover {
     border-radius: 4px;
     background-color: var(--kt-defaultButton-hoverBackground);
+    color: var(--kt-defaultButton-hoverForeground);
   }
 
   &.selected {

--- a/packages/core-browser/src/style/normalize.less
+++ b/packages/core-browser/src/style/normalize.less
@@ -78,11 +78,6 @@ html {
   li {
     list-style: none;
   }
-
-  ::selection {
-    color: inherit;
-    background: var(--editor-selectionBackground);
-  }
 }
 
 /* ---- 该样式主要用于让带 tabindex='-1' 的元素焦点态时拥有高亮边框，以便于实现如Tree，List组件焦点态时的自动高亮边框效果  ---- */
@@ -94,3 +89,7 @@ html {
   }
 }
 /* -------- */
+
+::selection {
+  background-color: var(--selection-background);
+}

--- a/packages/debug/src/browser/view/configuration/debug-configuration.module.less
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.module.less
@@ -58,6 +58,9 @@
     margin-left: 8px;
     margin-right: 6px;
 
+    &:focus-visible {
+      outline: 0;
+    }
     :global(.kt-select-value) {
       & > option {
         min-width: 22px;

--- a/packages/extension-manager/src/browser/vsx-extension.module.less
+++ b/packages/extension-manager/src/browser/vsx-extension.module.less
@@ -3,6 +3,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  user-select: none;
 }
 
 .accordion {

--- a/packages/file-tree-next/src/browser/file-tree-node.module.less
+++ b/packages/file-tree-next/src/browser/file-tree-node.module.less
@@ -143,9 +143,6 @@
   width: 100%;
   input {
     font-size: @base-font-size;
-    &::selection {
-      color: inherit;
-    }
   }
 }
 

--- a/packages/main-layout/src/browser/tabbar/styles.module.less
+++ b/packages/main-layout/src/browser/tabbar/styles.module.less
@@ -401,7 +401,6 @@
     background-size: cover;
     &:hover {
       transform: scale(1);
-      color: var(--activityBar-activeForeground);
     }
     &:last-child {
       margin-bottom: 18px;

--- a/packages/menu-bar/src/browser/menu-bar.module.less
+++ b/packages/menu-bar/src/browser/menu-bar.module.less
@@ -27,6 +27,7 @@
   align-items: center;
   padding: 0 12px;
   color: var(--kt-menubar-foreground);
+  user-select: none;
 
   // 目前尚未开启使用 kt.menubar.separatorBackground
 

--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -278,6 +278,7 @@
   .tabs {
     padding: 0 !important;
     font-size: @base-font-size;
+    user-select: none;
     :global {
       .kt-tab {
         padding-left: 10px;

--- a/packages/search/src/browser/search.module.less
+++ b/packages/search/src/browser/search.module.less
@@ -8,6 +8,7 @@
   box-sizing: border-box;
   position: absolute;
   font-size: 12px;
+  user-select: none;
 
   .search_options {
     padding: 0 8px;

--- a/packages/theme/src/common/color-tokens/custom/button.ts
+++ b/packages/theme/src/common/color-tokens/custom/button.ts
@@ -262,41 +262,41 @@ export const ktDangerGhostButtonClickBorder = registerColor(
 /* default button */
 export const ktDefaultButtonForeground = registerColor(
   'kt.defaultButton.foreground',
-  { dark: '#D7DBDE', light: '#4D4D4D', hc: null },
-  localize('ktDefaultButtonForeground', 'Danger Ghost Button Foreground color.'),
+  { dark: buttonForeground, light: buttonForeground, hc: buttonBackground },
+  localize('ktDefaultButtonForeground', 'Default Button Foreground color.'),
 );
 export const ktDefaultButtonBackground = registerColor(
   'kt.defaultButton.background',
-  { dark: '#43484D', light: '#FFFFFF', hc: null },
-  localize('ktDefaultButtonBackground', 'Danger Ghost Button Background color.'),
+  { dark: buttonBackground, light: buttonBackground, hc: buttonBackground },
+  localize('ktDefaultButtonBackground', 'Default Button Background color.'),
 );
 export const ktDefaultButtonBorder = registerColor(
   'kt.defaultButton.border',
-  { dark: '#00000000', light: '#E0E0E0', hc: null },
-  localize('ktDefaultButtonBorder', 'Danger Ghost Button Border color.'),
+  { dark: buttonBorder, light: buttonBorder, hc: buttonBorder },
+  localize('ktDefaultButtonBorder', 'Default Button Border color.'),
 );
 export const ktDefaultButtonHoverBackground = registerColor(
   'kt.defaultButton.hoverBackground',
-  { dark: '#b8b8b82f', light: '#b8b8b82f', hc: null },
-  localize('ktDefaultButtonHoverBackground', 'Danger Ghost Button Hover Background color.'),
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
+  localize('ktDefaultButtonHoverBackground', 'Default Button Hover Background color.'),
 );
 export const ktDefaultButtonHoverForeground = registerColor(
   'kt.defaultButton.hoverForeground',
-  { dark: '#D7DBDE', light: '#4D4D4D', hc: null },
-  localize('ktDefaultButtonHoverForeground', 'Danger Ghost Button Hover Foreground color.'),
+  { dark: buttonForeground, light: buttonForeground, hc: buttonForeground },
+  localize('ktDefaultButtonHoverForeground', 'Default Button Hover Foreground color.'),
 );
 export const ktDefaultButtonHoverBorder = registerColor(
   'kt.defaultButton.hoverBorder',
-  { dark: '#00000000', light: '#3895EB', hc: null },
-  localize('ktDefaultButtonHoverBorder', 'Danger Ghost Button Hover Border color.'),
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
+  localize('ktDefaultButtonHoverBorder', 'Default Button Hover Border color.'),
 );
 export const ktDefaultButtonClickBackground = registerColor(
   'kt.defaultButton.clickBackground',
-  { dark: '#35393D', light: '#FFFFFF', hc: null },
-  localize('ktDefaultButtonClickBackground', 'Danger Ghost Button Click Background color.'),
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
+  localize('ktDefaultButtonClickBackground', 'Default Button Click Background color.'),
 );
 export const ktDefaultButtonClickBorder = registerColor(
   'kt.defaultButton.clickBorder',
-  { dark: '#00000000', light: '#167CDB', hc: null },
-  localize('ktDangerGhostButtonClickBorder', 'Danger Ghost Button Click Border color.'),
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
+  localize('ktDangerGhostButtonClickBorder', 'Default Button Click Border color.'),
 );

--- a/packages/theme/src/common/color-tokens/custom/icon.ts
+++ b/packages/theme/src/common/color-tokens/custom/icon.ts
@@ -1,30 +1,30 @@
 import { localize } from '@opensumi/ide-core-common';
 
-import { actionbarForeground } from '../../color-tokens/custom/actionbar';
-import { registerColor } from '../../utils';
+import { registerColor, transparent } from '../../utils';
+import { buttonBackground, buttonForeground, buttonHoverBackground } from '../button';
 
 export const ktIconForeground = registerColor(
   'kt.icon.foreground',
-  { dark: '#D7DBDE', light: '#D7DBDE', hc: null },
+  { dark: buttonForeground, light: buttonForeground, hc: buttonForeground },
   localize('ktIconForeground', 'Icon Foreground color.'),
 );
 export const ktIconHoverForeground = registerColor(
   'kt.icon.hoverForeground',
-  { dark: '#FFFFFF', light: actionbarForeground, hc: null },
+  { dark: buttonBackground, light: buttonBackground, hc: buttonBackground },
   localize('ktIconHoverForeground', 'Icon Hover Foreground color.'),
 );
 export const ktIconHoverBackground = registerColor(
   'kt.icon.hoverBackground',
-  { dark: '#1B2F44', light: '#1B2F44', hc: null },
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
   localize('Icon Hover Background color.'),
 );
 export const ktIconClickHoverForeground = registerColor(
   'kt.icon.clickForeground',
-  { dark: '#FFFFFF', light: '#FFFFFF', hc: null },
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
   localize('Icon Click Foreground color.'),
 );
 export const ktIconDisableForeground = registerColor(
   'kt.icon.disableForeground',
-  { dark: '#5F656B', light: '#5F656B', hc: null },
+  { dark: transparent(ktIconForeground, 0.5), light: transparent(ktIconForeground, 0.5), hc: null },
   localize('ktIconDisableForeground', 'Icon Disabled Foreground color.'),
 );

--- a/packages/theme/src/common/color-tokens/custom/input.ts
+++ b/packages/theme/src/common/color-tokens/custom/input.ts
@@ -1,7 +1,7 @@
 import { localize } from '@opensumi/ide-core-common';
 
 import { registerColor } from '../../utils';
-import { contrastBorder } from '../base';
+import { contrastBorder, selectionBackground } from '../base';
 import { inputBorder, inputOptionActiveBorder } from '../input';
 
 export const ktInputBorder = registerColor(
@@ -21,7 +21,7 @@ export const ktInputDisableBackground = registerColor(
 );
 export const ktInputSelectionBackground = registerColor(
   'kt.input.selectionBackground',
-  { dark: '#1A66AC', light: '#1A66AC', hc: null },
+  { dark: selectionBackground, light: selectionBackground, hc: selectionBackground },
   localize('Input Selection background color.'),
 );
 

--- a/packages/theme/src/common/color-tokens/custom/select.ts
+++ b/packages/theme/src/common/color-tokens/custom/select.ts
@@ -1,18 +1,33 @@
 import { localize } from '@opensumi/ide-core-common';
 
-import { registerColor } from '../../utils';
-import { dropdownBackground, dropdownBorder } from '../dropdown';
-import { inputForeground, inputBackground } from '../input';
+import { darken, lighten, registerColor } from '../../utils';
+import { dropdownBackground, dropdownBorder, dropdownForeground } from '../dropdown';
+import {
+  inputForeground,
+  inputBackground,
+  inputPlaceholderForeground,
+  inputOptionActiveBorder,
+  inputOptionActiveBackground,
+} from '../input';
+import {
+  listActiveSelectionBackground,
+  listActiveSelectionForeground,
+  listErrorForeground,
+  listHoverBackground,
+  listInactiveSelectionBackground,
+  listInactiveSelectionForeground,
+  listWarningForeground,
+} from '../list-tree';
 import { settingsSelectBorder } from '../settings';
 
 export const ktSelectForeground = registerColor(
   'kt.select.foreground',
-  { dark: '#D7DBDE', light: inputForeground, hc: null },
+  { dark: inputForeground, light: inputForeground, hc: inputForeground },
   localize('ktSelectForeground', 'Select Foreground color.'),
 );
 export const ktSelectBackground = registerColor(
   'kt.select.background',
-  { dark: '#00000040', light: inputBackground, hc: null },
+  { dark: inputBackground, light: inputBackground, hc: inputBackground },
   localize('ktSelectBackground', 'Select Background color.'),
 );
 export const ktSelectBorder = registerColor(
@@ -22,40 +37,53 @@ export const ktSelectBorder = registerColor(
 );
 export const ktSelectPlaceholderForeground = registerColor(
   'kt.select.placeholderForeground',
-  { dark: '#5F656B', light: '#5F656B', hc: null },
+  { dark: inputPlaceholderForeground, light: inputPlaceholderForeground, hc: inputPlaceholderForeground },
   localize('ktSelectPlaceholder', 'Select Placeholder Foreground color.'),
 );
 export const ktSelectDisableBackground = registerColor(
   'kt.select.disableBackground',
-  { dark: '#5F656B40', light: '#5F656B40', hc: null },
+  {
+    dark: listInactiveSelectionBackground,
+    light: listInactiveSelectionBackground,
+    hc: listInactiveSelectionBackground,
+  },
   localize('ktSelectDisableBackground', 'Select Disable Background color.'),
 );
 export const ktSelectDisableForeground = registerColor(
   'kt.select.disableForeground',
-  { dark: '#5F656B', light: '#5F656B', hc: null },
+  {
+    dark: listInactiveSelectionForeground,
+    light: listInactiveSelectionForeground,
+    hc: listInactiveSelectionForeground,
+  },
   localize('ktSelectDisableForeground', 'Select Disable Foreground color.'),
 );
-export const ktSelectWarningColor = registerColor(
-  'kt.select.warningColor',
-  { dark: '#D77915', light: '#D77915', hc: null },
-  localize('ktSelectWarningColor', 'Select Warning Color.'),
+export const ktSelectWarningForeground = registerColor(
+  'kt.select.warningForeground',
+  { dark: listWarningForeground, light: listWarningForeground, hc: listWarningForeground },
+  localize('ktSelectWarningForeground', 'Select Warning Foreground.'),
+);
+export const ktSelectErrorForeground = registerColor(
+  'kt.select.warningForeground',
+  { dark: listErrorForeground, light: listErrorForeground, hc: listErrorForeground },
+  localize('ktSelectErrorForeground', 'Select Error Foreground.'),
 );
 
 export const ktSelectOptionActiveBackground = registerColor(
   'selectOption.activeBackground',
-  { dark: '#00000040', light: '#FFFFFF40', hc: null },
+  { dark: inputOptionActiveBackground, light: inputOptionActiveBackground, hc: inputOptionActiveBackground },
   localize('ktSelectOptionActiveBackground', 'Select Option Active Background color.'),
 );
 export const ktSelectOptionActiveBorder = registerColor(
   'kt.selectOption.activeBorder',
-  { dark: '#167CDB', light: '#167CDB', hc: null },
+  { dark: inputOptionActiveBorder, light: inputOptionActiveBorder, hc: inputOptionActiveBorder },
   localize('ktSelectOptionActiveBorder', 'Select Option Active Border color.'),
 );
 
 /* select dropdown */
 export const ktSelectDropdownForeground = registerColor(
   'kt.selectDropdown.foreground',
-  { dark: '#D7DBDE', light: inputForeground, hc: null },
+  { dark: dropdownForeground, light: dropdownForeground, hc: dropdownForeground },
   localize('ktSelectDropdownForeground', 'Select Dropdown Foreground color.'),
 );
 export const ktSelectDropdownBackground = registerColor(
@@ -65,16 +93,21 @@ export const ktSelectDropdownBackground = registerColor(
 );
 export const ktSelectDropdownHoverBackground = registerColor(
   'kt.selectDropdown.hoverBackground',
-  { dark: '#5F656B40', light: '#5F656B40', hc: null },
+  { dark: listHoverBackground, light: listHoverBackground, hc: listHoverBackground },
   localize('ktSelectDropdownHoverBackground', 'Select Dropdown Hover Background color.'),
 );
 export const ktSelectDropdownSelectionBackground = registerColor(
   'kt.selectDropdown.selectionBackground',
-  { dark: '#203E5A', light: '#5F656B40', hc: null },
+  { dark: listActiveSelectionBackground, light: listActiveSelectionBackground, hc: listActiveSelectionBackground },
   localize('ktSelectDropdownSelectionBackground', 'Select Dropdown Selection Background color.'),
+);
+export const ktSelectDropdownSelectionForeground = registerColor(
+  'kt.selectDropdown.selectionForeground',
+  { dark: listActiveSelectionForeground, light: listActiveSelectionForeground, hc: listActiveSelectionForeground },
+  localize('ktSelectDropdownSelectionForeground', 'Select Dropdown Selection Foreground color.'),
 );
 export const ktSelectDropdownTeamForeground = registerColor(
   'kt.selectDropdown.teamForeground',
-  { dark: '#868C91', light: '#999999', hc: null },
+  { dark: darken(ktSelectDropdownBackground, 0.2), light: lighten(ktSelectDropdownBackground, 0.2), hc: null },
   localize('ktSelectDropdownSelectionBackground', 'Select Dropdown Selection Background color.'),
 );


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

close #1678.

调整自定义 ColorToken 注册 fallback 色值，使框架更贴合主题效果

修改后:

<img width="484" alt="image" src="https://user-images.githubusercontent.com/9823838/191202002-b0a0c1a3-27fe-4a32-9aca-ba0ead113f68.png">

![image](https://user-images.githubusercontent.com/9823838/191202165-205dfb64-8167-4de2-81be-79c29615b12c.png)

### Changelog

- improve select component and global color tokens style