### PR TITLE
feat: support base64 icon on editor glyphMargin and treeview

### DIFF
--- a/packages/editor/src/browser/editor.decoration.service.ts
+++ b/packages/editor/src/browser/editor.decoration.service.ts
@@ -1,6 +1,6 @@
 import { Autowired, Injectable } from '@opensumi/di';
 import { URI, IDisposable, Disposable, IEventBus } from '@opensumi/ide-core-browser';
-import { IThemeService } from '@opensumi/ide-theme';
+import { IIconService, IThemeService } from '@opensumi/ide-theme';
 import { ICSSStyleService } from '@opensumi/ide-theme/lib/common/style';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
@@ -22,13 +22,16 @@ export class EditorDecorationCollectionService implements IEditorDecorationColle
   decorations: Map<string, IBrowserTextEditorDecorationType> = new Map();
 
   @Autowired(ICSSStyleService)
-  cssManager: ICSSStyleService;
+  private readonly cssManager: ICSSStyleService;
 
   @Autowired(IThemeService)
-  themeService: IThemeService;
+  private readonly themeService: IThemeService;
+
+  @Autowired(IIconService)
+  private readonly iconService: IIconService;
 
   @Autowired(IEventBus)
-  eventBus: IEventBus;
+  private readonly eventBus: IEventBus;
 
   private tempId = 0;
 
