### PR TITLE
chore: xterm version bump

### DIFF
--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -23,11 +23,11 @@
     "event-kit": "^2.5.3",
     "node-pty": "0.11.0-beta19",
     "os-locale": "^4.0.0",
-    "xterm": "5.0.0-beta.48",
-    "xterm-addon-canvas": "0.2.0-beta.17",
-    "xterm-addon-fit": "^0.6.0-beta.17",
-    "xterm-addon-search": "0.10.0-beta.5",
-    "xterm-addon-webgl": "0.13.0-beta.46"
+    "xterm": "5.0.0",
+    "xterm-addon-fit": "0.6.0",
+    "xterm-addon-search": "0.10.0",
+    "xterm-addon-webgl": "0.13.0",
+    "xterm-addon-canvas": "0.2.0"
   },
   "devDependencies": {
     "@opensumi/ide-components": "2.20.8",


### PR DESCRIPTION
### Types

Xterm Version Bump
升级Xterm版本。

- [x] 🧹 Chores
- [ ] Other Changes

### Background or solution
在Xterm 5.0.0 beta18种发现了一个bug，导致cursorStyle不管设置什么都会触发一个异常，即使这个配置是正确的。
<img width="846" alt="image" src="https://user-images.githubusercontent.com/12879047/197722976-8a33ece0-cab4-4b03-a88f-94d9b8a77cf2.png">

恰好Xterm 5.0.0 release，对终端的依赖做一次整体的升级。

### Changelog
- chore: xterm version bump