### PR TITLE
fix: update unsupported watch exclude glob

### DIFF
--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -18,7 +18,8 @@ export const FILES_DEFAULTS = {
   filesWatcherExclude: {
     '**/.git/objects/**': true,
     '**/.git/subtree-cache/**': true,
-    '**/node_modules/**/*': true,
+    '**/node_modules/**': true,
+    '**/.hg/store/**': true,
   },
   filesExclude: {
     '**/.git': true,

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -41,8 +41,8 @@ import {
 
 import { ParcelWatcherServer } from './file-service-watcher';
 
-const UNIX_DEFAULT_NODE_MODULES_EXCLUDE = '**/node_modules/**/*';
-const WINDOWS_DEFAULT_NODE_MODULES_EXCLUDE = '**/node_modules/*/**';
+const UNSUPPORTED_NODE_MODULES_EXCLUDE = '**/node_modules/*/**';
+const DEFAULT_NODE_MODULES_EXCLUDE = '**/node_modules/**';
 
 export interface IRPCDiskFileSystemProvider {
   onDidFilesChanged(event: DidFilesChangedParams): void;
@@ -327,12 +327,9 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   // 出于通信成本的考虑，排除文件的逻辑必须放在node层（fs provider层，不同的fs实现的exclude应该不一样）
   setWatchFileExcludes(excludes: string[]) {
     let watchExcludes = excludes;
-    // 兼容 Windows 下对 node_modules 默认排除监听的逻辑
-    // 由于 files.watcherExclude 允许用户手动修改，所以只对默认值做处理
-    // 在 Windows 下将 **/node_modules/**/* 替换为 **/node_modules/*/**
-    if (isWindows && excludes.includes(UNIX_DEFAULT_NODE_MODULES_EXCLUDE)) {
-      const idx = watchExcludes.findIndex((v) => v === UNIX_DEFAULT_NODE_MODULES_EXCLUDE);
-      watchExcludes = watchExcludes.splice(idx, 1, WINDOWS_DEFAULT_NODE_MODULES_EXCLUDE);
+    if (excludes.includes(UNSUPPORTED_NODE_MODULES_EXCLUDE)) {
+      const idx = watchExcludes.findIndex((v) => v === UNSUPPORTED_NODE_MODULES_EXCLUDE);
+      watchExcludes = watchExcludes.splice(idx, 1, DEFAULT_NODE_MODULES_EXCLUDE);
     }
     // 每次调用之后都需要重新初始化 WatcherServer，保证最新的规则生效
     this.logger.log('Set watcher exclude:', watchExcludes);

--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -290,7 +290,7 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
   }
 
   private getDefaultWatchExclude() {
-    return ['**/.git/objects/**', '**/.git/subtree-cache/**', '**/node_modules/**/*'];
+    return ['**/.git/objects/**', '**/.git/subtree-cache/**', '**/node_modules/**', '**/.hg/store/**'];
   }
 
   protected async start(


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

在使用 @parcel/wathcer 后，原有的 glob 表达式 `**/node_modules/*/**` 在转换为 ignore path 时存在转换失效问题，该 PR 针对该入参做了转化处理（集成侧不需要改动也可正常运行）

### Changelog

update unsupported watch exclude glob
