### PR TITLE
feat: render conflict actions

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -4,6 +4,7 @@ import { Disposable, MonacoService } from '@opensumi/ide-core-browser';
 import { ICodeEditor } from '../../monaco-api/editor';
 
 import { ComputerDiffModel } from './model/computer-diff';
+import { ActionsManager } from './view/actions-manager';
 import { CurrentCodeEditor } from './view/editors/currentCodeEditor';
 import { IncomingCodeEditor } from './view/editors/incomingCodeEditor';
 import { ResultCodeEditor } from './view/editors/resultCodeEditor';
@@ -23,6 +24,7 @@ export class MergeEditorService extends Disposable {
   private incomingView: IncomingCodeEditor;
 
   private computerDiffModel: ComputerDiffModel;
+  private actionsManager: ActionsManager;
 
   public scrollSynchronizer: ScrollSynchronizer;
   public stickinessConnectManager: StickinessConnectManager;
@@ -32,6 +34,7 @@ export class MergeEditorService extends Disposable {
     this.computerDiffModel = new ComputerDiffModel();
     this.scrollSynchronizer = new ScrollSynchronizer();
     this.stickinessConnectManager = new StickinessConnectManager();
+    this.actionsManager = new ActionsManager();
   }
 
   public instantiationCodeEditor(current: HTMLDivElement, result: HTMLDivElement, incoming: HTMLDivElement): void {
@@ -45,6 +48,7 @@ export class MergeEditorService extends Disposable {
 
     this.scrollSynchronizer.mount(this.currentView, this.resultView, this.incomingView);
     this.stickinessConnectManager.mount(this.currentView, this.resultView, this.incomingView);
+    this.actionsManager.mount(this.currentView, this.resultView, this.incomingView);
   }
 
   public override dispose(): void {
@@ -54,6 +58,7 @@ export class MergeEditorService extends Disposable {
     this.incomingView.dispose();
     this.scrollSynchronizer.dispose();
     this.stickinessConnectManager.dispose();
+    this.actionsManager.dispose();
   }
 
   public getCurrentEditor(): ICodeEditor {

--- a/packages/monaco/src/browser/contrib/merge-editor/model/conflict-actions.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/conflict-actions.ts
@@ -1,0 +1,56 @@
+import { Injectable, Optional } from '@opensumi/di';
+import { Disposable } from '@opensumi/ide-core-common';
+import { IEditorDecorationsCollection } from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
+import { ModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model/textModel';
+
+import { ICodeEditor, IModelDeltaDecoration } from '../../../monaco-api/editor';
+import { IActionsDescription } from '../types';
+import { BaseCodeEditor } from '../view/editors/baseCodeEditor';
+
+import { LineRange } from './line-range';
+
+@Injectable({ multiple: false })
+export class ConflictActions extends Disposable {
+  private decorationsCollection: IEditorDecorationsCollection;
+  private actionsCollect: Map<number, LineRange>;
+
+  private get editor(): ICodeEditor {
+    return this.codeEditor.getEditor();
+  }
+
+  constructor(@Optional() private readonly codeEditor: BaseCodeEditor) {
+    super();
+
+    this.decorationsCollection = this.editor.createDecorationsCollection();
+    this.actionsCollect = new Map();
+  }
+
+  public override dispose(): void {
+    super.dispose();
+    this.decorationsCollection.clear();
+    this.actionsCollect.clear();
+  }
+
+  public setActions(actions: IActionsDescription[]): void {
+    const newDecorations: IModelDeltaDecoration[] = actions.map((action) => {
+      const { range } = action;
+      this.actionsCollect.set(range.startLineNumber, range);
+
+      return {
+        range: {
+          startLineNumber: range.startLineNumber,
+          startColumn: 0,
+          endLineNumber: range.startLineNumber,
+          endColumn: 0,
+        },
+        options: ModelDecorationOptions.register(action.decorationOptions),
+      };
+    });
+
+    this.decorationsCollection.set(newDecorations);
+  }
+
+  public getActions(line: number): LineRange | undefined {
+    return this.actionsCollect.get(line);
+  }
+}

--- a/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
@@ -26,7 +26,7 @@ export interface IDiffDecoration {
   readonly editorDecoration: IModelDeltaDecoration;
 }
 
-@Injectable({ multiple: true })
+@Injectable({ multiple: false })
 export class MergeEditorDecorations extends Disposable {
   private deltaDecoration: IDiffDecoration[] = [];
   private retainDecoration: IDiffDecoration[] = [];

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -1,3 +1,5 @@
+import { IRange } from '@opensumi/monaco-editor-core';
+import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 import { LineRange as MonacoLineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 
 export class LineRange extends MonacoLineRange {
@@ -11,5 +13,12 @@ export class LineRange extends MonacoLineRange {
 
   public isTendencyLeft(refer: LineRange): boolean {
     return !this.isEmpty && refer.isEmpty;
+  }
+
+  public toIRange(): IRange {
+    return Range.fromPositions(
+      { lineNumber: this.startLineNumber, column: 0 },
+      { lineNumber: this.endLineNumberExclusive - 1, column: 0 },
+    );
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/sticky-piece.ts
@@ -1,5 +1,3 @@
-import clone from 'lodash/clone';
-
 import { IStickyPiece, IStickyPiecePath, IStickyPiecePosition, LineRangeType } from '../types';
 
 export class StickyPieceModel implements IStickyPiece {

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -1,3 +1,4 @@
+import { getIcon } from '@opensumi/ide-core-browser';
 import { IEditorMouseEvent } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
 
 import { IModelDecorationOptions } from '../../monaco-api/editor';
@@ -47,8 +48,15 @@ export interface IActionsProvider {
     resultView: IBaseCodeEditor,
     incomingView: IBaseCodeEditor,
   ) => void;
+  mouseDownGuard?: (e: IEditorMouseEvent) => boolean;
   /**
    * 提供 actions 操作项
    */
   provideActionsItems: () => IActionsDescription[];
+}
+
+export namespace CONFLICT_ACTIONS_ICON {
+  export const RIGHT = `conflict-actions ${ACCEPT_CURRENT} ${getIcon('right')}`;
+  export const LEFT = `conflict-actions ${ACCEPT_CURRENT} ${getIcon('left')}`;
+  export const CLOSE = `conflict-actions ${IGNORE} ${getIcon('close')}`;
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -1,3 +1,13 @@
+import { IEditorMouseEvent } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
+
+import { IModelDecorationOptions } from '../../monaco-api/editor';
+
+import { LineRange } from './model/line-range';
+
+export interface IBaseCodeEditor {
+  mount(): void;
+}
+
 export type LineRangeType = 'insert' | 'modify' | 'remove';
 
 export type EditorViewType = 'current' | 'result' | 'incoming';
@@ -19,4 +29,26 @@ export interface IStickyPiece {
   height: number;
   position: IStickyPiecePosition;
   path: IStickyPiecePath;
+}
+
+export interface IActionsDescription {
+  range: LineRange;
+  decorationOptions: IModelDecorationOptions;
+}
+
+export const ACCEPT_CURRENT = 'accpet_current';
+export const ACCEPT_COMBINATION = 'accpet_combination';
+export const IGNORE = 'ignore';
+
+export interface IActionsProvider {
+  onActionsClick?: (
+    e: IEditorMouseEvent,
+    currentView: IBaseCodeEditor,
+    resultView: IBaseCodeEditor,
+    incomingView: IBaseCodeEditor,
+  ) => void;
+  /**
+   * 提供 actions 操作项
+   */
+  provideActionsItems: () => IActionsDescription[];
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -1,0 +1,34 @@
+import { Disposable } from '@opensumi/ide-core-common';
+
+import { BaseCodeEditor } from './editors/baseCodeEditor';
+
+export class ActionsManager extends Disposable {
+  private currentView: BaseCodeEditor | undefined;
+  private resultView: BaseCodeEditor | undefined;
+  private incomingView: BaseCodeEditor | undefined;
+
+  constructor() {
+    super();
+  }
+
+  public mount(currentView: BaseCodeEditor, resultView: BaseCodeEditor, incomingView: BaseCodeEditor): void {
+    this.currentView = currentView;
+    this.resultView = resultView;
+    this.incomingView = incomingView;
+
+    this.addDispose(
+      this.currentView.getEditor().onMouseDown((e) => {
+        const provider = currentView.actionsProvider;
+        if (!provider) {
+          return;
+        }
+
+        const { onActionsClick } = provider;
+
+        if (onActionsClick) {
+          onActionsClick.call(currentView, e, currentView, resultView, incomingView);
+        }
+      }),
+    );
+  }
+}

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -1,4 +1,7 @@
 import { Disposable } from '@opensumi/ide-core-common';
+import { IEditorMouseEvent, MouseTargetType } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
+
+import { IActionsDescription } from '../types';
 
 import { BaseCodeEditor } from './editors/baseCodeEditor';
 
@@ -16,19 +19,43 @@ export class ActionsManager extends Disposable {
     this.resultView = resultView;
     this.incomingView = incomingView;
 
-    this.addDispose(
-      this.currentView.getEditor().onMouseDown((e) => {
-        const provider = currentView.actionsProvider;
-        if (!provider) {
-          return;
-        }
+    const handleMouseDown = (e: IEditorMouseEvent, _this: BaseCodeEditor) => {
+      const provider = _this.actionsProvider;
+      if (!provider) {
+        return;
+      }
 
-        const { onActionsClick } = provider;
+      let { mouseDownGuard } = provider;
+      const { onActionsClick, provideActionsItems } = provider;
 
-        if (onActionsClick) {
-          onActionsClick.call(currentView, e, currentView, resultView, incomingView);
-        }
-      }),
-    );
+      if (typeof mouseDownGuard === 'undefined') {
+        const items = provideActionsItems();
+        mouseDownGuard = (e: IEditorMouseEvent) => {
+          if (e.event.rightButton) {
+            return false;
+          }
+
+          if (e.target.type !== MouseTargetType.GUTTER_LINE_DECORATIONS) {
+            return false;
+          }
+
+          const { position } = e.target;
+
+          if (!items.some((item: IActionsDescription) => item.range.startLineNumber === position.lineNumber)) {
+            return false;
+          }
+
+          return true;
+        };
+      }
+
+      if (mouseDownGuard(e) === true && onActionsClick) {
+        onActionsClick.call(_this, e, currentView, resultView, incomingView);
+      }
+    };
+
+    this.addDispose(currentView.getEditor().onMouseDown((e: IEditorMouseEvent) => handleMouseDown(e, currentView)));
+    this.addDispose(incomingView.getEditor().onMouseDown((e: IEditorMouseEvent) => handleMouseDown(e, incomingView)));
+    this.addDispose(resultView.getEditor().onMouseDown((e: IEditorMouseEvent) => handleMouseDown(e, resultView)));
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -1,4 +1,6 @@
-import { Injectable } from '@opensumi/di';
+import { Injectable, Injector } from '@opensumi/di';
+import { getIcon, MonacoService } from '@opensumi/ide-core-browser';
+import { IEditorMouseEvent, MouseTargetType } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
 import { Margin } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/viewParts/margin/margin';
 import { Range } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
@@ -7,19 +9,21 @@ import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-co
 
 import { IDiffDecoration } from '../../model/decorations';
 import { LineRange } from '../../model/line-range';
-import { EditorViewType } from '../../types';
+import { ACCEPT_CURRENT, EditorViewType, IGNORE } from '../../types';
 import { flatInnerOriginal, flatOriginal } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
 
 import { BaseCodeEditor } from './baseCodeEditor';
 
+// 用来寻址点击事件时的标记
+const ADDRESSING_TAG_CLASSNAME = 'ADDRESSING_TAG_CLASSNAME_';
 
 @Injectable({ multiple: false })
 export class CurrentCodeEditor extends BaseCodeEditor {
   public computeResultRangeMapping: LineRangeMapping[] = [];
 
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
-    return { readOnly: true };
+    return { readOnly: true, lineNumbersMinChars: 5 };
   }
 
   protected getRetainDecoration(): IDiffDecoration[] {
@@ -49,9 +53,57 @@ export class CurrentCodeEditor extends BaseCodeEditor {
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {
     this.computeResultRangeMapping = changes;
 
-    const [c, i] = [flatOriginal(changes), flatInnerOriginal(changes)];
+    const [ranges, innerRanges] = [flatOriginal(changes), flatInnerOriginal(changes)];
 
-    this.renderDecorations(c, i);
+    this.renderDecorations(ranges, innerRanges);
+
+    this.registerActionsProvider({
+      provideActionsItems: () => ranges.map((range) => {
+          const posiMark = `${ADDRESSING_TAG_CLASSNAME}${range.startLineNumber}`;
+          return {
+            range,
+            decorationOptions: {
+              description: 'current editor view conflict actions',
+              glyphMarginClassName: `conflict-actions offset-left ${ACCEPT_CURRENT} ${getIcon('right')} ${posiMark}`,
+              marginClassName: `conflict-actions ${IGNORE} ${getIcon('close')} ${posiMark}`,
+            },
+          };
+        }),
+      onActionsClick: (e: IEditorMouseEvent) => {
+        /**
+         * 注: 由于 current view 视图已经将 margin 区域和 code 区域交换了
+         * 导致 editor mousedown 在处理点击事件的时候无法通过内部逻辑找到 target type 和 position 等信息
+         * 进而导致没法知道点击了哪个位置上的 actions 图标
+         * 所以这里通过 ADDRESSING_TAG_CLASSNAME 标志符加 lineNumber 给 className 类名的方式，来找到具体点击了哪个 actions
+         */
+        if (!(e.target.type === MouseTargetType.GUTTER_GLYPH_MARGIN || e.target.type === MouseTargetType.UNKNOWN)) {
+          return;
+        }
+
+        if (e.event.rightButton || !e.target.element) {
+          return;
+        }
+
+        const { element } = e.target;
+        if (element.classList.contains(ACCEPT_CURRENT)) {
+          const toArry = Array.from(element.classList);
+          const find = toArry.find((c) => c.startsWith(ADDRESSING_TAG_CLASSNAME));
+          if (find) {
+            const posiLine = Number(find.replace(ADDRESSING_TAG_CLASSNAME, ''));
+            if (typeof posiLine === 'number') {
+              // console.log('onActionsClick: >>> ', posiLine)
+            }
+          }
+
+          return;
+        }
+
+        if (element.classList.contains(IGNORE)) {
+          // console.log(e, IGNORE)
+          return;
+        }
+      },
+    });
 
     this.layout();
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -1,11 +1,10 @@
-import { Injectable, Injector } from '@opensumi/di';
-import { getIcon, MonacoService } from '@opensumi/ide-core-browser';
+import { Injectable } from '@opensumi/di';
 import { LineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 import { IModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
 import { IDiffDecoration } from '../../model/decorations';
-import { ACCEPT_CURRENT, EditorViewType, IGNORE } from '../../types';
+import { CONFLICT_ACTIONS_ICON, EditorViewType } from '../../types';
 import { flatInnerModified, flatModified } from '../../utils';
 import { GuidelineWidget } from '../guideline-widget';
 
@@ -49,8 +48,8 @@ export class IncomingCodeEditor extends BaseCodeEditor {
       provideActionsItems: () => {
         const decorationOptions = {
           description: 'incoming editor view conflict actions',
-          glyphMarginClassName: `conflict-actions offset-right ${IGNORE} ${getIcon('close')}`,
-          firstLineDecorationClassName: `conflict-actions ${ACCEPT_CURRENT} ${getIcon('left')}`,
+          glyphMarginClassName: CONFLICT_ACTIONS_ICON.CLOSE + ' offset-right',
+          firstLineDecorationClassName: CONFLICT_ACTIONS_ICON.LEFT,
         };
         return ranges.map((range) => ({ range, decorationOptions }));
       },

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -15,7 +15,7 @@ import { BaseCodeEditor } from './baseCodeEditor';
 @Injectable({ multiple: false })
 export class ResultCodeEditor extends BaseCodeEditor {
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
-    return {};
+    return { lineNumbersMinChars: 2, lineDecorationsWidth: 24 };
   }
 
   private currentBaseRange: 0 | 1;
@@ -58,8 +58,12 @@ export class ResultCodeEditor extends BaseCodeEditor {
     return this.decorations.getLineWidgets();
   }
 
-  public getMonacoDecorationOptions(): Omit<IModelDecorationOptions, 'description'> {
-    return {};
+  public getMonacoDecorationOptions(
+    preDecorations: IModelDecorationOptions,
+  ): Omit<IModelDecorationOptions, 'description'> {
+    return {
+      linesDecorationsClassName: preDecorations.className,
+    };
   }
 
   public getEditorViewType(): EditorViewType {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
@@ -74,4 +74,20 @@
       }
     }
   }
+
+  .conflict-actions {
+    cursor: pointer;
+    z-index: 1;
+
+    &.offset-left {
+      left: 18px !important;
+      z-index: 2;
+    }
+
+    &.offset-right {
+      left: initial !important;
+      right: 8px !important;
+      z-index: 2;
+    }
+  }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
@@ -138,12 +138,22 @@ export class StickinessConnectManager extends Disposable {
       flatModified(computeResultRangeMapping),
     ];
     const lineHeight = view!.getEditor().getOption(EditorOption.lineHeight);
-    const { contentLeft } = this.resultView!.getEditor().getLayoutInfo();
+    const layoutInfo =
+      editorType === 'current'
+        ? this.resultView!.getEditor().getLayoutInfo()
+        : this.incomingView!.getEditor().getLayoutInfo();
+
+    let marginWidth: number = layoutInfo.contentLeft;
+
+    const lineDecorationsWidth = (editorType === 'current' ? this.resultView : this.incomingView)!
+      .getEditor()
+      .getOption(EditorOption.lineDecorationsWidth);
+    marginWidth -= typeof lineDecorationsWidth === 'number' ? lineDecorationsWidth : 0;
 
     const pieces = this.generatePiece(
       originRange,
       modifyRange,
-      { marginWidth: contentLeft, lineHeight },
+      { marginWidth, lineHeight },
       editorType === 'incoming' ? 1 : 0,
     ).map((p) => p.movePosition(...this.getScrollTopWithBoth(editorType)));
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

同时调整了 3 个编辑器的 margin 区域的边距，使其容纳得下图标

![image](https://user-images.githubusercontent.com/20262815/203461837-fe7414b1-6260-42ae-b7c6-60f3accdc570.png)

### Changelog
渲染 3-way 视图下的 conflict actions 操作