### PR TITLE
chore: update view quick open prefix

### DIFF
--- a/packages/main-layout/src/browser/quick-open-view.ts
+++ b/packages/main-layout/src/browser/quick-open-view.ts
@@ -12,7 +12,7 @@ import { IMainLayoutService } from '../common';
 
 @Injectable()
 export class ViewQuickOpenHandler implements QuickOpenHandler {
-  readonly prefix: string = 'view';
+  readonly prefix: string = 'view ';
   readonly description: string = localize('layout.action.openView');
   protected items: QuickOpenItem[];
 


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

原来的写法会导致无法搜索 `view` 开头的文件内容，如 `view.ts`

### Changelog
