### PR TITLE
fix: ignore composition start when filetree rename

### DIFF
--- a/packages/components/src/recycle-tree/prompt/PromptHandle.ts
+++ b/packages/components/src/recycle-tree/prompt/PromptHandle.ts
@@ -37,6 +37,7 @@ export abstract class PromptHandle {
   private _hasValidateElement = false;
   private _hasAddonAfter = false;
   private _validateClassName: string;
+  private _inComposition = false;
 
   // event
   private onChangeEmitter: Emitter<string> = new Emitter();
@@ -63,6 +64,8 @@ export abstract class PromptHandle {
     this.$.addEventListener('keydown', this.handleKeydown);
     this.$.addEventListener('focus', this.handleFocus);
     this.$.addEventListener('blur', this.handleBlur);
+    this.$.addEventListener('compositionstart', this.handleCompositionstart);
+    this.$.addEventListener('compositionend', this.handleCompositionend);
     this.$validate = document.createElement('div');
     this.$validate.setAttribute('style', 'top: 100%;');
     this.$addonAfter = document.createElement('div');
@@ -211,11 +214,25 @@ export abstract class PromptHandle {
     ev.stopPropagation();
   };
 
-  private handleKeyup = (ev) => {
+  private handleCompositionstart = () => {
+    this._inComposition = true;
+  };
+
+  private handleCompositionend = () => {
+    this._inComposition = false;
+  };
+
+  private handleKeyup = () => {
+    if (this._inComposition) {
+      return;
+    }
     this.onChangeEmitter.fire(this.$.value);
   };
 
   private handleKeydown = async (ev) => {
+    if (this._inComposition) {
+      return;
+    }
     if (ev.key === 'Escape') {
       const res: IAsyncResult<boolean>[] = await this.onCancelEmitter.fireAndAwait(this.$.value);
       // 当有回调函数报错或返回结果为false时，终止后续操作


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fixed #1912 .

![Kapture 2022-11-03 at 16 09 10](https://user-images.githubusercontent.com/9823838/199673018-19d45d46-1de5-40fc-a423-fa7d8a7e166e.gif)

### Changelog

ignore composition start when filetree rename