### PR TITLE
fix: use bash resolve shellpath

### DIFF
--- a/packages/core-node/src/bootstrap/shell-path.ts
+++ b/packages/core-node/src/bootstrap/shell-path.ts
@@ -49,7 +49,7 @@ async function createUpdateShellPathPromise(): Promise<void> {
     shellPath = await new Promise((resolve, reject) => {
       const buf: Buffer[] = [];
       const proc = spawn(
-        process.env.SHELL || '/bin/bash',
+        '/bin/bash',
         ['-ilc', 'echo -n "_SHELL_ENV_DELIMITER_"; env; echo -n "_SHELL_ENV_DELIMITER_"; exit;'],
         {
           stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes

### Background or solution

### Changelog
-  use bash resolve shell path by default