### PR TITLE
fix: 解决代码片段（Snippets）prefix 不支持数组的问题

### DIFF
--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -217,7 +217,7 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
       if (Array.isArray(body)) {
         body = body.join('\n');
       }
-      if (typeof prefix !== 'string' || typeof body !== 'string') {
+      if (typeof body !== 'string') {
         return;
       }
       const scopes: string[] = [];
@@ -235,16 +235,31 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
           }
         }
       }
-      toDispose.push(
-        this.push({
-          scopes,
-          name,
-          prefix,
-          description,
-          body,
-          source,
-        }),
-      );
+      if (Array.isArray(prefix)) {
+        for (const key of prefix) {
+          toDispose.push(
+            this.push({
+              scopes,
+              name,
+              prefix: key,
+              description,
+              body,
+              source,
+            }),
+          );
+        }
+      } else {
+        toDispose.push(
+          this.push({
+            scopes,
+            name,
+            prefix,
+            description,
+            body,
+            source,
+          }),
+        );
+      }
     });
 
     return toDispose;
@@ -303,7 +318,7 @@ export interface JsonSerializedSnippets {
 export interface JsonSerializedSnippet {
   body: string | string[];
   scope: string;
-  prefix: string;
+  prefix: string | string[];
   description: string;
 }
 export namespace JsonSerializedSnippet {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
vscode中的snippets代码片段属性prefix支持数组，但是opensumi中不支持

### Changelog
调整 monaco 代码，使代码片段 prefix 属性支持数组
