### PR TITLE
feat: implement editing result view code update range mapping

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -3,8 +3,8 @@ import { Disposable, MonacoService } from '@opensumi/ide-core-browser';
 
 import { ICodeEditor } from '../../monaco-api/editor';
 
+import { MappingManagerService } from './mapping-manager.service';
 import { ComputerDiffModel } from './model/computer-diff';
-import { MappingManagerService } from './service/mapping-manager.service';
 import { ActionsManager } from './view/actions-manager';
 import { CurrentCodeEditor } from './view/editors/currentCodeEditor';
 import { IncomingCodeEditor } from './view/editors/incomingCodeEditor';
@@ -41,6 +41,15 @@ export class MergeEditorService extends Disposable {
     this.actionsManager = this.injector.get(ActionsManager, [this.mappingManagerService]);
   }
 
+  private initListenEvent(): void {
+    this.addDispose(
+      this.resultView.onDidChangeContent(() => {
+        this.currentView.launchChange();
+        this.incomingView.launchChange();
+      }),
+    );
+  }
+
   public instantiationCodeEditor(current: HTMLDivElement, result: HTMLDivElement, incoming: HTMLDivElement): void {
     if (this.currentView && this.resultView && this.incomingView) {
       return;
@@ -53,6 +62,8 @@ export class MergeEditorService extends Disposable {
     this.scrollSynchronizer.mount(this.currentView, this.resultView, this.incomingView);
     this.stickinessConnectManager.mount(this.currentView, this.resultView, this.incomingView);
     this.actionsManager.mount(this.currentView, this.resultView, this.incomingView);
+
+    this.initListenEvent();
   }
 
   public override dispose(): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -44,6 +44,7 @@ export class MergeEditorService extends Disposable {
   private initListenEvent(): void {
     this.addDispose(
       this.resultView.onDidChangeContent(() => {
+        this.resultView.updateDecorations();
         this.currentView.launchChange();
         this.incomingView.launchChange();
       }),

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -85,19 +85,19 @@ export class DocumentMapping extends Disposable {
     for (const [key, pick] of this.adjacentComputeRangeMap.entries()) {
       if (pick.isAfter(sameRange)) {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
-      }
-
-      if (isContainSelf && pick.id === sameRange.id) {
+      } else if (isContainSelf && pick.id === sameRange.id) {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
       }
     }
   }
 
-  public deltaEndAdjacent(sameRange: LineRange, offset: number): void {
+  public deltaEndAdjacentQueue(sameRange: LineRange, offset: number): void {
     for (const [key, pick] of this.adjacentComputeRangeMap.entries()) {
       if (pick.id === sameRange.id) {
         this.adjacentComputeRangeMap.set(key, sameRange.deltaEnd(offset));
-        return;
+        // 将在 sameRange 之后的 range offset 都增加
+      } else if (pick.isAfter(sameRange)) {
+        this.adjacentComputeRangeMap.set(key, pick.delta(offset));
       }
     }
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -70,8 +70,9 @@ export class DocumentMapping extends Disposable {
   }
 
   /**
-   * @param range
-   * @param offset
+   * 将 range 之后的所有 range 都增量 offset
+   * @param range 目标 range
+   * @param offset 有增有减
    * @param isContainSelf 是否包含自己，也增量 offset
    * @returns
    */
@@ -106,11 +107,41 @@ export class DocumentMapping extends Disposable {
    * @param sameRange 对位 lineRange，不一定存在于 map 中
    * @returns 下一个最近的 lineRange
    */
-  public huntForNextSameRange(sameRange: LineRange): LineRange | undefined {
+  public findNextSameRange(sameRange: LineRange): LineRange | undefined {
     const values = this.adjacentComputeRangeMap.values();
 
     for (const range of values) {
       if (range.id !== sameRange.id && range.isAfter(sameRange)) {
+        return range;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * 找出 sameRange 是否被包裹在哪一个 lineRange 里，如果有并返回该 lineRange
+   */
+  public findIncludeRange(sameRange: LineRange): LineRange | undefined {
+    const values = this.adjacentComputeRangeMap.values();
+
+    for (const range of values) {
+      if (range.isInclude(sameRange)) {
+        return range;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * 找出 sameRange 是否与哪一个 lineRange 接触
+   */
+  public findTouchesRange(sameRange: LineRange): LineRange | undefined {
+    const values = this.adjacentComputeRangeMap.values();
+
+    for (const range of values) {
+      if (range.isTouches(sameRange)) {
         return range;
       }
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -6,6 +6,10 @@ import { EditorViewType, IRangeContrast, LineRangeType } from '../types';
 import { InnerRange } from './inner-range';
 
 export class LineRange extends MonacoLineRange implements IRangeContrast {
+  static fromPositions(startLineNumber: number, endLineNumber: number = startLineNumber): LineRange {
+    return new LineRange(startLineNumber, endLineNumber);
+  }
+
   private _id: string;
   public get id(): string {
     return this._id;

--- a/packages/monaco/src/browser/contrib/merge-editor/service/mapping-manager.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/service/mapping-manager.service.ts
@@ -44,13 +44,14 @@ export class MappingManagerService extends Disposable {
       } else {
         const marginLength = range.calcMargin(sameRange);
 
-        mapping.deltaAdjacentQueue(range, marginLength);
+        mapping.deltaAdjacentQueueAfter(range, marginLength);
         doMark();
+        mapping.deltaEndAdjacent(sameRange, marginLength);
 
         const findNextRange = sameMapping.huntForNextSameRange(sameRange);
         const reverseRange = findNextRange && sameMapping.reverse(findNextRange);
         if (reverseRange) {
-          sameMapping.deltaAdjacentQueue(reverseRange, marginLength);
+          sameMapping.deltaAdjacentQueueAfter(reverseRange, marginLength, true);
         }
       }
     };

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -2,8 +2,8 @@ import { Disposable, Event } from '@opensumi/ide-core-common';
 import { IEditorMouseEvent, MouseTargetType } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
 import { IRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 
+import { MappingManagerService } from '../mapping-manager.service';
 import { LineRange } from '../model/line-range';
-import { MappingManagerService } from '../service/mapping-manager.service';
 import { EditorViewType, IActionsDescription, IConflictActionsEvent, ACCEPT_CURRENT, IGNORE } from '../types';
 
 import { BaseCodeEditor } from './editors/baseCodeEditor';

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -56,11 +56,11 @@ export class ActionsManager extends Disposable {
         this.resultView.onDidConflictActions,
         this.incomingView.onDidConflictActions,
       )(({ range, withViewType, action }) => {
-        const markComplete = (range: LineRange, isIgnore: boolean) => {
+        const markComplete = (range: LineRange) => {
           if (withViewType === EditorViewType.CURRENT) {
-            this.mappingManagerService.markCompleteTurnLeft(range, isIgnore);
+            this.mappingManagerService.markCompleteTurnLeft(range);
           } else if (withViewType === EditorViewType.INCOMING) {
-            this.mappingManagerService.markCompleteTurnRight(range, isIgnore);
+            this.mappingManagerService.markCompleteTurnRight(range);
           }
         };
 
@@ -87,7 +87,7 @@ export class ActionsManager extends Disposable {
             ]);
           }
 
-          markComplete(range, action === IGNORE);
+          markComplete(range);
 
           viewEditor!.updateDecorations();
           viewEditor!.clearActions(range);

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -160,7 +160,8 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
     this.decorations
       .setRetainDecoration(this.getRetainDecoration())
       .setRetainLineWidget(this.getRetainLineWidget())
-      .updateDecorations(r, i);
+      .clearDecorations()
+      .render(r, i);
   }
 
   protected registerActionsProvider(provider: IActionsProvider): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -6,13 +6,13 @@ import { EditorLayoutInfo, EditorOption } from '@opensumi/monaco-editor-core/esm
 import { IModelDecorationOptions, ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
+import { MappingManagerService } from '../../mapping-manager.service';
 import { ConflictActions } from '../../model/conflict-actions';
 import { IDiffDecoration, MergeEditorDecorations } from '../../model/decorations';
 import { DocumentMapping } from '../../model/document-mapping';
 import { InnerRange } from '../../model/inner-range';
 import { LineRange } from '../../model/line-range';
 import { LineRangeMapping } from '../../model/line-range-mapping';
-import { MappingManagerService } from '../../service/mapping-manager.service';
 import { EditorViewType, IActionsProvider, IBaseCodeEditor, IConflictActionsEvent, LineRangeType } from '../../types';
 import { GuidelineWidget } from '../guideline-widget';
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -87,17 +87,8 @@ export class ResultCodeEditor extends BaseCodeEditor {
             const toLineRange = LineRange.fromPositions(startLineNumber, endLineNumber);
             const { [EditorViewType.CURRENT]: includeLeftRange, [EditorViewType.INCOMING]: includeRightRange } =
               this.mappingManagerService.findIncludeRanges(toLineRange);
-
-            if (includeLeftRange) {
-              this.documentMappingTurnLeft.deltaEndAdjacent(includeLeftRange, offset);
-            }
-
-            if (includeRightRange) {
-              this.documentMappingTurnRight.deltaEndAdjacent(includeRightRange, offset);
-            }
-
             /**
-             * 这里需要处理 touch 的情况（也就是 toLineRange 与 documentMapping 里的某一个 lineRange 有重叠的部分，表明当前编辑的 edits changes 是在这个 lineRange 范围内）
+             * 这里需要处理 touch 的情况（也就是 toLineRange 与 documentMapping 里的某一个 lineRange 有重叠的部分）
              * 那么就要以当前 touch range 的结果作为要 delta 的起点
              */
             const { [EditorViewType.CURRENT]: touchLeftRanges, [EditorViewType.INCOMING]: touchRightRanges } =
@@ -108,18 +99,21 @@ export class ResultCodeEditor extends BaseCodeEditor {
             const leftRange = touchLeftRanges || nextLeftRanges;
             const rightRange = touchRightRanges || nextRightRanges;
 
-            if (leftRange) {
+            if (includeLeftRange) {
+              this.documentMappingTurnLeft.deltaEndAdjacentQueue(includeLeftRange, offset);
+            } else if (leftRange) {
               const reverse = this.documentMappingTurnLeft.reverse(leftRange);
               if (reverse) {
-                // 如果 includeLeftRange 存在则表示不需要计算自己的增量 offset
-                this.documentMappingTurnLeft.deltaAdjacentQueueAfter(reverse, offset, !includeLeftRange);
+                this.documentMappingTurnLeft.deltaAdjacentQueueAfter(reverse, offset, true);
               }
             }
 
-            if (rightRange) {
+            if (includeRightRange) {
+              this.documentMappingTurnRight.deltaEndAdjacentQueue(includeRightRange, offset);
+            } else if (rightRange) {
               const reverse = this.documentMappingTurnRight.reverse(rightRange);
               if (reverse) {
-                this.documentMappingTurnRight.deltaAdjacentQueueAfter(reverse, offset, !includeRightRange);
+                this.documentMappingTurnRight.deltaAdjacentQueueAfter(reverse, offset, true);
               }
             }
           });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
@@ -19,6 +19,8 @@ export class GuidelineWidget extends ZoneWidget {
       showFrame: false,
       arrowColor: undefined,
       frameColor: undefined,
+      // 这里有个小坑，如果不开启这个配置，那么在调用 show 函数的时候会自动对焦并滚动到对应 range，导致在编辑 result 视图中代码时光标总是滚动在最后一个 widget 上
+      keepEditorSelection: true,
     });
   }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { useInjectable } from '@opensumi/ide-core-browser';
 import { Disposable, Emitter, Event } from '@opensumi/ide-core-common';
@@ -8,7 +8,7 @@ import { ICodeEditor } from '../../../monaco-api/types';
 import { MergeEditorService } from '../merge-editor.service';
 import { LineRange } from '../model/line-range';
 import { StickyPieceModel } from '../model/sticky-piece';
-import { EditorViewType, LineRangeType } from '../types';
+import { EditorViewType } from '../types';
 
 import { BaseCodeEditor } from './editors/baseCodeEditor';
 
@@ -117,21 +117,13 @@ export class StickinessConnectManager extends Disposable {
         rightBottom: (sameModify.endLineNumberExclusive - minTop) * lineHeight,
       };
 
-      let rangeType: LineRangeType = 'modify';
-
-      if (range.isTendencyLeft(sameModify)) {
-        rangeType = withBase === 0 ? 'insert' : 'remove';
-      } else if (range.isTendencyRight(sameModify)) {
-        rangeType = withBase === 0 ? 'remove' : 'insert';
-      }
-
       result.push(
         new StickyPieceModel(
           width,
           height,
           path,
           position,
-          rangeType,
+          range.type,
           withBase === 0 ? range.isComplete : sameModify.isComplete,
         ),
       );


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

在每次新增行或删减行时，重新计算 3 个视图中 document mapping 的对应关系，使其 diff 区域能对应上

https://user-images.githubusercontent.com/20262815/205592595-619da17b-c5f5-463e-b4ec-d630fbdd6183.mp4

### Changelog
支持在编辑 result 视图中的代码时动态更新 diff 区域范围