### PR TITLE
fix: 编辑器向右拆分后不滚动到屏幕中间

### DIFF
--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -605,7 +605,6 @@ export class EditorContribution
     commands.registerCommand(EDITOR_COMMANDS.SPLIT_TO_RIGHT, {
       execute: async (resource: ResourceArgs | URI, editorGroup?: EditorGroup) => {
         const { group, uri } = this.extractGroupAndUriFromArgs(resource, editorGroup);
-
         if (group && uri) {
           await group.split(EditorGroupSplitAction.Right, uri, { focus: true });
         }

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1230,10 +1230,15 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       }
     }
 
-    return editorGroup.open(uri, { ...options, preview: false });
+    return editorGroup.open(uri, { ...options, preview: false, revealRangeInCenter: false });
   }
 
-  async open(uri: URI, options: IResourceOpenOptions = {}): Promise<IOpenResourceResult> {
+  async open(
+    uri: URI,
+    options: IResourceOpenOptions = {
+      revealRangeInCenter: true,
+    },
+  ): Promise<IOpenResourceResult> {
     if (uri.scheme === Schemes.file) {
       // 只记录 file 类型的
       this.recentFilesManager.setMostRecentlyOpenedFile!(uri.withoutFragment().toString());
@@ -1485,9 +1490,11 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
             // setModel 后立即调用 revealRangeInCenter 编辑器无法获取到 viewport 宽高
             // 导致无法正确计算滚动位置
             this.codeEditor.monacoEditor.setSelection(range);
-            setTimeout(() => {
-              this.codeEditor.monacoEditor.revealRangeInCenter(range, 1);
-            });
+            if (options.revealRangeInCenter) {
+              setTimeout(() => {
+                this.codeEditor.monacoEditor.revealRangeInCenter(range, 1);
+              });
+            }
           }
 
           // 同上

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -402,6 +402,12 @@ export interface IResourceOpenOptions {
    */
   range?: Partial<IRange>;
 
+  /**
+   * 打开编辑器后是否滚动到屏幕中间
+   * 默认为 true
+   */
+  revealRangeInCenter?: boolean;
+
   scrollTop?: number;
   scrollLeft?: number;
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

https://user-images.githubusercontent.com/17701805/196366685-82272948-912d-4b96-ba12-2b50520038bb.mp4


### Changelog
-  编辑器向右拆分后不滚动到屏幕中间