### PR TITLE
fix: parcel watcher version bump

### DIFF
--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -20,7 +20,7 @@
     "@opensumi/ide-core-common": "2.20.10",
     "@opensumi/ide-core-node": "2.20.10",
     "@opensumi/ide-logs": "2.20.10",
-    "@parcel/watcher": "2.0.5",
+    "@parcel/watcher": "2.0.6",
     "drivelist": "^6.4.3",
     "file-type": "^12.0.0",
     "iconv-lite": "^0.6.3",

--- a/tools/electron/package.json
+++ b/tools/electron/package.json
@@ -37,7 +37,7 @@
   "license": "ISC",
   "dependencies": {
     "node-pty": "0.11.0-beta19",
-    "@parcel/watcher": "2.0.5",
+    "@parcel/watcher": "2.0.6",
     "spdlog": "^0.9.0",
     "vscode-oniguruma": "1.6.1",
     "@opensumi/vscode-ripgrep": "^1.4.0"


### PR DESCRIPTION
### Types

修复旧版本 Parcel Watcher 段错误导致的 IDE 进程 Crash 问题。
Parcel Watcher 的修复PR： https://github.com/parcel-bundler/watcher/pull/103

- [x] 🐛 Bug Fixes

### Background or solution
之前的 parcel watcher 存在一个会导致 SegmentFault 的错误，这个段错误会导致IDE进程Crash。
在推进官方修复后，发了新版本，现在来集成新版本修复 IDE 的 Crash 问题。

### Changelog
- fix: parcel watcher version bump
