### PR TITLE
style: conditional and log points should have a focused style

### DIFF
--- a/packages/debug/src/browser/debug-style.less
+++ b/packages/debug/src/browser/debug-style.less
@@ -63,9 +63,13 @@
   .sumi-breakpoint-icon-size;
 }
 
-.monaco-editor .sumi-debug-top-stack-frame.sumi-debug-breakpoint {
-  background: url('./assets/current-and-breakpoint.svg') center center no-repeat;
-  .sumi-breakpoint-icon-size;
+.monaco-editor .sumi-debug-top-stack-frame {
+  &.sumi-debug-breakpoint,
+  &.sumi-debug-conditional-breakpoint,
+  &.logpoint {
+    background: url('./assets/current-and-breakpoint.svg') center center no-repeat;
+    .sumi-breakpoint-icon-size;
+  }
 }
 
 .monaco-editor .view-overlays .sumi-debug-top-stack-frame-line {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

表达式及 Log 断点在聚焦时均需要有断点样式来展示断点是否生效信息，如下所示：

![image](https://user-images.githubusercontent.com/9823838/201815207-c31044c3-a0fc-4ae0-a95e-dbea0b7c9ffb.png)

之前：
![image](https://user-images.githubusercontent.com/9823838/201815291-3771f3e2-3e43-416f-9144-dac0d7fbdb6a.png)


### Changelog

conditional and log points should have a focused style