### PR TITLE
feat: improve workspaceService initialize speed

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -248,7 +248,9 @@ export class WorkspaceService implements IWorkspaceService {
     this._workspace = workspaceStat;
     if (this._workspace) {
       const uri = new URI(this._workspace.uri);
-      this.toDisposeOnWorkspace.push(await this.fileServiceClient.watchFileChanges(uri));
+      this.fileServiceClient.watchFileChanges(uri).then((watcher) => {
+        this.toDisposeOnWorkspace.push(watcher);
+      });
     }
     this.updateTitle();
     await this.updateWorkspace();


### PR DESCRIPTION
### Types

把工作空间连接过程中对workspace uri的watch优化成异步操作。
进而优化工作空间连接速度。

- [x] 🚀 Performance Improvements

### Background or solution
通过对工作空间连接过程的耗时分析与打点，发现在Storage初始化过程中会依赖workspace-service.ready，而workspace.ready需要等待watch完成。
watch的耗时大部分情况下需要300ms左右，但是在容器不稳定的情况下可能需要4s甚至更多，而且watch本身不应该阻塞工作空间的启动，因此做了异步处理。会优化极端情况下的工作空间连接速度。

附件：某些极端情况下的watch耗时
![image](https://user-images.githubusercontent.com/12879047/197485440-31363648-41c0-45b1-a8b1-2418276eb568.png)


### Changelog
- improve workspaceService initialize speed