### PR TITLE
fix: limit editor tab subname length

### DIFF
--- a/packages/editor/src/browser/resource.service.ts
+++ b/packages/editor/src/browser/resource.service.ts
@@ -234,7 +234,6 @@ export class ResourceServiceImpl extends WithEventBus implements ResourceService
   getResourceSubname(resource: IResource<any>, groupResources: IResource<any>[]): string | null {
     const provider = this.getProvider(resource.uri);
     if (!provider) {
-      this.logger.error('URI has no resource provider: ' + resource.uri);
       return null; // no provider
     } else if (!provider.provideResourceSubname) {
       return null;

--- a/packages/file-scheme/__tests__/browser/resource.test.ts
+++ b/packages/file-scheme/__tests__/browser/resource.test.ts
@@ -107,13 +107,13 @@ describe('file scheme tests', () => {
     expect(subname).toBe('.../');
     expect(await resourceProvider.provideResourceSubname(resource, [resource])).toBeNull();
 
-    dialogResult = localize('file.prompt.dontSave', '不保存');
+    dialogResult = localize('file.prompt.dontSave', "Don't Save");
     expect(await resourceProvider.shouldCloseResource(resource, [[resource]])).toBeTruthy();
 
-    dialogResult = localize('file.prompt.save', '保存');
+    dialogResult = localize('file.prompt.save', 'Save');
     expect(await resourceProvider.shouldCloseResource(resource, [[resource]])).toBeTruthy();
 
-    dialogResult = localize('file.prompt.cancel', '取消');
+    dialogResult = localize('file.prompt.cancel', 'Cancel');
     expect(await resourceProvider.shouldCloseResource(resource, [[resource]])).toBeFalsy();
   });
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

closed #1708.

### Changelog

limit editor tab subname length