@@ -139,9 +142,12 @@ export class EditorDecorationCollectionService implements IEditorDecorationColle
   }
 
   private resolveCSSStyle(styles: IThemeDecorationRenderOptions): CSSStyleDeclaration {
+    const iconPath = styles.backgroundIcon?.startsWith('data:')
+      ? this.iconService.encodeBase64Path(decodeURIComponent(styles.backgroundIcon))
+      : styles.backgroundIcon;
     return {
       backgroundColor: this.themeService.getColorVar(styles.backgroundColor),
-      background: styles.backgroundIcon ? `url('${styles.backgroundIcon}') center center no-repeat` : undefined,
+      background: styles.backgroundIcon ? `url("${iconPath}") center center no-repeat` : undefined,
       backgroundSize: styles.backgroundIconSize ? `${styles.backgroundIconSize}` : undefined,
 
       outline: styles.outline,

--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -19,6 +19,7 @@ import {
   Disposable,
   CancellationToken,
   BinaryBuffer,
+  isString,
 } from '@opensumi/ide-core-browser';
 import {
   AbstractMenuService,
@@ -33,7 +34,7 @@ import { IMainLayoutService, ViewCollapseChangedEvent } from '@opensumi/ide-main
 import { IIconService, IconType, IThemeService } from '@opensumi/ide-theme';
 
 import { ExtensionHostType } from '../../../common';
-import { TreeViewItem, TreeViewBaseOptions, ITreeViewRevealOptions } from '../../../common/vscode';
+import { TreeViewItem, TreeViewBaseOptions, ITreeViewRevealOptions, IconUrl } from '../../../common/vscode';
 import { IMainThreadTreeView, IExtHostTreeView, ExtHostAPIIdentifier } from '../../../common/vscode';
 import { DataTransfer } from '../../../common/vscode/converter';
 import { createStringDataTransferItem, VSDataTransfer } from '../../../common/vscode/data-transfer';
@@ -426,9 +427,27 @@ export class TreeViewDataProvider extends Tree {
     return node;
   }
 
+  private isBase64Icon(iconPath?: IconUrl | string) {
+    const isBase64Regx = /^data:image\//;
+    if (iconPath) {
+      if (isString(iconPath)) {
+        return isBase64Regx.test(iconPath);
+      } else {
+        return isBase64Regx.test(iconPath.dark);
+      }
+    }
+    return false;
+  }
+
   async toIconClass(item: TreeViewItem): Promise<string | undefined> {
     if (item.iconUrl || item.icon) {
-      return this.iconService.fromIcon('', item.iconUrl || item.icon, IconType.Background, undefined, true);
+      return this.iconService.fromIcon(
+        '',
+        item.iconUrl || item.icon,
+        this.isBase64Icon(item.iconUrl || item.icon) ? IconType.Base64 : IconType.Background,
+        undefined,
+        true,
+      );
     } else if (item.themeIcon) {
       let themeIconClass = getExternalIcon(item.themeIcon.id);
       if (item.resourceUri) {

--- a/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
@@ -747,6 +747,8 @@ class ExtHostTreeView<T extends vscode.TreeItem> implements IDisposable {
     if (Uri.isUri(iconPath)) {
       if (/^http(s)?/.test(iconPath.scheme)) {
         return iconPath.toString();
+      } else if (/^image/.test(iconPath.path.toString())) {
+        return `data:${iconPath.fsPath.toString()}`;
       }
       return iconPath.with({ scheme: '' }).toString();
     }

--- a/packages/theme/src/browser/icon.service.ts
+++ b/packages/theme/src/browser/icon.service.ts
@@ -210,6 +210,12 @@ export class IconService extends WithEventBus implements IIconService {
     return className;
   }
 
+  encodeBase64Path(iconPath: string) {
+    // 由于进行 Background 样式拼接时采用的 `url("${iconPath}")` 结构
+    // 故这里需要对 iconPath 中的 `"` 及常见字符进行转义处理
+    return iconPath.replace(/"/g, '\\"').replace(/\?|#/g, (m) => encodeURIComponent(m));
+  }
+
   fromIcon(
     basePath = '',
     icon?: { [index in IconThemeType]: string } | string,
@@ -233,7 +239,7 @@ export class IconService extends WithEventBus implements IIconService {
        * 此时无需 static service
        */
       if (type === IconType.Base64) {
-        this.appendStyleSheet(this.getBackgroundStyleSheet(icon, randomClass), fromExtension);
+        this.appendStyleSheet(this.getBackgroundStyleSheet(this.encodeBase64Path(icon), randomClass), fromExtension);
       } else {
         const targetPath = this.getPath(basePath, icon);
         if (type === IconType.Mask) {
@@ -246,8 +252,19 @@ export class IconService extends WithEventBus implements IIconService {
       // eslint-disable-next-line guard-for-in
       for (const themeType in icon) {
         const themeSelector = getThemeTypeSelector(themeType as ThemeType);
-        const targetPath = this.getPath(basePath, icon[themeType]);
-        if (type === IconType.Mask) {
+        const iconPath = icon[themeType];
+        const targetPath = this.getPath(basePath, iconPath);
+        if (type === IconType.Base64) {
+          /**
+           * 处理 data:image 格式，/^data:image\//
+           * 如 data:image/svg+xml or data:image/gif;base64,
+           * 此时无需 static service
+           */
+          this.appendStyleSheet(
+            this.getBackgroundStyleSheet(this.encodeBase64Path(iconPath), randomClass, `.${themeSelector}`),
+            fromExtension,
+          );
+        } else if (type === IconType.Mask) {
           this.appendStyleSheet(
             this.getMaskStyleSheetWithStaticService(targetPath, randomClass, `.${themeSelector}`),
             fromExtension,

--- a/packages/theme/src/common/theme.service.ts
+++ b/packages/theme/src/common/theme.service.ts
@@ -44,6 +44,11 @@ export interface IIconService {
    * */
   applyTheme(themeId: string): Promise<void>;
   /**
+   * 将 Base64 路径进行转义，便于在 `background: url("${iconPath}")` 结构中使用
+   * @param iconPath Base64 路径
+   */
+  encodeBase64Path(iconPath: string): string;
+  /**
    * 将 codicon 的 id 转换为 codicon 的 class
    * @param str codicon id eg. $(add), $(add~sync)
    */


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

Bookmarks 插件在升级到 13.0+ 版本后，采用了 base64 图标，原有不支持导致新版本插件显示异常

支持前：

![image](https://user-images.githubusercontent.com/9823838/203690350-3ad2afa8-fd1f-4594-ad7f-02b503671e39.png)

支持后：

<img width="972" alt="image" src="https://user-images.githubusercontent.com/9823838/203690055-18a9ca48-6e9d-4e3a-a485-e77cef7fe7b3.png">

### Changelog

support base64 icon on editor glyphMargin and treeview
