### PR TITLE
style: improve secondaryButton style

### DIFF
--- a/packages/components/src/button/style.less
+++ b/packages/components/src/button/style.less
@@ -36,7 +36,6 @@
   border-radius: 2px;
   color: var(--button-foreground);
   background-color: var(--button-background);
-  transition: all 0.15s;
   white-space: nowrap;
 
   &.block-button {
@@ -46,16 +45,6 @@
   & > .@{prefix}-button-secondary-more {
     color: inherit;
     margin-left: 5px;
-  }
-}
-
-.ghost-button {
-  border-style: solid;
-  border-width: 1px;
-
-  &:disabled {
-    border-color: transparent;
-    border: none;
   }
 }
 
@@ -114,6 +103,16 @@
     color: var(--kt-secondaryButton-clickForeground);
     background-color: var(--kt-secondaryButton-clickBackground);
     border-color: var(--kt-secondaryButton-clickBorder);
+  }
+}
+
+.ghost-button {
+  border-style: solid;
+  border-width: 1px;
+
+  &:disabled {
+    border-color: transparent;
+    border: none;
   }
 }
 

--- a/packages/components/src/button/style.less
+++ b/packages/components/src/button/style.less
@@ -86,6 +86,7 @@
 .primary-button {
   color: var(--kt-primaryButton-foreground);
   background-color: var(--kt-primaryButton-background);
+  border: 1px solid var(--kt-primaryButton-border);
 
   &:hover {
     background-color: var(--kt-primaryButton-hoverBackground);

--- a/packages/theme/src/common/color-tokens/custom/button.ts
+++ b/packages/theme/src/common/color-tokens/custom/button.ts
@@ -49,6 +49,11 @@ export const ktPrimaryButtonBackground = registerColor(
   { dark: buttonBackground, light: buttonBackground, hc: buttonBackground },
   localize('primaryButtonBackground', 'Primary Button Background color.'),
 );
+export const ktPrimaryButtonBorder = registerColor(
+  'kt.primaryButton.border',
+  { dark: buttonBorder, light: buttonBorder, hc: buttonBorder },
+  localize('primaryButtonBorder', 'Primary Button Border color.'),
+);
 export const ktPrimaryButtonHoverBackground = registerColor(
   'kt.primaryButton.hoverBackground',
   { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
@@ -98,32 +103,40 @@ export const ktPrimaryGhostButtonClickBorder = registerColor(
 /* secondary button */
 export const ktSecondaryButtonForeground = registerColor(
   'kt.secondaryButton.foreground',
-  { dark: buttonSecondaryForeground, light: buttonSecondaryForeground, hc: buttonSecondaryForeground },
+  {
+    dark: darken(buttonSecondaryForeground, 0.2),
+    light: lighten(buttonSecondaryForeground, 0.2),
+    hc: buttonSecondaryForeground,
+  },
   localize('ktSecondaryButtonForeground', 'Secondary Button Foreground color.'),
 );
 export const ktSecondaryButtonBackground = registerColor(
   'kt.secondaryButton.background',
-  { dark: buttonSecondaryBackground, light: buttonSecondaryBackground, hc: buttonSecondaryBackground },
+  { dark: null, light: null, hc: null },
   localize('ktSecondaryButtonBackground', 'Secondary Button Background color.'),
 );
 export const ktSecondaryButtonBorder = registerColor(
   'kt.secondaryButton.border',
-  { dark: buttonBorder, light: buttonBorder, hc: buttonBorder },
+  {
+    dark: darken(buttonSecondaryForeground, 0.2),
+    light: lighten(buttonSecondaryForeground, 0.2),
+    hc: buttonSecondaryForeground,
+  },
   localize('ktSecondaryButtonForeground', 'Secondary Button Foreground color.'),
 );
 export const ktSecondaryButtonHoverBackground = registerColor(
   'kt.secondaryButton.hoverBackground',
-  { dark: buttonSecondaryHoverBackground, light: buttonSecondaryHoverBackground, hc: buttonSecondaryHoverBackground },
+  { dark: null, light: null, hc: null },
   localize('ktSecondaryButtonHoverBackground', 'Secondary Button Hover Background color'),
 );
 export const ktSecondaryButtonHoverForeground = registerColor(
   'kt.secondaryButton.hoverForeground',
-  { dark: buttonSecondaryForeground, light: buttonSecondaryForeground, hc: null },
+  { dark: buttonSecondaryHoverBackground, light: buttonSecondaryHoverBackground, hc: buttonSecondaryHoverBackground },
   localize('ktSecondaryButtonHoverForeground', 'Secondary Button Hover Foreground color'),
 );
 export const ktSecondaryButtonHoverBorder = registerColor(
   'kt.secondaryButton.hoverBorder',
-  { dark: buttonBorder, light: buttonBorder, hc: buttonBorder },
+  { dark: buttonSecondaryHoverBackground, light: buttonSecondaryHoverBackground, hc: buttonSecondaryHoverBackground },
   localize('ktSecondaryButtonHoverBorder', 'Secondary Button Hover Border color'),
 );
 export const ktSecondaryButtonClickForeground = registerColor(

--- a/packages/theme/src/common/color-tokens/custom/button.ts
+++ b/packages/theme/src/common/color-tokens/custom/button.ts
@@ -41,12 +41,12 @@ export const ktButtonDisableBorder = registerColor(
 /* primary button */
 export const ktPrimaryButtonForeground = registerColor(
   'kt.primaryButton.foreground',
-  { dark: buttonForeground, light: buttonForeground, hc: buttonForeground },
+  { dark: buttonForeground, light: buttonForeground, hc: Color.white },
   localize('primaryButtonForground', 'Primary Button Forground color.'),
 );
 export const ktPrimaryButtonBackground = registerColor(
   'kt.primaryButton.background',
-  { dark: buttonBackground, light: buttonBackground, hc: buttonBackground },
+  { dark: buttonBackground, light: buttonBackground, hc: null },
   localize('primaryButtonBackground', 'Primary Button Background color.'),
 );
 export const ktPrimaryButtonBorder = registerColor(
@@ -56,19 +56,21 @@ export const ktPrimaryButtonBorder = registerColor(
 );
 export const ktPrimaryButtonHoverBackground = registerColor(
   'kt.primaryButton.hoverBackground',
-  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: null },
   localize('primaryButtonHoverBackground', 'Primary Button Hover Background color'),
 );
 export const ktPrimaryButtonClickBackground = registerColor(
   'kt.primaryButton.clickBackground',
-  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: buttonHoverBackground },
+  { dark: buttonHoverBackground, light: buttonHoverBackground, hc: null },
   localize('primaryButtonClickBackground', 'Primary Button Click Background color'),
 );
 
 /* primary ghost button */
 export const ktPrimaryGhostButtonForeground = registerColor(
   'kt.primaryGhostButton.foreground',
-  { dark: ktPrimaryButtonBackground, light: ktPrimaryButtonBackground, hc: ktPrimaryButtonBackground },
+  // Light 模式下使用 `ktPrimaryButtonBackground` 能兼容更多主题下展示效果
+  // 已达到 https://github.com/opensumi/core/wiki/Button-%E6%8C%89%E9%92%AE#%E5%9B%BE%E4%BE%8B 规范
+  { dark: ktPrimaryButtonForeground, light: ktPrimaryButtonBackground, hc: Color.white },
   localize('ktPrimaryGhostButtonForeground', 'Primary Ghost Button Foreground color.'),
 );
 export const ktPrimaryGhostButtonBackground = registerColor(
@@ -78,7 +80,7 @@ export const ktPrimaryGhostButtonBackground = registerColor(
 );
 export const ktPrimaryGhostButtonBorder = registerColor(
   'kt.primaryGhostButton.border',
-  { dark: ktPrimaryButtonBackground, light: ktPrimaryButtonBackground, hc: ktPrimaryButtonBackground },
+  { dark: ktPrimaryButtonForeground, light: ktPrimaryButtonBackground, hc: ktPrimaryButtonForeground },
   localize('ktPrimaryGhostButtonBorder', 'Primary Ghost Button Border color.'),
 );
 export const ktPrimaryGhostButtonClickForeground = registerColor(
@@ -104,8 +106,8 @@ export const ktPrimaryGhostButtonClickBorder = registerColor(
 export const ktSecondaryButtonForeground = registerColor(
   'kt.secondaryButton.foreground',
   {
-    dark: darken(buttonSecondaryForeground, 0.2),
-    light: lighten(buttonSecondaryForeground, 0.2),
+    dark: buttonSecondaryForeground,
+    light: buttonSecondaryBackground,
     hc: buttonSecondaryForeground,
   },
   localize('ktSecondaryButtonForeground', 'Secondary Button Foreground color.'),
@@ -118,8 +120,8 @@ export const ktSecondaryButtonBackground = registerColor(
 export const ktSecondaryButtonBorder = registerColor(
   'kt.secondaryButton.border',
   {
-    dark: darken(buttonSecondaryForeground, 0.2),
-    light: lighten(buttonSecondaryForeground, 0.2),
+    dark: buttonSecondaryForeground,
+    light: buttonSecondaryBackground,
     hc: buttonSecondaryForeground,
   },
   localize('ktSecondaryButtonForeground', 'Secondary Button Foreground color.'),


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

在 Button 的设计规范中， Secondary Button 应该与 Primary Button 保持一致的无 Border 样式

before:
![image](https://user-images.githubusercontent.com/9823838/194741648-d0f14571-d59a-4fe9-8abe-0cd59d491365.png)

after:
![image](https://user-images.githubusercontent.com/9823838/194742373-c0725d32-04b7-4593-8cca-1d4ddfd4def7.png)

### Changelog

remove useless sencondaryButtonBorder style
