### PR TITLE
fix: file tree input validateMessage not hide

### DIFF
--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1373,12 +1373,12 @@ export class FileTreeModelService {
     };
 
     const blurCommit = async (newName) => {
-      if (isCommit) {
-        return false;
-      }
       if (!!this.validateMessage && this.validateMessage.type === PROMPT_VALIDATE_TYPE.ERROR) {
         this.validateMessage = undefined;
         return true;
+      }
+      if (isCommit) {
+        return false;
       }
       if (!newName) {
         // 清空节点路径焦点态


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复文件树在提示错误信息时失焦后不消失的问题
