### PR TITLE
fix: support cancel refresh when edit file

### DIFF
--- a/packages/components/src/recycle-tree/tree/Tree.ts
+++ b/packages/components/src/recycle-tree/tree/Tree.ts
@@ -7,16 +7,11 @@ import { TreeNode, CompositeTreeNode } from './TreeNode';
 export abstract class Tree implements ITree {
   protected _root: CompositeTreeNode | undefined;
   protected readonly onChangedEmitter = new Emitter<void>();
-  protected readonly onNodeRefreshedEmitter = new Emitter<void>();
   protected readonly toDispose = new DisposableCollection();
 
   protected nodes: {
     [id: string]: TreeNode | undefined;
   } = {};
-
-  get onNodeRefreshed() {
-    return this.onNodeRefreshedEmitter.event;
-  }
 
   dispose(): void {
     this.toDispose.dispose();

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -603,6 +603,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       TreeNode.setGlobalTreeState(this.path, {
         isExpanding: false,
       });
+      TreeNode.setTreeNode(this.id, this.path, this);
     }
   }
 
@@ -1049,6 +1050,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       this.shrinkBranch(this, quiet);
     }
     this.isExpanded = false;
+    TreeNode.setTreeNode(this.id, this.path, this);
     this._watcher.notifyDidChangeExpansionState(this, false);
   }
 

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -115,6 +115,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
   private readonly onWorkspaceChangeEmitter = new Emitter<Directory>();
   private readonly onTreeIndentChangeEmitter = new Emitter<ITreeIndent>();
   private readonly onFilterModeChangeEmitter = new Emitter<boolean>();
+  private readonly onNodeRefreshedEmitter = new Emitter<void>();
 
   // 筛选模式开关
   private _filterMode = false;
@@ -123,6 +124,10 @@ export class FileTreeService extends Tree implements IFileTreeService {
   private _refreshable = true;
 
   private refreshCancelToken: CancellationTokenSource;
+
+  get onNodeRefreshed() {
+    return this.onNodeRefreshedEmitter.event;
+  }
 
   get refreshable() {
     return this._refreshable;

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1453,16 +1453,6 @@ export class FileTreeModelService {
       promptHandle.onDestroy(handleDestroy);
       promptHandle.onCancel(handleCancel);
     }
-
-    // 如果上一次文件树刷新操作刚好在插件输入框时执行
-    // 会让重命名/新建输入框销毁
-    this.disposableCollection.push(
-      Event.once(this.fileTreeService.onNodeRefreshed)(() => {
-        if (promptHandle && !promptHandle.destroyed) {
-          promptHandle.destroy();
-        }
-      }),
-    );
   };
 
   private async getPromptTarget(uri: URI, isCreatingFile?: boolean) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

进一步降低文件树刷新导致的用户输入框被阻断的问题

### Changelog

support cancel refresh when edit file