### PR TITLE
fix: unified menubar background color

### DIFF
--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -22,7 +22,7 @@
   }
 
   :global .menubarWrapper {
-    background-color: var(--menu-background);
+    background-color: var(--kt-menubar-background);
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes


### Background or solution

现在我们对 menubar 设置颜色的 css 变量是错的：
![CleanShot 2022-10-19 at 19 31 41@2x](https://user-images.githubusercontent.com/13938334/196679289-bfe607db-08b0-4793-8bdd-bade82caa617.png)

而且造成了错误的样式生效，
<img width="940" alt="CleanShot 2022-10-19 at 19 33 08@2x" src="https://user-images.githubusercontent.com/13938334/196679532-a38de3f2-9438-492d-a907-6b4ce0b287d2.png">


应该使用 --kt-menubar-background

<img width="1292" alt="CleanShot 2022-10-19 at 19 32 24@2x" src="https://user-images.githubusercontent.com/13938334/196679351-e3292f07-d1be-45a5-8d33-b3d3eb55cd85.png">



### Changelog
unified menubar background color