### PR TITLE
feat: custom electron headerbar title compoment

### DIFF
--- a/packages/electron-basic/src/browser/header/header.tsx
+++ b/packages/electron-basic/src/browser/header/header.tsx
@@ -123,6 +123,7 @@ export const HeaderBarRightComponent = () => {
 interface ElectronHeaderBarPorps {
   LeftComponent?: React.FunctionComponent;
   RightComponent?: React.FunctionComponent;
+  TitleComponent?: React.FunctionComponent<TitleBarProps>;
   Icon?: React.FunctionComponent;
   autoHide?: boolean;
 }
@@ -131,7 +132,13 @@ interface ElectronHeaderBarPorps {
  * autoHide: Hide the HeaderBar when the macOS full screen
  */
 export const ElectronHeaderBar = observer(
-  ({ LeftComponent, RightComponent, Icon, autoHide = true }: React.PropsWithChildren<ElectronHeaderBarPorps>) => {
+  ({
+    LeftComponent,
+    RightComponent,
+    TitleComponent,
+    Icon,
+    autoHide = true,
+  }: React.PropsWithChildren<ElectronHeaderBarPorps>) => {
     const windowService: IWindowService = useInjectable(IWindowService);
 
     const { isFullScreen } = useFullScreen();
@@ -142,12 +149,15 @@ export const ElectronHeaderBar = observer(
     if (!RightComponent) {
       RightComponent = HeaderBarRightComponent;
     }
+    if (!TitleComponent) {
+      TitleComponent = HeaderBarTitleComponent;
+    }
 
     // in Mac, hide the header bar if it is in full screen mode
     if (isMacintosh && isFullScreen && autoHide) {
       return (
         <div>
-          <TitleInfo hidden={true} />
+          <TitleComponent hidden={true} transformer={defaultTitleTransformer} />
         </div>
       );
     }
@@ -167,7 +177,7 @@ export const ElectronHeaderBar = observer(
         }}
       >
         <LeftComponent />
-        <TitleInfo />
+        <TitleComponent transformer={defaultTitleTransformer} />
         <RightComponent />
       </div>
     );
@@ -176,7 +186,30 @@ export const ElectronHeaderBar = observer(
 
 declare const ResizeObserver: any;
 
-export const TitleInfo = observer(({ hidden }: { hidden?: boolean }) => {
+export interface TitleInfo {
+  currentResourceName?: string;
+  workspaceName?: string;
+  appName?: string;
+  remoteMode?: boolean;
+  extensionDevelopmentHost?: boolean;
+}
+
+export interface TitleBarProps {
+  hidden?: boolean;
+  transformer?: (titleInfo: TitleInfo) => string;
+}
+
+const defaultTitleTransformer = (titleInfo: TitleInfo) => {
+  const developmentTitle = titleInfo.extensionDevelopmentHost ? `[${localize('workspace.development.title')}]` : '';
+  const currentResourceName = titleInfo.currentResourceName ? titleInfo.currentResourceName + ' — ' : '';
+  const workspaceName = titleInfo.workspaceName ? titleInfo.workspaceName + ' — ' : '';
+  const remoteMode = titleInfo.remoteMode ? ` [${localize('common.remoteMode')}]` : '';
+  return (
+    developmentTitle + currentResourceName + workspaceName + replaceLocalizePlaceholder(titleInfo.appName) + remoteMode
+  );
+};
+
+export const HeaderBarTitleComponent = observer(({ hidden, transformer }: TitleBarProps) => {
   const editorService = useInjectable(WorkbenchEditorService) as WorkbenchEditorService;
   const [currentResource, setCurrentResource] = useState<MaybeNull<IResource>>(editorService.currentResource);
   const ref = useRef<HTMLDivElement>(null);
@@ -228,21 +261,20 @@ export const TitleInfo = observer(({ hidden }: { hidden?: boolean }) => {
 
   const dirname = appConfig.workspaceDir ? basename(appConfig.workspaceDir) : undefined;
 
-  const title =
-    (currentResource ? currentResource.name + ' — ' : '') +
-    (dirname ? dirname + ' — ' : '') +
-    replaceLocalizePlaceholder(appConfig.appName) +
-    (appConfig.isRemote ? ` [${localize('common.remoteMode')}]` : '');
-
   // 同时更新 Html Title
   useEffect(() => {
-    let documentTitle = title;
-    if (appConfig.extensionDevelopmentHost) {
-      documentTitle = `[${localize('workspace.development.title')}] ${title}`;
-    }
+    const titleInfo: TitleInfo = {
+      currentResourceName: currentResource?.name,
+      workspaceName: dirname,
+      appName: replaceLocalizePlaceholder(appConfig.appName),
+      remoteMode: appConfig.isRemote,
+      extensionDevelopmentHost: appConfig.extensionDevelopmentHost,
+    };
+    const documentTitle = (transformer && transformer(titleInfo)) || defaultTitleTransformer(titleInfo);
+
     document.title = documentTitle;
     setAppTitle(documentTitle);
-  }, [title]);
+  }, [currentResource?.name]);
 
   if (hidden) {
     return null;

--- a/packages/electron-basic/src/browser/header/header.tsx
+++ b/packages/electron-basic/src/browser/header/header.tsx
@@ -201,12 +201,14 @@ export interface TitleBarProps {
 
 const defaultTitleTransformer = (titleInfo: TitleInfo) => {
   const developmentTitle = titleInfo.extensionDevelopmentHost ? `[${localize('workspace.development.title')}]` : '';
-  const currentResourceName = titleInfo.currentResourceName ? titleInfo.currentResourceName + ' — ' : '';
-  const workspaceName = titleInfo.workspaceName ? titleInfo.workspaceName + ' — ' : '';
   const remoteMode = titleInfo.remoteMode ? ` [${localize('common.remoteMode')}]` : '';
-  return (
-    developmentTitle + currentResourceName + workspaceName + replaceLocalizePlaceholder(titleInfo.appName) + remoteMode
-  );
+
+  const workspaceName = titleInfo.workspaceName ?? '';
+  let currentResourceName = titleInfo.currentResourceName ?? '';
+  if (workspaceName !== '') {
+    currentResourceName += ' — ';
+  }
+  return developmentTitle + currentResourceName + workspaceName + remoteMode;
 };
 
 export const HeaderBarTitleComponent = observer(({ hidden, transformer }: TitleBarProps) => {

--- a/packages/main-layout/src/browser/main-layout.contribution.ts
+++ b/packages/main-layout/src/browser/main-layout.contribution.ts
@@ -319,7 +319,7 @@ export class MainLayoutModuleContribution
 
     commands.registerCommand(LAYOUT_COMMANDS.OPEN_VIEW, {
       execute: () => {
-        this.commandService.executeCommand(QUICK_OPEN_COMMANDS.OPEN.id, 'view ');
+        this.commandService.executeCommand(QUICK_OPEN_COMMANDS.OPEN.id, 'view');
       },
     });
   }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/2226423/192296929-2717362b-6bdc-480a-bc7a-f6e60ff2e39f.png">
- 默认在标题栏不加应用名
- 支持自定义标题栏组件，比如自己添加 commander 组件到 headerbar

> 红绿灯位置已经在 #1584  修复


### Changelog
支持自定义 electron 的 header 组件