### PR TITLE
chore: optimize default extension icon

### DIFF
--- a/packages/extension-manager/src/browser/const.ts
+++ b/packages/extension-manager/src/browser/const.ts
@@ -1,5 +1,3 @@
 import { EXTENSION_CONTAINER_ID } from '@opensumi/ide-core-browser/lib/common/container-id';
 export const OPEN_VSX_EXTENSION_MANAGER_CONTAINER_ID = EXTENSION_CONTAINER_ID;
 export const EXTENSION_SCHEME = 'extension';
-export const DEFAULT_EXTENSION_ICON_URL =
-  'https://marketplace.opentrscdn.com/static/A_TKtCQIToMwgAAAAAAAAAAABkARQnAQ.png';

--- a/packages/extension-manager/src/browser/extension-overview/index.tsx
+++ b/packages/extension-manager/src/browser/extension-overview/index.tsx
@@ -9,7 +9,6 @@ import { Markdown } from '@opensumi/ide-markdown';
 
 import { InstallState, IVSXExtensionService, VSXExtension, VSXExtensionServiceToken } from '../../common';
 import { VSXExtensionRaw } from '../../common/vsx-registry-types';
-import { DEFAULT_EXTENSION_ICON_URL } from '../const';
 
 import styles from './overview.module.less';
 
@@ -183,10 +182,16 @@ export const ExtensionOverview: ReactEditorComponent<
     <div className={styles.extension_overview_container}>
       <ProgressBar loading={loading} />
       <div className={styles.extension_overview_header}>
-        <img
-          src={resource.metadata?.iconUrl || DEFAULT_EXTENSION_ICON_URL}
-          alt={replaceLocalizePlaceholder(resource.metadata?.displayName, resource.metadata?.extensionId)}
-        />
+        {resource.metadata?.iconUrl ? (
+          <img
+            src={resource.metadata?.iconUrl}
+            alt={replaceLocalizePlaceholder(resource.metadata?.displayName, resource.metadata?.extensionId)}
+          />
+        ) : (
+          <div className={styles.default_icon}>
+            <Icon iconClass={getIcon('extension')} />
+          </div>
+        )}
         <div className={styles.extension_detail}>
           <div className={styles.extension_name}>
             <h1>

--- a/packages/extension-manager/src/browser/extension-overview/overview.module.less
+++ b/packages/extension-manager/src/browser/extension-overview/overview.module.less
@@ -11,6 +11,29 @@
   font-size: 14px;
   align-items: center;
   justify-content: center;
+
+  .default_icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 128px;
+    width: 128px;
+    flex-shrink: 0;
+    object-fit: contain;
+    background-color: #f1f2f2;
+    border-radius: 50%;
+
+    :global {
+      .kaitian-icon {
+        font-size: 80px;
+      }
+
+      .kt-icon {
+        color: #d8d9d9;
+      }
+    }
+  }
+
   img {
     height: 128px;
     width: 128px;

--- a/packages/extension-manager/src/browser/extension/extension.module.less
+++ b/packages/extension-manager/src/browser/extension/extension.module.less
@@ -24,6 +24,30 @@
     padding-right: 14px;
   }
 
+  .default_icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    height: 26px;
+    width: 26px;
+    flex-shrink: 0;
+    object-fit: contain;
+    margin-right: 14px;
+    background-color: #f1f2f2;
+    border-radius: 50%;
+
+    :global {
+      .kaitian-icon {
+        font-size: 14px;
+      }
+
+      .kt-icon {
+        color: #d8d9d9;
+      }
+    }
+  }
+
   .extension_detail {
     flex: 1;
     padding: 4px 0;

--- a/packages/extension-manager/src/browser/extension/index.tsx
+++ b/packages/extension-manager/src/browser/extension/index.tsx
@@ -4,7 +4,6 @@ import { Button, Icon, getIcon } from '@opensumi/ide-components';
 import { localize, replaceLocalizePlaceholder } from '@opensumi/ide-core-common';
 
 import { InstallState, VSXExtension } from '../../common';
-import { DEFAULT_EXTENSION_ICON_URL } from '../const';
 
 import styles from './extension.module.less';
 
@@ -58,11 +57,17 @@ export const Extension = React.memo(
 
     return (
       <div className={styles.extension_item} onClick={onClickCallback}>
-        <img
-          className={styles.icon}
-          src={extension.iconUrl || DEFAULT_EXTENSION_ICON_URL}
-          alt={replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`)}
-        />
+        {extension.iconUrl ? (
+          <img
+            className={styles.icon}
+            src={extension.iconUrl}
+            alt={replaceLocalizePlaceholder(extension.displayName, `${extension.publisher}.${extension.name}`)}
+          />
+        ) : (
+          <div className={styles.default_icon}>
+            <Icon iconClass={getIcon('extension')} />
+          </div>
+        )}
         <div className={styles.extension_detail}>
           <div className={styles.base_info}>
             <span className={styles.display_name}>


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution
插件默认 logo 为一张图片，改为由内置的 iconfont 实现

### Changelog
Before:
![image](https://user-images.githubusercontent.com/12130901/204740822-98b40625-7ece-441d-ba7d-8d9a82e9bc94.png)


After:
![image](https://user-images.githubusercontent.com/12130901/204740359-9bba7d0b-ed2a-4f74-9f4c-e3735a1b2a5a.png)

