### PR TITLE
fix: electron header height incorrect

### DIFF
--- a/packages/core-browser/src/layout/constants.ts
+++ b/packages/core-browser/src/layout/constants.ts
@@ -2,6 +2,6 @@ export namespace LAYOUT_VIEW_SIZE {
   export const MENUBAR_HEIGHT = 35;
   export const EDITOR_TABS_HEIGHT = 35;
   export const BIG_SUR_TITLEBAR_HEIGHT = 28;
-  export const TITLEBAR_HEIGHT = 35;
+  export const TITLEBAR_HEIGHT = 22;
   export const PANEL_TITLEBAR_HEIGHT = 35;
 }

--- a/packages/electron-basic/src/browser/header/header.tsx
+++ b/packages/electron-basic/src/browser/header/header.tsx
@@ -125,13 +125,20 @@ interface ElectronHeaderBarPorps {
   RightComponent?: React.FunctionComponent;
   Icon?: React.FunctionComponent;
   autoHide?: boolean;
+  height?: number;
 }
 
 /**
  * autoHide: Hide the HeaderBar when the macOS full screen
  */
 export const ElectronHeaderBar = observer(
-  ({ LeftComponent, RightComponent, Icon, autoHide = true }: React.PropsWithChildren<ElectronHeaderBarPorps>) => {
+  ({
+    LeftComponent,
+    RightComponent,
+    Icon,
+    autoHide = true,
+    height = isNewMacHeaderBar() ? LAYOUT_VIEW_SIZE.BIG_SUR_TITLEBAR_HEIGHT : LAYOUT_VIEW_SIZE.TITLEBAR_HEIGHT,
+  }: React.PropsWithChildren<ElectronHeaderBarPorps>) => {
     const windowService: IWindowService = useInjectable(IWindowService);
 
     const { isFullScreen } = useFullScreen();
@@ -155,9 +162,7 @@ export const ElectronHeaderBar = observer(
     return (
       <div
         className={styles.header}
-        style={{
-          height: isNewMacHeaderBar() ? LAYOUT_VIEW_SIZE.BIG_SUR_TITLEBAR_HEIGHT : LAYOUT_VIEW_SIZE.TITLEBAR_HEIGHT,
-        }}
+        style={{ height }}
         onDoubleClick={async () => {
           if (await getMaximized()) {
             windowService.unmaximize();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
修复 Electron 版本在 Big Sur 之前的版本高度不正确
<img width="960" alt="image" src="https://user-images.githubusercontent.com/2226423/198226836-754e55a9-55aa-4c4a-b5b1-1de325724412.png">


### Changelog
修复 Electron 版本的 Header Bar 异常