### PR TITLE
chore: remove activityBar badge border

### DIFF
--- a/packages/main-layout/src/browser/tabbar/styles.module.less
+++ b/packages/main-layout/src/browser/tabbar/styles.module.less
@@ -4,7 +4,6 @@
 .tab_badge {
   background-color: var(--activityBarBadge-background) !important;
   color: var(--activityBarBadge-foreground) !important;
-  border-color: var(--kt-activityBarBadge-border) !important;
   position: absolute;
   top: 22px;
   right: 8px;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution
Activity Bar 的 badge 加了 border 后分散注意力，2.20 是突然出现的，感觉可以去掉
![image](https://user-images.githubusercontent.com/2226423/197998220-0386b473-aefa-4740-9cf4-2160c00daebf.png)
![image](https://user-images.githubusercontent.com/2226423/197998235-e9b49803-c1d7-4a1e-9498-d7065318edc5.png)


### Changelog
chore: 移除 Activity Bar 的 badge 的 border 样式
