### PR TITLE
fix: monaco-editor snippets support prefix array

### DIFF
--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -218,7 +218,7 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
       if (Array.isArray(body)) {
         body = body.join('\n');
       }
-      if (typeof prefix !== 'string' || typeof body !== 'string') {
+      if (typeof body !== 'string') {
         return;
       }
       const scopes: string[] = [];
@@ -236,16 +236,31 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
           }
         }
       }
-      toDispose.push(
-        this.push({
-          scopes,
-          name,
-          prefix,
-          description,
-          body,
-          source,
-        }),
-      );
+      if (Array.isArray(prefix)) {
+        for (const key of prefix) {
+          toDispose.push(
+            this.push({
+              scopes,
+              name,
+              prefix: key,
+              description,
+              body,
+              source,
+            }),
+          );
+        }
+      } else {
+        toDispose.push(
+          this.push({
+            scopes,
+            name,
+            prefix,
+            description,
+            body,
+            source,
+          }),
+        );
+      }
     });
 
     return toDispose;
@@ -308,7 +323,7 @@ export interface JsonSerializedSnippets {
 export interface JsonSerializedSnippet {
   body: string | string[];
   scope: string;
-  prefix: string;
+  prefix: string | string[];
   description: string;
 }
 export namespace JsonSerializedSnippet {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution


### Changelog

