### PR TITLE
fix: editor copy path command

### DIFF
--- a/packages/editor/__tests__/browser/editor.contribution.test.ts
+++ b/packages/editor/__tests__/browser/editor.contribution.test.ts
@@ -1,22 +1,40 @@
+import { CommandRegistry, CommandService, EDITOR_COMMANDS, FILE_COMMANDS, URI } from '@opensumi/ide-core-browser';
 import { EditorModule } from '@opensumi/ide-editor/lib/browser';
-import { EditorContribution } from '@opensumi/ide-editor/lib/browser/editor.contribution';
+import {
+  EditorAutoSaveEditorContribution,
+  EditorContribution,
+} from '@opensumi/ide-editor/lib/browser/editor.contribution';
 
 import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 
 describe('Editor contribution should be work', () => {
-  let mockInjector: MockInjector;
+  let injector: MockInjector;
 
   beforeEach(() => {
-    mockInjector = createBrowserInjector([EditorModule]);
+    injector = createBrowserInjector([EditorModule]);
   });
 
   describe('01 #contribution should be work', () => {
     it('should registerCommands be work', () => {
-      const contribution = mockInjector.get(EditorContribution);
+      const contribution = injector.get(EditorContribution);
       const register = jest.fn();
       contribution.registerCommands({ registerCommand: register } as any);
       expect(register).toBeCalled();
+    });
+
+    it('should recive correct command arguments', async () => {
+      const contribution = injector.get(EditorAutoSaveEditorContribution);
+      const mockCopyRelativePath = jest.fn();
+      injector.mockCommand(FILE_COMMANDS.COPY_RELATIVE_PATH.id, mockCopyRelativePath);
+      const registry = injector.get<CommandRegistry>(CommandRegistry);
+      contribution.registerCommands(registry);
+      const commandService = injector.get<CommandService>(CommandService);
+      const resource = {
+        uri: new URI('/test.js'),
+      };
+      await commandService.executeCommand(EDITOR_COMMANDS.COPY_RELATIVE_PATH.id, resource);
+      expect(mockCopyRelativePath).toBeCalledWith(resource.uri);
     });
   });
 });

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -703,7 +703,6 @@ export class EditorContribution
               });
             }
           }
-
         }
       },
     });
@@ -1339,15 +1338,19 @@ export class EditorAutoSaveEditorContribution implements BrowserEditorContributi
       },
     });
     commands.registerCommand(EDITOR_COMMANDS.COPY_PATH, {
-      execute: (uri) => {
-        if (!uri) {return;}
-        this.commandService.executeCommand(FILE_COMMANDS.COPY_PATH.id, uri);
+      execute: (resource: ResourceArgs) => {
+        if (!resource) {
+          return;
+        }
+        this.commandService.executeCommand(FILE_COMMANDS.COPY_PATH.id, resource.uri);
       },
     });
     commands.registerCommand(EDITOR_COMMANDS.COPY_RELATIVE_PATH, {
-      execute: (uri) => {
-        if (!uri) {return;}
-        this.commandService.executeCommand(FILE_COMMANDS.COPY_RELATIVE_PATH.id, uri);
+      execute: (resource: ResourceArgs) => {
+        if (!resource) {
+          return;
+        }
+        this.commandService.executeCommand(FILE_COMMANDS.COPY_RELATIVE_PATH.id, resource.uri);
       },
     });
   }

--- a/tools/dev-tool/src/mock-injector.ts
+++ b/tools/dev-tool/src/mock-injector.ts
@@ -52,7 +52,7 @@ export class MockInjector extends Injector {
     return creator && creator.status === CreatorStatus.done;
   }
 
-  public mockCommand(commandId, fn?) {
+  public mockCommand(commandId: string, fn?) {
     const registry = this.get(CommandRegistry) as CommandRegistry;
     if (registry.getCommand(commandId)) {
       registry.unregisterCommand(commandId);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog

fix editor copy path command