### PR TITLE
feat: implement TestController refreshHandler API

### DIFF
--- a/packages/core-browser/src/contextkey/testing.ts
+++ b/packages/core-browser/src/contextkey/testing.ts
@@ -6,3 +6,4 @@ export const TestingHasAnyResults = new RawContextKey('testing.hasAnyResults', f
 export const TestingIsRunning = new RawContextKey('testing.isRunning', false);
 export const TestingIsInPeek = new RawContextKey('testing.isInPeek', true);
 export const TestingIsPeekVisible = new RawContextKey('testing.isPeekVisible', false);
+export const TestingCanRefreshTests = new RawContextKey('testing.canRefresh', false);

--- a/packages/extension/src/common/vscode/tests.ts
+++ b/packages/extension/src/common/vscode/tests.ts
@@ -24,7 +24,11 @@ import {
 } from '@opensumi/ide-testing/lib/common/testCollection';
 
 export interface IExtHostTests {
-  createTestController(controllerId: string, label: string): vscode.TestController;
+  createTestController(
+    controllerId: string,
+    label: string,
+    refreshHandler?: ((token: CancellationToken) => Thenable<void> | void) | undefined,
+  ): vscode.TestController;
 
   // #region API for main thread
   $runControllerTests(req: RunTestForControllerRequest, token: CancellationToken): Promise<void>;
@@ -49,16 +53,23 @@ export interface IExtHostTests {
   ): Promise<CoverageDetails[]>;
   /** Configures a test run config. */
   $configureRunProfile(controllerId: string, configId: number): void;
+  /** Asks the controller to refresh its tests */
+  $refreshTests(controllerId: string, token: CancellationToken): Promise<void>;
   // #endregion
+}
+
+export interface ITestControllerPatch {
+  label?: string;
+  canRefresh?: boolean;
 }
 
 export interface IMainThreadTesting {
   // --- test lifecycle:
 
   /** Registers that there's a test controller with the given ID */
-  $registerTestController(controllerId: string, label: string): void;
+  $registerTestController(controllerId: string, label: string, canRefresh: boolean): void;
   /** Updates the label of an existing test controller. */
-  $updateControllerLabel(controllerId: string, label: string): void;
+  $updateController(controllerId: string, patch: ITestControllerPatch): void;
   /** Disposes of the test controller with the given ID */
   $unregisterTestController(controllerId: string): void;
   /** Requests tests published to VS Code. */

--- a/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
@@ -232,8 +232,8 @@ export function createApiFactory(
       },
     },
     tests: {
-      createTestController(controllerId: string, label: string) {
-        return extHostTests.createTestController(controllerId, label);
+      createTestController(controllerId: string, label: string, refreshHandler?: () => Thenable<void> | void) {
+        return extHostTests.createTestController(controllerId, label, refreshHandler);
       },
     },
     // 类型定义

--- a/packages/testing/src/browser/icons/icons.ts
+++ b/packages/testing/src/browser/icons/icons.ts
@@ -25,6 +25,7 @@ export const testingStatesToIcons = new Map<TestResultState, string>([
 
 export const testingRunIcon = getExternalIcon('run');
 export const testingRunAllIcon = getExternalIcon('run-all');
+export const testingRefreshTests = getExternalIcon('refresh');
 
 export const getIconWithColor = (state: TestResultState) =>
   `${testingStatesToIcons.get(state)} ${testStatesToIconColors[state]}` || '';

--- a/packages/testing/src/browser/test.service.ts
+++ b/packages/testing/src/browser/test.service.ts
@@ -10,7 +10,7 @@ import {
   SlotLocation,
 } from '@opensumi/ide-core-browser';
 import { IContextKey, IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
-import { TestingServiceProviderCount } from '@opensumi/ide-core-browser/lib/contextkey/testing';
+import { TestingCanRefreshTests, TestingServiceProviderCount } from '@opensumi/ide-core-browser/lib/contextkey/testing';
 import { IMainLayoutService } from '@opensumi/ide-main-layout';
 
 import { AmbiguousRunTestsRequest, ITestController, ITestService, TestId } from '../common';
@@ -27,6 +27,7 @@ import { TestingView } from './components/testing.view';
 export class TestServiceImpl extends Disposable implements ITestService {
   private controllers = new Map<string, ITestController>();
   private controllerCount: IContextKey<number>;
+  private canRefreshTests: IContextKey<boolean>;
 
   private readonly processDiffEmitter = new Emitter<TestsDiff>();
   private viewId = '';
@@ -49,6 +50,24 @@ export class TestServiceImpl extends Disposable implements ITestService {
   constructor() {
     super();
     this.controllerCount = TestingServiceProviderCount.bind(this.contextKeyService);
+    this.canRefreshTests = TestingCanRefreshTests.bind(this.contextKeyService);
+  }
+
+  public getTestController(controllerId: string): ITestController | undefined {
+    return this.controllers.get(controllerId);
+  }
+
+  public async refreshTests(controllerId?: string): Promise<void> {
+    const cts = new CancellationTokenSource();
+    try {
+      if (controllerId) {
+        await this.controllers.get(controllerId)?.refreshTests(cts.token);
+      } else {
+        await Promise.all([...this.controllers.values()].map((c) => c.refreshTests(cts.token)));
+      }
+    } finally {
+      cts.dispose(true);
+    }
   }
 
   private registerTestingExplorerView(): string {
@@ -70,27 +89,41 @@ export class TestServiceImpl extends Disposable implements ITestService {
   registerTestController(id: string, testController: ITestController): IDisposable {
     this.controllers.set(id, testController);
     this.controllerCount.set(this.controllers.size);
+    this.updateCanRefresh();
 
     if (this.controllers.size > 0 && !this.viewId) {
       this.viewId = this.registerTestingExplorerView();
     }
 
-    return Disposable.create(() => {
-      const diff: TestsDiff = [];
-      for (const root of this.collection.rootItems) {
-        if (root.controllerId === id) {
-          diff.push([TestDiffOpType.Remove, root.item.extId]);
-        }
-      }
-      this.publishDiff(id, diff);
+    const disposable = new Disposable();
 
-      if (this.controllers.delete(id)) {
-        this.controllerCount.set(this.controllers.size);
-        if (this.controllers.size === 0 && this.viewId) {
-          this.mainlayoutService.disposeContainer(this.viewId);
+    disposable.addDispose(
+      Disposable.create(() => {
+        const diff: TestsDiff = [];
+        for (const root of this.collection.rootItems) {
+          if (root.controllerId === id) {
+            diff.push([TestDiffOpType.Remove, root.item.extId]);
+          }
         }
-      }
-    });
+        this.publishDiff(id, diff);
+
+        if (this.controllers.delete(id)) {
+          this.controllerCount.set(this.controllers.size);
+          this.updateCanRefresh();
+          if (this.controllers.size === 0 && this.viewId) {
+            this.mainlayoutService.disposeContainer(this.viewId);
+          }
+        }
+      }),
+    );
+
+    disposable.addDispose(testController.canRefresh.onDidChange(this.updateCanRefresh, this));
+
+    return disposable;
+  }
+
+  private updateCanRefresh() {
+    this.canRefreshTests.set(Array.from(this.controllers.values()).some((c) => c.canRefresh));
   }
 
   public async expandTest(id: string, levels: number) {

--- a/packages/testing/src/browser/testing.contribution.ts
+++ b/packages/testing/src/browser/testing.contribution.ts
@@ -18,7 +18,7 @@ import {
   ToolbarRegistry,
   URI,
 } from '@opensumi/ide-core-browser';
-import { TestingIsPeekVisible } from '@opensumi/ide-core-browser/lib/contextkey/testing';
+import { TestingCanRefreshTests, TestingIsPeekVisible } from '@opensumi/ide-core-browser/lib/contextkey/testing';
 import { IMenuRegistry, MenuContribution, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { Emitter, IMarkdownString } from '@opensumi/ide-core-common';
 import {
@@ -47,6 +47,7 @@ import {
   GoToTestCommand,
   OpenMessageInEditor,
   PeekTestError,
+  RefreshTestsCommand,
   RuntAllTestCommand,
   RuntTestCommand,
   TestingDebugCurrentFile,
@@ -334,6 +335,12 @@ export class TestingContribution
       await this.testService.runTests({ tests: roots, group });
     };
 
+    commands.registerCommand(RefreshTestsCommand, {
+      execute: async () => {
+        await this.testService.refreshTests();
+      },
+    });
+
     commands.registerCommand(RuntAllTestCommand, {
       execute: async () => {
         await runOrDebugAllTestsAction(TestRunProfileBitset.Run);
@@ -398,6 +405,12 @@ export class TestingContribution
   }
 
   registerToolbarItems(registry: ToolbarRegistry): void {
+    registry.registerItem({
+      id: RefreshTestsCommand.id,
+      command: RefreshTestsCommand.id,
+      viewId: Testing.ExplorerViewId,
+      when: TestingCanRefreshTests.equalsTo(true),
+    });
     registry.registerItem({
       id: RuntAllTestCommand.id,
       command: RuntAllTestCommand.id,

--- a/packages/testing/src/common/commands.ts
+++ b/packages/testing/src/common/commands.ts
@@ -70,3 +70,9 @@ export const DebugAllTestCommand: Command = {
   label: 'Debug All Test',
   iconClass: getIcon('debug-alt-small'),
 };
+
+export const RefreshTestsCommand: Command = {
+  id: 'testing.refresshTests',
+  label: 'Refresh Tests',
+  iconClass: getIcon('refresh'),
+};

--- a/packages/testing/src/common/index.ts
+++ b/packages/testing/src/common/index.ts
@@ -1,5 +1,6 @@
 import { Event, IDisposable, CancellationToken } from '@opensumi/ide-core-browser';
 
+import { ObservableValue } from './observableValue';
 import { ITestResult } from './test-result';
 import {
   InternalTestItem,
@@ -15,9 +16,10 @@ export * from './testId';
 export interface ITestController {
   readonly id: string;
   readonly label: string;
-
+  readonly canRefresh: ObservableValue<boolean>;
   configureRunProfile(profileId: number): void;
   expandTest(testId: string, levels: number): Promise<void>;
+  refreshTests(token: CancellationToken): Promise<void>;
   runTests(request: RunTestForControllerRequest, token: CancellationToken): Promise<void>;
 }
 
@@ -36,8 +38,9 @@ export interface ITestService {
   runTests(req: AmbiguousRunTestsRequest, token?: CancellationToken): Promise<ITestResult>;
   publishDiff(controllerId: string, diff: TestsDiff): void;
   runResolvedTests(req: ResolvedTestRunRequest, token?: CancellationToken): Promise<ITestResult>;
-
   onDidProcessDiff: Event<TestsDiff>;
+  getTestController(controllerId: string): ITestController | undefined;
+  refreshTests(controllerId?: string): Promise<void>;
 }
 
 export interface AmbiguousRunTestsRequest {

--- a/packages/testing/src/common/observableValue.ts
+++ b/packages/testing/src/common/observableValue.ts
@@ -1,0 +1,27 @@
+import { Disposable, Emitter, Event } from '@opensumi/ide-core-common';
+
+export interface IObservableValue<T> {
+  onDidChange: Event<T>;
+  readonly value: T;
+}
+
+export class ObservableValue<T> extends Disposable implements IObservableValue<T> {
+  private readonly changeEmitter = this.registerDispose(new Emitter<T>());
+
+  public readonly onDidChange = this.changeEmitter.event;
+
+  public get value() {
+    return this._value;
+  }
+
+  public set value(v: T) {
+    if (v !== this._value) {
+      this._value = v;
+      this.changeEmitter.fire(v);
+    }
+  }
+
+  constructor(private _value: T) {
+    super();
+  }
+}

--- a/packages/types/vscode/typings/vscode.tests.d.ts
+++ b/packages/types/vscode/typings/vscode.tests.d.ts
@@ -180,6 +180,20 @@ declare module "vscode" {
      * requested, or `undefined` to resolve the controller's initial {@link items}.
      */
     resolveHandler?: (item: TestItem | undefined) => Thenable<void> | void;
+
+    /**
+     * If this method is present, a refresh button will be present in the
+     * UI, and this method will be invoked when it's clicked. When called,
+     * the extension should scan the workspace for any new, changed, or
+     * removed tests.
+     *
+     * It's recommended that extensions try to update tests in realtime, using
+     * a {@link FileSystemWatcher} for example, and use this method as a fallback.
+     *
+     * @returns A thenable that resolves when tests have been refreshed.
+     */
+    refreshHandler: ((token: CancellationToken) => Thenable<void> | void) | undefined;
+
     /**
      * Creates a {@link TestRun}. This should be called by the
      * {@link TestRunProfile} when a request is made to execute tests, and may


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

**背景:** 默认情况下 Testing 是没有提供刷新操作的，需要插件自己往 workbench.view.testing 贡献点上注册刷新按钮，但这会导致 UI 上的冲突（比如会出现俩刷新按钮）

所以在 TestController 提供了 refreshHandler 的 API 方法，一旦实现了该方法，那么就会在如图所示的地方只出现一个刷新按钮
![image](https://user-images.githubusercontent.com/20262815/198276621-a983f231-970a-41c4-9ce3-1c2eb24a3f9d.png)

### Changelog
实现 TestController.refreshHandler API