### PR TITLE
refactor: remove package vscode-languageserver-protocol

### DIFF
--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -45,7 +45,6 @@
     "reconnecting-websocket": "^4.2.0",
     "resize-observer-polyfill": "1.5.1",
     "strip-json-comments": "3.0.1",
-    "vscode-languageserver-protocol": "3.16.0",
     "vscode-textmate": "7.0.1"
   }
 }

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -1,5 +1,4 @@
 import { CancellationToken } from 'vscode';
-import { DocumentFilter } from 'vscode-languageserver-protocol';
 
 import { Autowired, Injectable, Optional } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
@@ -71,8 +70,9 @@ import {
   ResourceTextEditDto,
   ResourceFileEditDto,
   ILinkDto,
+  isDocumentFilter,
+  FoldingRangeProvider,
 } from '../../../common/vscode/model.api';
-import { FoldingRangeProvider } from '../../../common/vscode/model.api';
 import { mixin, reviveIndentationRule, reviveOnEnterRules, reviveRegExp } from '../../../common/vscode/utils';
 
 import {
@@ -377,7 +377,7 @@ export class MainThreadLanguages implements IMainThreadLanguages {
       return selector.some((filter) => this.matchLanguage(filter, languageId));
     }
 
-    if (DocumentFilter.is(selector)) {
+    if (isDocumentFilter(selector)) {
       if (!selector.language && (selector.pattern || selector.scheme)) {
         return true;
       }
@@ -392,7 +392,7 @@ export class MainThreadLanguages implements IMainThreadLanguages {
     if (Array.isArray(selector)) {
       return selector.some((filter) => this.matchModel(filter, model));
     }
-    if (DocumentFilter.is(selector)) {
+    if (isDocumentFilter(selector)) {
       if (!!selector.language && selector.language !== model.languageId) {
         return false;
       }

--- a/packages/extension/src/common/vscode/model.api.ts
+++ b/packages/extension/src/common/vscode/model.api.ts
@@ -2,6 +2,7 @@ import type vscode from 'vscode';
 import { SymbolInformation } from 'vscode-languageserver-types';
 
 import {
+  isString,
   Uri as URI,
   IRange,
   IDisposable,
@@ -610,6 +611,56 @@ export interface SignatureHelpResult extends IDisposable {
 export interface RenameLocation {
   range: Range;
   text: string;
+}
+
+/**
+ * A document filter denotes a document by different properties like
+ * the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+ * its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
+ *
+ * Glob patterns can have the following syntax:
+ * - `*` to match one or more characters in a path segment
+ * - `?` to match on one character in a path segment
+ * - `**` to match any number of path segments, including none
+ * - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+ * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+ * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+ *
+ * @sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`
+ * @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
+ */
+export type TextDocumentFilter =
+  | {
+      /** A language id, like `typescript`. */
+      language: string;
+      /** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
+      scheme?: string;
+      /** A glob pattern, like `*.{ts,js}`. */
+      pattern?: string;
+    }
+  | {
+      /** A language id, like `typescript`. */
+      language?: string;
+      /** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
+      scheme: string;
+      /** A glob pattern, like `*.{ts,js}`. */
+      pattern?: string;
+    }
+  | {
+      /** A language id, like `typescript`. */
+      language?: string;
+      /** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
+      scheme?: string;
+      /** A glob pattern, like `*.{ts,js}`. */
+      pattern: string;
+    };
+
+/**
+ * From vscode-languageserver-node/protocol/src/common/protocol.ts
+ */
+export function isDocumentFilter(value: any): value is TextDocumentFilter {
+  const candidate: TextDocumentFilter = value;
+  return isString(candidate.language) || isString(candidate.scheme) || isString(candidate.pattern);
 }
 
 export interface Rejection {

--- a/packages/startup/entry/web-lite/lite-module/language-service/simple.service.ts
+++ b/packages/startup/entry/web-lite/lite-module/language-service/simple.service.ts
@@ -1,7 +1,6 @@
 import * as monaco from '@ali/monaco-editor-core/esm/vs/editor/editor.api';
 import type * as vscode from 'vscode';
 import { DocumentSelector, HoverProvider, CancellationToken, DefinitionProvider, ReferenceProvider } from 'vscode';
-import { DocumentFilter } from 'vscode-languageserver-protocol';
 
 import { Autowired, Injectable, ConstructorOf } from '@opensumi/di';
 import { Uri, URI, LRUMap, DisposableCollection } from '@opensumi/ide-core-common';
@@ -18,6 +17,7 @@ import {
   DefinitionLink,
   ReferenceContext,
   Location,
+  isDocumentFilter,
 } from '@opensumi/ide-extension/lib/common/vscode/model.api';
 import { ExtHostDocumentData } from '@opensumi/ide-extension/lib/hosted/api/vscode/doc/ext-data.host';
 import { Adapter } from '@opensumi/ide-extension/lib/hosted/api/vscode/ext.host.language';
@@ -336,7 +336,7 @@ export class SimpleLanguageService implements Partial<IExtHostLanguages> {
       return selector.some((filter) => this.matchLanguage(filter, languageId));
     }
 
-    if (DocumentFilter.is(selector)) {
+    if (isDocumentFilter(selector)) {
       return !selector.language || selector.language === languageId;
     }
 
@@ -347,7 +347,7 @@ export class SimpleLanguageService implements Partial<IExtHostLanguages> {
     if (Array.isArray(selector)) {
       return selector.some((filter) => this.matchModel(filter, model));
     }
-    if (DocumentFilter.is(selector)) {
+    if (isDocumentFilter(selector)) {
       if (!!selector.language && selector.language !== model.languageId) {
         return false;
       }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🪚 Refactors

### Background or solution

编译后有不同版本的 vscode-jsonrpc 存在。由于 vscode-languageserver-protocol 模块引入了另外一个 vscode-jsonrpc 包导致的多个同类的包。

现在用 `isDocumentFilter` 替代这个方法，优化编译后的包体积，减少大概 97KB，减少 0.9% 的体积。

  | bundle.js size (production)
-- | --
before | 10804079
after | 10706805

> 使用 tools/electron 来进行的编译

### Changelog
refactor: remove package vscode-languageserver-protocol