### PR TITLE
feat: box panel generate child with className

### DIFF
--- a/packages/core-browser/src/components/layout/box-panel.tsx
+++ b/packages/core-browser/src/components/layout/box-panel.tsx
@@ -44,6 +44,8 @@ type ChildComponent = React.ReactElement<IChildComponentProps>;
 
 /**
  * 包裹放入其中的元素，并为每个元素创建一个 div
+ *
+ * 可以通过修改传入的 children 的 props 来定义一些属性，props 的定义可见：{ @link ChildComponent }
  */
 export const BoxPanel: React.FC<{
   children?: ChildComponent | ChildComponent[];

--- a/packages/core-browser/src/components/layout/box-panel.tsx
+++ b/packages/core-browser/src/components/layout/box-panel.tsx
@@ -5,14 +5,46 @@ import { Layout } from './layout';
 import styles from './styles.module.less';
 
 export interface IChildComponentProps {
+  /**
+   * 创建的 div 标签样式中要使用的 flex 属性
+   */
   flex?: number;
+  /**
+   * 创建的 div 标签样式中要使用的默认宽度
+   */
   defaultSize?: number;
   id: string;
   overflow: string;
+  /**
+   * 创建的 div 标签样式中要使用的 zIndex 属性
+   */
+  zIndex?: number;
+  /**
+   * 创建的 div 标签样式中要使用的 z-index 属性
+   */
+  'z-index'?: number;
+  /**
+   * 创建的 div 标签样式中要使用的 backgroundColor 属性
+   */
+  backgroundColor?: string;
+
+  // 以上都是老代码，直接取 props 的相关属性太直接了
+  // 优雅一些的做法是使用 data- 标签
+  /**
+   * 创建的 div 标签要使用的 id
+   */
+  'data-wrapper-id'?: string;
+  /**
+   * 创建的 div 标签要使用的 className
+   */
+  'data-wrapper-class'?: string;
 }
 
 type ChildComponent = React.ReactElement<IChildComponentProps>;
 
+/**
+ * 包裹放入其中的元素，并为每个元素创建一个 div
+ */
 export const BoxPanel: React.FC<{
   children?: ChildComponent | ChildComponent[];
   className?: string;
@@ -21,7 +53,7 @@ export const BoxPanel: React.FC<{
   zIndex?: number;
 }> = ({ className, children = [], direction = 'left-to-right', ...restProps }) => {
   // convert children to list
-  const arrayChildren = React.Children.toArray(children);
+  const arrayChildren = React.Children.toArray(children) as ChildComponent[];
 
   return (
     <div
@@ -32,7 +64,8 @@ export const BoxPanel: React.FC<{
       {arrayChildren.map((child, index) => (
         <div
           key={index}
-          className={clsx(styles.wrapper, child['props']?.className)}
+          id={child['props']?.['data-wrapper-id']}
+          className={clsx(styles.wrapper, child['props']?.['data-wrapper-class'])}
           style={
             child['props']
               ? {

--- a/packages/core-browser/src/components/layout/box-panel.tsx
+++ b/packages/core-browser/src/components/layout/box-panel.tsx
@@ -32,7 +32,7 @@ export const BoxPanel: React.FC<{
       {arrayChildren.map((child, index) => (
         <div
           key={index}
-          className={clsx(styles.wrapper)}
+          className={clsx(styles.wrapper, child['props']?.className)}
           style={
             child['props']
               ? {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

原来我们将 Top Slot 的 zIndex 设置的比较高以便于我们顶部的 popOver 可以展示出来。

所以 #1676 这个修复在支付宝小程序 IDE 上还是没生效，我们现在可以动态调整 zIndex，但是 BoxPanel 并没有生成这些 SlotRenderer 的 className，导致我们取不到这个 DOM

![CleanShot 2022-09-22 at 15 14 07@2x](https://user-images.githubusercontent.com/13938334/191682361-c784e300-66cc-4009-baba-73c92566579f.png)


### Changelog

BoxPanel generate child with className