### PR TITLE
feat: implement stickiness connect effect

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -8,6 +8,7 @@ import { CurrentCodeEditor } from './view/editors/currentCodeEditor';
 import { IncomingCodeEditor } from './view/editors/incomingCodeEditor';
 import { ResultCodeEditor } from './view/editors/resultCodeEditor';
 import { ScrollSynchronizer } from './view/scroll-synchronizer';
+import { StickinessConnectManager } from './view/stickiness-connect-manager';
 
 @Injectable()
 export class MergeEditorService extends Disposable {
@@ -24,10 +25,13 @@ export class MergeEditorService extends Disposable {
   private computerDiffModel: ComputerDiffModel;
   private scrollSynchronizer: ScrollSynchronizer;
 
+  public stickinessConnectManager: StickinessConnectManager;
+
   constructor() {
     super();
     this.computerDiffModel = new ComputerDiffModel();
     this.scrollSynchronizer = new ScrollSynchronizer();
+    this.stickinessConnectManager = new StickinessConnectManager();
   }
 
   public instantiationCodeEditor(current: HTMLDivElement, result: HTMLDivElement, incoming: HTMLDivElement): void {
@@ -40,6 +44,7 @@ export class MergeEditorService extends Disposable {
     this.incomingView = this.injector.get(IncomingCodeEditor, [incoming, this.monacoService, this.injector]);
 
     this.scrollSynchronizer.mount(this.currentView, this.resultView, this.incomingView);
+    this.stickinessConnectManager.mount(this.currentView, this.resultView, this.incomingView);
   }
 
   public override dispose(): void {
@@ -48,6 +53,7 @@ export class MergeEditorService extends Disposable {
     this.resultView.dispose();
     this.incomingView.dispose();
     this.scrollSynchronizer.dispose();
+    this.stickinessConnectManager.dispose();
   }
 
   public getCurrentEditor(): ICodeEditor {

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -23,8 +23,8 @@ export class MergeEditorService extends Disposable {
   private incomingView: IncomingCodeEditor;
 
   private computerDiffModel: ComputerDiffModel;
-  private scrollSynchronizer: ScrollSynchronizer;
 
+  public scrollSynchronizer: ScrollSynchronizer;
   public stickinessConnectManager: StickinessConnectManager;
 
   constructor() {

--- a/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
@@ -133,7 +133,7 @@ export class MergeEditorDecorations extends Disposable {
 
   private cleanUpLineWidget(widgets: Set<GuidelineWidget>): void {
     widgets.forEach((w) => {
-      w.dispose();
+      w.hide();
     });
     widgets.clear();
   }
@@ -179,5 +179,12 @@ export class MergeEditorDecorations extends Disposable {
 
   public render(ranges: IRenderChangesInput[], innerChanges: IRenderInnerChangesInput[]): void {
     this.setDecorations(ranges, innerChanges);
+  }
+
+  public dispose(): void {
+    super.dispose();
+
+    this.lineWidgetSet.forEach((w) => w.dispose());
+    this.retainLineWidgetSet.forEach((w) => w.dispose());
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
@@ -95,7 +95,7 @@ export class MergeEditorDecorations extends Disposable {
     this.editor.changeDecorations((accessor) => {
       const newDecorations: IDiffDecoration[] = this.retainDecoration;
       this.retainLineWidgetSet.forEach((widget) => {
-        widget.showByLine(widget.position?.lineNumber!);
+        widget.showByLine(widget.getRecordLine());
         this.lineWidgetSet.add(widget);
       });
 

--- a/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
@@ -5,7 +5,7 @@ import { ModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/edit
 import { IModelDecorationsChangedEvent } from '@opensumi/monaco-editor-core/esm/vs/editor/common/textModelEvents';
 
 import { ICodeEditor, IModelDeltaDecoration } from '../../../monaco-api/editor';
-import { LineRangeType } from '../types';
+import { EditorViewType, LineRangeType } from '../types';
 import { GuidelineWidget } from '../view/guideline-widget';
 
 import { LineRange } from './line-range';
@@ -39,7 +39,10 @@ export class MergeEditorDecorations extends Disposable {
   private readonly _onDidChangeDecorations = new Emitter<MergeEditorDecorations>();
   public readonly onDidChangeDecorations: Event<MergeEditorDecorations> = this._onDidChangeDecorations.event;
 
-  constructor(@Optional() private readonly editor: ICodeEditor) {
+  constructor(
+    @Optional() private readonly editor: ICodeEditor,
+    @Optional() public readonly editorViewType: EditorViewType,
+  ) {
     super();
     this.initListenEvent();
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
@@ -1,0 +1,87 @@
+import clone from 'lodash/clone';
+
+import { IStickyPiece, IStickyPiecePath, IStickyPiecePosition, LineRangeType } from '../types';
+
+export class StickyPieceModel implements IStickyPiece {
+  private _width: number;
+  private _height: number;
+  private _path: IStickyPiecePath;
+  private _position: IStickyPiecePosition;
+  private _rangeType: LineRangeType;
+  private readonly rawData: IStickyPiece;
+
+  public get width(): number {
+    return this._width;
+  }
+  public get height(): number {
+    return this._height;
+  }
+  public get path(): IStickyPiecePath {
+    return this._path;
+  }
+  public get position(): IStickyPiecePosition {
+    return this._position;
+  }
+  public get rangeType(): LineRangeType {
+    return this._rangeType;
+  }
+
+  constructor(
+    width: number,
+    height: number,
+    path: IStickyPiecePath,
+    position: IStickyPiecePosition,
+    rangeType: LineRangeType,
+  ) {
+    this._width = width;
+    this._height = height;
+    this._path = path;
+    this._position = position;
+    this._rangeType = rangeType;
+    this.rawData = Object.freeze({
+      rangeType: clone(rangeType),
+      width: clone(width),
+      height: clone(height),
+      position: Object.freeze(clone(position)),
+      path: Object.freeze(clone(path)),
+    });
+  }
+
+  private calcHeight(leftOffest: number, rightOffest: number): number {
+    const { leftTop, rightTop, leftBottom, rightBottom } = this.rawData.path;
+
+    const minTop = Math.min(leftTop - leftOffest, rightTop - rightOffest);
+    const maxBottom = Math.max(leftBottom - leftOffest, rightBottom - rightOffest);
+    return Math.abs(maxBottom - minTop);
+  }
+
+  private calcPath(leftOffest: number, rightOffest: number): IStickyPiecePath {
+    const { path: rawPath } = this.rawData;
+
+    const offestLeftTop = rawPath.leftTop - leftOffest;
+    const offestRightTop = rawPath.rightTop - rightOffest;
+
+    const leftTop = Math.max(0, offestLeftTop - offestRightTop);
+    const rightTop = Math.max(0, offestRightTop - offestLeftTop);
+    const leftBottom = Math.min(this.height, leftTop + (rawPath.leftBottom - rawPath.leftTop));
+    const rightBottom = Math.min(this.height, rightTop + (rawPath.rightBottom - rawPath.rightTop));
+
+    return {
+      leftTop,
+      rightTop,
+      leftBottom,
+      rightBottom,
+    };
+  }
+
+  public movePosition(leftOffest: number, rightOffest: number): this {
+    const rawTop = this.rawData.position.top;
+    const { leftTop, rightTop } = this.rawData.path;
+
+    const top = Math.min(rawTop + leftTop - leftOffest, rawTop + rightTop - rightOffest);
+    this._position = { top };
+    this._height = this.calcHeight(leftOffest, rightOffest);
+    this._path = this.calcPath(leftOffest, rightOffest);
+    return this;
+  }
+}

--- a/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
@@ -8,7 +8,7 @@ export class StickyPieceModel implements IStickyPiece {
   private _path: IStickyPiecePath;
   private _position: IStickyPiecePosition;
   private _rangeType: LineRangeType;
-  private readonly rawData: IStickyPiece;
+  private readonly rawData: Readonly<IStickyPiece>;
 
   public get width(): number {
     return this._width;
@@ -39,11 +39,11 @@ export class StickyPieceModel implements IStickyPiece {
     this._position = position;
     this._rangeType = rangeType;
     this.rawData = Object.freeze({
-      rangeType: clone(rangeType),
-      width: clone(width),
-      height: clone(height),
-      position: Object.freeze(clone(position)),
-      path: Object.freeze(clone(path)),
+      rangeType,
+      width,
+      height,
+      position,
+      path,
     });
   }
 
@@ -78,7 +78,7 @@ export class StickyPieceModel implements IStickyPiece {
     const rawTop = this.rawData.position.top;
     const { leftTop, rightTop } = this.rawData.path;
 
-    const top = Math.min(rawTop + leftTop - leftOffest, rawTop + rightTop - rightOffest);
+    const top = rawTop + Math.min(leftTop - leftOffest, rightTop - rightOffest);
     this._position = { top };
     this._height = this.calcHeight(leftOffest, rightOffest);
     this._path = this.calcPath(leftOffest, rightOffest);

--- a/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
@@ -58,11 +58,11 @@ export class StickyPieceModel implements IStickyPiece {
   private calcPath(leftOffest: number, rightOffest: number): IStickyPiecePath {
     const { path: rawPath } = this.rawData;
 
-    const offestLeftTop = rawPath.leftTop - leftOffest;
-    const offestRightTop = rawPath.rightTop - rightOffest;
+    const offestLT = rawPath.leftTop - leftOffest;
+    const offestRT = rawPath.rightTop - rightOffest;
 
-    const leftTop = Math.max(0, offestLeftTop - offestRightTop);
-    const rightTop = Math.max(0, offestRightTop - offestLeftTop);
+    const leftTop = Math.max(0, offestLT - offestRT);
+    const rightTop = Math.max(0, offestRT - offestLT);
     const leftBottom = Math.min(this.height, leftTop + (rawPath.leftBottom - rawPath.leftTop));
     const rightBottom = Math.min(this.height, rightTop + (rawPath.rightBottom - rawPath.rightTop));
 

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -1,1 +1,18 @@
 export type LineRangeType = 'insert' | 'modify' | 'remove';
+
+export type EditorViewType = 'current' | 'result' | 'incoming';
+
+export interface IStickyPiece {
+  rangeType: LineRangeType;
+  width: number;
+  height: number;
+  position: {
+    top: number;
+  };
+  path: {
+    leftTop: number;
+    rightTop: number;
+    leftBottom: number;
+    rightBottom: number;
+  };
+}

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -2,17 +2,21 @@ export type LineRangeType = 'insert' | 'modify' | 'remove';
 
 export type EditorViewType = 'current' | 'result' | 'incoming';
 
+export interface IStickyPiecePosition {
+  top: number;
+}
+
+export interface IStickyPiecePath {
+  leftTop: number;
+  rightTop: number;
+  leftBottom: number;
+  rightBottom: number;
+}
+
 export interface IStickyPiece {
   rangeType: LineRangeType;
   width: number;
   height: number;
-  position: {
-    top: number;
-  };
-  path: {
-    leftTop: number;
-    rightTop: number;
-    leftBottom: number;
-    rightBottom: number;
-  };
+  position: IStickyPiecePosition;
+  path: IStickyPiecePath;
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -48,6 +48,7 @@ export abstract class BaseCodeEditor extends Disposable {
       minimap: {
         enabled: false,
       },
+      scrollBeyondLastLine: false,
       ...this.getMonacoEditorOptions(),
     });
 
@@ -91,7 +92,7 @@ export abstract class BaseCodeEditor extends Disposable {
 
   public abstract computeResultRangeMapping: LineRangeMapping[];
 
-  protected abstract getEditorViewType(): EditorViewType;
+  public abstract getEditorViewType(): EditorViewType;
 
   protected abstract getMonacoEditorOptions(): IStandaloneEditorConstructionOptions;
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -15,6 +15,7 @@ import {
   MergeEditorDecorations,
 } from '../../model/decorations';
 import { LineRange } from '../../model/line-range';
+import { EditorViewType } from '../../types';
 import { flatModified, flatOriginal } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
 
@@ -50,7 +51,7 @@ export abstract class BaseCodeEditor extends Disposable {
       ...this.getMonacoEditorOptions(),
     });
 
-    this.decorations = this.injector.get(MergeEditorDecorations, [this.editor]);
+    this.decorations = this.injector.get(MergeEditorDecorations, [this.editor, this.getEditorViewType()]);
 
     this.addDispose(
       Event.debounce(
@@ -76,6 +77,10 @@ export abstract class BaseCodeEditor extends Disposable {
     );
   }
 
+  public get onDidChangeDecorations(): Event<MergeEditorDecorations> {
+    return this.decorations.onDidChangeDecorations;
+  }
+
   public getEditor(): ICodeEditor {
     return this.editor;
   }
@@ -84,7 +89,9 @@ export abstract class BaseCodeEditor extends Disposable {
     return this.editor.getModel();
   }
 
-  protected abstract computeResultRangeMapping: LineRangeMapping[];
+  public abstract computeResultRangeMapping: LineRangeMapping[];
+
+  protected abstract getEditorViewType(): EditorViewType;
 
   protected abstract getMonacoEditorOptions(): IStandaloneEditorConstructionOptions;
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -15,10 +15,6 @@ import { BaseCodeEditor } from './baseCodeEditor';
 export class CurrentCodeEditor extends BaseCodeEditor {
   public computeResultRangeMapping: LineRangeMapping[] = [];
 
-  protected getEditorViewType(): EditorViewType {
-    return 'current';
-  }
-
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return { readOnly: true };
   }
@@ -33,6 +29,10 @@ export class CurrentCodeEditor extends BaseCodeEditor {
 
   protected override prepareRenderDecorations(ranges: LineRange[], innerChanges: Range[][]) {
     return super.prepareRenderDecorations(ranges, innerChanges, 1);
+  }
+
+  public getEditorViewType(): EditorViewType {
+    return 'current';
   }
 
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -3,20 +3,25 @@ import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/ra
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
-import { IDiffDecoration, IRenderChangesInput, IRenderInnerChangesInput } from '../../model/decorations';
+import { IDiffDecoration } from '../../model/decorations';
 import { LineRange } from '../../model/line-range';
-import { flatInnerOriginal, flatModified, flatOriginal } from '../../utils';
+import { flatInnerOriginal, flatOriginal } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
+import { EditorViewType } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
 
 @Injectable({ multiple: false })
 export class CurrentCodeEditor extends BaseCodeEditor {
+  public computeResultRangeMapping: LineRangeMapping[] = [];
+
+  protected getEditorViewType(): EditorViewType {
+    return 'current';
+  }
+
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return { readOnly: true };
   }
-
-  protected computeResultRangeMapping: LineRangeMapping[] = [];
 
   protected getRetainDecoration(): IDiffDecoration[] {
     return [];
@@ -36,7 +41,6 @@ export class CurrentCodeEditor extends BaseCodeEditor {
     const [c, i] = [flatOriginal(changes), flatInnerOriginal(changes)];
 
     this.renderDecorations(c, i);
-    this.computeResultRangeMapping = [];
   }
 
   public layout(): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -1,27 +1,25 @@
-import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
+import { Injectable } from '@opensumi/di';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
-import {
-  IDiffDecoration,
-  IRenderChangesInput,
-  IRenderInnerChangesInput,
-  MergeEditorDecorations,
-} from '../../model/decorations';
-import { LineRange } from '../../model/line-range';
-import { flatInnerModified, flatModified, flatOriginal, flatInnerOriginal } from '../../utils';
+import { IDiffDecoration } from '../../model/decorations';
+import { flatInnerModified, flatModified } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
+import { EditorViewType } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
 
 @Injectable({ multiple: false })
 export class IncomingCodeEditor extends BaseCodeEditor {
+  public computeResultRangeMapping: LineRangeMapping[] = [];
+
+  protected getEditorViewType(): EditorViewType {
+    return 'incoming';
+  }
+
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return { readOnly: true };
   }
-
-  protected computeResultRangeMapping: LineRangeMapping[] = [];
 
   protected getRetainDecoration(): IDiffDecoration[] {
     return [];
@@ -36,6 +34,5 @@ export class IncomingCodeEditor extends BaseCodeEditor {
 
     const [c, i] = [flatModified(changes), flatInnerModified(changes)];
     this.renderDecorations(c, i);
-    this.computeResultRangeMapping = [];
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -13,10 +13,6 @@ import { BaseCodeEditor } from './baseCodeEditor';
 export class IncomingCodeEditor extends BaseCodeEditor {
   public computeResultRangeMapping: LineRangeMapping[] = [];
 
-  protected getEditorViewType(): EditorViewType {
-    return 'incoming';
-  }
-
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return { readOnly: true };
   }
@@ -27,6 +23,10 @@ export class IncomingCodeEditor extends BaseCodeEditor {
 
   protected getRetainLineWidget(): GuidelineWidget[] {
     return [];
+  }
+
+  public getEditorViewType(): EditorViewType {
+    return 'incoming';
   }
 
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -1,4 +1,4 @@
-import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
+import { Injectable } from '@opensumi/di';
 import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
@@ -7,9 +7,10 @@ import {
   IDiffDecoration,
   IRenderChangesInput,
   IRenderInnerChangesInput,
-  MergeEditorDecorations,
 } from '../../model/decorations';
+
 import { LineRange } from '../../model/line-range';
+import { EditorViewType } from '../../types';
 import { flatInnerModified, flatModified, flatOriginal, flatInnerOriginal } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
 
@@ -17,12 +18,16 @@ import { BaseCodeEditor } from './baseCodeEditor';
 
 @Injectable({ multiple: false })
 export class ResultCodeEditor extends BaseCodeEditor {
+  protected getEditorViewType(): EditorViewType {
+    return 'result';
+  }
+
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return {};
   }
 
-  protected computeResultRangeMapping: LineRangeMapping[] = [];
   private currentBaseRange: 0 | 1;
+  public computeResultRangeMapping: LineRangeMapping[] = [];
 
   protected override prepareRenderDecorations(
     ranges: LineRange[],
@@ -72,7 +77,5 @@ export class ResultCodeEditor extends BaseCodeEditor {
       const [c, i] = [flatOriginal(changes), flatInnerOriginal(changes)];
       this.renderDecorations(c, i);
     }
-
-    this.computeResultRangeMapping = [];
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -18,10 +18,6 @@ import { BaseCodeEditor } from './baseCodeEditor';
 
 @Injectable({ multiple: false })
 export class ResultCodeEditor extends BaseCodeEditor {
-  protected getEditorViewType(): EditorViewType {
-    return 'result';
-  }
-
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return {};
   }
@@ -64,6 +60,10 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
   protected getRetainLineWidget(): GuidelineWidget[] {
     return this.decorations.getLineWidgets();
+  }
+
+  public getEditorViewType(): EditorViewType {
+    return 'result';
   }
 
   public inputDiffComputingResult(changes: LineRangeMapping[], baseRange: 0 | 1): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -5,6 +5,8 @@ import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 
 import { MergeEditorService } from '../merge-editor.service';
 
+import { WithViewStickinessConnectComponent } from './stickiness-connect-manager';
+
 export const Grid = () => {
   const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
 
@@ -32,9 +34,17 @@ export const Grid = () => {
   return (
     <div className={'merge-editor-container'}>
       <SplitPanel overflow='hidden' id='merge-editor-container' flex={2}>
-        <div className={'currentEditorContainer'} ref={currentEditorContainer}></div>
-        <div className={'resultEditorContainer'} ref={resultEditorContainer}></div>
-        <div className={'incomingEditorContainer'} ref={incomingEditorContainer}></div>
+        <div className={'editor-container-arrange'}>
+          <div className={'currentEditorContainer'} ref={currentEditorContainer}></div>
+        </div>
+        <div className={'editor-container-arrange'}>
+          <WithViewStickinessConnectComponent contrastType={'current'}></WithViewStickinessConnectComponent>
+          <div className={'resultEditorContainer'} ref={resultEditorContainer}></div>
+          <WithViewStickinessConnectComponent contrastType={'incoming'}></WithViewStickinessConnectComponent>
+        </div>
+        <div className={'editor-container-arrange'}>
+          <div className={'incomingEditorContainer'} ref={incomingEditorContainer}></div>
+        </div>
       </SplitPanel>
     </div>
   );

--- a/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
@@ -3,11 +3,17 @@ import { ZoneWidget } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/z
 import { LineRangeType } from '../types';
 
 export class GuidelineWidget extends ZoneWidget {
+  private recordLine: number;
+
   protected applyClass(): void {}
   protected applyStyle(): void {}
 
   protected _fillContainer(): void {
     this.setCssClass('merge-editor-guide-underline-widget');
+  }
+
+  public getRecordLine(): number {
+    return this.recordLine;
   }
 
   public setContainerStyle(style: { [key in string]: string }): void {
@@ -25,6 +31,7 @@ export class GuidelineWidget extends ZoneWidget {
   }
 
   public showByLine(line: number): void {
+    this.recordLine = line;
     super.show(
       {
         startLineNumber: line,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
@@ -1,5 +1,6 @@
 import { ZoneWidget } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/zoneWidget/browser/zoneWidget';
 
+import { ICodeEditor } from '../../../monaco-api/types';
 import { LineRangeType } from '../types';
 
 export class GuidelineWidget extends ZoneWidget {
@@ -10,6 +11,15 @@ export class GuidelineWidget extends ZoneWidget {
 
   protected _fillContainer(): void {
     this.setCssClass('merge-editor-guide-underline-widget');
+  }
+
+  constructor(editor: ICodeEditor) {
+    super(editor, {
+      showArrow: false,
+      showFrame: false,
+      arrowColor: undefined,
+      frameColor: undefined,
+    });
   }
 
   public getRecordLine(): number {
@@ -32,6 +42,7 @@ export class GuidelineWidget extends ZoneWidget {
 
   public showByLine(line: number): void {
     this.recordLine = line;
+    super.hide();
     super.show(
       {
         startLineNumber: line,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
@@ -4,7 +4,8 @@
   .currentEditorContainer,
   .resultEditorContainer,
   .incomingEditorContainer {
-    height: 100%;
+    height: inherit;
+    width: 100%;
   }
 
   .merge-editor-guide-underline-widget {
@@ -42,6 +43,33 @@
     }
     &.remove {
       background-color: var(--mergeEditor-removedInnerCharColor);
+    }
+  }
+
+  .editor-container-arrange {
+    height: 100%;
+    display: flex;
+    .stickiness-connect-container {
+      height: 100%;
+      position: relative;
+      .piece-view-lines {
+        position: absolute;
+        z-index: 1;
+        & svg {
+          width: 100%;
+          & path {
+            &.insert {
+              fill: var(--mergeEditor-insertedBackground);
+            }
+            &.modify {
+              fill: var(--mergeEditor-modifyBackground);
+            }
+            &.remove {
+              fill: var(--mergeEditor-removedBackground);
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
@@ -1,5 +1,6 @@
 .merge-editor-container {
   height: 100%;
+  overflow: hidden;
 
   .currentEditorContainer,
   .resultEditorContainer,
@@ -57,6 +58,7 @@
         z-index: 1;
         & svg {
           width: 100%;
+          overflow: initial;
           & path {
             &.insert {
               fill: var(--mergeEditor-insertedBackground);

--- a/packages/monaco/src/browser/contrib/merge-editor/view/scroll-synchronizer.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/scroll-synchronizer.ts
@@ -8,7 +8,7 @@ import { ResultCodeEditor } from './editors/resultCodeEditor';
 
 export class ScrollSynchronizer extends Disposable {
   private readonly _onScrollChange = new Emitter<{ event: IScrollEvent; editor: BaseCodeEditor }>();
-  private readonly onScrollChange: Event<{ event: IScrollEvent; editor: BaseCodeEditor }> = this._onScrollChange.event;
+  public readonly onScrollChange: Event<{ event: IScrollEvent; editor: BaseCodeEditor }> = this._onScrollChange.event;
 
   constructor() {
     super();

--- a/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback } from 'react';
+
+import { useInjectable } from '@opensumi/ide-core-browser';
+import { Disposable, Emitter, Event } from '@opensumi/ide-core-common';
+import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
+
+import { MergeEditorService } from '../merge-editor.service';
+import { MergeEditorDecorations } from '../model/decorations';
+import { LineRange } from '../model/line-range';
+import { EditorViewType, IStickyPiece, LineRangeType } from '../types';
+import { flatModified, flatOriginal } from '../utils';
+
+import { BaseCodeEditor } from './editors/baseCodeEditor';
+import { CurrentCodeEditor } from './editors/currentCodeEditor';
+import { IncomingCodeEditor } from './editors/incomingCodeEditor';
+import { ResultCodeEditor } from './editors/resultCodeEditor';
+
+const PieceSVG: React.FC<{ piece: IStickyPiece }> = ({ piece }) => {
+  const { leftTop, rightTop, leftBottom, rightBottom } = piece.path;
+
+  const drawPath = useCallback(() => `M0,${leftTop} L${piece.width},${rightTop} L${piece.width},${rightBottom} L0,${leftBottom} L0,0 z`, [leftTop, rightTop, rightBottom, leftBottom, piece.width]);
+
+  return (
+    <div className={'piece-view-lines'} style={{ top: piece.position.top, width: piece.width }}>
+      <svg viewBox={`0 0 ${piece.width} ${piece.height}`} style={{ height: piece.height }}>
+        <path className={piece.rangeType} d={drawPath()}></path>
+      </svg>
+    </div>
+  );
+};
+
+export const WithViewStickinessConnectComponent: React.FC<{ contrastType: EditorViewType }> = ({ contrastType }) => {
+  const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
+  const [pieces, setPieces] = React.useState<IStickyPiece[]>([]);
+
+  React.useEffect(() => {
+    const disposable = Event.filter(
+      mergeEditorService.stickinessConnectManager.onDidChangePiece,
+      ({ editorType }) => editorType === contrastType,
+    )(({ pieces }) => {
+      setPieces(pieces);
+    });
+    return () => disposable.dispose();
+  }, [mergeEditorService, pieces]);
+
+  return (
+    <div className={'stickiness-connect-container'}>
+      {pieces.map((p, i) => (
+        <PieceSVG key={i} piece={p}></PieceSVG>
+      ))}
+    </div>
+  );
+};
+
+export class StickinessConnectManager extends Disposable {
+  private currentView: BaseCodeEditor | undefined;
+  private resultView: BaseCodeEditor | undefined;
+  private incomingView: BaseCodeEditor | undefined;
+
+  private readonly _onDidChangePiece = new Emitter<{ pieces: IStickyPiece[]; editorType: EditorViewType }>();
+  public readonly onDidChangePiece: Event<{ pieces: IStickyPiece[]; editorType: EditorViewType }> =
+    this._onDidChangePiece.event;
+
+  constructor() {
+    super();
+  }
+
+  private generatePiece(
+    origin: LineRange[],
+    modify: LineRange[],
+    editorLayoutInfo: { marginWidth: number; lineHeight: number },
+    withBase: 0 | 1 = 0,
+  ): IStickyPiece[] {
+    const result: IStickyPiece[] = [];
+    const { marginWidth, lineHeight } = editorLayoutInfo;
+
+    origin.forEach((range, idx) => {
+      const sameModify = modify[idx];
+      const minTop = Math.min(range.startLineNumber, sameModify.startLineNumber);
+      const maxBottom = Math.max(range.endLineNumberExclusive, sameModify.endLineNumberExclusive);
+      const width = marginWidth;
+      const height = lineHeight * (maxBottom - minTop);
+      const position = {
+        top: (minTop - 1) * lineHeight,
+      };
+      const path = {
+        leftTop: Math.abs(minTop - range.startLineNumber) * lineHeight,
+        rightTop: Math.abs(minTop - sameModify.startLineNumber) * lineHeight,
+        leftBottom: (range.endLineNumberExclusive - minTop) * lineHeight,
+        rightBottom: (sameModify.endLineNumberExclusive - minTop) * lineHeight,
+      };
+
+      let rangeType: LineRangeType = 'modify';
+
+      if (range.isTendencyLeft(sameModify)) {
+        rangeType = withBase === 0 ? 'insert' : 'remove';
+      } else if (range.isTendencyRight(sameModify)) {
+        rangeType = withBase === 0 ? 'remove' : 'insert';
+      }
+
+      result.push({ width, height, path, position, rangeType });
+    });
+
+    return result;
+  }
+
+  private computePiece(editorType: EditorViewType) {
+    if (editorType === 'result') {
+      return;
+    }
+
+    if (!(this.currentView || this.resultView || this.incomingView)) {
+      return;
+    }
+
+    const view = editorType === 'current' ? this.currentView : this.incomingView;
+
+    const { computeResultRangeMapping } = view!;
+    const [originRange, modifyRange] = [
+      flatOriginal(computeResultRangeMapping),
+      flatModified(computeResultRangeMapping),
+    ];
+    const lineHeight = view!.getEditor().getOption(EditorOption.lineHeight);
+    const { contentLeft } = this.resultView!.getEditor().getLayoutInfo();
+    this._onDidChangePiece.fire({
+      pieces: this.generatePiece(
+        originRange,
+        modifyRange,
+        { marginWidth: contentLeft, lineHeight },
+        editorType === 'incoming' ? 1 : 0,
+      ),
+      editorType: 'current',
+    });
+  }
+
+  public mount(currentView: BaseCodeEditor, resultView: BaseCodeEditor, incomingView: BaseCodeEditor): void {
+    this.currentView = currentView;
+    this.resultView = resultView;
+    this.incomingView = incomingView;
+
+    this.addDispose(
+      Event.debounce(
+        currentView.onDidChangeDecorations,
+        () => {},
+        10,
+      )(() => {
+        this.computePiece('current');
+      }),
+    );
+
+    this.addDispose(
+      Event.debounce(
+        incomingView.onDidChangeDecorations,
+        () => {},
+        10,
+      )(() => {
+        this.computePiece('incoming');
+      }),
+    );
+  }
+}

--- a/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react';
 import { useInjectable } from '@opensumi/ide-core-browser';
 import { Disposable, Emitter, Event } from '@opensumi/ide-core-common';
 import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
-import { IScrollEvent } from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
 
 import { ICodeEditor } from '../../../monaco-api/types';
 import { MergeEditorService } from '../merge-editor.service';
@@ -13,8 +12,6 @@ import { EditorViewType, LineRangeType } from '../types';
 import { flatModified, flatOriginal } from '../utils';
 
 import { BaseCodeEditor } from './editors/baseCodeEditor';
-import { ResultCodeEditor } from './editors/resultCodeEditor';
-
 
 const PieceSVG: React.FC<{ piece: StickyPieceModel }> = ({ piece }) => {
   const { leftTop, rightTop, leftBottom, rightBottom } = piece.path;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

**基本实现**
通过左右 editor 内绘制的相邻的 decoration 位置，计算出高度和绝对定位 top 值，再利用 SVG 标签以及 [path](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) 标签来绘制路径区域

![image](https://user-images.githubusercontent.com/20262815/202975652-c2c21c49-ea38-4989-b913-e1dd5f879bf8.png)

定义的基本模型为
```
width: // 默认是 monaco editor layout info 的 contentLeft
path: { // svg 标签要绘制的 path 路径上下左右 4 个端点
  leftTop
  rightTop
  leftBottom
  rightBottom
}
height: // path 路径最大的 bottom 点和最小的 top 点的差值
position: // 绝对定位 top 值（也就是 path 路径最小的 top 点）
```
计算方式见代码 `generatePiece` 函数

**滚动计算**
当 3 个视图都上下滚动时，由于代码行数的差异会存在左右滚动位置不同步的情况，此时 decoration 的位置也会上下变化
此时只需要根据滚动的 scrollTop 值来重新计算 position、height 和 path 路径即可

其中新的 position 和 height 计算方式与一开始的计算方式一样，只需要引入一个变量 scrollTop 即可

而 path 路径的重新绘制比较麻烦些，因为这会影响 path 路径的 4 个端点坐标

例: 当右侧 editor 的滚动区域大于左侧 editor 的滚动区域时

原 4个坐标
![image](https://user-images.githubusercontent.com/20262815/202981025-e41d6a7a-73d3-49c7-be3b-910e368e3e45.png)

通过计算转换成新的 4个坐标
![image](https://user-images.githubusercontent.com/20262815/202981387-29f5a5a3-75cb-478f-bcb4-bb24ad87803f.png)
计算方式见代码 sticky-piece 模型的 movePosition 函数

**最终效果**

https://user-images.githubusercontent.com/20262815/202982242-4d714485-2629-428b-b026-ffe9fa35af4e.mp4

### Changelog
实现 3-way 视图下 diff 区域彼此粘性相连的效果