### PR TITLE
fix(extension): windows get globalStorageUri error

### DIFF
--- a/packages/extension-storage/src/browser/storage.ts
+++ b/packages/extension-storage/src/browser/storage.ts
@@ -98,7 +98,7 @@ export class ExtensionStorageServer implements IExtensionStorageServer {
     return {
       logUri: logUri.codeUri || undefined,
       storageUri: storageUri?.codeUri,
-      globalStorageUri: Uri.parse(this.globalDataPath),
+      globalStorageUri: Uri.file(this.globalDataPath),
     };
   }
 


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

Windows 上调用 ExtensionContext.globalStoragePath 的地址有误：
![CleanShot 2022-12-07 at 18 23 18@2x](https://user-images.githubusercontent.com/13938334/206154195-72307437-e0e6-49d7-ab18-688b15d22406.png)


原理可见：

<img width="710" alt="CleanShot 2022-12-07 at 18 22 27@2x" src="https://user-images.githubusercontent.com/13938334/206153428-eaddd340-8266-4584-8bb5-6c6c71581ca1.png">

又是一例 Uri.parse 和 Uri.file 的混用错误，会导致插件获取的 globalStoragePath 错误。


### Changelog

Fix invoke `ExtensionContext.globalStoragePath` error in Windows
