### PR TITLE
fix: parcel watcher subscribe retry catch

### DIFF
--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -314,7 +314,7 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
           return await ParcelWatcher.subscribe(
             realPath,
             (err, events: ParcelWatcher.Event[]) => {
-              // 对于巨型events做屏蔽优化，避免潜在的卡死问题
+              // 对于超过500数量的 events 做屏蔽优化，避免潜在的卡死问题
               if (events.length > 5000) {
                 // FIXME: 研究此处屏蔽的影响，考虑下阈值应该设置多少，或者更加优雅的方式
                 return;

--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -299,7 +299,6 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
     rawOptions: WatchOptions | undefined,
   ): Promise<DisposableCollection> {
     const disposables = new DisposableCollection();
-    let hanlder: ParcelWatcher.AsyncSubscription;
     if (!(await fs.pathExists(basePath))) {
       return disposables;
     }
@@ -308,29 +307,55 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
       realPath,
       this.excludes.concat(rawOptions?.excludes || this.getDefaultWatchExclude()),
     );
-    hanlder = await ParcelWatcher.subscribe(
-      realPath,
-      (err, events: ParcelWatcher.Event[]) => {
-        const handlers = ParcelWatcherServer.WATCHER_HANDLERS.get(watcherId)?.handlers;
-        if (!handlers) {
-          return;
+
+    const tryWatchDir = async (maxRetries = 3) => {
+      for (let times = 0; times < maxRetries; times++) {
+        try {
+          return await ParcelWatcher.subscribe(
+            realPath,
+            (err, events: ParcelWatcher.Event[]) => {
+              // 对于巨型events做屏蔽优化，避免潜在的卡死问题
+              if (events.length > 5000) {
+                // FIXME: 研究此处屏蔽的影响，考虑下阈值应该设置多少，或者更加优雅的方式
+                return;
+              }
+              const handlers = ParcelWatcherServer.WATCHER_HANDLERS.get(watcherId)?.handlers;
+              if (!handlers) {
+                return;
+              }
+              for (const handler of handlers) {
+                handler(err, events);
+              }
+            },
+            {
+              backend: ParcelWatcherServer.PARCEL_WATCHER_BACKEND,
+              ignore,
+            },
+          );
+        } catch (e) {
+          // Parcel Watcher 启动失败，尝试重试
+          this.logger.error('watcher subscribe failed ', e, ' try times ', times);
         }
-        for (const handler of handlers) {
-          handler(err, events);
-        }
-      },
-      {
-        backend: ParcelWatcherServer.PARCEL_WATCHER_BACKEND,
-        ignore,
-      },
-    );
-    disposables.push(
-      Disposable.create(async () => {
-        if (hanlder) {
-          await hanlder.unsubscribe();
-        }
-      }),
-    );
+      }
+
+      // 经过若干次的尝试后，Parcel Watcher 依然启动失败，此时就不再尝试重试
+      this.logger.error(`watcher subscribe finally failed after ${maxRetries} times`);
+      return undefined; // watch 失败则返回 undefined
+    };
+
+    const hanlder: ParcelWatcher.AsyncSubscription | undefined = await tryWatchDir();
+
+    if (hanlder) {
+      // watch 成功才加入 disposables，否则也就无需 dispose
+      disposables.push(
+        Disposable.create(async () => {
+          if (hanlder) {
+            await hanlder.unsubscribe();
+          }
+        }),
+      );
+    }
+
     return disposables;
   }
 

--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -308,7 +308,7 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
       this.excludes.concat(rawOptions?.excludes || this.getDefaultWatchExclude()),
     );
 
-    const tryWatchDir = async (maxRetries = 3) => {
+    const tryWatchDir = async (maxRetries = 3, retryDelay = 1000) => {
       for (let times = 0; times < maxRetries; times++) {
         try {
           return await ParcelWatcher.subscribe(
@@ -335,6 +335,9 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
         } catch (e) {
           // Parcel Watcher 启动失败，尝试重试
           this.logger.error('watcher subscribe failed ', e, ' try times ', times);
+          await new Promise(function (resolve) {
+            setTimeout(resolve, retryDelay);
+          });
         }
       }
 

--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -314,7 +314,7 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
           return await ParcelWatcher.subscribe(
             realPath,
             (err, events: ParcelWatcher.Event[]) => {
-              // 对于超过500数量的 events 做屏蔽优化，避免潜在的卡死问题
+              // 对于超过5000数量的 events 做屏蔽优化，避免潜在的卡死问题
               if (events.length > 5000) {
                 // FIXME: 研究此处屏蔽的影响，考虑下阈值应该设置多少，或者更加优雅的方式
                 return;

--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -335,7 +335,7 @@ export class ParcelWatcherServer implements IFileSystemWatcherServer {
         } catch (e) {
           // Parcel Watcher 启动失败，尝试重试
           this.logger.error('watcher subscribe failed ', e, ' try times ', times);
-          await new Promise(function (resolve) {
+          await new Promise((resolve) => {
             setTimeout(resolve, retryDelay);
           });
         }


### PR DESCRIPTION
### Types

Parcel Watcher 在 watch 的时候做了 try catch 以及自动重试，避免 watcher 抛出错误导致IDE进程崩溃。
同时对单次大于5000的批量时间做了屏蔽，避免前后端的突发过大负载。

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes


### Background or solution
线上偶现watch失败的问题，inotify add watch failed，需要对 watch 做 try catch 以及重试。

### Changelog
- feat: parcel watcher subscribe retry catch
- feat: add parcel watcher retry delay
