### PR TITLE
fix: support mousewheel on editor tabs

### DIFF
--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -421,7 +421,6 @@ export const Tabs = ({ group }: ITabsProps) => {
       >
         {!wrapMode ? (
           <Scrollbars
-            thumbSize={5}
             forwardedRef={(el) => (el ? (tabContainer.current = el) : null)}
             className={styles.kt_editor_tabs_scroll}
           >


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

修复在 2.20 版本中编辑器标签页中丢失的鼠标滚轮处理逻辑

close #1922 

### Changelog

support mousewheel on editor tabs