### PR TITLE
fix: add default watcher exclude

### DIFF
--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -289,6 +289,10 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
     return undefined;
   }
 
+  private getDefaultWatchExclude() {
+    return ['**/.git/objects/**', '**/.git/subtree-cache/**', '**/node_modules/**/*'];
+  }
+
   protected async start(
     watcherId: number,
     basePath: string,
@@ -300,7 +304,10 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
       return disposables;
     }
     const realPath = await fs.realpath(basePath);
-    const ignore = this.toExcludePaths(realPath, this.excludes.concat(rawOptions?.excludes || []));
+    const ignore = this.toExcludePaths(
+      realPath,
+      this.excludes.concat(rawOptions?.excludes || this.getDefaultWatchExclude()),
+    );
     hanlder = await ParcelWatcher.subscribe(
       realPath,
       (err, events: ParcelWatcher.Event[]) => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

设置未传入 exclude 参数时，ParcelWatcher 的默认监听行为，减少首次监听带来的性能问题

### Changelog

add default watcher exclude