### PR TITLE
build: fix build

### DIFF
--- a/packages/remote-cli/package.json
+++ b/packages/remote-cli/package.json
@@ -21,7 +21,7 @@
     "chalk": "^4.1.2",
     "got": "^12.1.0",
     "mri": "^1.2.0",
-    "@opensumi/ide-utils": "2.20.2"
+    "@opensumi/ide-utils": "2.20.3"
   },
   "devDependencies": {
     "@opensumi/ide-dev-tool": "^1.3.1"


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🏗️ Build System


### Background or solution

`packages/remote-cli` 这个包是 private 的，然后无法被 lerna 更新到 2.20.3，所以在 core 里 run init 会报错

### Changelog

fix build
