### PR TITLE
解决代码片段（Snippets）prefix不支持数组的问题。

### DIFF
--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -217,7 +217,7 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
       if (Array.isArray(body)) {
         body = body.join('\n');
       }
-      if (typeof prefix !== 'string' || typeof body !== 'string') {
+      if (typeof body !== 'string') {
         return;
       }
       const scopes: string[] = [];
@@ -235,16 +235,31 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
           }
         }
       }
-      toDispose.push(
-        this.push({
-          scopes,
-          name,
-          prefix,
-          description,
-          body,
-          source,
-        }),
-      );
+      if (Array.isArray(prefix)) {
+        for (const prefixKey of prefix) {
+          toDispose.push(
+            this.push({
+              scopes,
+              name,
+              prefix: prefixKey,
+              description,
+              body,
+              source
+            })
+          )
+        }
+      } else {
+        toDispose.push(
+          this.push({
+            scopes,
+            name,
+            prefix,
+            description,
+            body,
+            source
+          })
+        )
+      }
     });
 
     return toDispose;


### PR DESCRIPTION
### Types
- [ ] 🐛 Bug Fixes

vscode中Snippets代码片段prefix属性是支持数组的，但是opensumi里不支持，以下逻辑修正该问题。
