### PR TITLE
feat: update watch exclude rule

### DIFF
--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -18,7 +18,8 @@ export const FILES_DEFAULTS = {
   filesWatcherExclude: {
     '**/.git/objects/**': true,
     '**/.git/subtree-cache/**': true,
-    '**/node_modules/**/*': true,
+    '**/node_modules/*/**': true,
+    '**/.hg/store/**': true,
   },
   filesExclude: {
     '**/.git': true,

--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -290,7 +290,7 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
   }
 
   private getDefaultWatchExclude() {
-    return ['**/.git/objects/**', '**/.git/subtree-cache/**', '**/node_modules/**/*'];
+    return ['**/.git/objects/**', '**/.git/subtree-cache/**', '**/node_modules/*/**', '**/.hg/store/**'];
   }
 
   protected async start(


### PR DESCRIPTION
### Types

update watch exclude rule

- [x] 🎉 New Features


### Background or solution
Parcel Watcher 有一些BUG，但是Parcel Watcher本身是不支持glob的，所以只能退而求其次调整默认exclude策略，屏蔽掉node_modules目录。

### Changelog
- update watch exclude rule
