### PR TITLE
test: get correct git decoration on filetree

### DIFF
--- a/tools/playwright/src/tests/scm.test.ts
+++ b/tools/playwright/src/tests/scm.test.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+
+import { expect } from '@playwright/test';
+
+import { OpenSumiApp } from '../app';
+import { OpenSumiExplorerView } from '../explorer-view';
+import { OpenSumiFileTreeView } from '../filetree-view';
+import { OpenSumiTerminal } from '../terminal';
+import { OpenSumiWorkspace } from '../workspace';
+
+import test, { page } from './hooks';
+
+let app: OpenSumiApp;
+let explorer: OpenSumiExplorerView;
+let fileTreeView: OpenSumiFileTreeView;
+let workspace: OpenSumiWorkspace;
+
+test.describe('OpenSumi SCM Panel', () => {
+  test.beforeAll(async () => {
+    workspace = new OpenSumiWorkspace([path.resolve('./src/tests/workspaces/git-workspace')]);
+    app = await OpenSumiApp.load(page, workspace);
+    explorer = await app.open(OpenSumiExplorerView);
+    explorer.initFileTreeView(workspace.workspace.displayName);
+    fileTreeView = explorer.fileTreeView;
+  });
+
+  test.afterAll(() => {
+    app.dispose();
+  });
+
+  test('The "U" charset should on the files tail after git initialized', async () => {
+    await explorer.fileTreeView.open();
+    const terminal = await app.open(OpenSumiTerminal);
+    // There should have GIT on the PATH
+    await terminal.sendText('git init');
+    const action = await fileTreeView.getTitleActionByName('Refresh');
+    await action?.click();
+    await app.page.waitForTimeout(2000);
+    const node = await explorer.getFileStatTreeNodeByPath('a.js');
+    const badge = await node?.badge();
+    expect(badge).toBe('U');
+  });
+});

--- a/tools/playwright/src/tree-node.ts
+++ b/tools/playwright/src/tree-node.ts
@@ -6,6 +6,7 @@ import { OpenSumiContextMenu } from './context-menu';
 export interface IOpenSumiTreeNodeSelector {
   labelClass: string;
   descriptionClass: string;
+  badgeClass: string;
   toggleClass: string;
   selectedClass: string;
   focusedClass: string;
@@ -19,6 +20,7 @@ export class OpenSumiTreeNode {
     private selector: IOpenSumiTreeNodeSelector = {
       labelClass: "[class*='tree_node_displayname__']",
       descriptionClass: "[class*='tree_node_description__']",
+      badgeClass: "[class*='tree_node_status___']",
       toggleClass: "[class*='expansion_toggle__']",
       selectedClass: "[class*='mod_selected__']",
       focusedClass: "[class*='mod_focused__']",
@@ -45,6 +47,14 @@ export class OpenSumiTreeNode {
       throw new Error(`Cannot read description from ${this.selector.descriptionClass} of ${this.elementHandle}`);
     }
     return descriptionElement.textContent();
+  }
+
+  async badge() {
+    const badgeElement = await this.elementHandle.$(this.selector.badgeClass);
+    if (!badgeElement) {
+      throw new Error(`Cannot read description from ${this.selector.badgeClass} of ${this.elementHandle}`);
+    }
+    return badgeElement.textContent();
   }
 
   async isSelected() {


### PR DESCRIPTION
### Types

- [x] ⏱ Tests

### Background or solution

打开一个 Git 项目，文件树根据文件 Git 状态显示对应的装饰逻辑，如：初始化 Git 项目后，文件末尾有个 "U" 字符

### Changelog
