### PR TITLE
feat: switch margin and code editor widget content

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
@@ -6,6 +6,7 @@ import { IModelDecorationsChangedEvent } from '@opensumi/monaco-editor-core/esm/
 
 import { ICodeEditor, IModelDeltaDecoration } from '../../../monaco-api/editor';
 import { EditorViewType, LineRangeType } from '../types';
+import { BaseCodeEditor } from '../view/editors/baseCodeEditor';
 import { GuidelineWidget } from '../view/guideline-widget';
 
 import { LineRange } from './line-range';
@@ -39,8 +40,12 @@ export class MergeEditorDecorations extends Disposable {
   private readonly _onDidChangeDecorations = new Emitter<MergeEditorDecorations>();
   public readonly onDidChangeDecorations: Event<MergeEditorDecorations> = this._onDidChangeDecorations.event;
 
+  private get editor(): ICodeEditor {
+    return this.codeEditor.getEditor();
+  }
+
   constructor(
-    @Optional() private readonly editor: ICodeEditor,
+    @Optional() private readonly codeEditor: BaseCodeEditor,
     @Optional() public readonly editorViewType: EditorViewType,
   ) {
     super();
@@ -59,6 +64,12 @@ export class MergeEditorDecorations extends Disposable {
   }
 
   private createLineDecoration(range: LineRange, type: LineRangeType): IDiffDecoration {
+    const options = ModelDecorationOptions.register({
+      description: 'merge-editor-diff-line',
+      className: `merge-editor-diff-line-background ${type}`,
+      isWholeLine: true,
+    });
+
     return {
       id: '',
       editorDecoration: {
@@ -68,11 +79,10 @@ export class MergeEditorDecorations extends Disposable {
           endLineNumber: range.endLineNumberExclusive - 1,
           endColumn: Number.MAX_SAFE_INTEGER,
         },
-        options: ModelDecorationOptions.register({
-          description: 'merge-editor-diff-line',
-          className: `merge-editor-diff-line-background ${type}`,
-          isWholeLine: true,
-        }),
+        options: {
+          ...options,
+          ...this.codeEditor.getMonacoDecorationOptions(options),
+        },
       },
     };
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -5,7 +5,7 @@ import { ICodeEditor } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/
 import { EditorLayoutInfo } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
-import { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
+import { IModelDecorationOptions, ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
 import {
@@ -52,7 +52,7 @@ export abstract class BaseCodeEditor extends Disposable {
       ...this.getMonacoEditorOptions(),
     });
 
-    this.decorations = this.injector.get(MergeEditorDecorations, [this.editor, this.getEditorViewType()]);
+    this.decorations = this.injector.get(MergeEditorDecorations, [this, this.getEditorViewType()]);
 
     this.addDispose(
       Event.debounce(
@@ -93,6 +93,10 @@ export abstract class BaseCodeEditor extends Disposable {
   public abstract computeResultRangeMapping: LineRangeMapping[];
 
   public abstract getEditorViewType(): EditorViewType;
+
+  public abstract getMonacoDecorationOptions(
+    inputDecoration: IModelDecorationOptions,
+  ): Omit<IModelDecorationOptions, 'description'>;
 
   protected abstract getMonacoEditorOptions(): IStandaloneEditorConstructionOptions;
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -1,11 +1,12 @@
 import { Injectable } from '@opensumi/di';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
+import { IModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
 import { IDiffDecoration } from '../../model/decorations';
+import { EditorViewType } from '../../types';
 import { flatInnerModified, flatModified } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
-import { EditorViewType } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
 
@@ -23,6 +24,10 @@ export class IncomingCodeEditor extends BaseCodeEditor {
 
   protected getRetainLineWidget(): GuidelineWidget[] {
     return [];
+  }
+
+  public getMonacoDecorationOptions(): Omit<IModelDecorationOptions, 'description'> {
+    return {};
   }
 
   public getEditorViewType(): EditorViewType {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -1,14 +1,10 @@
 import { Injectable } from '@opensumi/di';
 import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
+import { IModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
-import {
-  IDiffDecoration,
-  IRenderChangesInput,
-  IRenderInnerChangesInput,
-} from '../../model/decorations';
-
+import { IDiffDecoration, IRenderChangesInput, IRenderInnerChangesInput } from '../../model/decorations';
 import { LineRange } from '../../model/line-range';
 import { EditorViewType } from '../../types';
 import { flatInnerModified, flatModified, flatOriginal, flatInnerOriginal } from '../../utils';
@@ -60,6 +56,10 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
   protected getRetainLineWidget(): GuidelineWidget[] {
     return this.decorations.getLineWidgets();
+  }
+
+  public getMonacoDecorationOptions(): Omit<IModelDecorationOptions, 'description'> {
+    return {};
   }
 
   public getEditorViewType(): EditorViewType {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

在后续的 accept current change 等操作中，需要将左侧的 margin 区域和中间的 margin 区域放在一起，这样交互上会更友好一些


![image](https://user-images.githubusercontent.com/20262815/203030833-a5baa2e1-5519-4fdc-a70d-b855acaa76af.png)


### Changelog
交换 3-way 视图中 ours editor 的 margin 和 code 编辑区域的位置
