### PR TITLE
fix: localEcho exclude program config type defense

### DIFF
--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -375,13 +375,17 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     const onBeforeProcessEvent = this._attachAddon.onBeforeProcessData;
 
     if (this.preferenceService.get(CodeTerminalSettingId.LocalEchoEnabled)) {
+      // 某些奇怪的情况下 用户会把这个字段设置成字符串 导致终端crash
+      const exclueProgramConfig = this.preferenceService.get(
+        CodeTerminalSettingId.LocalEchoExcludePrograms,
+        DEFAULT_LOCAL_ECHO_EXCLUDE,
+      );
       const typeAheadAddon = new TypeAheadAddon(
         onBeforeProcessEvent,
         {
-          localEchoExcludePrograms: this.preferenceService.get(
-            CodeTerminalSettingId.LocalEchoExcludePrograms,
-            DEFAULT_LOCAL_ECHO_EXCLUDE,
-          ),
+          localEchoExcludePrograms: Array.isArray(exclueProgramConfig)
+            ? exclueProgramConfig
+            : DEFAULT_LOCAL_ECHO_EXCLUDE,
           localEchoLatencyThreshold: this.preferenceService.get(CodeTerminalSettingId.LocalEchoLatencyThreshold, 30),
           localEchoStyle: this.preferenceService.get(CodeTerminalSettingId.LocalEchoStyle, 'dim'),
         },

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -375,7 +375,7 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     const onBeforeProcessEvent = this._attachAddon.onBeforeProcessData;
 
     if (this.preferenceService.get(CodeTerminalSettingId.LocalEchoEnabled)) {
-      // 某些奇怪的情况下 用户会把这个字段设置成字符串 导致终端crash
+      // 某些奇怪的情况下，用户会把这个字段设置成字符串，导致终端crash
       const exclueProgramConfig = this.preferenceService.get(
         CodeTerminalSettingId.LocalEchoExcludePrograms,
         DEFAULT_LOCAL_ECHO_EXCLUDE,


### PR DESCRIPTION
### Types

Fix: 某些奇怪的情况下 用户会无意中把这个字段设置成字符串  导致终端crash

- [x] 🐛 Bug Fixes

### Background or solution


用户反馈终端不可用，排查发现是 localEchoExcludePrograms.map 不可用导致的。然后发现设置中此项变成了字符串，因此需要做个防御。

### Changelog
- add localEcho exclude program config type defense
