### PR TITLE
fix: ide-utils miss package mri

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "iconv-lite": "^0.6.3",
+    "mri": "^1.2.0",
     "nanoid": "^3.3.3",
     "vscode-uri": "3.0.2"
   },


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
修复引入 ide-* 模块缺少 mri 依赖， #1726

### Changelog

