### PR TITLE
chore: update iconfont page resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build
+        run: |
+          npm i
+          npm run update:iconfont
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "jsdom": "^20.0.0",
     "jsdom-worker": "^0.2.1",
     "node-fetch": "^2.6.7",
-    "offline-iconfont": "^1.1.0",
+    "offline-iconfont": "^1.2.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "semver": "^6.3.0",

--- a/packages/components/src/icon/iconfont/iconfont.html
+++ b/packages/components/src/icon/iconfont/iconfont.html
@@ -85,7 +85,7 @@
   <body>
     <div style="text-align: center">
       <h2>OpenSumi built-in icon list</h2>
-      <p>OpenSumi v2.21.0</p>
+      <p>OpenSumi v2.21.2</p>
       <p>//at.alicdn.com/t/a/font_1432262_0gpk8o1jvjfn.css</p>
 
       <div>click to copy icon name</div>

--- a/packages/components/src/icon/iconfont/index.html
+++ b/packages/components/src/icon/iconfont/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta http-equiv="refresh" content="0; url= ./iconfont.html" />
+  </head>
+  <title></title>
+</head>
+<body>
+  
+</body>
+</html>


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

升级构建依赖 `offline-iconfont`, 感谢  @vagusX 支持 https://github.com/vagusX/offline-iconfont/pull/3.

自动化 Iconfont Page 部署及构建逻辑 

增加 index.html 重定向文件，保障原有访问路径可用

### Changelog
