### PR TITLE
fix: active debug view once when parent session is not changed

### DIFF
--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -337,6 +337,7 @@ export class DebugContribution
   protected readonly extensionsPointService: IExtensionsSchemaService;
 
   private firstSessionStart = true;
+  private openedViewSessions = new Set();
 
   get selectedBreakpoint(): SelectedBreakpoint | undefined {
     const { selectedBreakpoint } = this.breakpointManager;
@@ -430,7 +431,12 @@ export class DebugContribution
           this.openDebugView();
         }
       } else if (openDebug !== 'neverOpen') {
-        this.openDebugView();
+        const parentSession = session.parentSession;
+        const sessionId = parentSession?.id || session.id;
+        if (!this.openedViewSessions.has(sessionId)) {
+          this.openedViewSessions.add(sessionId);
+          this.openDebugView();
+        }
       }
 
       if (


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #1966 

### Changelog

active debug view once when parent session is not changed