### PR TITLE
refactor: optimize scoped storage bootstrap speed

### DIFF
--- a/packages/core-browser/src/services/storage-service.ts
+++ b/packages/core-browser/src/services/storage-service.ts
@@ -93,7 +93,12 @@ abstract class BaseBrowserStorageService implements StorageService {
     if (isUndefinedOrNull(result)) {
       return defaultValue;
     }
-    return JSON.parse(result);
+    try {
+      return JSON.parse(result);
+    } catch (e) {
+      this.logger.error(`storage getDate error: ${e}, use defaultValue as result.`);
+    }
+    return defaultValue;
   }
 
   public removeData<T>(key: string): void {

--- a/packages/storage/__tests__/browser/storage.service.test.ts
+++ b/packages/storage/__tests__/browser/storage.service.test.ts
@@ -12,6 +12,7 @@ import {
   STORAGE_NAMESPACE,
   ScopedBrowserStorageService,
   GlobalBrowserStorageService,
+  AppConfig,
 } from '@opensumi/ide-core-browser';
 import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { IFileServiceClient, IDiskFileProvider } from '@opensumi/ide-file-service';
@@ -92,6 +93,12 @@ describe('StorageProvider should be work', () => {
         useValue: MockWorkspaceService,
       },
       {
+        token: AppConfig,
+        useValue: {
+          workspaceDir: MockWorkspaceService.workspace.uri,
+        },
+      },
+      {
         token: StorageProvider,
         useFactory: () => (storageId) => injector.get(DefaultStorageProvider).get(storageId),
       },
@@ -154,7 +161,7 @@ describe('StorageProvider should be work', () => {
     expect(cache?.recents).toBe(JSON.stringify(recents));
   });
 
-  it('Custom ScopedStorage will disable cache on LocalStorage', async () => {
+  it('Custom ScopedStorage will not cache on LocalStorage', async () => {
     const getStorage: StorageProvider = injector.get(StorageProvider);
     const customId = new URI('test').withScheme(STORAGE_SCHEMA.SCOPE);
     const extensionStorage = await getStorage(customId);

--- a/packages/storage/src/browser/storage.contribution.ts
+++ b/packages/storage/src/browser/storage.contribution.ts
@@ -50,14 +50,16 @@ export class DatabaseStorageContribution implements StorageResolverContribution,
         if (!this.scopedLocalStorage) {
           this.scopedLocalStorage = this.injector.get(ScopedBrowserStorageService, [this.appConfig.workspaceDir]);
         }
+        storage = new Storage(
+          this.workspaceStorage,
+          this.workspaceService,
+          this.appConfig,
+          storageName,
+          this.scopedLocalStorage,
+        );
+      } else {
+        storage = new Storage(this.workspaceStorage, this.workspaceService, this.appConfig, storageName);
       }
-      storage = new Storage(
-        this.workspaceStorage,
-        this.workspaceService,
-        this.appConfig,
-        storageName,
-        this.scopedLocalStorage,
-      );
     } else if (storageId.scheme === STORAGE_SCHEMA.GLOBAL) {
       if (this.isBuiltinStorage(storageId)) {
         // 如果是内置的 Storage，在初始化过程中采用 GlobalBrowserStorageService 代理

--- a/packages/storage/src/browser/storage.contribution.ts
+++ b/packages/storage/src/browser/storage.contribution.ts
@@ -37,24 +37,26 @@ export class DatabaseStorageContribution implements StorageResolverContribution,
   @Autowired(GlobalBrowserStorageService)
   private globalLocalStorage: GlobalBrowserStorageService;
 
+  private scopedLocalStorage: ScopedBrowserStorageService;
+
   storage: IStorage;
 
   async resolve(storageId: URI) {
     const storageName = storageId.path.toString();
     let storage: IStorage;
-    await this.workspaceService.whenReady;
     if (storageId.scheme === STORAGE_SCHEMA.SCOPE) {
-      let scopedLocalStorage;
       // 如果是内置的 Storage，在初始化过程中采用 ScopedBrowserStorageService 代理
       if (this.isBuiltinStorage(storageId)) {
-        scopedLocalStorage = this.injector.get(ScopedBrowserStorageService, [this.workspaceService.workspace?.uri]);
+        if (!this.scopedLocalStorage) {
+          this.scopedLocalStorage = this.injector.get(ScopedBrowserStorageService, [this.appConfig.workspaceDir]);
+        }
       }
       storage = new Storage(
         this.workspaceStorage,
         this.workspaceService,
         this.appConfig,
         storageName,
-        scopedLocalStorage,
+        this.scopedLocalStorage,
       );
     } else if (storageId.scheme === STORAGE_SCHEMA.GLOBAL) {
       if (this.isBuiltinStorage(storageId)) {


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors
- [x] 🚀 Performance Improvements

### Background or solution

优化 ScopedStorage 冷启动速度，不再依赖 `workspaceService.whenReady` 逻辑，框架内启动速度提升约 50%

Before:
![image](https://user-images.githubusercontent.com/9823838/203215894-e32349f4-c886-403a-80de-0d0b337b54b5.png)
After:
![image](https://user-images.githubusercontent.com/9823838/203215916-87f37de7-15fe-44e9-99b4-16a4797ae7d4.png)

同时修改 Terminal 恢复逻辑，采用 `ScopedBrowserStorageService` 进行浏览器存储管理。

局部浏览器缓存路径从 `scoped:file:///...:/recent` 修改为 `scoped:/....:/recent` 移除了多余的 `file://`，该修改会导致用户首次加载新版本时进入冷启动逻辑（字段改动导致之前的缓存失效），影响不大。

### Changelog

optimize scoped storage bootstrap speed