### PR TITLE
fix: make the search references clean up

### DIFF
--- a/packages/comments/src/browser/comments.service.ts
+++ b/packages/comments/src/browser/comments.service.ts
@@ -412,7 +412,7 @@ export class CommentsService extends Disposable implements ICommentsService {
       return await cache.promise;
     }
 
-    const model = this.documentService.getModelReference(uri);
+    const model = this.documentService.getModelReference(uri, 'get-contribution-rages');
     const rangePromise: Promise<IRange[] | undefined>[] = [];
     for (const rangeProvider of this.rangeProviderMap) {
       const [id, provider] = rangeProvider;

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -2106,7 +2106,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
   calcDirtyCount(countedUris: Set<string> = new Set<string>()): number {
     let count = 0;
     for (const r of this.resources) {
-      const docRef = this.documentModelManager.getModelReference(r.uri);
+      const docRef = this.documentModelManager.getModelReference(r.uri, 'calc-dirty-count');
       if (countedUris.has(r.uri.toString())) {
         continue;
       }

--- a/packages/search/src/browser/search-tree.service.ts
+++ b/packages/search/src/browser/search-tree.service.ts
@@ -95,10 +95,9 @@ export class RangeHighlightDecorations implements IDisposable {
     if (this._model !== model) {
       this.clearModelListeners();
       this._model = model;
+
       this._modelDisposables.add(
         this._model.onWillDispose(() => {
-          this._modelRef?.dispose();
-          this._modelRef = null;
           this.clearModelListeners();
           this.removeHighlightRange();
           this._model = null;
@@ -108,6 +107,8 @@ export class RangeHighlightDecorations implements IDisposable {
   }
 
   private clearModelListeners() {
+    this._modelRef?.dispose();
+    this._modelRef = null;
     this._modelDisposables.clear();
   }
 
@@ -382,7 +383,7 @@ export class SearchTreeService {
       this.replaceDocumentModelContentProvider.delete(replaceURI);
     } else {
       const uri = new URI(result.fileUri);
-      await this.workbenchEditorService.open(new URI(result.fileUri), {
+      const openResourceResult = await this.workbenchEditorService.open(new URI(result.fileUri), {
         preview: isPreview,
         focus: !isPreview,
         range: {
@@ -393,10 +394,12 @@ export class SearchTreeService {
         },
       });
 
-      this.rangeHighlightDecorations.highlightRange(
-        uri,
-        new monaco.Range(result.line, result.matchStart, result.line, result.matchStart + result.matchLength),
-      );
+      if (openResourceResult && !openResourceResult.resource.deleted) {
+        this.rangeHighlightDecorations.highlightRange(
+          uri,
+          new monaco.Range(result.line, result.matchStart, result.line, result.matchStart + result.matchLength),
+        );
+      }
     }
   }
 

--- a/packages/search/src/browser/search-tree.service.ts
+++ b/packages/search/src/browser/search-tree.service.ts
@@ -92,6 +92,10 @@ export class RangeHighlightDecorations implements IDisposable {
   }
 
   private setModel(model: ITextModel) {
+    if (this._modelRef) {
+      this._modelRef.dispose();
+      this._modelRef = null;
+    }
     if (this._model !== model) {
       this.clearModelListeners();
       this._model = model;
@@ -107,8 +111,6 @@ export class RangeHighlightDecorations implements IDisposable {
   }
 
   private clearModelListeners() {
-    this._modelRef?.dispose();
-    this._modelRef = null;
     this._modelDisposables.clear();
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution
已经删除的文件，出现在全局搜索的结果中，有两个问题导致：
1. 使用双击打开结果列表，其中第一次点击的引用留在 reference 中，导致 dispose 的执行不够彻底
2. 对于代码逻辑中，尝试打开已经删除的文件路径，要判断一下结果中是否标记为已删除，不然会导致一些逻辑无法清理干净

### Changelog
fix: make the search references clean up