### PR TITLE
fix: 文件保存取消后不抛出错误

### DIFF
--- a/packages/core-common/src/types/editor.ts
+++ b/packages/core-common/src/types/editor.ts
@@ -220,7 +220,18 @@ export function isEditChange(change: IEditorDocumentChange): change is IEditorDo
   return !!(change as IEditorDocumentEditChange).changes;
 }
 
-export type EditorDocumentModelSaveResultState = 'success' | 'error' | 'diff';
+export const enum SaveTaskErrorCause {
+  CANCEL = 'cancel',
+  USE_BY_CONTENT = 'useByContent',
+}
+
+export enum SaveTaskResponseState {
+  ERROR = 'error',
+  SUCCESS = 'success',
+  DIFF = 'diff',
+}
+
+export type EditorDocumentModelSaveResultState = SaveTaskResponseState;
 
 export interface IEditorDocumentModelSaveResult {
   state: EditorDocumentModelSaveResultState;

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -15,6 +15,8 @@ import {
   localize,
   PreferenceService,
   REPORT_NAME,
+  SaveTaskErrorCause,
+  SaveTaskResponseState,
   URI,
 } from '@opensumi/ide-core-browser';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
@@ -360,13 +362,15 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
       this.initSave();
     }
     const res = await task.finished;
-    if (res.state === 'success') {
+    if (res.state === SaveTaskResponseState.SUCCESS) {
       return true;
-    } else if (res.state === 'error') {
-      this.logger.error(res.errorMessage);
-      this.messageService.error(localize('doc.saveError.failed') + '\n' + res.errorMessage);
+    } else if (res.state === SaveTaskResponseState.ERROR) {
+      if (res.errorMessage !== SaveTaskErrorCause.CANCEL) {
+        this.logger.error(res.errorMessage);
+        this.messageService.error(localize('doc.saveError.failed') + '\n' + res.errorMessage);
+      }
       return false;
-    } else if (res.state === 'diff') {
+    } else if (res.state === SaveTaskResponseState.DIFF) {
       this.messageService
         .error(formatLocalize('doc.saveError.diff', this.uri.toString()), [localize('doc.saveError.diffAndSave')])
         .then((res) => {

--- a/packages/editor/src/browser/doc-model/save-task.ts
+++ b/packages/editor/src/browser/doc-model/save-task.ts
@@ -6,7 +6,8 @@ import {
   CancellationTokenSource,
   Disposable,
   CancellationToken,
-  EditorDocumentModelSaveResultState,
+  SaveTaskResponseState,
+  SaveTaskErrorCause,
 } from '@opensumi/ide-core-browser';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
@@ -67,9 +68,9 @@ export class SaveTask extends Disposable {
       this.deferred.resolve(res);
       return res;
     } catch (e) {
-      const res = {
-        errorMessage: e.message as string,
-        state: 'error' as EditorDocumentModelSaveResultState,
+      const res: IEditorDocumentModelSaveResult = {
+        errorMessage: e.message,
+        state: SaveTaskResponseState.ERROR,
       };
       this.deferred.resolve(res);
       return res;
@@ -78,9 +79,9 @@ export class SaveTask extends Disposable {
 
   cancel() {
     this.cancelToken.cancel();
-    const res = {
-      errorMessage: 'cancel',
-      state: 'error' as EditorDocumentModelSaveResultState,
+    const res: IEditorDocumentModelSaveResult = {
+      errorMessage: SaveTaskErrorCause.CANCEL,
+      state: SaveTaskResponseState.ERROR,
     };
     this.deferred.resolve(res);
   }

--- a/packages/editor/src/browser/fs-resource/fs-editor-doc.ts
+++ b/packages/editor/src/browser/fs-resource/fs-editor-doc.ts
@@ -14,6 +14,7 @@ import {
   UTF8_with_bom,
   UTF8,
   detectEncodingFromBuffer,
+  SaveTaskResponseState,
 } from '@opensumi/ide-core-browser';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
@@ -167,11 +168,11 @@ export class BaseFileSystemEditorDocumentProvider implements IEditorDocumentMode
         await this.fileServiceClient.setContent(fileStat, content, { encoding });
       }
       return {
-        state: 'success',
+        state: SaveTaskResponseState.SUCCESS,
       };
     } catch (e) {
       return {
-        state: 'error',
+        state: SaveTaskResponseState.ERROR,
         errorMessage: e.message,
       };
     }

--- a/packages/editor/src/browser/untitled-resource.ts
+++ b/packages/editor/src/browser/untitled-resource.ts
@@ -18,6 +18,7 @@ import {
   MessageType,
   path,
   isWindows,
+  SaveTaskResponseState,
 } from '@opensumi/ide-core-browser';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import { IDialogService } from '@opensumi/ide-overlay';
@@ -143,7 +144,7 @@ export class UntitledSchemeDocumentProvider implements IEditorDocumentModelConte
       });
     }
     return {
-      state: 'success',
+      state: SaveTaskResponseState.SUCCESS,
     };
   }
   onDidDisposeModel() {}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

快速触发多次保存后会有概率提示`文件保存失败，原因：cancel ` 
 
### Changelog
- 文件保存取消后不抛出错误