### PR TITLE
fix: dispose all task executor when exit or refresh

### DIFF
--- a/packages/terminal-next/src/browser/contribution/terminal.lifecycle.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.lifecycle.ts
@@ -38,6 +38,8 @@ export class TerminalLifeCycleContribution implements ClientAppContribution, Mai
   }
 
   onStop() {
+    // dispose all task executor
+    this.terminalController.disposeTerminalClients({ isTaskExecutor: true });
     this.store.save();
   }
 }

--- a/packages/terminal-next/src/common/controller.ts
+++ b/packages/terminal-next/src/common/controller.ts
@@ -58,6 +58,12 @@ export interface ICreateClientWithWidgetOptions {
   beforeCreate?: (terminalId: string) => void;
 }
 
+export interface TerminalCliterFilter {
+  id?: string;
+  name?: string;
+  isTaskExecutor?: boolean;
+}
+
 export const ITerminalController = Symbol('ITerminalController');
 export interface ITerminalController extends Disposable {
   ready: Deferred<void>;
@@ -67,6 +73,7 @@ export interface ITerminalController extends Disposable {
   themeBackground: string;
   contextKeyService?: IContextKeyService;
   viewReady: Deferred<void>;
+  disposeTerminalClients(filter?: TerminalCliterFilter): void;
   initContextKey(dom: HTMLDivElement): void;
   firstInitialize(): void;
   recovery(history: ITerminalBrowserHistory): Promise<void>;


### PR DESCRIPTION
### Types

### Background or solution

### Changelog
- fix: dispose all task executor when exit or refresh