### PR TITLE
fix: recover deleted input selection style

### DIFF
--- a/packages/components/src/input/input.less
+++ b/packages/components/src/input/input.less
@@ -45,6 +45,10 @@
       &::placeholder {
         color: var(--input-placeholderForeground);
       }
+
+      &::selection {
+        background-color: var(--kt-input-selectionBackground);
+      }
     }
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

![image](https://user-images.githubusercontent.com/6399899/192188820-2b2390ae-2047-4190-862f-4f14abda624b.png)

lost selection style

### Changelog
recover deleted input selection style