### PR TITLE
fix: only handle scheme `file` on collaborative mode

### DIFF
--- a/packages/collaboration/src/browser/collaboration.service.ts
+++ b/packages/collaboration/src/browser/collaboration.service.ts
@@ -275,7 +275,7 @@ export class CollaborationService extends WithEventBus implements ICollaboration
 
   @OnEvent(EditorDocumentModelRemovalEvent)
   private async editorDocumentModelRemovalHandler(e: EditorDocumentModelRemovalEvent) {
-    if (e.payload.scheme !== 'file') {
+    if (e.payload.codeUri.scheme !== 'file') {
       return;
     }
 

--- a/packages/collaboration/src/browser/collaboration.service.ts
+++ b/packages/collaboration/src/browser/collaboration.service.ts
@@ -255,6 +255,10 @@ export class CollaborationService extends WithEventBus implements ICollaboration
 
   @OnEvent(EditorDocumentModelCreationEvent)
   private async editorDocumentModelCreationHandler(e: EditorDocumentModelCreationEvent) {
+    if (e.payload.uri.scheme !== 'file') {
+      return;
+    }
+
     const uriString = e.payload.uri.toString();
     const { bindingReady, yMapReady } = this.getDeferred(uriString);
     await this.backService.requestInitContent(uriString);
@@ -271,6 +275,10 @@ export class CollaborationService extends WithEventBus implements ICollaboration
 
   @OnEvent(EditorDocumentModelRemovalEvent)
   private async editorDocumentModelRemovalHandler(e: EditorDocumentModelRemovalEvent) {
+    if (e.payload.scheme !== 'file') {
+      return;
+    }
+
     const uriString = e.payload.codeUri.toString();
     const { bindingReady } = this.getDeferred(uriString);
     await bindingReady.promise;

--- a/packages/collaboration/src/node/y-websocket-server.ts
+++ b/packages/collaboration/src/node/y-websocket-server.ts
@@ -27,6 +27,8 @@ export class YWebsocketServerImpl implements IYWebsocketServer {
 
   private server: http.Server;
 
+  private requestingPromises: Map<string, Set<(reason: string) => void>> = new Map();
+
   initialize() {
     this.logger.debug('init y-websocket server');
 
@@ -84,13 +86,21 @@ export class YWebsocketServerImpl implements IYWebsocketServer {
 
   removeYText(uri: string) {
     this.logger.debug('trying to remove uri', uri);
+
+    // break all still-awaiting promise
+    const promises = this.requestingPromises.get(uri);
+    if (promises) {
+      promises.forEach((reject) => reject('Remove unresolved promise of this uri'));
+      promises.clear();
+    }
+
     if (this.yMap.has(uri)) {
       this.yMap.delete(uri);
       this.logger.debug('removed', uri);
     }
   }
 
-  async requestInitContent(uri: string): Promise<void> {
+  private async doRequestInitContent(uri: string): Promise<void> {
     try {
       // load content from disk, not client
       const { content } = await this.fileService.resolveContent(uri);
@@ -102,6 +112,19 @@ export class YWebsocketServerImpl implements IYWebsocketServer {
     } catch (e) {
       this.logger.error(e);
     }
+  }
+
+  async requestInitContent(uri: string): Promise<void> {
+    const promise = new Promise<void>((resolve, reject) => {
+      this.doRequestInitContent(uri).then(() => resolve());
+
+      if (!this.requestingPromises.has(uri)) {
+        this.requestingPromises.set(uri, new Set());
+      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.requestingPromises.get(uri)!.add(reject);
+    });
+    await promise;
   }
 
   destroy() {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

handle了scheme不为`file`的TextModel，引起报错

![image](https://user-images.githubusercontent.com/28241963/191725285-9c3e9c88-94e8-46e9-a00f-b944dcdcd1af.png)

- [fix: only handle scheme file on collaborative mode](https://github.com/opensumi/core/commit/c51eaf9dba6eeb69c1f19a357e7a0432f09448ae)
- [fix: should break all awaiting init content request before removal](https://github.com/opensumi/core/commit/a4b1202954877f0d42ea6702d9c69d9a2af365a4)

### Changelog

- only handle scheme file on collaborative mode
