### PR TITLE
feat: implement accept combination conflict actions

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/model/inner-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/inner-range.ts
@@ -1,7 +1,7 @@
 import { Range as MonacoRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 
 import { IPosition } from '../../../monaco-api/types';
-import { EditorViewType, IRangeContrast, LineRangeType } from '../types';
+import { ETurnDirection, IRangeContrast, LineRangeType } from '../types';
 
 export class InnerRange extends MonacoRange implements IRangeContrast {
   private _isComplete: boolean;
@@ -9,8 +9,8 @@ export class InnerRange extends MonacoRange implements IRangeContrast {
     return this._isComplete;
   }
 
-  private _turnDirection: EditorViewType.CURRENT | EditorViewType.INCOMING;
-  public get turnDirection(): EditorViewType.CURRENT | EditorViewType.INCOMING {
+  private _turnDirection: ETurnDirection;
+  public get turnDirection(): ETurnDirection {
     return this._turnDirection;
   }
 
@@ -18,7 +18,7 @@ export class InnerRange extends MonacoRange implements IRangeContrast {
     return new InnerRange(start.lineNumber, start.column, end.lineNumber, end.column);
   }
 
-  public setTurnDirection(t: EditorViewType.CURRENT | EditorViewType.INCOMING) {
+  public setTurnDirection(t: ETurnDirection) {
     this._turnDirection = t;
     return this;
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -72,6 +72,10 @@ export class MergeStateModel {
   public has(metaRange: LineRange): boolean {
     return this.metaRanges.some((m) => m.id === metaRange.id);
   }
+
+  public getMetaRanges(): LineRange[] {
+    return this.metaRanges;
+  }
 }
 
 export class LineRange extends MonacoLineRange implements IRangeContrast {
@@ -189,14 +193,26 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this.startLineNumber === range.startLineNumber && this.length === range.length;
   }
 
+  public get metaMergeRanges(): LineRange[] {
+    return this.mergeStateModel.getMetaRanges();
+  }
+
+  public recordMergeRange(range: LineRange): this {
+    this.mergeStateModel.add(range);
+    return this;
+  }
+
   /**
    * 与 other range 合并成一个 range
+   * @param isKeep: 是否记录被合并的 range
    */
-  public merge(other: LineRange): LineRange {
-    if (!this.mergeStateModel.has(this)) {
-      this.mergeStateModel.add(this);
+  public merge(other: LineRange, isKeep = true): LineRange {
+    if (isKeep) {
+      if (!this.mergeStateModel.has(this)) {
+        this.recordMergeRange(this);
+      }
+      this.recordMergeRange(other);
     }
-    this.mergeStateModel.add(other);
 
     return this.retainState(
       new LineRange(

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -1,9 +1,78 @@
+import { uuid } from '@opensumi/ide-core-common';
 import { IRange } from '@opensumi/monaco-editor-core';
 import { LineRange as MonacoLineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 
-import { EditorViewType, IRangeContrast, LineRangeType } from '../types';
+import { ETurnDirection, IRangeContrast, LineRangeType } from '../types';
 
 import { InnerRange } from './inner-range';
+
+/**
+ * 如果 lineRange 是通过 merge 合并生成的
+ * 则跟 merge 相关的数据状态都在该 model 来处理
+ */
+export class MergeStateModel {
+  /**
+   * 存储合并前的所有 lineRange 元数据
+   */
+  private metaRanges: LineRange[] = [];
+
+  public get isMerge(): boolean {
+    return this.metaRanges.length > 0;
+  }
+
+  /**
+   * 只有当 metaRanges 里的 range 彼此都只是表面接触时才允许 combination 操作
+   * (能被 accept combination 意味着这块 diff 区域，左右两边的代码合并后不会出现被覆盖的情况)
+   * 例如
+   *    左边               中间               右边
+   *    ```               ```               ```
+   * 1. const a = 1       const a = 2       const a = 1
+   * 2. const b = 1       const b = 1       const b = 2
+   * 3. const c = 1       const c = 2       const c = 1
+   *    ```               ```               ```
+   *
+   * 其中第一行中间与两边都有 diff，但不管是接受左边的还是右边的，最终对结果的影响不变（接受左右两边都一样）
+   * 如果这三行都是这样的情况，则被允许 combination
+   */
+  public get isAllowCombination(): boolean {
+    const length = this.metaRanges.length;
+    if (length <= 1) {
+      return false;
+    }
+
+    let slow = 0;
+    for (let fast = 0; fast < length; fast++) {
+      const slowRange = this.metaRanges[slow];
+      const fastRange = this.metaRanges[fast];
+
+      if (slowRange.id === fastRange.id) {
+        continue;
+      }
+
+      if (!fastRange.isContact(slowRange)) {
+        return false;
+      }
+
+      slow += 1;
+    }
+
+    return true;
+  }
+
+  public add(range: LineRange): this {
+    this.metaRanges.push(range);
+    return this;
+  }
+
+  public reset(): this {
+    this.metaRanges = [];
+    return this;
+  }
+
+  public has(metaRange: LineRange): boolean {
+    return this.metaRanges.some((m) => m.id === metaRange.id);
+  }
+}
 
 export class LineRange extends MonacoLineRange implements IRangeContrast {
   static fromPositions(startLineNumber: number, endLineNumber: number = startLineNumber): LineRange {
@@ -25,16 +94,27 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this._isComplete;
   }
 
-  private _turnDirection: EditorViewType.CURRENT | EditorViewType.INCOMING;
-  public get turnDirection(): EditorViewType.CURRENT | EditorViewType.INCOMING {
+  private _turnDirection: ETurnDirection;
+  public get turnDirection(): ETurnDirection {
     return this._turnDirection;
   }
+
+  public get isMerge(): boolean {
+    return this.mergeStateModel.isMerge;
+  }
+
+  public get isAllowCombination(): boolean {
+    return this.mergeStateModel.isAllowCombination;
+  }
+
+  private mergeStateModel: MergeStateModel;
 
   constructor(startLineNumber: number, endLineNumberExclusive: number) {
     super(startLineNumber, endLineNumberExclusive);
     this._type = 'insert';
     this._isComplete = false;
-    this._id = `${this.startLineNumber}_${this.endLineNumberExclusive}_${this.length}`;
+    this._id = uuid(6);
+    this.mergeStateModel = new MergeStateModel();
   }
 
   private setId(id: string): this {
@@ -42,7 +122,7 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this;
   }
 
-  public setTurnDirection(t: EditorViewType.CURRENT | EditorViewType.INCOMING) {
+  public setTurnDirection(t: ETurnDirection) {
     this._turnDirection = t;
     return this;
   }
@@ -52,13 +132,14 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this;
   }
 
-  public setType(v: LineRangeType): this {
-    this._type = v;
+  private setMergeStateModel(state: MergeStateModel): this {
+    this.mergeStateModel = state;
     return this;
   }
 
-  public calcMargin(range: LineRange): number {
-    return this.length - range.length;
+  public setType(v: LineRangeType): this {
+    this._type = v;
+    return this;
   }
 
   public isTendencyRight(refer: LineRange): boolean {
@@ -81,6 +162,15 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this.endLineNumberExclusive >= range.startLineNumber && range.endLineNumberExclusive >= this.startLineNumber;
   }
 
+  /**
+   * 是否仅仅只是表面接触
+   */
+  public isContact(range: LineRange): boolean {
+    return (
+      this.startLineNumber === range.endLineNumberExclusive || this.endLineNumberExclusive === range.startLineNumber
+    );
+  }
+
   public isInclude(range: LineRange | InnerRange): boolean {
     if (range instanceof LineRange) {
       return (
@@ -99,13 +189,21 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this.startLineNumber === range.startLineNumber && this.length === range.length;
   }
 
+  /**
+   * 与 other range 合并成一个 range
+   */
   public merge(other: LineRange): LineRange {
+    if (!this.mergeStateModel.has(this)) {
+      this.mergeStateModel.add(this);
+    }
+    this.mergeStateModel.add(other);
+
     return this.retainState(
       new LineRange(
         Math.min(this.startLineNumber, other.startLineNumber),
         Math.max(this.endLineNumberExclusive, other.endLineNumberExclusive),
       ),
-    );
+    ).setTurnDirection(ETurnDirection.BOTH);
   }
 
   // 生一个除 id 以外，state 状态都相同的 lineRange
@@ -131,7 +229,8 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
       .setId(this._id)
       .setType(this._type)
       .setTurnDirection(this._turnDirection)
-      .setComplete(this._isComplete);
+      .setComplete(this._isComplete)
+      .setMergeStateModel(this.mergeStateModel);
   }
 
   public override delta(offset: number): LineRange {

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -1,4 +1,4 @@
-import { getIcon } from '@opensumi/ide-core-browser';
+import { getExternalIcon, getIcon } from '@opensumi/ide-core-browser';
 import { IEditorMouseEvent } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
 
 import { IModelDecorationOptions } from '../../monaco-api/editor';
@@ -7,15 +7,18 @@ import { LineRange } from './model/line-range';
 
 export interface IRangeContrast {
   type: LineRangeType;
-  // 是否解决操作完成
+  /**
+   * 是否解决操作完成
+   */
   get isComplete(): boolean;
   setComplete: (b: boolean) => this;
   /**
    * 表示这个 range 区域是倾向于 current editor 还是 incoming editor（如果本身就是在 current editor 则返回 current）
    * 在 result editor 视图里可以通过该字段来判读它是与 current editor 相比较的还是与 incoming 相比较的 diff
+   * 当然也有可能是两者都有，这种情况一般是 merge 合成后的 range
    */
-  get turnDirection(): EditorViewType.CURRENT | EditorViewType.INCOMING;
-  setTurnDirection: (t: EditorViewType.CURRENT | EditorViewType.INCOMING) => this;
+  get turnDirection(): ETurnDirection;
+  setTurnDirection: (t: ETurnDirection) => this;
 }
 
 export interface IBaseCodeEditor {
@@ -23,6 +26,12 @@ export interface IBaseCodeEditor {
 }
 
 export type LineRangeType = 'insert' | 'modify' | 'remove';
+
+export enum ETurnDirection {
+  BOTH = 'both',
+  CURRENT = 'current',
+  INCOMING = 'incoming',
+}
 
 export enum EditorViewType {
   CURRENT = 'current',
@@ -82,6 +91,7 @@ export interface IActionsProvider {
 export namespace CONFLICT_ACTIONS_ICON {
   export const RIGHT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleright')}`;
   export const LEFT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleleft')}`;
+  export const WAND = `conflict-actions ${ACCEPT_COMBINATION_ACTIONS} ${getExternalIcon('wand')}`;
   export const CLOSE = `conflict-actions ${IGNORE_ACTIONS} ${getIcon('close')}`;
   export const REVOKE = `conflict-actions ${REVOKE_ACTIONS} ${getIcon('revoke')}`;
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -3,10 +3,8 @@ import { IEditorMouseEvent, MouseTargetType } from '@opensumi/monaco-editor-core
 import { IRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/range';
 
 import { MappingManagerService } from '../mapping-manager.service';
-import { LineRange } from '../model/line-range';
 import {
   EditorViewType,
-  IActionsDescription,
   IConflictActionsEvent,
   ACCEPT_CURRENT_ACTIONS,
   IGNORE_ACTIONS,
@@ -15,6 +13,7 @@ import {
   ACCEPT_COMBINATION_ACTIONS,
   REVOKE_ACTIONS,
   IActionsProvider,
+  ETurnDirection,
 } from '../types';
 
 import { BaseCodeEditor } from './editors/baseCodeEditor';
@@ -84,11 +83,11 @@ export class ActionsManager extends Disposable {
         const { turnDirection } = range;
 
         const documentMapping =
-          turnDirection === EditorViewType.CURRENT
+          turnDirection === ETurnDirection.CURRENT
             ? this.mappingManagerService.documentMappingTurnLeft
             : this.mappingManagerService.documentMappingTurnRight;
 
-        const viewEditor = turnDirection === EditorViewType.CURRENT ? this.currentView : this.incomingView;
+        const viewEditor = turnDirection === ETurnDirection.CURRENT ? this.currentView : this.incomingView;
 
         /**
          * accept current 或 ignore
@@ -113,9 +112,9 @@ export class ActionsManager extends Disposable {
             ]);
           }
 
-          if (turnDirection === EditorViewType.CURRENT) {
+          if (turnDirection === ETurnDirection.CURRENT) {
             this.mappingManagerService.markCompleteTurnLeft(range);
-          } else if (turnDirection === EditorViewType.INCOMING) {
+          } else if (turnDirection === ETurnDirection.INCOMING) {
             this.mappingManagerService.markCompleteTurnRight(range);
           }
 
@@ -124,9 +123,9 @@ export class ActionsManager extends Disposable {
           /**
            * revoke
            */
-          if (turnDirection === EditorViewType.CURRENT) {
+          if (turnDirection === ETurnDirection.CURRENT) {
             this.mappingManagerService.revokeActionsTurnLeft(range);
-          } else if (turnDirection === EditorViewType.INCOMING) {
+          } else if (turnDirection === ETurnDirection.INCOMING) {
             this.mappingManagerService.revokeActionsTurnRight(range);
           }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -16,6 +16,7 @@ import { LineRangeMapping } from '../../model/line-range-mapping';
 import {
   EDiffRangeTurn,
   EditorViewType,
+  ETurnDirection,
   IActionsDescription,
   IActionsProvider,
   IBaseCodeEditor,
@@ -141,7 +142,7 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
     turnLeft.forEach((range, idx) => {
       const sameRange = turnRight[idx];
       const _exec = (type: LineRangeType) => {
-        const direction = withBase === 1 ? EditorViewType.CURRENT : EditorViewType.INCOMING;
+        const direction = withBase === 1 ? ETurnDirection.CURRENT : ETurnDirection.INCOMING;
         // 同时将 sameRange 赋予一样的状态
         sameRange.setType(type).setTurnDirection(direction);
         changesResult.push(range.setType(type).setTurnDirection(direction));

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -212,9 +212,8 @@ export class ResultCodeEditor extends BaseCodeEditor {
       mergeRange: LineRange;
     }[],
   ): void {
-    const pickMapping = (range: LineRange) => range.turnDirection === ETurnDirection.CURRENT
-        ? this.documentMappingTurnLeft
-        : this.documentMappingTurnRight;
+    const pickMapping = (range: LineRange) =>
+      range.turnDirection === ETurnDirection.CURRENT ? this.documentMappingTurnLeft : this.documentMappingTurnRight;
 
     for (const { rawRanges, mergeRange } of needMergeRanges) {
       // 需要合并的 range 一定多于两个
@@ -283,12 +282,12 @@ export class ResultCodeEditor extends BaseCodeEditor {
       }
 
       if (mergeRangeTurnLeft) {
-        const newLineRange = mergeRangeTurnLeft.born().setTurnDirection(ETurnDirection.CURRENT);
+        const newLineRange = mergeRangeTurnLeft.setTurnDirection(ETurnDirection.CURRENT);
         this.documentMappingTurnLeft.addRange(newLineRange, mergeRange);
       }
 
       if (mergeRangeTurnRight) {
-        const newLineRange = mergeRangeTurnRight.born().setTurnDirection(ETurnDirection.INCOMING);
+        const newLineRange = mergeRangeTurnRight.setTurnDirection(ETurnDirection.INCOMING);
         this.documentMappingTurnRight.addRange(newLineRange, mergeRange);
       }
     }

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
 
-export function uuid(): string {
-  return nanoid();
+export function uuid(size?: number): string {
+  return nanoid(size);
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![image](https://user-images.githubusercontent.com/20262815/206911927-c6424583-fdca-4f3f-809b-0db83f27a1b5.png)

允许 combination 的条件有以下几点
1. 该 diff 区域是由多个 lineRange 合并而成
2. 被合并的这些 lineRange 彼此之间仅仅只是表面接触，而没有相交关系。
 e.g
    `{ startLine: 1, endLine: 2 } ` 和 `{ startLine: 2, endLine: 3 }` 就是表面接触
    `{ startLine: 1, endLine: 3 } ` 和 `{ startLine: 2, endLine: 4 }` 就是相交关系

这样才能保证 accept combination 之后左右两边的 diff 内容彼此不会被覆盖

### Changelog
实现 accept combination 操作