### PR TITLE
feat: implement test item sort text api

### DIFF
--- a/packages/components/src/recycle-tree/basic/types.ts
+++ b/packages/components/src/recycle-tree/basic/types.ts
@@ -79,6 +79,10 @@ export interface IBasicTreeData {
    */
   expandable?: boolean;
   /**
+   * 用于排序的字符串，若为空则默认以 label 作排序
+   */
+  sortText?: string | null;
+  /**
    * 其他属性
    */
   [key: string]: any;

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1649,7 +1649,7 @@ export namespace TestTag {
 export namespace TestItem {
   export type Raw = vscode.TestItem;
 
-  export function from(item: TestItemImpl): ITestItem {
+  export function from(item: vscode.TestItem): ITestItem {
     const ctrlId = getPrivateApiFor(item).controllerId;
     return {
       extId: TestId.fromExtHostTestItem(item, ctrlId).toString(),
@@ -1658,6 +1658,7 @@ export namespace TestItem {
       tags: item.tags.map((t) => TestTag.namespace(ctrlId, t.id)),
       range: Range.from(item.range) || null,
       description: item.description || null,
+      sortText: item.sortText || null,
       error: item.error ? MarkdownString.fromStrict(item.error) || null : null,
     };
   }
@@ -1678,6 +1679,7 @@ export namespace TestItem {
       canResolveChildren: false,
       busy: false,
       description: item.description || undefined,
+      sortText: item.sortText || undefined,
     };
   }
 

--- a/packages/extension/src/common/vscode/testing/testApi.ts
+++ b/packages/extension/src/common/vscode/testing/testApi.ts
@@ -49,13 +49,13 @@ export type ExtHostTestItemEvent =
 
 export interface IExtHostTestItemApi {
   controllerId: string;
-  parent?: TestItemImpl;
+  parent?: vscode.TestItem;
   listener?: (evt: ExtHostTestItemEvent) => void;
 }
 
-const eventPrivateApis = new WeakMap<TestItemImpl, IExtHostTestItemApi>();
+const eventPrivateApis = new WeakMap<vscode.TestItem, IExtHostTestItemApi>();
 
-export const createPrivateApiFor = (impl: TestItemImpl, controllerId: string) => {
+export const createPrivateApiFor = (impl: vscode.TestItem, controllerId: string) => {
   const api: IExtHostTestItemApi = { controllerId };
   eventPrivateApis.set(impl, api);
   return api;
@@ -66,7 +66,7 @@ export const createPrivateApiFor = (impl: TestItemImpl, controllerId: string) =>
  * is a managed object, but we keep a weakmap to avoid exposing any of the
  * internals to extensions.
  */
-export const getPrivateApiFor = (impl: TestItemImpl) => eventPrivateApis.get(impl)!;
+export const getPrivateApiFor = (impl: vscode.TestItem) => eventPrivateApis.get(impl)!;
 
 const testItemPropAccessor = <K extends keyof vscode.TestItem>(
   api: IExtHostTestItemApi,
@@ -98,7 +98,7 @@ const testItemPropAccessor = <K extends keyof vscode.TestItem>(
 
 type WritableProps = Pick<
   vscode.TestItem,
-  'range' | 'label' | 'description' | 'canResolveChildren' | 'busy' | 'error' | 'tags'
+  'range' | 'label' | 'description' | 'canResolveChildren' | 'busy' | 'error' | 'tags' | 'sortText'
 >;
 
 const strictEqualComparator = <T>(a: T, b: T) => a === b;
@@ -117,6 +117,7 @@ const propComparators: {
   },
   label: strictEqualComparator,
   description: strictEqualComparator,
+  sortText: strictEqualComparator,
   busy: strictEqualComparator,
   error: strictEqualComparator,
   canResolveChildren: strictEqualComparator,
@@ -142,6 +143,7 @@ const makePropDescriptors = (
   range: testItemPropAccessor(api, 'range', undefined, propComparators.range),
   label: testItemPropAccessor(api, 'label', label, propComparators.label),
   description: testItemPropAccessor(api, 'description', undefined, propComparators.description),
+  sortText: testItemPropAccessor(api, 'sortText', undefined, propComparators.sortText),
   canResolveChildren: testItemPropAccessor(api, 'canResolveChildren', false, propComparators.canResolveChildren),
   busy: testItemPropAccessor(api, 'busy', false, propComparators.busy),
   error: testItemPropAccessor(api, 'error', undefined, propComparators.error),
@@ -282,6 +284,7 @@ export class TestItemImpl implements vscode.TestItem {
 
   public range!: vscode.Range | undefined;
   public description!: string | undefined;
+  public sortText!: string | undefined;
   public label!: string;
   public error!: string | vscode.MarkdownString;
   public busy!: boolean;

--- a/packages/testing/src/browser/components/testing.explorer.tree.tsx
+++ b/packages/testing/src/browser/components/testing.explorer.tree.tsx
@@ -11,7 +11,7 @@ import { TestItemExpandState, TestRunProfileBitset } from '../../common/testColl
 import { TestingExplorerInlineMenus } from '../../common/testing-view';
 import { ITestTreeData, ITestTreeItem, TestTreeViewModelToken } from '../../common/tree-view.model';
 import { getIconWithColor } from '../icons/icons';
-import { TestTreeViewModelImpl } from '../test-tree-view.model';
+import { TestTreeItem, TestTreeViewModelImpl } from '../test-tree-view.model';
 
 import styles from './testing.module.less';
 
@@ -25,7 +25,7 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
   const getItemIcon = React.useCallback((item: ITestTreeItem) => getIconWithColor(item.state), []);
 
   const asTreeData = React.useCallback(
-    (item: ITestTreeItem): ITestTreeData => ({
+    (item: TestTreeItem): ITestTreeData => ({
       label: item.label,
       icon: '',
       get iconClassName() {
@@ -33,6 +33,7 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
       },
       expandable: item.test.expand !== TestItemExpandState.NotExpandable,
       rawItem: item,
+      sortText: item.sortText,
       get children() {
         if (item.test.expand === TestItemExpandState.Expandable || item.children) {
           const testTree = testViewModel.getTestTreeItem(item.test.item.extId);
@@ -52,10 +53,12 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
     )(() => {
       for (const root of testViewModel.roots) {
         if (root.depth === 0 && root.children.size > 0) {
-          const result: ITestTreeData[] = [];
+          let result: ITestTreeData[] = [];
           for (const child of root.children) {
             result.push(asTreeData(child));
           }
+
+          result = result.sort((a, b) => (a.sortText || a.label).localeCompare(b.sortText || b.label));
           setTreeData(result);
         }
       }

--- a/packages/testing/src/browser/test-tree-view.model.ts
+++ b/packages/testing/src/browser/test-tree-view.model.ts
@@ -44,6 +44,10 @@ export class TestTreeItem implements ITestTreeItem {
     return this.test.item.label;
   }
 
+  public get sortText() {
+    return this.test.item.sortText;
+  }
+
   public state = TestResultState.Unset;
 
   public ownState = TestResultState.Unset;

--- a/packages/testing/src/common/testCollection.ts
+++ b/packages/testing/src/common/testCollection.ts
@@ -218,6 +218,7 @@ export interface ITestItem {
   range: IRange | null;
   description: string | null;
   error: string | IMarkdownString | null;
+  sortText: string | null;
 }
 
 export const enum TestItemExpandState {

--- a/packages/types/vscode/typings/vscode.tests.d.ts
+++ b/packages/types/vscode/typings/vscode.tests.d.ts
@@ -471,6 +471,12 @@ declare module "vscode" {
      */
     description?: string;
     /**
+     * A string that should be used when comparing this item
+     * with other items. When `falsy` the {@link TestItem.label label}
+     * is used.
+     */
+    sortText?: string | undefined;
+    /**
      * Location of the test item in its {@link uri}.
      *
      * This is only meaningful if the `uri` points to a file.
@@ -571,24 +577,6 @@ declare module "vscode" {
      */
     readonly removed: ReadonlyArray<TestItem>;
   }
-
-  /**
-   * A test item is an item shown in the "test explorer" view. It encompasses
-   * both a suite and a test, since they have almost or identical capabilities.
-   */
-  export interface TestItem {
-    /**
-     * Marks the test as outdated. This can happen as a result of file changes,
-     * for example. In "auto run" mode, tests that are outdated will be
-     * automatically rerun after a short delay. Invoking this on a
-     * test with children will mark the entire subtree as outdated.
-     *
-     * Extensions should generally not override this method.
-     */
-    // todo@api still unsure about this
-    invalidateResults(): void;
-  }
-
 
   /**
    * TestResults can be provided to the editor in {@link tests.publishTestResult},


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

该 API 主要用于在展示树视图时排序所需要计算的字段，若为 null 则根据 label 字段排序

例如：
![image](https://user-images.githubusercontent.com/20262815/198943303-b0229736-c5bc-4c65-a554-42098d245480.png)

此时给 aaa.md 添加 'zzzzz' 的 sortText

![image](https://user-images.githubusercontent.com/20262815/198943456-44795867-6fe9-4d48-a6c6-8228f29263c1.png)


### Changelog
实现 TestItem.sortText API