### PR TITLE
feat: support quickopen render codicons

### DIFF
--- a/packages/quick-open/package.json
+++ b/packages/quick-open/package.json
@@ -24,6 +24,7 @@
     "@opensumi/ide-dev-tool": "^1.3.1",
     "@opensumi/ide-monaco": "2.20.2",
     "@opensumi/ide-static-resource": "2.20.2",
+    "@opensumi/ide-utils": "2.20.2",
     "@opensumi/ide-theme": "2.20.2",
     "@opensumi/ide-workspace": "2.20.2"
   }

--- a/packages/quick-open/src/browser/components/highlight-label/index.tsx
+++ b/packages/quick-open/src/browser/components/highlight-label/index.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 
+import { getExternalIcon, LabelIcon, LabelPart, parseLabel } from '@opensumi/ide-core-browser';
 import { Highlight } from '@opensumi/ide-core-browser/lib/quick-open';
 import { strings } from '@opensumi/ide-core-common';
 
 const { escape } = strings;
+
+const labelWithIcons = (str: string) => parseLabel(escape(str)).reduce((pre: string | LabelPart, cur: LabelPart) => {
+    if (!(typeof cur === 'string') && LabelIcon.is(cur)) {
+      return pre + `<span class='${getExternalIcon(cur.name)}'></span>`;
+    }
+    return pre + cur;
+  }, '');
 
 export interface HighlightLabelProp {
   text?: string;
@@ -32,19 +40,18 @@ export const HighlightLabel: React.FC<HighlightLabelProp> = ({
       }
       if (pos < highlight.start) {
         const substring = text.substring(pos, highlight.start);
-        children.push(`<span class=${labelClassName}>${escape(substring)}</span>`);
+        children.push(`<span class='${labelClassName}'>${labelWithIcons(substring)}</span>`);
         pos = highlight.end;
       }
       const substring = text.substring(highlight.start, highlight.end);
-      children.push(`<span class=${hightLightClassName}>${escape(substring)}</span>`);
+      children.push(`<span class='${hightLightClassName}'>${labelWithIcons(substring)}</span>`);
       pos = highlight.end;
     }
 
     if (pos < text.length) {
       const substring = text.substring(pos);
-      children.push(`<span class=${labelClassName}>${escape(substring)}</span>`);
+      children.push(`<span class='${labelClassName}'>${labelWithIcons(substring)}</span>`);
     }
-
     return children.join('');
   }, [text, highlights]);
   return (

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -15,7 +15,6 @@ import {
 import { VALIDATE_TYPE } from '@opensumi/ide-core-browser/lib/components';
 import {
   HideReason,
-  Highlight,
   IKeyMods,
   QuickOpenItem,
   QuickOpenModel as IKaitianQuickOpenModel,
@@ -23,7 +22,7 @@ import {
   QuickOpenService,
 } from '@opensumi/ide-core-browser/lib/quick-open';
 import { MonacoContextKeyService } from '@opensumi/ide-monaco/lib/browser/monaco.context-key.service';
-import { matchesFuzzy } from '@opensumi/monaco-editor-core/esm/vs/base/common/filters';
+import { matchesFuzzyIconAware, parseLabelWithIcons } from '@opensumi/ide-utils/lib/iconLabels';
 
 import { IAutoFocus, IQuickOpenModel, QuickOpenContext } from './quick-open.type';
 import { QuickOpenView } from './quick-open.view';
@@ -359,15 +358,23 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
     const { fuzzyMatchLabel, fuzzyMatchDescription, fuzzyMatchDetail } = this.options;
     // 自动匹配若为空，取自定义的匹配
     const labelHighlights = fuzzyMatchLabel
-      ? this.matchesFuzzy(lookFor, item.getLabel(), fuzzyMatchLabel, item.getLabelHighlights.bind(item))
+      ? matchesFuzzyIconAware(lookFor, parseLabelWithIcons(item.getLabel() || ''))
       : item.getLabelHighlights();
 
     const descriptionHighlights = this.options.fuzzyMatchDescription
-      ? this.matchesFuzzy(lookFor, item.getDescription(), fuzzyMatchDescription)
+      ? matchesFuzzyIconAware(
+          lookFor,
+          parseLabelWithIcons(item.getDescription() || ''),
+          typeof fuzzyMatchDescription === 'object' && fuzzyMatchDescription.enableSeparateSubstringMatching,
+        )
       : item.getDescriptionHighlights();
 
     const detailHighlights = this.options.fuzzyMatchDetail
-      ? this.matchesFuzzy(lookFor, item.getDetail(), fuzzyMatchDetail)
+      ? matchesFuzzyIconAware(
+          lookFor,
+          parseLabelWithIcons(item.getDetail() || ''),
+          typeof fuzzyMatchDetail === 'object' && fuzzyMatchDetail.enableSeparateSubstringMatching,
+        )
       : item.getDetailHighlights();
 
     if (
@@ -379,29 +386,8 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
     ) {
       return undefined;
     }
-    item.setHighlights(labelHighlights || [], descriptionHighlights, detailHighlights);
+    item.setHighlights(labelHighlights || [], descriptionHighlights || [], detailHighlights || []);
     return item;
-  }
-
-  protected matchesFuzzy(
-    lookFor: string,
-    value: string | undefined,
-    options?: QuickOpenOptions.FuzzyMatchOptions | boolean,
-    fallback?: () => Highlight[] | undefined,
-  ): Highlight[] | undefined {
-    if (!lookFor || !value) {
-      return [];
-    }
-    const enableSeparateSubstringMatching = typeof options === 'object' && options.enableSeparateSubstringMatching;
-    const res = matchesFuzzy(lookFor, value, enableSeparateSubstringMatching) || undefined;
-    if (res && res.length) {
-      return res;
-    }
-    const fallbackRes = fallback && fallback();
-    if (fallbackRes && fallbackRes.length) {
-      return fallbackRes;
-    }
-    return undefined;
   }
 
   getAutoFocus(lookFor: string): IAutoFocus {

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -358,7 +358,11 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
     const { fuzzyMatchLabel, fuzzyMatchDescription, fuzzyMatchDetail } = this.options;
     // 自动匹配若为空，取自定义的匹配
     const labelHighlights = fuzzyMatchLabel
-      ? matchesFuzzyIconAware(lookFor, parseLabelWithIcons(item.getLabel() || ''))
+      ? matchesFuzzyIconAware(
+          lookFor,
+          parseLabelWithIcons(item.getLabel() || ''),
+          typeof fuzzyMatchLabel === 'object' && fuzzyMatchLabel.enableSeparateSubstringMatching,
+        )
       : item.getLabelHighlights();
 
     const descriptionHighlights = this.options.fuzzyMatchDescription

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -257,7 +257,8 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           {iconClass && <span className={clx(styles.item_icon, iconClass)}></span>}
           <HighlightLabel
             className={styles.item_label_name}
-            hightLightClassName={clx(styles.label_icon_container, styles.item_label_highlight)}
+            labelClassName={styles.label_icon_container}
+            hightLightClassName={clx(styles.item_label_highlight)}
             text={label}
             highlights={labelHighlights}
           />
@@ -265,7 +266,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
             <HighlightLabel
               className={styles.item_label_description}
               labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
-              hightLightClassName={clx(styles.label_icon_container, styles.item_label_description_highlight)}
+              hightLightClassName={clx(styles.item_label_description_highlight)}
               text={description}
               highlights={descriptionHighlights}
             />
@@ -276,7 +277,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
             OutElementType='div'
             className={styles.item_label_detail}
             labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
-            hightLightClassName={clx(styles.label_icon_container, styles.item_label_description_highlight)}
+            hightLightClassName={clx(styles.item_label_description_highlight)}
             text={detail}
             highlights={detailHighlights}
           />

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -257,15 +257,15 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           {iconClass && <span className={clx(styles.item_icon, iconClass)}></span>}
           <HighlightLabel
             className={styles.item_label_name}
-            hightLightClassName={styles.item_label_highlight}
+            hightLightClassName={clx(styles.label_icon_container, styles.item_label_highlight)}
             text={label}
             highlights={labelHighlights}
           />
           {description && (
             <HighlightLabel
               className={styles.item_label_description}
-              labelClassName={styles.item_label_description_label}
-              hightLightClassName={styles.item_label_description_highlight}
+              labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
+              hightLightClassName={clx(styles.label_icon_container, styles.item_label_description_highlight)}
               text={description}
               highlights={descriptionHighlights}
             />
@@ -275,8 +275,8 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           <HighlightLabel
             OutElementType='div'
             className={styles.item_label_detail}
-            labelClassName={styles.item_label_description_label}
-            hightLightClassName={styles.item_label_description_highlight}
+            labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
+            hightLightClassName={clx(styles.label_icon_container, styles.item_label_description_highlight)}
             text={detail}
             highlights={detailHighlights}
           />

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -107,6 +107,12 @@
   }
 }
 
+.item_label_name,
+.item_label_description,
+.item_label_detail {
+  display: flex;
+}
+
 .item_label_description_label {
   color: var(--descriptionForeground);
 }
@@ -142,7 +148,7 @@
 
 .item_label {
   display: flex;
-  align-items: baseline;
+  align-items: center;
 }
 
 .label_icon_container {

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -145,6 +145,11 @@
   align-items: baseline;
 }
 
+.label_icon_container {
+  display: flex;
+  align-items: center;
+}
+
 .input {
   display: flex;
   margin: 4px 10px;

--- a/packages/utils/src/iconLabels.ts
+++ b/packages/utils/src/iconLabels.ts
@@ -1,0 +1,149 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// Some code copied and modified from  https://github.com/microsoft/vscode/blob/main/src/vs/base/common/iconLabels.ts
+
+import { matchesFuzzy } from './filters';
+import { ltrim } from './strings';
+
+export const iconStartMarker = '$(';
+
+const iconNameCharacterRegexp = new RegExp('[A-Za-z0-9~-]');
+
+export interface IParsedLabelWithIcons {
+  readonly text: string;
+  readonly iconOffsets?: readonly number[];
+}
+
+export function parseLabelWithIcons(text: string): IParsedLabelWithIcons {
+  const firstIconIndex = text.indexOf(iconStartMarker);
+  if (firstIconIndex === -1) {
+    return { text }; // return early if the word does not include an icon
+  }
+
+  return doParseLabelWithIcons(text, firstIconIndex);
+}
+
+function doParseLabelWithIcons(text: string, firstIconIndex: number): IParsedLabelWithIcons {
+  const iconOffsets: number[] = [];
+  let textWithoutIcons = '';
+
+  function appendChars(chars: string) {
+    if (chars) {
+      textWithoutIcons += chars;
+
+      for (const _ of chars) {
+        iconOffsets.push(iconsOffset); // make sure to fill in icon offsets
+      }
+    }
+  }
+
+  let currentIconStart = -1;
+  let currentIconValue = '';
+  let iconsOffset = 0;
+
+  let char: string;
+  let nextChar: string;
+
+  let offset = firstIconIndex;
+  const length = text.length;
+
+  // Append all characters until the first icon
+  appendChars(text.substr(0, firstIconIndex));
+
+  // example: $(file-symlink-file) my cool $(other-icon) entry
+  while (offset < length) {
+    char = text[offset];
+    nextChar = text[offset + 1];
+
+    // beginning of icon: some value $( <--
+    if (char === iconStartMarker[0] && nextChar === iconStartMarker[1]) {
+      currentIconStart = offset;
+
+      // if we had a previous potential icon value without
+      // the closing ')', it was actually not an icon and
+      // so we have to add it to the actual value
+      appendChars(currentIconValue);
+
+      currentIconValue = iconStartMarker;
+
+      offset++; // jump over '('
+    }
+
+    // end of icon: some value $(some-icon) <--
+    else if (char === ')' && currentIconStart !== -1) {
+      const currentIconLength = offset - currentIconStart + 1; // +1 to include the closing ')'
+      iconsOffset += currentIconLength;
+      currentIconStart = -1;
+      currentIconValue = '';
+    }
+
+    // within icon
+    else if (currentIconStart !== -1) {
+      // Make sure this is a real icon name
+      if (iconNameCharacterRegexp.test(char)) {
+        currentIconValue += char;
+      } else {
+        // This is not a real icon, treat it as text
+        appendChars(currentIconValue);
+
+        currentIconStart = -1;
+        currentIconValue = '';
+      }
+    }
+
+    // any value outside of icon
+    else {
+      appendChars(char);
+    }
+
+    offset++;
+  }
+
+  // if we had a previous potential icon value without
+  // the closing ')', it was actually not an icon and
+  // so we have to add it to the actual value
+  appendChars(currentIconValue);
+
+  return { text: textWithoutIcons, iconOffsets };
+}
+
+export function matchesFuzzyIconAware(
+  query: string,
+  target: IParsedLabelWithIcons,
+  enableSeparateSubstringMatching = false,
+):
+  | {
+      start: number;
+      end: number;
+    }[]
+  | null {
+  const { text, iconOffsets } = target;
+
+  // Return early if there are no icon markers in the word to match against
+  if (!iconOffsets || iconOffsets.length === 0) {
+    return matchesFuzzy(query, text, enableSeparateSubstringMatching);
+  }
+
+  // Trim the word to match against because it could have leading
+  // whitespace now if the word started with an icon
+  const wordToMatchAgainstWithoutIconsTrimmed = ltrim(text, ' ');
+  const leadingWhitespaceOffset = text.length - wordToMatchAgainstWithoutIconsTrimmed.length;
+
+  // match on value without icon
+  const matches = matchesFuzzy(query, wordToMatchAgainstWithoutIconsTrimmed, enableSeparateSubstringMatching);
+
+  // Map matches back to offsets with icon and trimming
+  if (matches) {
+    for (const match of matches) {
+      const iconOffset =
+        iconOffsets[match.start + leadingWhitespaceOffset] /* icon offsets at index */ +
+        leadingWhitespaceOffset; /* overall leading whitespace offset */
+      match.start += iconOffset;
+      match.end += iconOffset;
+    }
+  }
+
+  return matches;
+}


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

命令面板的 label、description 和 detail 都支持渲染 codicons 图标，同时修改之前的搜索匹配逻辑，在命令搜索时不会去搜索图标内的文本。如: $(git-commit)

![image](https://user-images.githubusercontent.com/20262815/191670677-cee4abfc-7eac-4ef0-8f32-74d1379ef20d.png)


https://user-images.githubusercontent.com/20262815/191670705-52207e16-418d-4844-a53d-ebae26e310ac.mp4


### Changelog
quickOpen 支持 codicons 图标渲染