### PR TITLE
chore: show toolbar button id

### DIFF
--- a/packages/addons/src/browser/toolbar-customize/toolbar-customize.tsx
+++ b/packages/addons/src/browser/toolbar-customize/toolbar-customize.tsx
@@ -90,7 +90,7 @@ export const ToolbarCustomizeComponent = () => {
                 }}
                 defaultChecked={visible}
                 id={id}
-                label={action.description}
+                label={action.description ?? action.id}
               />
             </div>,
           );


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

### Changelog

show toolbar button id in Toolbar Customize