### PR TITLE
style: improve tabs and breadcrumb icon style

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -238,6 +238,9 @@
         &:hover {
           transform: scale(1.2);
           background-color: var(--kt-defaultButton-hoverBackground);
+          .close_tab {
+            color: var(--kt-defaultButton-foreground);
+          }
         }
       }
       .dirty {

--- a/packages/editor/src/browser/navigation.module.less
+++ b/packages/editor/src/browser/navigation.module.less
@@ -15,6 +15,7 @@
 
   .navigation_icon {
     font-size: 12px;
+    color: var(--breadcrumb-foreground);
   }
   .navigation-part {
     color: var(--breadcrumb-foreground);


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

#### before:
![image](https://user-images.githubusercontent.com/9823838/191887271-7b1134b7-44a1-4f91-8012-1d9458714c5e.png)
![image](https://user-images.githubusercontent.com/9823838/191887285-a7e211af-bc92-41a0-be56-58c947f1c4a5.png)

#### after:
![image](https://user-images.githubusercontent.com/9823838/191887297-4b2052ab-5a2e-42c4-bd36-829906ae8714.png)
![image](https://user-images.githubusercontent.com/9823838/191887308-27b5b8ec-0601-488d-97c6-12e27425829f.png)

### Changelog

- improve tabs and breadcrumb icon style