### PR TITLE
fix: the preference markdown display with placeholder

### DIFF
--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -189,7 +189,7 @@ export const corePreferenceSchema: PreferenceSchema = {
     },
     'files.associations': {
       type: 'object',
-      markdownDescription: localize('preference.files.associations'),
+      markdownDescription: '%preference.files.associations%',
     },
     'files.encoding': {
       type: 'string',

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -189,7 +189,7 @@ export const corePreferenceSchema: PreferenceSchema = {
     },
     'files.associations': {
       type: 'object',
-      description: '%preference.files.associations%',
+      markdownDescription: localize('preference.files.associations'),
     },
     'files.encoding': {
       type: 'string',

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1692,7 +1692,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.autoSaveDelay': {
     type: 'number',
     default: 1000,
-    description: '%editor.configuration.autoSaveDelay%',
+    markdownDescription: localize('editor.configuration.autoSaveDelay'),
   },
   'editor.preferredFormatter': {
     type: 'object',
@@ -1712,7 +1712,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.enablePreviewFromCodeNavigation': {
     type: 'boolean',
     default: false,
-    description: '%editor.configuration.enablePreviewFromCodeNavigation%',
+    markdownDescription: localize('editor.configuration.enablePreviewFromCodeNavigation'),
   },
   'editor.minimap': {
     type: 'boolean',
@@ -1802,7 +1802,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.formatOnSaveTimeout': {
     type: 'number',
     default: 750,
-    description: '%editor.configuration.formatOnSaveTimeout%',
+    markdownDescription: localize('editor.configuration.formatOnSaveTimeout'),
   },
   'editor.lineHeight': {
     type: 'number',
@@ -1851,7 +1851,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   },
   'workbench.editorAssociations': {
     type: 'object',
-    description: '%preference.workbench.editorAssociations%',
+    markdownDescription: localize('preference.workbench.editorAssociations'),
     default: {},
     additionalProperties: {
       type: 'string',

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1692,7 +1692,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.autoSaveDelay': {
     type: 'number',
     default: 1000,
-    markdownDescription: localize('editor.configuration.autoSaveDelay'),
+    markdownDescription: '%editor.configuration.autoSaveDelay%',
   },
   'editor.preferredFormatter': {
     type: 'object',
@@ -1712,7 +1712,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.enablePreviewFromCodeNavigation': {
     type: 'boolean',
     default: false,
-    markdownDescription: localize('editor.configuration.enablePreviewFromCodeNavigation'),
+    markdownDescription: '%editor.configuration.enablePreviewFromCodeNavigation%',
   },
   'editor.minimap': {
     type: 'boolean',
@@ -1802,7 +1802,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.formatOnSaveTimeout': {
     type: 'number',
     default: 750,
-    markdownDescription: localize('editor.configuration.formatOnSaveTimeout'),
+    markdownDescription: '%editor.configuration.formatOnSaveTimeout%',
   },
   'editor.lineHeight': {
     type: 'number',
@@ -1851,7 +1851,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   },
   'workbench.editorAssociations': {
     type: 'object',
-    markdownDescription: localize('preference.workbench.editorAssociations'),
+    markdownDescription: '%preference.workbench.editorAssociations%',
     default: {},
     additionalProperties: {
       type: 'string',

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -552,7 +552,7 @@ export const localizationBundle = {
     'preference.editor.minimap': 'minimap',
     'preference.editor.forceReadOnly': 'readOnly',
     'preference.editor.renderLineHighlight': 'Render Line Highlight',
-    'preference.editor.askIfDiff': 'Error If File On Disk is ewer',
+    'preference.editor.askIfDiff': 'Error If File On Disk is newer',
     'preference.editor.autoSave': 'Editor Auto Save',
     'preference.editor.autoSaveDelay': 'Auto Save Delay',
     'preference.editor.detectIndentation': 'Auto Detect Indentation',

--- a/packages/preferences/src/browser/preference-contribution.ts
+++ b/packages/preferences/src/browser/preference-contribution.ts
@@ -43,7 +43,6 @@ import {
 import { IFileServiceClient } from '@opensumi/ide-file-service/lib/common';
 
 import { PREF_SCHEME, SettingContribution } from '../common';
-import { SettingJSONGlyphMarginEdit } from '../common/commands';
 
 import { PreferenceSettingsService, defaultSettingGroup, defaultSettingSections } from './preference-settings.service';
 import { EditPreferenceDecorationsContribution } from './preference-widgets';

--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -188,9 +188,8 @@ export const NextPreferenceItem = ({
   );
 };
 
-const renderDescriptionExpression = (des: string) => {
+const renderDescriptionExpression = (description: string) => {
   const preferenceSettingService: PreferenceSettingsService = useInjectable(IPreferenceSettingsService);
-  const description = replaceLocalizePlaceholder(des);
   if (!description) {
     return null;
   }
@@ -221,7 +220,7 @@ const renderDescriptionExpression = (des: string) => {
 };
 
 const renderDescription = (data: { description?: string; markdownDescription?: string }) => {
-  const description = data.description ?? data.markdownDescription;
+  const description = replaceLocalizePlaceholder(data.description ?? data.markdownDescription);
   if (!description) {
     return null;
   }
@@ -229,9 +228,7 @@ const renderDescription = (data: { description?: string; markdownDescription?: s
 
   return (
     <div className={styles.desc}>
-      {data.markdownDescription
-        ? toMarkdown(data.markdownDescription, openerService)
-        : renderDescriptionExpression(description)}
+      {data.markdownDescription ? toMarkdown(description, openerService) : renderDescriptionExpression(description)}
     </div>
   );
 };

--- a/packages/search/src/browser/search-preferences.ts
+++ b/packages/search/src/browser/search-preferences.ts
@@ -18,7 +18,7 @@ export const searchPreferenceSchema: PreferenceSchema = {
   properties: {
     [SearchSettingId.Exclude]: {
       type: 'object',
-      markdownDescription: localize('preference.search.exclude'),
+      markdownDescription: '%preference.search.exclude%',
       default: {
         '**/node_modules': true,
         '**/bower_components': true,

--- a/packages/search/src/browser/search-preferences.ts
+++ b/packages/search/src/browser/search-preferences.ts
@@ -18,7 +18,7 @@ export const searchPreferenceSchema: PreferenceSchema = {
   properties: {
     [SearchSettingId.Exclude]: {
       type: 'object',
-      description: '%preference.search.exclude%',
+      markdownDescription: localize('preference.search.exclude'),
       default: {
         '**/node_modules': true,
         '**/bower_components': true,

--- a/packages/task/src/common/index.ts
+++ b/packages/task/src/common/index.ts
@@ -1,5 +1,4 @@
-import { IJSONSchemaMap } from '@opensumi/ide-core-browser';
-import { IDisposable, Event, URI, TaskIdentifier, Uri, Deferred } from '@opensumi/ide-core-common';
+import { IDisposable, Event, URI, TaskIdentifier, Uri, Deferred, IJSONSchemaMap } from '@opensumi/ide-core-common';
 import { UriComponents } from '@opensumi/ide-editor';
 import { IShellLaunchConfig, ITerminalClient } from '@opensumi/ide-terminal-next/lib/common';
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
- 修复部分设置项需要转为 markdown 展示，如果是用 localize 会提前让英文见面也展示为中文
- 修正文字错误

![image](https://user-images.githubusercontent.com/2226423/197994002-d9355802-81cb-4b10-a59f-cbd5e477c9dc.png)

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/2226423/197993676-8bdf7931-d7f6-45e8-a0ea-9efb4b777667.png">


### Changelog
fix: 修复设置项不能展示 markdown