### PR TITLE
fix: title bar height narrow

### DIFF
--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -9,6 +9,7 @@
   user-select: none;
 
   .title_info {
+    height: 100%;
     display: flex;
     align-items: center;
     -webkit-app-region: drag;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution
titlebar 的高度没有撑满整个 headerbar，导致拖拽区域狭窄。
<img width="614" alt="image" src="https://user-images.githubusercontent.com/2226423/191880969-f6372606-0935-4d68-9b6b-190a9d4a9343.png">

### Changelog
修复 Electron HeaderBar 的拖动区域狭窄问题
