### PR TITLE
fix: change statusbar view when tooltip updated

### DIFF
--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -77,7 +77,7 @@ export const StatusBarItem = React.memo((props: StatusBarEntry) => {
       return toMarkdown((tooltip as IMarkdownString).value, openerService);
     }
     return <div className={styles.popover_tooltip}>{tooltip}</div>;
-  }, []);
+  }, [tooltip]);
 
   const getColor = (color: string | IThemeColor | undefined): string => {
     if (!color) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

extension demo:

```
const statusBar = vscode.window.createStatusBarItem();

  statusBar.text = 'eslint';
  statusBar.tooltip = 'stopping';
  statusBar.show();

  setTimeout(() => {
    statusBar.tooltip = 'running';
  }, 3000);
```

### Changelog
change statusbar view when tooltip updated