### PR TITLE
chore: remove workspaceName when resourceName is empty

### DIFF
--- a/packages/electron-basic/src/browser/header/header.tsx
+++ b/packages/electron-basic/src/browser/header/header.tsx
@@ -205,7 +205,7 @@ const defaultTitleTransformer = (titleInfo: TitleInfo) => {
 
   const workspaceName = titleInfo.workspaceName ?? '';
   let currentResourceName = titleInfo.currentResourceName ?? '';
-  if (workspaceName !== '') {
+  if (workspaceName !== '' && currentResourceName) {
     currentResourceName += ' — ';
   }
   return developmentTitle + currentResourceName + workspaceName + remoteMode;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
打开的项目中，如果没有打开的文件，会出现下面的情况
<img width="264" alt="image" src="https://user-images.githubusercontent.com/2226423/194842373-465cafb8-1032-4276-a793-d2cc401071e9.png">


### Changelog
修复没有打开文件的情况标题栏信息展示异常