### PR TITLE
feat: improve dirty diff

### DIFF
--- a/packages/core-browser/src/menu/next/menu.contrib.interface.ts
+++ b/packages/core-browser/src/menu/next/menu.contrib.interface.ts
@@ -1,6 +1,7 @@
 import type vscode from 'vscode';
 
-import { URI, ILineChange } from '@opensumi/ide-core-common';
+import { URI } from '@opensumi/ide-core-common';
+import type { IChange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/smartLinesDiffComputer';
 
 // explorer/context
 // 资源管理器 ctxmenu
@@ -58,7 +59,7 @@ export type ScmResourceStateContextCallback = (...args: [vscode.SourceControlRes
 // diff editor 的最右侧 ellipsis 图标点击 dropdown
 // 此处 Uri 是 git scheme 的
 // todo: scm/change/title 是 diff widget 的菜单，这里不对待更新
-export type ScmChangeTitleCallback = (...args: [URI, ILineChange[], number]) => void;
+export type ScmChangeTitleCallback = (...args: [URI, IChange[], number]) => void;
 
 // view/title
 // 自定义 contributed view 的 inline actions/more actions

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -278,6 +278,7 @@ export const localizationBundle = {
     'scm.diff.change.next': 'Next Change',
     'scm.diff.change.previous': 'Previous Change',
     'scm.diff.toggle.renderSideBySide': 'Toggle Inline View',
+    'scm.dirtyDiff.changes': '{0} of {1} changes',
 
     'debug.action.add.configuration': 'Add Configuration...',
     'debug.action.no.configuration': 'No Configurations',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -243,6 +243,7 @@ export const localizationBundle = {
     'scm.diff.change.next': '下一个变化',
     'scm.diff.change.previous': '上一个变化',
     'scm.diff.toggle.renderSideBySide': '切换内联视图',
+    'scm.dirtyDiff.changes': '第 {0} 个更改 (共 {1} 个)',
 
     'debug.action.start': '启动调试',
     'debug.action.no.configuration': '暂无配置',

--- a/packages/monaco/__mocks__/monaco/editor/code-editor.ts
+++ b/packages/monaco/__mocks__/monaco/editor/code-editor.ts
@@ -161,7 +161,9 @@ export class MockedCodeEditor extends Disposable implements monaco.editor.ICodeE
     throw new Error('Method not implemented.');
   }
   getOption(_: any): any {
-    throw new Error('Method not implemented.');
+    const options = new Map();
+    options.set(60, 30);
+    return options;
   }
   getContentWidth(): number {
     throw new Error('Method not implemented.');

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-decorator.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-decorator.test.ts
@@ -61,7 +61,7 @@ describe('test for scm/src/browser/dirty-diff/dirty-diff-decorator.ts', () => {
       const spy = jest.spyOn(monacoModel, 'deltaDecorations');
 
       // ChangeType#Add
-      const change0: ILineChange = [10, 0, 111, 0, []];
+      const change0: ILineChange = [10, 10, 111, 0, []];
       dirtyDiffModel['_changes'] = [change0];
       dirtyDiffModel['_onDidChange'].fire([
         {
@@ -74,10 +74,13 @@ describe('test for scm/src/browser/dirty-diff/dirty-diff-decorator.ts', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const decos = spy.mock.calls[0][1];
       expect(decos.length).toBe(1);
+      const startLineNumber = change0[2];
+      const endLineNumber = change0[3] - 1 || startLineNumber - 1;
+
       expect(decos[0].range).toEqual({
-        startLineNumber: change0[2],
+        startLineNumber,
         startColumn: 1,
-        endLineNumber: change0[2],
+        endLineNumber,
         endColumn: 1,
       });
       expect(decos[0].options.linesDecorationsClassName).toBe('dirty-diff-glyph dirty-diff-added');
@@ -105,7 +108,7 @@ describe('test for scm/src/browser/dirty-diff/dirty-diff-decorator.ts', () => {
       const spy = jest.spyOn(monacoModel, 'deltaDecorations');
 
       // ChangeType#Delete
-      const change0: ILineChange = [1, 10, 111, 0, []];
+      const change0: ILineChange = [10, 11, 111, 111, []];
       dirtyDiffModel['_changes'] = [change0];
       dirtyDiffModel['_onDidChange'].fire([
         {
@@ -118,10 +121,11 @@ describe('test for scm/src/browser/dirty-diff/dirty-diff-decorator.ts', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const decos = spy.mock.calls[0][1];
       expect(decos.length).toBe(1);
+      const startLineNumber = change0[2];
       expect(decos[0].range).toEqual({
-        startLineNumber: change0[2],
+        startLineNumber: startLineNumber - 1,
         startColumn: Number.MAX_VALUE,
-        endLineNumber: change0[2],
+        endLineNumber: startLineNumber > 0 ? startLineNumber - 1 : startLineNumber,
         endColumn: Number.MAX_VALUE,
       });
       expect(decos[0].options.linesDecorationsClassName).toBeNull();
@@ -162,10 +166,13 @@ describe('test for scm/src/browser/dirty-diff/dirty-diff-decorator.ts', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const decos = spy.mock.calls[0][1];
       expect(decos.length).toBe(1);
+      const startLineNumber = change0[2];
+      const endLineNumber = change0[3] - 1 || startLineNumber - 1;
+
       expect(decos[0].range).toEqual({
-        startLineNumber: change0[2],
+        startLineNumber,
         startColumn: 1,
-        endLineNumber: change0[3],
+        endLineNumber,
         endColumn: 1,
       });
       expect(decos[0].options.linesDecorationsClassName).toBeNull();

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-decorator.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-decorator.test.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@opensumi/di';
+import { IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
 import { ILineChange, URI } from '@opensumi/ide-core-common';
 import { OverviewRulerLane, IDocPersistentCacheProvider } from '@opensumi/ide-editor';
 import { EmptyDocCacheImpl } from '@opensumi/ide-editor/src/browser';
@@ -8,6 +9,7 @@ import { ITextModel } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
 import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../../tools/dev-tool/src/mock-injector';
+import { MockContextKeyService } from '../../../../monaco/__mocks__/monaco.context-key.service';
 import { DirtyDiffDecorator } from '../../../src/browser/dirty-diff/dirty-diff-decorator';
 import { DirtyDiffModel } from '../../../src/browser/dirty-diff/dirty-diff-model';
 import { SCMPreferences } from '../../../src/browser/scm-preference';
@@ -31,6 +33,10 @@ describe('test for scm/src/browser/dirty-diff/dirty-diff-decorator.ts', () => {
       injector = createBrowserInjector(
         [],
         new MockInjector([
+          {
+            token: IContextKeyService,
+            useClass: MockContextKeyService,
+          },
           {
             token: IDocPersistentCacheProvider,
             useClass: EmptyDocCacheImpl,

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
@@ -441,11 +441,11 @@ describe('scm/src/browser/dirty-diff/dirty-diff-model.ts', () => {
 
         // monacoEditor.revealLineInCenter
         expect(revealLineInCenterSpy).toBeCalledTimes(1);
-        expect(revealLineInCenterSpy).toBeCalledWith(12 - 9);
+        expect(revealLineInCenterSpy).toBeCalledWith(7);
 
         expect(dirtyDiffWidget.currentIndex).toBe(1);
-        expect(dirtyDiffWidget.currentRange).toEqual(positionToRange(12));
-        expect(dirtyDiffWidget.currentHeightInLines).toBe(18);
+        expect(dirtyDiffWidget.currentRange).toEqual(positionToRange(11));
+        expect(dirtyDiffWidget.currentHeightInLines).toBe(10);
 
         // this.onDidChange
         dirtyDiffModel['_changes'].unshift(change0);
@@ -458,8 +458,8 @@ describe('scm/src/browser/dirty-diff/dirty-diff-model.ts', () => {
         ]);
 
         expect(dirtyDiffWidget.currentIndex).toBe(2);
-        expect(dirtyDiffWidget.currentRange).toEqual(positionToRange(12));
-        expect(dirtyDiffWidget.currentHeightInLines).toBe(18);
+        expect(dirtyDiffWidget.currentRange).toEqual(positionToRange(11));
+        expect(dirtyDiffWidget.currentHeightInLines).toBe(10);
 
         // originalEditor.monacoEditor.onDidChangeModelContent
         originalMonacoEditor['_onDidChangeModelContent'].fire();

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
@@ -464,7 +464,7 @@ describe('scm/src/browser/dirty-diff/dirty-diff-model.ts', () => {
         // originalEditor.monacoEditor.onDidChangeModelContent
         originalMonacoEditor['_onDidChangeModelContent'].fire();
         expect(relayoutSpy).toBeCalledTimes(1);
-        expect(relayoutSpy).toBeCalledWith(18);
+        expect(relayoutSpy).toBeCalledWith(10);
 
         // widget.onDispose
         dirtyDiffWidget.dispose();

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
@@ -1,4 +1,5 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
 import { toDisposable, Event, CommandService, positionToRange, URI, ILineChange } from '@opensumi/ide-core-common';
 import { IDocPersistentCacheProvider } from '@opensumi/ide-editor';
 import { EditorCollectionService } from '@opensumi/ide-editor';
@@ -15,6 +16,7 @@ import { StandaloneServices } from '@opensumi/monaco-editor-core/esm/vs/editor/s
 import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../../tools/dev-tool/src/mock-injector';
 import { createMockedMonaco } from '../../../../monaco/__mocks__/monaco';
+import { MockContextKeyService } from '../../../../monaco/__mocks__/monaco.context-key.service';
 import { SCMService, ISCMRepository } from '../../../src';
 import { DirtyDiffModel } from '../../../src/browser/dirty-diff/dirty-diff-model';
 import { DirtyDiffWidget } from '../../../src/browser/dirty-diff/dirty-diff-widget';
@@ -95,6 +97,10 @@ describe('scm/src/browser/dirty-diff/dirty-diff-model.ts', () => {
       injector = createBrowserInjector(
         [],
         new MockInjector([
+          {
+            token: IContextKeyService,
+            useClass: MockContextKeyService,
+          },
           {
             token: IDocPersistentCacheProvider,
             useClass: EmptyDocCacheImpl,

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-widget.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-widget.test.ts
@@ -1,10 +1,17 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import { IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
-import { positionToRange, URI, CommandService, ILineChange } from '@opensumi/ide-core-common';
+import {
+  positionToRange,
+  URI,
+  CommandService,
+  ILineChange,
+  registerLocalizationBundle,
+} from '@opensumi/ide-core-common';
 import { IDocPersistentCacheProvider } from '@opensumi/ide-editor';
 import { EmptyDocCacheImpl, IEditorDocumentModelService } from '@opensumi/ide-editor/src/browser';
 import { IEditorDocumentModel } from '@opensumi/ide-editor/src/browser/';
 import { EditorDocumentModel } from '@opensumi/ide-editor/src/browser/doc-model/main';
+import { toChange } from '@opensumi/ide-scm/lib/browser/dirty-diff/dirty-diff-util';
 
 import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../../tools/dev-tool/src/mock-injector';
@@ -13,6 +20,15 @@ import { MockContextKeyService } from '../../../../monaco/__mocks__/monaco.conte
 import { SCMService } from '../../../src';
 import { DirtyDiffModel } from '../../../src/browser/dirty-diff/dirty-diff-model';
 import { DirtyDiffWidget } from '../../../src/browser/dirty-diff/dirty-diff-widget';
+
+registerLocalizationBundle({
+  languageId: 'zh-CN',
+  contents: {
+    'scm.dirtyDiff.changes': '第 {0} 个更改 (共 {1} 个)',
+  },
+  languageName: 'Chinese',
+  localizedLanguageName: '中文(中国)',
+});
 
 @Injectable()
 class MockEditorDocumentModelService {
@@ -179,13 +195,23 @@ describe('scm/src/browser/dirty-diff/dirty-diff-widget.ts', () => {
       // add
       actionList[0].click();
       expect(fakeExecCmd).toBeCalledTimes(1);
-      expect(fakeExecCmd.mock.calls[0]).toEqual(['git.stageChange', URI.file('/test/workspace/abc.ts'), changes, 1]);
+      expect(fakeExecCmd.mock.calls[0]).toEqual([
+        'git.stageChange',
+        URI.file('/test/workspace/abc.ts'),
+        changes.map(toChange),
+        1,
+      ]);
       expect(fakeDispose).toHaveBeenCalledTimes(1);
 
       // revert
       actionList[1].click();
       expect(fakeExecCmd).toBeCalledTimes(2);
-      expect(fakeExecCmd.mock.calls[1]).toEqual(['git.revertChange', URI.file('/test/workspace/abc.ts'), changes, 1]);
+      expect(fakeExecCmd.mock.calls[1]).toEqual([
+        'git.revertChange',
+        URI.file('/test/workspace/abc.ts'),
+        changes.map(toChange),
+        1,
+      ]);
       expect(fakeDispose).toHaveBeenCalledTimes(2);
 
       // next
@@ -231,13 +257,13 @@ describe('scm/src/browser/dirty-diff/dirty-diff-widget.ts', () => {
       const detail = title.children[0];
       expect(detail.tagName).toBe('SPAN');
       expect(detail.className).toBe('dirty-diff-widget-title-detail');
-      expect((detail as HTMLElement).innerText).toBe('第 2 个更改（共 4 个）');
+      expect((detail as HTMLElement).innerText).toBe('第 2 个更改 (共 4 个)');
 
       dirtyDiffWidget.updateCurrent(4);
 
       dirtyDiffWidget['applyStyle']();
       // 上一个 children[0] 已经被移除了
-      expect((title.children[0] as HTMLElement).innerText).toBe('第 4 个更改（共 4 个）');
+      expect((title.children[0] as HTMLElement).innerText).toBe('第 4 个更改 (共 4 个)');
     });
 
     it('ok for relayout', () => {

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-widget.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-widget.test.ts
@@ -172,7 +172,7 @@ describe('scm/src/browser/dirty-diff/dirty-diff-widget.ts', () => {
       const actionList = Array.from(actions.children) as HTMLElement[];
       expect(actionList.length).toBe(5);
       expect(actionList.map((n) => n.className)).toEqual(
-        ['plus', 'rollback', 'up', 'down', 'close'].map((n) => `kaitian-icon kticon-${n}`),
+        ['add', 'discard', 'arrow-up', 'arrow-down', 'close'].map((n) => `kt-icon codicon codicon-${n}`),
       );
       // onclick test
 

--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-widget.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-widget.test.ts
@@ -1,4 +1,5 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
 import { positionToRange, URI, CommandService, ILineChange } from '@opensumi/ide-core-common';
 import { IDocPersistentCacheProvider } from '@opensumi/ide-editor';
 import { EmptyDocCacheImpl, IEditorDocumentModelService } from '@opensumi/ide-editor/src/browser';
@@ -8,6 +9,7 @@ import { EditorDocumentModel } from '@opensumi/ide-editor/src/browser/doc-model/
 import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../../tools/dev-tool/src/mock-injector';
 import { createMockedMonaco } from '../../../../monaco/__mocks__/monaco';
+import { MockContextKeyService } from '../../../../monaco/__mocks__/monaco.context-key.service';
 import { SCMService } from '../../../src';
 import { DirtyDiffModel } from '../../../src/browser/dirty-diff/dirty-diff-model';
 import { DirtyDiffWidget } from '../../../src/browser/dirty-diff/dirty-diff-widget';
@@ -53,6 +55,10 @@ describe('scm/src/browser/dirty-diff/dirty-diff-widget.ts', () => {
       injector = createBrowserInjector(
         [],
         new MockInjector([
+          {
+            token: IContextKeyService,
+            useClass: MockContextKeyService,
+          },
           {
             token: IDocPersistentCacheProvider,
             useClass: EmptyDocCacheImpl,

--- a/packages/scm/__tests__/browser/dirty-diff/index.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/index.test.ts
@@ -1,5 +1,5 @@
 import { Autowired, Injectable, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { PreferenceChange } from '@opensumi/ide-core-browser';
+import { IContextKeyService, PreferenceChange } from '@opensumi/ide-core-browser';
 import {
   DisposableCollection,
   PreferenceScope,
@@ -26,6 +26,7 @@ import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
 import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../../tools/dev-tool/src/mock-injector';
+import { MockContextKeyService } from '../../../../monaco/__mocks__/monaco.context-key.service';
 import { IDirtyDiffWorkbenchController } from '../../../src';
 import { DirtyDiffWorkbenchController, DirtyDiffItem } from '../../../src/browser/dirty-diff';
 import { DirtyDiffDecorator } from '../../../src/browser/dirty-diff/dirty-diff-decorator';
@@ -92,6 +93,10 @@ describe('scm/src/browser/dirty-diff/index.ts', () => {
     injector = createBrowserInjector(
       [],
       new Injector([
+        {
+          token: IContextKeyService,
+          useClass: MockContextKeyService,
+        },
         {
           token: IDocPersistentCacheProvider,
           useClass: EmptyDocCacheImpl,
@@ -423,20 +428,8 @@ describe('scm/src/browser/dirty-diff/index.ts', () => {
       const dirtyDiffDecorator = injector.get(DirtyDiffDecorator, [editorModel, dirtyDiffModel]);
       const dirtyDiffWidget = injector.get(DirtyDiffWidget, [monacoEditor, dirtyDiffModel, commandService]);
 
-      const change0: ILineChange = [
-        11,
-        11,
-        11,
-        11,
-        [],
-      ];
-      const change1: ILineChange = [
-        12,
-        12,
-        12,
-        12,
-        [],
-      ];
+      const change0: ILineChange = [11, 11, 11, 11, []];
+      const change1: ILineChange = [12, 12, 12, 12, []];
 
       dirtyDiffModel['_changes'] = [change0, change1];
       dirtyDiffWidget.updateCurrent(1);

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-decorator.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-decorator.ts
@@ -128,7 +128,7 @@ export class DirtyDiffDecorator extends Disposable {
             range: {
               startLineNumber: startLineNumber - 1,
               startColumn: Number.MAX_VALUE,
-              endLineNumber: startLineNumber - 1,
+              endLineNumber: startLineNumber > 0 ? startLineNumber - 1 : startLineNumber,
               endColumn: Number.MAX_VALUE,
             },
             options: this.deletedOptions,

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-decorator.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-decorator.ts
@@ -10,46 +10,33 @@ import {
   overviewRulerModifiedForeground,
   overviewRulerDeletedForeground,
   overviewRulerAddedForeground,
+  minimapGutterAddedBackground,
+  minimapGutterModifiedBackground,
+  minimapGutterDeletedBackground,
 } from '../scm-color';
 import { SCMPreferences } from '../scm-preference';
 
 import { DirtyDiffModel } from './dirty-diff-model';
-
-enum ChangeType {
-  Modify = 'Modify',
-  Add = 'Add',
-  Delete = 'Delete',
-}
-
-function getChangeType(change: ILineChange): ChangeType {
-  if (change[1] === 0) {
-    return ChangeType.Add;
-  } else if (change[3] === 0) {
-    return ChangeType.Delete;
-  }
-  return ChangeType.Modify;
-}
+import { ChangeType, getChangeType } from './dirty-diff-util';
 
 @Injectable({ multiple: true })
 export class DirtyDiffDecorator extends Disposable {
   /**
-   * -------------------------------- IMPORTANT --------------------------------
-   * 需要注意区分 model.IModelDecorationOptions 与 monaco.editor.IModelDecorationOptions 两个类型
-   * 将 model.IModelDecorationOptions 类型的对象传给签名为 monaco.editor.IModelDecorationOptions 的方法时需要做 Type Assertion
-   * 这是因为 monaco.d.ts 与 vs/editor/common/model 分别导出了枚举 TrackedRangeStickiness
-   * 这种情况下两个枚举的类型是不兼容的，即使他们是同一段代码的编译产物
-   * -------------------------------- IMPORTANT --------------------------------
    * @param className
    * @param foregroundColor
    * @param options
    */
   static createDecoration(
     className: string,
-    foregroundColor: string,
-    options: { gutter: boolean; overview: boolean; isWholeLine: boolean },
+    options: {
+      gutter: boolean;
+      overview: { active: boolean; color: string };
+      minimap: { active: boolean; color: string };
+      isWholeLine: boolean;
+    },
   ): textModel.ModelDecorationOptions {
     const decorationOptions: model.IModelDecorationOptions = {
-      description: 'dirty-diff',
+      description: 'dirty-diff-decoration',
       isWholeLine: options.isWholeLine,
     };
 
@@ -57,19 +44,27 @@ export class DirtyDiffDecorator extends Disposable {
       decorationOptions.linesDecorationsClassName = `dirty-diff-glyph ${className}`;
     }
 
-    if (options.overview) {
+    if (options.overview.active) {
       decorationOptions.overviewRuler = {
-        color: themeColorFromId(foregroundColor),
+        color: themeColorFromId(options.overview.color),
         position: OverviewRulerLane.Left,
+      };
+    }
+
+    if (options.minimap.active) {
+      decorationOptions.minimap = {
+        color: themeColorFromId(options.minimap.color),
+        position: model.MinimapPosition.Gutter,
       };
     }
 
     return textModel.ModelDecorationOptions.createDynamic(decorationOptions);
   }
 
-  private modifiedOptions: textModel.ModelDecorationOptions;
   private addedOptions: textModel.ModelDecorationOptions;
+  private modifiedOptions: textModel.ModelDecorationOptions;
   private deletedOptions: textModel.ModelDecorationOptions;
+
   private decorations: string[] = [];
   private editorModel: IEditorDocumentModel | null;
 
@@ -82,16 +77,26 @@ export class DirtyDiffDecorator extends Disposable {
     const decorations = this.scmPreferences['scm.diffDecorations'];
     const gutter = decorations === 'all' || decorations === 'gutter';
     const overview = decorations === 'all' || decorations === 'overview';
-    const options = { gutter, overview, isWholeLine: true };
+    const minimap = decorations === 'all' || decorations === 'minimap';
 
-    this.modifiedOptions = DirtyDiffDecorator.createDecoration(
-      'dirty-diff-modified',
-      overviewRulerModifiedForeground,
-      options,
-    );
-    this.addedOptions = DirtyDiffDecorator.createDecoration('dirty-diff-added', overviewRulerAddedForeground, options);
-    this.deletedOptions = DirtyDiffDecorator.createDecoration('dirty-diff-deleted', overviewRulerDeletedForeground, {
-      ...options,
+    this.modifiedOptions = DirtyDiffDecorator.createDecoration('dirty-diff-modified', {
+      gutter,
+      overview: { active: overview, color: overviewRulerModifiedForeground },
+      minimap: { active: minimap, color: minimapGutterModifiedBackground },
+      isWholeLine: true,
+    });
+
+    this.addedOptions = DirtyDiffDecorator.createDecoration('dirty-diff-added', {
+      gutter,
+      overview: { active: overview, color: overviewRulerAddedForeground },
+      minimap: { active: minimap, color: minimapGutterAddedBackground },
+      isWholeLine: true,
+    });
+
+    this.deletedOptions = DirtyDiffDecorator.createDecoration('dirty-diff-deleted', {
+      gutter,
+      overview: { active: overview, color: overviewRulerDeletedForeground },
+      minimap: { active: minimap, color: minimapGutterDeletedBackground },
       isWholeLine: false,
     });
 
@@ -105,7 +110,7 @@ export class DirtyDiffDecorator extends Disposable {
     const decorations = this.model.changes.map((change) => {
       const changeType = getChangeType(change);
       const startLineNumber = change[2];
-      const endLineNumber = change[3] || startLineNumber;
+      const endLineNumber = change[3] - 1 || startLineNumber - 1;
 
       switch (changeType) {
         case ChangeType.Add:
@@ -121,9 +126,9 @@ export class DirtyDiffDecorator extends Disposable {
         case ChangeType.Delete:
           return {
             range: {
-              startLineNumber,
+              startLineNumber: startLineNumber - 1,
               startColumn: Number.MAX_VALUE,
-              endLineNumber: startLineNumber,
+              endLineNumber: startLineNumber - 1,
               endColumn: Number.MAX_VALUE,
             },
             options: this.deletedOptions,
@@ -141,9 +146,7 @@ export class DirtyDiffDecorator extends Disposable {
       }
     });
 
-    this.decorations = this.editorModel
-      .getMonacoModel()
-      .deltaDecorations(this.decorations, decorations);
+    this.decorations = this.editorModel.getMonacoModel().deltaDecorations(this.decorations, decorations);
   }
 
   dispose(): void {

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-model.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-model.ts
@@ -371,7 +371,7 @@ export class DirtyDiffModel extends Disposable implements IDirtyDiffModel {
 
       function refreshWidget(current: number, currentChange: ILineChange) {
         widget.updateCurrent(current);
-        widget.show(positionToRange(currentChange[3] || currentChange[2]), DirtyDiffModel.heightInLines);
+        widget.show(positionToRange(currentChange[3] - 1), DirtyDiffModel.heightInLines);
         that.isDirtyDiffVisible.set(true);
       }
 

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-util.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-util.ts
@@ -1,4 +1,5 @@
 import { ILineChange } from '@opensumi/ide-core-common';
+import type { IChange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/smartLinesDiffComputer';
 
 export function compareChanges(a: ILineChange, b: ILineChange): number {
   let result = a[2] - b[2];
@@ -47,5 +48,39 @@ export function getChangeType(change: ILineChange): ChangeType {
     return ChangeType.Delete;
   } else {
     return ChangeType.Modify;
+  }
+}
+
+export function toChange(change: ILineChange): IChange {
+  const changeType = getChangeType(change);
+  switch (changeType) {
+    case ChangeType.Add:
+      return {
+        originalStartLineNumber: change[0],
+        originalEndLineNumber: 0,
+        modifiedStartLineNumber: change[2],
+        modifiedEndLineNumber: change[3],
+      };
+    case ChangeType.Modify:
+      return {
+        originalStartLineNumber: change[0],
+        originalEndLineNumber: change[1],
+        modifiedStartLineNumber: change[2],
+        modifiedEndLineNumber: change[3],
+      };
+    case ChangeType.Delete:
+      return {
+        originalStartLineNumber: change[0],
+        originalEndLineNumber: change[1],
+        modifiedStartLineNumber: change[2],
+        modifiedEndLineNumber: 0,
+      };
+    default:
+      return {
+        originalStartLineNumber: change[0],
+        originalEndLineNumber: change[1],
+        modifiedStartLineNumber: change[2],
+        modifiedEndLineNumber: change[3],
+      };
   }
 }

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-util.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-util.ts
@@ -29,3 +29,23 @@ export function getModifiedEndLineNumber(change: ILineChange): number {
     return change[3];
   }
 }
+
+export enum ChangeType {
+  Modify = 'Modify',
+  Add = 'Add',
+  Delete = 'Delete',
+}
+
+export function getChangeType(change: ILineChange): ChangeType {
+  // originalStartLine === originalEndLineNumber
+  if (change[1] - change[0] === 0) {
+    return ChangeType.Add;
+  }
+  // modifiedStartLine === modifiedEndLine &&
+  // originalEndLineNumber > originalStartLine
+  else if (change[1] > change[0] && change[2] === change[3]) {
+    return ChangeType.Delete;
+  } else {
+    return ChangeType.Modify;
+  }
+}

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -93,10 +93,11 @@ export class DirtyDiffWidget extends ZoneWidget {
 
     this._content.style.borderBottomColor = borderColor;
 
-    // 根据编辑器字号行高设置 header 高度
-    const options = this.editor.getOptions();
-    const lineHeight = options.get(60);
-    this._head.style.height = `${lineHeight}px`;
+    // 根据编辑器字号行高设置 header 和 content 高度
+    const editorLineHeight = this.editor.getOption(60 /** EditorOption.lineHeight */);
+    const headHeight = Math.ceil(editorLineHeight * 1.2);
+
+    this._head.style.height = `${headHeight}px`;
 
     this._renderTitle();
 

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -1,12 +1,11 @@
-import { URI, path, CommandService, formatLocalize, ILineChange } from '@opensumi/ide-core-browser';
+import { URI, path, CommandService, formatLocalize } from '@opensumi/ide-core-browser';
 import { ScmChangeTitleCallback } from '@opensumi/ide-core-browser/lib/menu/next';
 import { ZoneWidget } from '@opensumi/ide-monaco-enhance/lib/browser';
 import type { ICodeEditor as IMonacoCodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
-import type { IChange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/smartLinesDiffComputer';
 
 import { IDirtyDiffModel, OPEN_DIRTY_DIFF_WIDGET } from '../../common';
 
-import { ChangeType, getChangeType } from './dirty-diff-util';
+import { ChangeType, getChangeType, toChange } from './dirty-diff-util';
 
 export enum DirtyDiffWidgetActionType {
   close,
@@ -150,40 +149,6 @@ export class DirtyDiffWidget extends ZoneWidget {
     this._relayout(heightInLines);
   }
 
-  private toChange(change: ILineChange): IChange {
-    const changeType = getChangeType(change);
-    switch (changeType) {
-      case ChangeType.Add:
-        return {
-          originalStartLineNumber: change[0],
-          originalEndLineNumber: 0,
-          modifiedStartLineNumber: change[2],
-          modifiedEndLineNumber: change[3],
-        };
-      case ChangeType.Modify:
-        return {
-          originalStartLineNumber: change[0],
-          originalEndLineNumber: change[1],
-          modifiedStartLineNumber: change[2],
-          modifiedEndLineNumber: change[3],
-        };
-      case ChangeType.Delete:
-        return {
-          originalStartLineNumber: change[0],
-          originalEndLineNumber: change[1],
-          modifiedStartLineNumber: change[2],
-          modifiedEndLineNumber: 0,
-        };
-      default:
-        return {
-          originalStartLineNumber: change[0],
-          originalEndLineNumber: change[1],
-          modifiedStartLineNumber: change[2],
-          modifiedEndLineNumber: change[3],
-        };
-    }
-  }
-
   protected handleAction(type: DirtyDiffWidgetActionType) {
     let lineNumber: number;
     /**
@@ -195,7 +160,7 @@ export class DirtyDiffWidget extends ZoneWidget {
 
     const args: Parameters<ScmChangeTitleCallback> = [
       this.uri,
-      this._model.changes.map(this.toChange),
+      this._model.changes.map(toChange),
       this._currentChangeIndex - 1,
     ];
 

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -1,4 +1,4 @@
-import { URI, path, CommandService } from '@opensumi/ide-core-browser';
+import { URI, path, CommandService, formatLocalize } from '@opensumi/ide-core-browser';
 import { ScmChangeTitleCallback } from '@opensumi/ide-core-browser/lib/menu/next';
 import { ZoneWidget } from '@opensumi/ide-monaco-enhance/lib/browser';
 import type { ICodeEditor as IMonacoCodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
@@ -63,7 +63,7 @@ export class DirtyDiffWidget extends ZoneWidget {
 
     const detail = document.createElement('span');
     detail.className = 'dirty-diff-widget-title-detail';
-    detail.innerText = `第 ${this._currentChangeIndex} 个更改（共 ${this._model.changes.length} 个）`;
+    detail.innerText = formatLocalize('scm.dirtyDiff.changes', this._currentChangeIndex, this._model.changes.length);
     this._title.appendChild(detail);
   }
 

--- a/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
@@ -104,6 +104,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    background-color: var(--peekViewTitle-background);
 
     .file-name {
       flex: 1;

--- a/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
@@ -97,6 +97,7 @@
   }
 
   .dirty-diff-widget-header {
+    min-height: 24px;
     width: 100%;
     border-top: 1px solid;
     border-bottom: 1px solid;

--- a/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
@@ -97,10 +97,9 @@
   }
 
   .dirty-diff-widget-header {
-    height: 24px;
     width: 100%;
-    border-top: 1px solid lightblue;
-    border-bottom: 1px solid lightblue;
+    border-top: 1px solid;
+    border-bottom: 1px solid;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -115,6 +114,14 @@
       display: flex;
       justify-content: flex-end;
       cursor: pointer;
+
+      .kt-icon {
+        padding: 3px;
+        &:hover {
+          border-radius: 4px;
+          background-color: var(--kt-icon-hoverBackground);
+        }
+      }
 
       .iconfont-rotate-180 {
         transform: rotate(180deg) translateY(-2px);
@@ -131,6 +138,6 @@
   .dirty-diff-widget-content {
     flex: 1;
     width: 100%;
-    border-bottom: 1px solid lightblue;
+    border-bottom: 1px solid;
   }
 }

--- a/packages/scm/src/browser/dirty-diff/index.ts
+++ b/packages/scm/src/browser/dirty-diff/index.ts
@@ -102,8 +102,6 @@ export class DirtyDiffWorkbenchController extends Disposable implements IDirtyDi
     if (isNaN(width) || width <= 0 || width > 5) {
       width = 3;
     }
-    // @todo
-    // this.stylesheet.innerHTML = `.monaco-editor .dirty-diff-modified,.monaco-editor .dirty-diff-added{border-left-width:${width}px;}`;
   }
 
   private enable(): void {

--- a/packages/scm/src/browser/dirty-diff/index.ts
+++ b/packages/scm/src/browser/dirty-diff/index.ts
@@ -1,5 +1,11 @@
 import { Autowired, Injectable, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { Event, Disposable, DisposableStore, DisposableCollection } from '@opensumi/ide-core-browser';
+import {
+  Event,
+  Disposable,
+  DisposableStore,
+  DisposableCollection,
+  KeybindingRegistry,
+} from '@opensumi/ide-core-browser';
 import { IEventBus, CommandService, positionToRange } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { EditorGroupChangeEvent, IEditorFeatureRegistry } from '@opensumi/ide-editor/lib/browser';
@@ -8,11 +14,11 @@ import { IMonacoImplEditor } from '@opensumi/ide-editor/lib/browser/editor-colle
 import type { ICodeEditor as IMonacoCodeEditor, ITextModel } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
-import { IDirtyDiffWorkbenchController } from '../../common';
+import { CLOSE_DIRTY_DIFF_WIDGET, IDirtyDiffWorkbenchController } from '../../common';
 import { SCMPreferences } from '../scm-preference';
 
 import { DirtyDiffDecorator } from './dirty-diff-decorator';
-import { DirtyDiffModel } from './dirty-diff-model';
+import { DirtyDiffModel, isDirtyDiffVisible } from './dirty-diff-model';
 import { DirtyDiffWidget } from './dirty-diff-widget';
 
 import './dirty-diff.module.less';
@@ -52,8 +58,17 @@ export class DirtyDiffWorkbenchController extends Disposable implements IDirtyDi
   @Autowired(CommandService)
   private readonly commandService: CommandService;
 
+  @Autowired(KeybindingRegistry)
+  protected readonly keybindingRegistry: KeybindingRegistry;
+
   constructor() {
     super();
+
+    this.keybindingRegistry.registerKeybinding({
+      command: CLOSE_DIRTY_DIFF_WIDGET.id,
+      keybinding: 'esc',
+      when: isDirtyDiffVisible.equalsTo(true),
+    });
   }
 
   public start() {
@@ -178,6 +193,13 @@ export class DirtyDiffWorkbenchController extends Disposable implements IDirtyDi
   private onModelInvisible(editorModel: IEditorDocumentModel): void {
     this.items[editorModel.id].dispose();
     delete this.items[editorModel.id];
+  }
+
+  public closeDirtyDiffWidget(codeEditor: IMonacoCodeEditor) {
+    const widget = this.widgets.get(codeEditor.getId());
+    if (widget) {
+      widget.dispose();
+    }
   }
 
   public toggleDirtyDiffWidget(codeEditor: IMonacoCodeEditor, position: monaco.IPosition) {

--- a/packages/scm/src/browser/scm-color.ts
+++ b/packages/scm/src/browser/scm-color.ts
@@ -1,14 +1,14 @@
 import { localize } from '@opensumi/ide-core-common';
-import { registerColor, Color, RGBA } from '@opensumi/ide-theme';
+import { registerColor, Color, RGBA, transparent, editorErrorForeground } from '@opensumi/ide-theme';
 
 // 这里都是 scm 相关颜色变量注册
 /* istanbul ignore file */
 export const editorGutterModifiedBackground = registerColor(
   'editorGutter.modifiedBackground',
   {
-    dark: new Color(new RGBA(12, 125, 157)),
-    light: new Color(new RGBA(102, 175, 224)),
-    hcDark: new Color(new RGBA(0, 73, 122)),
+    dark: new Color(new RGBA(27, 129, 168)),
+    light: new Color(new RGBA(32, 144, 211)),
+    hcDark: new Color(new RGBA(27, 128, 168)),
     hcLight: new Color(new RGBA(32, 144, 211)),
   },
   localize('editorGutterModifiedBackground', 'Editor gutter background color for lines that are modified.'),
@@ -17,9 +17,9 @@ export const editorGutterModifiedBackground = registerColor(
 export const editorGutterAddedBackground = registerColor(
   'editorGutter.addedBackground',
   {
-    dark: new Color(new RGBA(88, 124, 12)),
-    light: new Color(new RGBA(129, 184, 139)),
-    hcDark: new Color(new RGBA(27, 82, 37)),
+    dark: new Color(new RGBA(72, 126, 2)),
+    light: new Color(new RGBA(72, 152, 93)),
+    hcDark: new Color(new RGBA(72, 126, 2)),
     hcLight: new Color(new RGBA(72, 152, 93)),
   },
   localize('editorGutterAddedBackground', 'Editor gutter background color for lines that are added.'),
@@ -28,23 +28,54 @@ export const editorGutterAddedBackground = registerColor(
 export const editorGutterDeletedBackground = registerColor(
   'editorGutter.deletedBackground',
   {
-    dark: new Color(new RGBA(148, 21, 27)),
-    light: new Color(new RGBA(202, 75, 81)),
-    hcDark: new Color(new RGBA(141, 14, 20)),
-    hcLight: new Color(new RGBA(181, 32, 13)),
+    dark: editorErrorForeground,
+    light: editorErrorForeground,
+    hcDark: editorErrorForeground,
+    hcLight: editorErrorForeground,
   },
   localize('editorGutterDeletedBackground', 'Editor gutter background color for lines that are deleted.'),
 );
 
-const overviewRulerDefault = new Color(new RGBA(0, 122, 204, 0.6));
+export const minimapGutterModifiedBackground = registerColor(
+  'minimapGutter.modifiedBackground',
+  {
+    dark: editorGutterModifiedBackground,
+    light: editorGutterModifiedBackground,
+    hcDark: editorGutterModifiedBackground,
+    hcLight: editorGutterModifiedBackground,
+  },
+  localize('minimapGutterModifiedBackground', 'Minimap gutter background color for lines that are modified.'),
+);
+
+export const minimapGutterAddedBackground = registerColor(
+  'minimapGutter.addedBackground',
+  {
+    dark: editorGutterAddedBackground,
+    light: editorGutterAddedBackground,
+    hcDark: editorGutterAddedBackground,
+    hcLight: editorGutterAddedBackground,
+  },
+  localize('minimapGutterAddedBackground', 'Minimap gutter background color for lines that are added.'),
+);
+
+export const minimapGutterDeletedBackground = registerColor(
+  'minimapGutter.deletedBackground',
+  {
+    dark: editorGutterDeletedBackground,
+    light: editorGutterDeletedBackground,
+    hcDark: editorGutterDeletedBackground,
+    hcLight: editorGutterDeletedBackground,
+  },
+  localize('minimapGutterDeletedBackground', 'Minimap gutter background color for lines that are deleted.'),
+);
 
 export const overviewRulerModifiedForeground = registerColor(
   'editorOverviewRuler.modifiedForeground',
   {
-    dark: overviewRulerDefault,
-    light: overviewRulerDefault,
-    hcDark: overviewRulerDefault,
-    hcLight: overviewRulerDefault,
+    dark: transparent(editorGutterModifiedBackground, 0.6),
+    light: transparent(editorGutterModifiedBackground, 0.6),
+    hcDark: transparent(editorGutterModifiedBackground, 0.6),
+    hcLight: transparent(editorGutterModifiedBackground, 0.6),
   },
   localize('overviewRulerModifiedForeground', 'Overview ruler marker color for modified content.'),
 );
@@ -52,10 +83,10 @@ export const overviewRulerModifiedForeground = registerColor(
 export const overviewRulerAddedForeground = registerColor(
   'editorOverviewRuler.addedForeground',
   {
-    dark: overviewRulerDefault,
-    light: overviewRulerDefault,
-    hcDark: overviewRulerDefault,
-    hcLight: overviewRulerDefault,
+    dark: transparent(editorGutterAddedBackground, 0.6),
+    light: transparent(editorGutterAddedBackground, 0.6),
+    hcDark: transparent(editorGutterAddedBackground, 0.6),
+    hcLight: transparent(editorGutterAddedBackground, 0.6),
   },
   localize('overviewRulerAddedForeground', 'Overview ruler marker color for added content.'),
 );
@@ -63,10 +94,10 @@ export const overviewRulerAddedForeground = registerColor(
 export const overviewRulerDeletedForeground = registerColor(
   'editorOverviewRuler.deletedForeground',
   {
-    dark: overviewRulerDefault,
-    light: overviewRulerDefault,
-    hcDark: overviewRulerDefault,
-    hcLight: overviewRulerDefault,
+    dark: transparent(editorGutterDeletedBackground, 0.6),
+    light: transparent(editorGutterDeletedBackground, 0.6),
+    hcDark: transparent(editorGutterDeletedBackground, 0.6),
+    hcLight: transparent(editorGutterDeletedBackground, 0.6),
   },
   localize('overviewRulerDeletedForeground', 'Overview ruler marker color for deleted content.'),
 );

--- a/packages/scm/src/browser/scm.contribution.ts
+++ b/packages/scm/src/browser/scm.contribution.ts
@@ -35,6 +35,7 @@ import {
   SET_SCM_TREE_VIEW_MODE,
   SET_SCM_LIST_VIEW_MODE,
   SCMViewModelMode,
+  CLOSE_DIRTY_DIFF_WIDGET,
 } from '../common';
 
 import { SCMTreeService } from './components/scm-resource-tree/scm-tree.service';
@@ -138,7 +139,17 @@ export class SCMContribution
           });
           setTimeout(() => {
             codeEditor.revealLineInCenter(lineNumber);
-          }, 50);
+          }, 0);
+        }
+      },
+    });
+
+    commands.registerCommand(CLOSE_DIRTY_DIFF_WIDGET, {
+      execute: async () => {
+        const editor = this.editorService.currentEditor;
+        if (editor) {
+          const codeEditor = editor.monacoEditor;
+          this.dirtyDiffWorkbenchController.closeDirtyDiffWidget(codeEditor);
         }
       },
     });

--- a/packages/scm/src/common/dirty-diff.ts
+++ b/packages/scm/src/common/dirty-diff.ts
@@ -17,6 +17,10 @@ export const OPEN_DIRTY_DIFF_WIDGET: Command = {
   id: 'OPEN_DIRTY_DIFF_WIDGET',
 };
 
+export const CLOSE_DIRTY_DIFF_WIDGET: Command = {
+  id: 'CLOSE_DIRTY_DIFF_WIDGET',
+};
+
 export const GOTO_NEXT_CHANGE: Command = {
   id: 'workbench.action.compareEditor.nextChange',
 };

--- a/packages/workspace-edit/src/browser/workspace-edit.service.ts
+++ b/packages/workspace-edit/src/browser/workspace-edit.service.ts
@@ -140,7 +140,7 @@ export class ResourceTextEditTask {
         newEOL = edit.textEdit.eol;
       }
       edits.push({
-        forceMoveMarkers: true,
+        forceMoveMarkers: false,
         range: Range.lift(edit.textEdit.range),
         text: edit.textEdit.text,
       });
@@ -148,7 +148,7 @@ export class ResourceTextEditTask {
 
     if (edits.length > 0) {
       monacoModel.pushStackElement();
-      monacoModel.pushEditOperations([], edits, () => []);
+      monacoModel.pushEditOperations(null, edits, () => null);
       monacoModel.pushStackElement();
     }
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

before

1. diff gutter 位置错误 
  ![image](https://user-images.githubusercontent.com/17701805/202100555-beaa675a-f1ba-4aef-85a9-3fce59840b1d.png)
2. 无法区分 changetype，所有改动都识别为 modified
3. dirtyWidget 样式丑
  ![image](https://user-images.githubusercontent.com/17701805/202100805-9498d804-9dbd-4a48-9d0d-3e5729726126.png)


after
1. 优化 diff guter 渲染的定位和样式，区分 add、delete、modified 三种状态
  ![image](https://user-images.githubusercontent.com/17701805/202100969-41923efe-9e5e-4f7b-a92e-9989d0a9afad.png)
2. 优化 dirtyWidget ，根据当前 changeType 展示不同边框颜色，优化默认 icon (使用 vscode-codicon)
  ![image](https://user-images.githubusercontent.com/17701805/202101125-4f124eff-6812-4032-bb78-ce255ebcbc05.png)
  ![image](https://user-images.githubusercontent.com/17701805/202101165-750a7586-a0f7-4ddb-bb01-a04ed6b7859a.png)
  ![image](https://user-images.githubusercontent.com/17701805/202101187-c25206f8-368f-43f3-887b-7fc52ba0cc7b.png)
3. 添加关闭 dirtyDiff widget 快捷键 `esc`

https://user-images.githubusercontent.com/17701805/202342527-499494f8-2bf3-40ed-8c5b-8f6d0aa9b3b6.mp4


### Changelog
- 优化 diff guter 渲染的定位和样式，区分 add、delete、modified 三种状态
- 化 dirtyWidget 样式，根据当前 changeType 展示不同边框颜色
- 默认 icon (使用 vscode-codicon)
- 添加关闭 dirtyDiff widget 快捷键 `esc`
- 修复 `revertChange` 失败的问题