### PR TITLE
fix(monaco): unexpected keyboard event mapped to a chord

### DIFF
--- a/packages/monaco/src/browser/monaco.resolved-keybinding.ts
+++ b/packages/monaco/src/browser/monaco.resolved-keybinding.ts
@@ -67,7 +67,7 @@ export class MonacoResolvedKeybinding extends ResolvedKeybinding {
   }
 
   public isChord(): boolean {
-    return this.parts.length >= 1;
+    return this.parts.length > 1;
   }
 
   public getDispatchParts(): (string | null)[] {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fix #2018 

### Changelog
