### PR TITLE
feat: support macos native dirty indicator

### DIFF
--- a/packages/core-common/src/electron.ts
+++ b/packages/core-common/src/electron.ts
@@ -113,6 +113,13 @@ export interface IElectronMainUIServiceShape {
   writeClipboardText(text: string): Promise<void>;
   readClipboardBuffer(field: string): Promise<Uint8Array>;
   writeClipboardBuffer(field: string, buffer: Uint8Array): Promise<void>;
+  /**
+   * Specifies whether the window’s document has been edited, and the icon in title
+   * bar will become gray when set to `true`.
+   *
+   * @platform darwin
+   */
+  setDocumentEdited(windowId: number, edited: boolean): void;
 }
 
 export interface IElectronMainUIService

--- a/packages/core-common/src/types/extension.ts
+++ b/packages/core-common/src/types/extension.ts
@@ -1,4 +1,3 @@
-import { ConstructorOf } from '@opensumi/di';
 import { Uri } from '@opensumi/ide-utils';
 
 import { BasicEvent } from '../event-bus';

--- a/packages/core-electron-main/src/bootstrap/services/ui.ts
+++ b/packages/core-electron-main/src/bootstrap/services/ui.ts
@@ -306,6 +306,13 @@ export class ElectronMainUIService
   async readClipboardBuffer(field: string): Promise<Uint8Array> {
     return clipboard.readBuffer(field);
   }
+
+  setDocumentEdited(windowId: number, edited: boolean) {
+    const window = BrowserWindow.fromId(windowId);
+    if (window) {
+      window.setDocumentEdited(edited);
+    }
+  }
 }
 
 @Domain(ElectronMainContribution)

--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -292,11 +292,11 @@ export class KTNodeProcess {
               EXTENSION_HOST_ENTRY: this.extensionEntry,
               EXTENSION_DIR: this.extensionDir,
               CODE_WINDOW_CLIENT_ID: this.windowClientId,
+              WORKSPACE_DIR: workspace,
             },
             stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
           };
           const forkArgs: string[] = [];
-          forkOptions.env!.WORKSPACE_DIR = workspace;
           forkArgs.push('--listenPath', rpcListenPath);
           this._process = fork(this.forkPath, forkArgs, forkOptions);
           this._process.on('message', (message) => {

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -247,9 +247,9 @@ export class EditorContribution
 
   @OnEvent(ResourceDecorationChangeEvent)
   onResourceDecorationChangeEvent() {
-    const dirtyCount = this.workbenchEditorService.calcDirtyCount();
+    const hasDirty = this.workbenchEditorService.hasDirty();
     // setup macos native dirty indicator
-    this.electronMainUIService.setDocumentEdited(electronEnv.currentWindowId, dirtyCount > 0 ? true : false);
+    this.electronMainUIService.setDocumentEdited(electronEnv.currentWindowId, hasDirty ? true : false);
   }
 
   onWillStop(app: IClientApp) {

--- a/packages/editor/src/browser/resource.service.ts
+++ b/packages/editor/src/browser/resource.service.ts
@@ -48,9 +48,6 @@ export class ResourceServiceImpl extends WithEventBus implements ResourceService
   private onUnregisterResourceProviderEmitter = new Emitter<IResourceProvider>();
   public readonly onUnregisterResourceProvider = this.onUnregisterResourceProviderEmitter.event;
 
-  private onAllResourceDirtyStateChangedEmitter = new Emitter<boolean>();
-  public readonly onAllResourceDirtyStateChanged = this.onAllResourceDirtyStateChangedEmitter.event;
-
   @Autowired(ILogger)
   logger: ILogger;
 
@@ -87,18 +84,6 @@ export class ResourceServiceImpl extends WithEventBus implements ResourceService
       Object.assign(this.resourceDecoration.get(e.payload.uri.toString())!, e.payload.decoration);
       this.eventBus.fire(new ResourceDecorationChangeEvent(e.payload));
     }
-
-    let dirtyState = false;
-    const it = this.resourceDecoration.values();
-    let result = it.next();
-    while (!result.done) {
-      dirtyState = result.value.dirty;
-      if (dirtyState) {
-        break;
-      }
-      result = it.next();
-    }
-    this.onAllResourceDirtyStateChangedEmitter.fire(dirtyState);
   }
 
   async getResource(uri: URI): Promise<IResource<any> | null> {

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -124,7 +124,7 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
 
   private _currentEditorGroup: IEditorGroup;
 
-  _onDidCurrentEditorGroupChanged = new EventEmitter<IEditorGroup>();
+  private _onDidCurrentEditorGroupChanged = new EventEmitter<IEditorGroup>();
   onDidCurrentEditorGroupChanged: Event<IEditorGroup> = this._onDidCurrentEditorGroupChanged.event;
 
   @Autowired(StorageProvider)

--- a/packages/editor/src/common/resource.ts
+++ b/packages/editor/src/common/resource.ts
@@ -37,10 +37,6 @@ export abstract class ResourceService {
    */
   readonly onUnregisterResourceProvider: Event<IResourceProvider>;
   /**
-   * 状态变化：当前 BrowserWindow 中是否有 dirty 的 resource
-   */
-  readonly onAllResourceDirtyStateChanged: Event<boolean>;
-  /**
    * 根据uri获得一个资源信息
    * 如果uri没有对应的resource提供者，则会返回null
    * @param uri

--- a/packages/editor/src/common/resource.ts
+++ b/packages/editor/src/common/resource.ts
@@ -36,7 +36,10 @@ export abstract class ResourceService {
    * 写在一个 ResourceProvider 会触发该事件
    */
   readonly onUnregisterResourceProvider: Event<IResourceProvider>;
-
+  /**
+   * 状态变化：当前 BrowserWindow 中是否有 dirty 的 resource
+   */
+  readonly onAllResourceDirtyStateChanged: Event<boolean>;
   /**
    * 根据uri获得一个资源信息
    * 如果uri没有对应的resource提供者，则会返回null


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![CleanShot 2022-10-11 at 21 57 05@2x](https://user-images.githubusercontent.com/13938334/195111543-8274547b-8afd-422d-9869-5669da08dd87.png)

MacOS 可以设置 document edit 的状态，见左上角的红绿灯。

### Changelog

support macos native dirty indicator