### PR TITLE
chore: fix unstalable e2e test case

### DIFF
--- a/tools/playwright/src/editor.ts
+++ b/tools/playwright/src/editor.ts
@@ -34,8 +34,8 @@ export class OpenSumiEditor extends OpenSumiView {
 
   async open(preview?: boolean) {
     await this.filestatElement.open(preview);
-    // waiting editor render
-    await this.app.page.waitForTimeout(200);
+    // waiting editor render, it maybe fail while opening a large file.
+    await this.app.page.waitForTimeout(1000);
     return this;
   }
 

--- a/tools/playwright/src/menubar.ts
+++ b/tools/playwright/src/menubar.ts
@@ -8,18 +8,16 @@ import { OpenSumiViewBase } from './view-base';
 export class OpenSumiMenubar extends OpenSumiViewBase {
   static USER_KEY_TYPING_DELAY = 100;
 
-  private elementHandle: ElementHandle;
   private _menuItems: ElementHandle[];
 
   selector = `#${OPENSUMI_VIEW_CONTAINERS.MENUBAR}`;
 
   constructor(app: OpenSumiApp) {
     super(app);
-    this.initMenubar();
   }
 
-  async initMenubar() {
-    this.elementHandle = await this.page.waitForSelector(this.selector);
+  async getMenubar() {
+    return await this.page.waitForSelector(this.selector);
   }
 
   async trigger(group: string, command: string) {
@@ -48,7 +46,7 @@ export class OpenSumiMenubar extends OpenSumiViewBase {
 
   async getMenuItems() {
     if (!this._menuItems) {
-      return await this.elementHandle.$$("[class*='menubar___']");
+      return await (await this.getMenubar())?.$$("[class^='menubar___']");
     }
     return this._menuItems;
   }

--- a/tools/playwright/src/tests/editor.test.ts
+++ b/tools/playwright/src/tests/editor.test.ts
@@ -52,7 +52,7 @@ console.log(a);`,
     let isDirty = await editor.isDirty();
     expect(isDirty).toBeTruthy();
     await editor.save();
-    await app.page.waitForTimeout(1000);
+    await app.page.waitForTimeout(2000);
     isDirty = await editor.isDirty();
     expect(isDirty).toBeFalsy();
     await editor.close();
@@ -88,39 +88,38 @@ console.log(a);`,
   });
 
   test('copy path from file explorer to the editor content', async () => {
-    await explorer.fileTreeView.open();
-    const node = await explorer.getFileStatTreeNodeByPath('editor.js');
+    const node = await explorer.getFileStatTreeNodeByPath('editor3.js');
     let fileMenu = await node?.openContextMenu();
     expect(await fileMenu?.isOpen()).toBeTruthy();
     const copyPath = await fileMenu?.menuItemByName('Copy Path');
     await copyPath?.click();
-    editor = await app.openEditor(OpenSumiTextEditor, explorer, 'editor.js');
-    await editor.addTextToNewLineAfterLineByLineNumber(3, 'File Path: ');
+    editor = await app.openEditor(OpenSumiTextEditor, explorer, 'editor3.js');
+    await editor.addTextToNewLineAfterLineByLineNumber(1, 'File Path: ');
     // cause of https://github.com/microsoft/playwright/issues/8114
     // we can just using keypress to fake the paste feature
-    let editorMenu = await editor.openLineContextMenuByLineNumber(4);
+    let editorMenu = await editor.openLineContextMenuByLineNumber(2);
     expect(await editorMenu?.isOpen()).toBeTruthy();
     let paste = await editorMenu?.menuItemByName('Paste');
     await paste?.click();
     await app.page.waitForTimeout(200);
-    expect(await editor.numberOfLines()).toBe(4);
+    expect(await editor.numberOfLines()).toBe(2);
     expect(
       await editor.textContentOfLineContainingText(
-        `File Path: ${workspace.workspace.resolve('editor.js').codeUri.fsPath.toString()}`,
+        `File Path: ${workspace.workspace.resolve('editor3.js').codeUri.fsPath.toString()}`,
       ),
     ).toBeTruthy();
     fileMenu = await node?.openContextMenu();
     const copyRelativePath = await fileMenu?.menuItemByName('Copy Relative Path');
     await copyRelativePath?.click();
     await app.page.waitForTimeout(200);
-    await editor.addTextToNewLineAfterLineByLineNumber(4, 'File Relative Path: ');
-    editorMenu = await editor.openLineContextMenuByLineNumber(5);
+    await editor.addTextToNewLineAfterLineByLineNumber(2, 'File Relative Path: ');
+    editorMenu = await editor.openLineContextMenuByLineNumber(3);
     expect(await editorMenu?.isOpen()).toBeTruthy();
     paste = await editorMenu?.menuItemByName('Paste');
     await paste?.click();
     await app.page.waitForTimeout(200);
-    expect(await editor.numberOfLines()).toBe(5);
-    expect(await editor.textContentOfLineContainingText('File Relative Path: editor.js')).toBeTruthy();
+    expect(await editor.numberOfLines()).toBe(3);
+    expect(await editor.textContentOfLineContainingText('File Relative Path: editor3.js')).toBeTruthy();
   });
 
   test('Go to Symbol... should be worked', async () => {

--- a/tools/playwright/src/tests/explorer-view.test.ts
+++ b/tools/playwright/src/tests/explorer-view.test.ts
@@ -120,7 +120,13 @@ test.describe('OpenSumi Explorer Panel', () => {
     await terminal.sendText(`cd ${workspace.workspace.codeUri.fsPath}`);
     await terminal.sendText(`mkdir ${dirname}`);
     await app.page.waitForTimeout(2000);
-    const newDir = await explorer.getFileStatTreeNodeByPath(dirname);
+    let newDir = await explorer.getFileStatTreeNodeByPath(dirname);
+    if (!newDir) {
+      const action = await fileTreeView.getTitleActionByName('Refresh');
+      await action?.click();
+      await app.page.waitForTimeout(200);
+      newDir = await explorer.getFileStatTreeNodeByPath(dirname);
+    }
     expect(newDir).toBeDefined();
   });
 });


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

E2E 测试过程中不能对 Dom 快照进行缓存，否则一旦页面更新，该快照即刻便会失效

### Changelog
