### PR TITLE
feat: implement contiguous region merge range

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -102,7 +102,7 @@ export class MergeEditorService extends Disposable {
     );
     const { changes: changes2 } = result2;
 
-    this.resultView.inputDiffComputingResult(changes2, EDiffRangeTurn.ORIGIN);
     this.incomingView.inputDiffComputingResult(changes2);
+    this.resultView.inputDiffComputingResult(changes2, EDiffRangeTurn.ORIGIN);
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -104,5 +104,8 @@ export class MergeEditorService extends Disposable {
 
     this.incomingView.inputDiffComputingResult(changes2);
     this.resultView.inputDiffComputingResult(changes2, EDiffRangeTurn.ORIGIN);
+
+    this.currentView.updateDecorations();
+    this.incomingView.updateDecorations();
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/decorations.ts
@@ -23,10 +23,7 @@ export interface IDiffDecoration {
 @Injectable({ multiple: false })
 export class MergeEditorDecorations extends Disposable {
   private deltaDecoration: IDiffDecoration[] = [];
-  private retainDecoration: IDiffDecoration[] = [];
-
   private lineWidgetSet: Set<GuidelineWidget> = new Set();
-  private retainLineWidgetSet: Set<GuidelineWidget> = new Set();
 
   private readonly _onDidChangeLineWidget = new Emitter<void>();
   private readonly onDidChangeLineWidget: Event<void> = this._onDidChangeLineWidget.event;
@@ -141,11 +138,7 @@ export class MergeEditorDecorations extends Disposable {
 
   private setDecorations(ranges: LineRange[], innerChanges: InnerRange[][]): void {
     this.editor.changeDecorations((accessor: IModelDecorationsChangeAccessor) => {
-      const newDecorations: IDiffDecoration[] = this.retainDecoration;
-      this.retainLineWidgetSet.forEach((widget) => {
-        widget.showByLine(widget.getRecordLine());
-        this.lineWidgetSet.add(widget);
-      });
+      const newDecorations: IDiffDecoration[] = [];
 
       for (const range of ranges) {
         if (range.isEmpty) {
@@ -206,20 +199,6 @@ export class MergeEditorDecorations extends Disposable {
     return Array.from(this.lineWidgetSet.keys());
   }
 
-  public setRetainDecoration(retain: IDiffDecoration[] = []): this {
-    this.retainDecoration = retain;
-    return this;
-  }
-
-  public setRetainLineWidget(retain: GuidelineWidget[] = []): this {
-    this.cleanUpLineWidget(this.retainLineWidgetSet);
-
-    retain.forEach((r) => {
-      this.retainLineWidgetSet.add(r);
-    });
-    return this;
-  }
-
   public render(ranges: LineRange[], innerChanges: InnerRange[][]): void {
     this.setDecorations(ranges, innerChanges);
   }
@@ -228,6 +207,5 @@ export class MergeEditorDecorations extends Disposable {
     super.dispose();
 
     this.lineWidgetSet.forEach((w) => w.dispose());
-    this.retainLineWidgetSet.forEach((w) => w.dispose());
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -43,6 +43,9 @@ export class DocumentMapping extends Disposable {
     );
   }
 
+  /**
+   * 取对位的 range
+   */
   public reverse(range: LineRange): LineRange | undefined {
     const entries = this.adjacentComputeRangeMap.entries();
     for (const pack of entries) {
@@ -58,13 +61,11 @@ export class DocumentMapping extends Disposable {
 
     if (this.diffRangeTurn === EDiffRangeTurn.MODIFIED) {
       modifiedRange.forEach((range, idx) => {
-        this.computeRangeMap.set(range.id, range);
-        this.adjacentComputeRangeMap.set(range.id, originalRange[idx]);
+        this.addRange(range, originalRange[idx]);
       });
     } else if (this.diffRangeTurn === EDiffRangeTurn.ORIGIN) {
       originalRange.forEach((range, idx) => {
-        this.computeRangeMap.set(range.id, range);
-        this.adjacentComputeRangeMap.set(range.id, modifiedRange[idx]);
+        this.addRange(range, modifiedRange[idx]);
       });
     }
   }
@@ -100,6 +101,16 @@ export class DocumentMapping extends Disposable {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
       }
     }
+  }
+
+  public deleteRange(range: LineRange): void {
+    this.computeRangeMap.delete(range.id);
+    this.adjacentComputeRangeMap.delete(range.id);
+  }
+
+  public addRange(newRange: LineRange, adjacentRange: LineRange): void {
+    this.computeRangeMap.set(newRange.id, newRange);
+    this.adjacentComputeRangeMap.set(newRange.id, adjacentRange);
   }
 
   /**

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -108,6 +108,13 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     );
   }
 
+  // 生一个除 id 以外，state 状态都相同的 lineRange
+  public born(): LineRange {
+    const child = LineRange.fromPositions(this.startLineNumber, this.endLineNumberExclusive);
+    const preId = child.id;
+    return this.retainState(child).setId(preId);
+  }
+
   public toRange(startColumn = 0, endColumn: number = Number.MAX_SAFE_INTEGER): IRange {
     if (this.isEmpty) {
       return InnerRange.fromPositions({ lineNumber: this.startLineNumber, column: startColumn }).setType(this._type);

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -99,6 +99,15 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this.startLineNumber === range.startLineNumber && this.length === range.length;
   }
 
+  public merge(other: LineRange): LineRange {
+    return this.retainState(
+      new LineRange(
+        Math.min(this.startLineNumber, other.startLineNumber),
+        Math.max(this.endLineNumberExclusive, other.endLineNumberExclusive),
+      ),
+    );
+  }
+
   public toRange(startColumn = 0, endColumn: number = Number.MAX_SAFE_INTEGER): IRange {
     if (this.isEmpty) {
       return InnerRange.fromPositions({ lineNumber: this.startLineNumber, column: startColumn }).setType(this._type);

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -2,7 +2,6 @@ import { Injectable } from '@opensumi/di';
 import { IModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IStandaloneEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 
-import { IDiffDecoration } from '../../model/decorations';
 import { DocumentMapping } from '../../model/document-mapping';
 import { LineRange } from '../../model/line-range';
 import { LineRangeMapping } from '../../model/line-range-mapping';
@@ -16,8 +15,6 @@ import {
   TActionsType,
   IActionsDescription,
 } from '../../types';
-import { flatInnerModified, flatModified } from '../../utils';
-import { GuidelineWidget } from '../guideline-widget';
 
 import { BaseCodeEditor } from './baseCodeEditor';
 
@@ -29,14 +26,6 @@ export class IncomingCodeEditor extends BaseCodeEditor {
 
   protected getMonacoEditorOptions(): IStandaloneEditorConstructionOptions {
     return { readOnly: true, lineDecorationsWidth: 42 };
-  }
-
-  protected getRetainDecoration(): IDiffDecoration[] {
-    return [];
-  }
-
-  protected getRetainLineWidget(): GuidelineWidget[] {
-    return [];
   }
 
   private provideActionsItems(): IActionsDescription[] {
@@ -76,22 +65,14 @@ export class IncomingCodeEditor extends BaseCodeEditor {
     return EditorViewType.INCOMING;
   }
 
-  public updateDecorations(): void {
-    const [range] = [this.documentMapping.getModifiedRange()];
-    this.decorations
-      .setRetainDecoration(this.getRetainDecoration())
-      .setRetainLineWidget(this.getRetainLineWidget())
-      .updateDecorations(range, []);
-
+  public override updateDecorations(): void {
+    super.updateDecorations();
     this.conflictActions.updateActions(this.provideActionsItems());
   }
 
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {
     this.mappingManagerService.inputComputeResultRangeMappingTurnRight(changes);
-
-    const [ranges, innerRanges] = [flatModified(changes), flatInnerModified(changes)];
-    this.renderDecorations(ranges, innerRanges);
-
+    this.updateDecorations();
     this.registerActionsProvider({
       provideActionsItems: this.provideActionsItems,
       onActionsClick: (range: LineRange, actionType: TActionsType) => {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

- [x] 重构 diff range 区域的 decoration 渲染逻辑，改为统一从 document mapping 这个唯一数据源来获取位置数据并渲染
- [x] 对于彼此相连的区域（也就是同一代码块左右两边都有 diff）做一个合并，后续实现 accpet_combination 需要依赖于此

before:

![image](https://user-images.githubusercontent.com/20262815/206621134-ccd5c5e6-c6dc-4dfe-9b41-93bff7b5d05c.png)

after:
![image](https://user-images.githubusercontent.com/20262815/206621273-ed12685b-3b38-4490-a8bd-2c89a69cfd5c.png)


### Changelog
实现彼此相连的 diff range 区域合并成一个
