### PR TITLE
fix: make watcher can be disposed

### DIFF
--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -391,6 +391,7 @@ export class FileServiceClient implements IFileServiceClient {
     if (!disposable || !disposable.dispose) {
       return;
     }
+    this.watcherDisposerMap.delete(watcherId);
     return disposable.dispose();
   }
 

--- a/packages/file-service/src/browser/watcher.ts
+++ b/packages/file-service/src/browser/watcher.ts
@@ -37,7 +37,10 @@ export class FileSystemWatcher implements IFileServiceWatcher {
     return this.changeEmitter.event;
   }
 
-  async dispose() {
-    return this.toDispose.dispose();
+  dispose() {
+    return Promise.all<void>([
+      this.toDispose.dispose(),
+      this.fileServiceClient.unwatchFileChanges(this.watchId),
+    ]) as any;
   }
 }

--- a/packages/file-service/src/browser/watcher.ts
+++ b/packages/file-service/src/browser/watcher.ts
@@ -37,8 +37,7 @@ export class FileSystemWatcher implements IFileServiceWatcher {
     return this.changeEmitter.event;
   }
 
-  dispose() {
-    this.toDispose.dispose();
-    return this.fileServiceClient.unwatchFileChanges(this.watchId);
+  async dispose() {
+    return this.toDispose.dispose();
   }
 }

--- a/packages/utils/src/disposable.ts
+++ b/packages/utils/src/disposable.ts
@@ -227,7 +227,7 @@ export class DisposableCollection implements IDisposable {
   }
 
   private disposingElements = false;
-  dispose(): void {
+  dispose(): MaybePromise<void> {
     if (this.disposed || this.disposingElements) {
       return;
     }

--- a/packages/utils/src/disposable.ts
+++ b/packages/utils/src/disposable.ts
@@ -227,7 +227,7 @@ export class DisposableCollection implements IDisposable {
   }
 
   private disposingElements = false;
-  dispose(): MaybePromise<void> {
+  dispose(): void {
     if (this.disposed || this.disposingElements) {
       return;
     }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

以下为猜测：

小程序 IDE 出现过很多次退出无响应，观察日志发现：
<img width="965" alt="CleanShot 2022-11-07 at 11 41 32@2x" src="https://user-images.githubusercontent.com/13938334/200221853-81562808-a273-493a-a374-9a6bb5ed9fe7.png">

有原生 module 在退出，然后尝试看了下代码，发现如果 watcher 不停掉的话，进程是不会退出的

现在的 watcher 逻辑并不是异步阻塞的

### Changelog

make watcher can be disposed