### PR TITLE
style: improve SCM delete decoration style

### DIFF
--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.view.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.view.tsx
@@ -314,7 +314,12 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
       <div className={clx(styles.scm_tree_node_content)}>
         {renderFolderToggle(item, handleTwistierClick)}
         {renderIcon(item)}
-        <div className={styles.scm_tree_node_overflow_wrap}>
+        <div
+          className={styles.scm_tree_node_overflow_wrap}
+          style={{
+            textDecoration: decoration && decoration.badge === 'D' ? 'line-through' : 'none',
+          }}
+        >
           {renderDisplayName(item)}
           {renderDescription(item)}
         </div>


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

已删除的文件在 SCM 面板下追加删除线样式便于区分

![image](https://user-images.githubusercontent.com/9823838/201589441-74c91acb-377b-4cdb-87f2-50dd91e78040.png)

### Changelog

improve SCM delete decoration style