### PR TITLE
fix: select option style in light mode

### DIFF
--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -250,7 +250,7 @@
           display: flex;
           flex-direction: row;
           justify-content: space-between;
-
+          color: inherit;
           &:hover .select_default_option_tips {
             color: var(--kt-selectDropdown-foreground);
           }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Code Style Changes


### Background or solution

before:

![image](https://user-images.githubusercontent.com/6399899/192270906-6a902b05-1c63-4225-9b90-974efd863b83.png)


after:
![image](https://user-images.githubusercontent.com/6399899/192270851-3ff06b7c-2ecc-4e49-b443-44b9a0108743.png)


### Changelog
select option style in light mode