### PR TITLE
fix(core-browser): accelerator string can only contain ASCII characters

### DIFF
--- a/packages/core-browser/__tests__/keyboard/keyboard-layout-service.test.ts
+++ b/packages/core-browser/__tests__/keyboard/keyboard-layout-service.test.ts
@@ -72,10 +72,10 @@ describe('KeyboardLayoutService should be work', () => {
       );
       const disposable = keyboardLayoutService.onKeyboardLayoutChanged(() => {
         const toggleComment = keyboardLayoutService.resolveKeyCode(KeyCode.createKeyCode('Slash+M1'));
-        expect(toggleComment.toString()).toBe(`${isOSX ? '⌘' : 'Ctrl'}+/`);
+        expect(toggleComment.toString()).toBe(`${isOSX ? 'Cmd' : 'Ctrl'}+/`);
         expect(keyboardLayoutService.getKeyboardCharacter(toggleComment.key!)).toBe('/');
         const indentLine = keyboardLayoutService.resolveKeyCode(KeyCode.createKeyCode('BracketRight+M1'));
-        expect(indentLine.toString()).toBe(`${isOSX ? '⌘' : 'Ctrl'}+]`);
+        expect(indentLine.toString()).toBe(`${isOSX ? 'Cmd' : 'Ctrl'}+]`);
         expect(keyboardLayoutService.getKeyboardCharacter(indentLine.key!)).toBe(']');
         disposable.dispose();
         done();

--- a/packages/core-browser/src/keyboard/keys.ts
+++ b/packages/core-browser/src/keyboard/keys.ts
@@ -160,7 +160,7 @@ export class KeyCode {
   public toString(): string {
     const result: string[] = [];
     if (this.meta) {
-      result.push(isOSX ? '⌘' : 'Win');
+      result.push(isOSX ? 'Cmd' : 'Win');
     }
     if (this.shift) {
       result.push(toNormalCase(Key.SHIFT_LEFT.easyString));


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

在注册 electron 快捷键时，使用了非 ASCII 字符，导致 electron 启动报错，如下：
```bash
[54244:1123/165632.053824:ERROR:accelerator_util.cc(24)] The accelerator string can only contain ASCII characters
[54244:1123/165632.053864:ERROR:accelerator_util.cc(24)] The accelerator string can only contain ASCII characters
[54244:1123/165632.053962:ERROR:accelerator_util.cc(24)] The accelerator string can only contain ASCII characters
[54244:1123/165632.053988:ERROR:accelerator_util.cc(24)] The accelerator string can only contain ASCII characters
[54244:1123/165632.054029:ERROR:accelerator_util.cc(24)] The accelerator string can only contain ASCII characters
[54244:1123/165632.054062:ERROR:accelerator_util.cc(24)] The accelerator string can only contain ASCII characters
``` 

对应的 electron 源码在: https://github.com/electron/electron/blob/32583ac756a8e201c3a4b0db86c0564e84f08b67/shell/browser/ui/accelerator_util.cc#L21-L26

其中 `base::IsStringASCII` 是 chromium 实现，见：https://source.chromium.org/chromium/chromium/src/+/main:base/strings/string_util_impl_helpers.h;drc=abe5c857a9dc6ed00c489725a4cb310ce37c188b;l=154

----

简要来说 [core-electron-main/src/bootstrap/services/menu/index.ts](https://github.com/opensumi/core/blob/1a8bb506c800d9e18c369c58c8737e881665109c/packages/core-electron-main/src/bootstrap/services/menu/index.ts) 在注册 `accelerator` 时，传入了 `⌘`。只需要让其转成: `Cmd` 即可

---

electron accelerator 文档见：https://www.electronjs.org/docs/latest/api/accelerator#available-modifiers


### Changelog

Fix accelerator string can only contain ASCII characters error