### PR TITLE
fix: submenus show/hide rule

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'classnames';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import { Button, CheckBox, Icon } from '@opensumi/ide-components';
 import { ClickParam, Menu } from '@opensumi/ide-components/lib/menu';
@@ -16,6 +16,8 @@ import {
   SubmenuItemNode,
   IMenuAction,
   ComponentMenuItemNode,
+  AbstractMenuService,
+  generateMergedCtxMenu,
 } from '../../menu/next';
 import { useInjectable } from '../../react-hooks';
 import { useMenus, useContextMenus } from '../../utils';
@@ -351,8 +353,8 @@ export const TitleActionList: React.FC<
     regroup = (...args: [MenuNode[], MenuNode[]]) => args,
   }) => {
     const ctxMenuRenderer = useInjectable<ICtxMenuRenderer>(ICtxMenuRenderer);
+    const abstractMenuService = useInjectable<AbstractMenuService>(AbstractMenuService);
     const [primary, secondary] = regroup(nav, more);
-
     const handleShowMore = React.useCallback(
       (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
@@ -389,6 +391,14 @@ export const TitleActionList: React.FC<
                 key={(item as ComponentMenuItemNode).nodeId}
               />
             );
+          }
+
+          if (item.id === SubmenuItemNode.ID) {
+            const menus = abstractMenuService.createMenu((item as SubmenuItemNode).submenuId);
+            const hasSubMenu = generateMergedCtxMenu({ menus }).length > 0;
+            if (!hasSubMenu) {
+              return;
+            }
           }
 
           // submenu 使用 submenu-id 作为 id 唯一值


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

对于没有 command 命令的 submenu，以及没有往 submenu 上贡献菜单项的菜单都应该隐藏起来

### Changelog
修复总是显示 editor/title/run 的菜单项问题
