### PR TITLE
refactor: 更新语法注册逻辑，解决新版本编辑器无法正确匹配括号的问题

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@opensumi/ide-core-common": "2.20.2",
+    "@opensumi/ide-utils": "2.20.2",
     "@opensumi/ide-core-node": "2.20.2",
     "@opensumi/ide-file-service": "2.20.2",
     "@opensumi/ide-monaco": "2.20.2",

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate-tokenizer.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate-tokenizer.ts
@@ -2,6 +2,7 @@ import { INITIAL, StackElement, IGrammar } from 'vscode-textmate';
 
 import { MetadataConsts } from '@opensumi/monaco-editor-core/esm/vs/editor/common/encodedTokenAttributes';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
+
 /** ******************************************************************************
  * Copyright (C) 2018 Ericsson and others.
  *
@@ -59,19 +60,19 @@ export function createTextmateTokenizer(
         const tokens = new Uint32Array(2);
         tokens[0] = 0;
         tokens[1] =
-          ((1 << MetadataConsts.LANGUAGEID_OFFSET) |
-            (0 << MetadataConsts.TOKEN_TYPE_OFFSET) |
-            (0 << MetadataConsts.FONT_STYLE_OFFSET) |
-            (1 << MetadataConsts.FOREGROUND_OFFSET) |
-            (2 << MetadataConsts.BACKGROUND_OFFSET)) >>>
-          0;
+          (1 << MetadataConsts.LANGUAGEID_OFFSET) |
+          (0 << MetadataConsts.TOKEN_TYPE_OFFSET) |
+          (0 << MetadataConsts.FONT_STYLE_OFFSET) |
+          (1 << MetadataConsts.FOREGROUND_OFFSET) |
+          (2 << MetadataConsts.BACKGROUND_OFFSET) |
+          (MetadataConsts.BALANCED_BRACKETS_MASK >>> 0);
         // Line is too long to be tokenized
         return {
           endState: new TokenizerState(INITIAL),
           tokens,
         };
       }
-      const result = grammar.tokenizeLine2(line, state.ruleStack);
+      const result = grammar.tokenizeLine2(line, state.ruleStack, 500);
       return {
         endState: new TokenizerState(result.ruleStack),
         tokens: result.tokens,

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -49,6 +49,7 @@ import {
 } from '@opensumi/ide-monaco/lib/common';
 import { IThemeData } from '@opensumi/ide-theme';
 import { ThemeChangedEvent } from '@opensumi/ide-theme/lib/common/event';
+import { asStringArray } from '@opensumi/ide-utils/lib/arrays';
 import type { ILanguageExtensionPoint } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
 import { ModesRegistry } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/modesRegistry';
 
@@ -298,12 +299,13 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
       toDispose.addDispose(
         Disposable.create(this.textmateRegistry.mapLanguageIdToTextmateGrammar(grammar.language, grammar.scopeName)),
       );
-
       toDispose.addDispose(
         Disposable.create(
           this.textmateRegistry.registerGrammarConfiguration(grammar.language, () => ({
             embeddedLanguages: this.convertEmbeddedLanguages(grammar.embeddedLanguages),
             tokenTypes: this.convertTokenTypes(grammar.tokenTypes),
+            balancedBracketSelectors: asStringArray(grammar.balancedBracketScopes, ['*']),
+            unbalancedBracketSelectors: asStringArray(grammar.unbalancedBracketScopes, []),
           })),
         ),
       );

--- a/packages/monaco/src/browser/contrib/tokenizer.ts
+++ b/packages/monaco/src/browser/contrib/tokenizer.ts
@@ -27,6 +27,8 @@ export interface GrammarsContribution {
   embeddedLanguages?: ScopeMap;
   tokenTypes?: ScopeMap;
   injectTo?: string[];
+  balancedBracketScopes?: string[];
+  unbalancedBracketScopes?: string[];
 
   /**
    * 定义统一的 resolvedConfiguration 数据

--- a/packages/monaco/src/common/index.ts
+++ b/packages/monaco/src/common/index.ts
@@ -117,6 +117,8 @@ export interface GrammarsContribution {
   embeddedLanguages?: ScopeMap;
   tokenTypes?: ScopeMap;
   injectTo?: string[];
+  balancedBracketScopes?: string[];
+  unbalancedBracketScopes?: string[];
 
   /**
    * 定义统一的 resolvedConfiguration 数据

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -7,6 +7,16 @@
 import { IDisposable } from './disposable';
 import { ISplice } from './sequence';
 
+export function asStringArray(array: unknown, defaultValue: string[]): string[] {
+  if (!Array.isArray(array)) {
+    return defaultValue;
+  }
+  if (!array.every((e) => typeof e === 'string')) {
+    return defaultValue;
+  }
+  return array;
+}
+
 export function isNonEmptyArray<T>(obj: ReadonlyArray<T> | undefined | null): obj is Array<T> {
   return Array.isArray(obj) && obj.length > 0;
 }


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

![image](https://user-images.githubusercontent.com/17701805/194701325-44c97b63-653f-4e0b-adc5-182f168f69c7.png)

Fixed #1746

### Changelog
- 更新语法注册逻辑，解决新版本编辑器无法正确匹配括号的问题