### PR TITLE
fix: use workspaceDir as default terminal store key

### DIFF
--- a/packages/terminal-next/src/browser/terminal.restore.ts
+++ b/packages/terminal-next/src/browser/terminal.restore.ts
@@ -1,7 +1,10 @@
 import { Injectable, Autowired } from '@opensumi/di';
+import { AppConfig } from '@opensumi/ide-core-browser/lib/react-providers/config-provider';
 import { Disposable } from '@opensumi/ide-core-common';
 
 import { ITerminalRestore, ITerminalController, ITerminalInternalService } from '../common';
+
+const DEFAULT_TERMINAL_STORE_KEY = 'OPENSUMI_TERMINAL_RESTORE';
 
 @Injectable()
 export class TerminalRestore extends Disposable implements ITerminalRestore {
@@ -11,9 +14,12 @@ export class TerminalRestore extends Disposable implements ITerminalRestore {
   @Autowired(ITerminalInternalService)
   protected readonly service: ITerminalInternalService;
 
+  @Autowired(AppConfig)
+  protected readonly appConfig: AppConfig;
+
   get storageKey() {
-    // 集成方根据自己的场景来自定义storageKey做到终端恢复场景的准确性
-    return 'OPENSUMI_TERMINAL_RESTORE';
+    // 集成方可以根据自己的场景来通过 override 自定义 storageKey 做到终端恢复场景的准确性
+    return `${this.appConfig.workspaceDir}-${DEFAULT_TERMINAL_STORE_KEY}`;
   }
 
   save() {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

之前默认的 storeKey 会导致切换 workspaceDir 后复用之前缓存的终端

### Changelog
- use workspaceDir as default terminal store key