### PR TITLE
feat: improve conflict action

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/mapping-manager.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/mapping-manager.service.ts
@@ -90,11 +90,14 @@ export class MappingManagerService extends Disposable {
     };
   }
 
-  public findTouchesRanges(target: LineRange): {
+  public findTouchesRanges(
+    target: LineRange,
+    isAllowContact = true,
+  ): {
     [key in EditorViewType.CURRENT | EditorViewType.INCOMING]: LineRange | undefined;
   } {
     const [turnLeftRange, turnRightRange] = [this.documentMappingTurnLeft, this.documentMappingTurnRight].map(
-      (mapping) => mapping.findTouchesRange(target),
+      (mapping) => mapping.findTouchesRange(target, isAllowContact),
     );
     return {
       [EditorViewType.CURRENT]: turnLeftRange,

--- a/packages/monaco/src/browser/contrib/merge-editor/mapping-manager.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/mapping-manager.service.ts
@@ -31,7 +31,13 @@ export class MappingManagerService extends Disposable {
       }
 
       range.setComplete(false);
-      sameRange.setComplete(false);
+      /**
+       * 这里需要从 mapping 的 adjacentComputeRangeMap 集合里获取并修改 complete 状态，否则变量内存就不是指向同一引用
+       */
+      const realSameRange = mapping.adjacentComputeRangeMap.get(range.id);
+      if (realSameRange) {
+        realSameRange.setComplete(false);
+      }
     };
   }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -105,7 +105,7 @@ export class MergeEditorService extends Disposable {
     this.incomingView.inputDiffComputingResult(changes2);
     this.resultView.inputDiffComputingResult(changes2, EDiffRangeTurn.ORIGIN);
 
-    this.currentView.updateDecorations();
-    this.incomingView.updateDecorations();
+    this.currentView.updateDecorations().updateActions();
+    this.incomingView.updateDecorations().updateActions();
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -151,12 +151,13 @@ export class DocumentMapping extends Disposable {
 
   /**
    * 找出 sameRange 是否与哪一个 lineRange 接触
+   * @param isAllowContact: 是否将表面接触的 range 也认为是 touch
    */
-  public findTouchesRange(sameRange: LineRange): LineRange | undefined {
+  public findTouchesRange(sameRange: LineRange, isAllowContact = true): LineRange | undefined {
     const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
-      if (range.isTouches(sameRange)) {
+      if (range.isTouches(sameRange) && (isAllowContact ? true : !range.isContact(sameRange))) {
         return range;
       }
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -82,26 +82,26 @@ export class DocumentMapping extends Disposable {
    * @returns
    */
   public deltaAdjacentQueueAfter(range: LineRange, offset: number, isContainSelf = false): void {
-    const sameRange = this.adjacentComputeRangeMap.get(range.id);
-    if (!sameRange) {
+    const oppositeRange = this.adjacentComputeRangeMap.get(range.id);
+    if (!oppositeRange) {
       return;
     }
 
     for (const [key, pick] of this.adjacentComputeRangeMap.entries()) {
-      if (pick.isAfter(sameRange)) {
+      if (pick.isAfter(oppositeRange)) {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
-      } else if (isContainSelf && pick.id === sameRange.id) {
+      } else if (isContainSelf && pick.id === oppositeRange.id) {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
       }
     }
   }
 
-  public deltaEndAdjacentQueue(sameRange: LineRange, offset: number): void {
+  public deltaEndAdjacentQueue(oppositeRange: LineRange, offset: number): void {
     for (const [key, pick] of this.adjacentComputeRangeMap.entries()) {
-      if (pick.id === sameRange.id) {
-        this.adjacentComputeRangeMap.set(key, sameRange.deltaEnd(offset));
-        // 将在 sameRange 之后的 range offset 都增加
-      } else if (pick.isAfter(sameRange)) {
+      if (pick.id === oppositeRange.id) {
+        this.adjacentComputeRangeMap.set(key, oppositeRange.deltaEnd(offset));
+        // 将在 oppositeRange 之后的 range offset 都增加
+      } else if (pick.isAfter(oppositeRange)) {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
       }
     }
@@ -118,15 +118,15 @@ export class DocumentMapping extends Disposable {
   }
 
   /**
-   * 寻找下一个离 sameRange 最近的 sameRange 点
-   * @param sameRange 对位 lineRange，不一定存在于 map 中
+   * 寻找下一个离 oppositeRange 最近的 oppositeRange 点
+   * @param oppositeRange 对位 lineRange，不一定存在于 map 中
    * @returns 下一个最近的 lineRange
    */
-  public findNextSameRange(sameRange: LineRange): LineRange | undefined {
+  public findNextOppositeRange(oppositeRange: LineRange): LineRange | undefined {
     const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
-      if (range.id !== sameRange.id && range.isAfter(sameRange)) {
+      if (range.id !== oppositeRange.id && range.isAfter(oppositeRange)) {
         return range;
       }
     }
@@ -135,13 +135,13 @@ export class DocumentMapping extends Disposable {
   }
 
   /**
-   * 找出 sameRange 是否被包裹在哪一个 lineRange 里，如果有并返回该 lineRange
+   * 找出 oppositeRange 是否被包裹在哪一个 lineRange 里，如果有并返回该 lineRange
    */
-  public findIncludeRange(sameRange: LineRange): LineRange | undefined {
+  public findIncludeRange(oppositeRange: LineRange): LineRange | undefined {
     const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
-      if (range.isInclude(sameRange)) {
+      if (range.isInclude(oppositeRange)) {
         return range;
       }
     }
@@ -150,14 +150,14 @@ export class DocumentMapping extends Disposable {
   }
 
   /**
-   * 找出 sameRange 是否与哪一个 lineRange 接触
+   * 找出 oppositeRange 是否与哪一个 lineRange 接触
    * @param isAllowContact: 是否将表面接触的 range 也认为是 touch
    */
-  public findTouchesRange(sameRange: LineRange, isAllowContact = true): LineRange | undefined {
+  public findTouchesRange(oppositeRange: LineRange, isAllowContact = true): LineRange | undefined {
     const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
-      if (range.isTouches(sameRange) && (isAllowContact ? true : !range.isContact(sameRange))) {
+      if (range.isTouches(oppositeRange) && (isAllowContact ? true : !range.isContact(oppositeRange))) {
         return range;
       }
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -27,8 +27,12 @@ export class DocumentMapping extends Disposable {
     super();
   }
 
+  private ensureSort(values: IterableIterator<LineRange>): LineRange[] {
+    return Array.from(values).sort((a, b) => a.startLineNumber - b.startLineNumber);
+  }
+
   public getOriginalRange(): LineRange[] {
-    return Array.from(
+    return this.ensureSort(
       this.diffRangeTurn === EDiffRangeTurn.ORIGIN
         ? this.computeRangeMap.values()
         : this.adjacentComputeRangeMap.values(),
@@ -36,7 +40,7 @@ export class DocumentMapping extends Disposable {
   }
 
   public getModifiedRange(): LineRange[] {
-    return Array.from(
+    return this.ensureSort(
       this.diffRangeTurn === EDiffRangeTurn.ORIGIN
         ? this.adjacentComputeRangeMap.values()
         : this.computeRangeMap.values(),
@@ -119,7 +123,7 @@ export class DocumentMapping extends Disposable {
    * @returns 下一个最近的 lineRange
    */
   public findNextSameRange(sameRange: LineRange): LineRange | undefined {
-    const values = this.adjacentComputeRangeMap.values();
+    const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
       if (range.id !== sameRange.id && range.isAfter(sameRange)) {
@@ -134,7 +138,7 @@ export class DocumentMapping extends Disposable {
    * 找出 sameRange 是否被包裹在哪一个 lineRange 里，如果有并返回该 lineRange
    */
   public findIncludeRange(sameRange: LineRange): LineRange | undefined {
-    const values = this.adjacentComputeRangeMap.values();
+    const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
       if (range.isInclude(sameRange)) {
@@ -149,7 +153,7 @@ export class DocumentMapping extends Disposable {
    * 找出 sameRange 是否与哪一个 lineRange 接触
    */
   public findTouchesRange(sameRange: LineRange): LineRange | undefined {
-    const values = this.adjacentComputeRangeMap.values();
+    const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
       if (range.isTouches(sameRange)) {

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -115,7 +115,6 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
 
   constructor(startLineNumber: number, endLineNumberExclusive: number) {
     super(startLineNumber, endLineNumberExclusive);
-    this._type = 'insert';
     this._isComplete = false;
     this._id = uuid(6);
     this.mergeStateModel = new MergeStateModel();

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -119,6 +119,9 @@ export namespace DECORATIONS_CLASSNAME {
 
   export const offset_right = 'offset-right';
   export const offset_left = 'offset-left';
+
+  export const rotate_turn_left = 'rotate-turn-left';
+  export const rotate_turn_right = 'rotate-turn-right';
 }
 
 export interface IConflictActionsEvent {

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -116,17 +116,19 @@ export interface IActionsProvider {
 }
 
 export namespace CONFLICT_ACTIONS_ICON {
-  export const RIGHT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleright')}`;
-  export const ROTATE_RIGHT = `conflict-actions ${APPEND_ACTIONS} ${DECORATIONS_CLASSNAME.rotate_turn_right}  ${getIcon(
+  const ACTIONS = 'conflict-actions';
+
+  export const RIGHT = `${ACTIONS} ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleright')}`;
+  export const ROTATE_RIGHT = `${ACTIONS} ${APPEND_ACTIONS} ${DECORATIONS_CLASSNAME.rotate_turn_right}  ${getIcon(
     'doubleright',
   )}`;
-  export const LEFT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleleft')}`;
-  export const ROTATE_LEFT = `conflict-actions ${APPEND_ACTIONS} ${DECORATIONS_CLASSNAME.rotate_turn_left}  ${getIcon(
+  export const LEFT = `${ACTIONS} ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleleft')}`;
+  export const ROTATE_LEFT = `${ACTIONS} ${APPEND_ACTIONS} ${DECORATIONS_CLASSNAME.rotate_turn_left}  ${getIcon(
     'doubleleft',
   )}`;
-  export const WAND = `conflict-actions ${ACCEPT_COMBINATION_ACTIONS} ${getExternalIcon('wand')}`;
-  export const CLOSE = `conflict-actions ${IGNORE_ACTIONS} ${getIcon('close')}`;
-  export const REVOKE = `conflict-actions ${REVOKE_ACTIONS} ${getIcon('revoke')}`;
+  export const WAND = `${ACTIONS} ${ACCEPT_COMBINATION_ACTIONS} ${getExternalIcon('wand')}`;
+  export const CLOSE = `${ACTIONS} ${IGNORE_ACTIONS} ${getIcon('close')}`;
+  export const REVOKE = `${ACTIONS} ${REVOKE_ACTIONS} ${getIcon('revoke')}`;
 }
 
 // 用来寻址点击事件时的标记
@@ -134,11 +136,7 @@ export const ADDRESSING_TAG_CLASSNAME = 'ADDRESSING_TAG_CLASSNAME_';
 
 export interface IConflictActionsEvent {
   range: LineRange;
-  action:
-    | typeof ACCEPT_CURRENT_ACTIONS
-    | typeof ACCEPT_COMBINATION_ACTIONS
-    | typeof IGNORE_ACTIONS
-    | typeof REVOKE_ACTIONS;
+  action: TActionsType;
   withViewType: EditorViewType;
 }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -68,37 +68,6 @@ export interface IActionsDescription {
   decorationOptions: Omit<IModelDecorationOptions, 'description'>;
 }
 
-export const ACCEPT_CURRENT_ACTIONS = 'accpet_current';
-export const ACCEPT_COMBINATION_ACTIONS = 'accpet_combination';
-export const IGNORE_ACTIONS = 'ignore';
-export const REVOKE_ACTIONS = 'revoke';
-
-export type TActionsType =
-  | typeof ACCEPT_CURRENT_ACTIONS
-  | typeof ACCEPT_COMBINATION_ACTIONS
-  | typeof IGNORE_ACTIONS
-  | typeof REVOKE_ACTIONS;
-
-export interface IActionsProvider {
-  onActionsClick?: (range: LineRange, actionType: TActionsType) => void;
-  mouseDownGuard?: (e: IEditorMouseEvent) => boolean;
-  /**
-   * 提供 actions 操作项
-   */
-  provideActionsItems: () => IActionsDescription[];
-}
-
-export namespace CONFLICT_ACTIONS_ICON {
-  export const RIGHT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleright')}`;
-  export const LEFT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleleft')}`;
-  export const WAND = `conflict-actions ${ACCEPT_COMBINATION_ACTIONS} ${getExternalIcon('wand')}`;
-  export const CLOSE = `conflict-actions ${IGNORE_ACTIONS} ${getIcon('close')}`;
-  export const REVOKE = `conflict-actions ${REVOKE_ACTIONS} ${getIcon('revoke')}`;
-}
-
-// 用来寻址点击事件时的标记
-export const ADDRESSING_TAG_CLASSNAME = 'ADDRESSING_TAG_CLASSNAME_';
-
 /**
  * 绘制 decoration 和 line widget 线的样式类名集合
  */
@@ -123,6 +92,45 @@ export namespace DECORATIONS_CLASSNAME {
   export const rotate_turn_left = 'rotate-turn-left';
   export const rotate_turn_right = 'rotate-turn-right';
 }
+
+export const ACCEPT_CURRENT_ACTIONS = 'accpet_current';
+export const ACCEPT_COMBINATION_ACTIONS = 'accpet_combination';
+export const IGNORE_ACTIONS = 'ignore';
+export const REVOKE_ACTIONS = 'revoke';
+export const APPEND_ACTIONS = 'append';
+
+export type TActionsType =
+  | typeof ACCEPT_CURRENT_ACTIONS
+  | typeof ACCEPT_COMBINATION_ACTIONS
+  | typeof IGNORE_ACTIONS
+  | typeof REVOKE_ACTIONS
+  | typeof APPEND_ACTIONS;
+
+export interface IActionsProvider {
+  onActionsClick?: (range: LineRange, actionType: TActionsType) => void;
+  mouseDownGuard?: (e: IEditorMouseEvent) => boolean;
+  /**
+   * 提供 actions 操作项
+   */
+  provideActionsItems: () => IActionsDescription[];
+}
+
+export namespace CONFLICT_ACTIONS_ICON {
+  export const RIGHT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleright')}`;
+  export const ROTATE_RIGHT = `conflict-actions ${APPEND_ACTIONS} ${DECORATIONS_CLASSNAME.rotate_turn_right}  ${getIcon(
+    'doubleright',
+  )}`;
+  export const LEFT = `conflict-actions ${ACCEPT_CURRENT_ACTIONS} ${getIcon('doubleleft')}`;
+  export const ROTATE_LEFT = `conflict-actions ${APPEND_ACTIONS} ${DECORATIONS_CLASSNAME.rotate_turn_left}  ${getIcon(
+    'doubleleft',
+  )}`;
+  export const WAND = `conflict-actions ${ACCEPT_COMBINATION_ACTIONS} ${getExternalIcon('wand')}`;
+  export const CLOSE = `conflict-actions ${IGNORE_ACTIONS} ${getIcon('close')}`;
+  export const REVOKE = `conflict-actions ${REVOKE_ACTIONS} ${getIcon('revoke')}`;
+}
+
+// 用来寻址点击事件时的标记
+export const ADDRESSING_TAG_CLASSNAME = 'ADDRESSING_TAG_CLASSNAME_';
 
 export interface IConflictActionsEvent {
   range: LineRange;

--- a/packages/monaco/src/browser/contrib/merge-editor/utils.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/utils.ts
@@ -1,7 +1,6 @@
 import { InnerRange } from './model/inner-range';
 import { LineRange } from './model/line-range';
 import { LineRangeMapping } from './model/line-range-mapping';
-import { EditorViewType } from './types';
 
 export const flatOriginal = (changes: LineRangeMapping[]): LineRange[] =>
   changes.map((c) => c.originalRange as LineRange);

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -6,7 +6,6 @@ import { MappingManagerService } from '../mapping-manager.service';
 import { DocumentMapping } from '../model/document-mapping';
 import { LineRange } from '../model/line-range';
 import {
-  EditorViewType,
   IConflictActionsEvent,
   ACCEPT_CURRENT_ACTIONS,
   IGNORE_ACTIONS,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -111,6 +111,10 @@ export class ActionsManager extends Disposable {
     ]);
 
     this.markComplete(range);
+    /**
+     * 操作完 result 视图的 actions 都需要更新一遍
+     */
+    this.resultView?.updateActions();
   }
 
   /**
@@ -127,7 +131,14 @@ export class ActionsManager extends Disposable {
 
     if (turnDirection === ETurnDirection.CURRENT) {
       this.mappingManagerService.revokeActionsTurnLeft(range);
-    } else if (turnDirection === ETurnDirection.INCOMING) {
+    }
+
+    if (turnDirection === ETurnDirection.INCOMING) {
+      this.mappingManagerService.revokeActionsTurnRight(range);
+    }
+
+    if (turnDirection === ETurnDirection.BOTH) {
+      this.mappingManagerService.revokeActionsTurnLeft(range);
       this.mappingManagerService.revokeActionsTurnRight(range);
     }
 
@@ -142,7 +153,14 @@ export class ActionsManager extends Disposable {
       this.applyLineRangeEdits([{ range: range.deltaStart(-1).toRange(Number.MAX_SAFE_INTEGER), text: null }]);
     }
 
-    viewEditor!.updateDecorations();
+    this.resultView?.updateActions();
+
+    if (turnDirection === ETurnDirection.BOTH) {
+      this.incomingView?.updateDecorations().updateActions();
+      this.currentView?.updateDecorations().updateActions();
+    } else {
+      viewEditor!.updateDecorations().updateActions();
+    }
   }
 
   /**
@@ -191,6 +209,8 @@ export class ActionsManager extends Disposable {
 
     this.markComplete(reverseLeftRange);
     this.markComplete(reverseRightRange);
+
+    this.resultView?.updateActions();
   }
 
   private markComplete(range: LineRange): void {
@@ -198,12 +218,12 @@ export class ActionsManager extends Disposable {
 
     if (turnDirection === ETurnDirection.CURRENT) {
       this.mappingManagerService.markCompleteTurnLeft(range);
-      this.currentView?.updateDecorations();
+      this.currentView!.updateDecorations().updateActions();
     }
 
     if (turnDirection === ETurnDirection.INCOMING) {
       this.mappingManagerService.markCompleteTurnRight(range);
-      this.incomingView?.updateDecorations();
+      this.incomingView!.updateDecorations().updateActions();
     }
   }
 
@@ -238,6 +258,7 @@ export class ActionsManager extends Disposable {
 
         if (action === IGNORE_ACTIONS) {
           this.markComplete(range);
+          this.resultView?.updateActions();
         }
 
         if (action === REVOKE_ACTIONS) {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -39,9 +39,12 @@ export class ActionsManager extends Disposable {
       return;
     }
 
-    model.pushStackElement();
-    model.pushEditOperations(
-      null,
+    /**
+     * 暂时先不处理 undo 和 redo 的情况
+     * 可放在第二期来实现
+     * 到时再采用 pushEditOperations 来处理
+     */
+    model.applyEdits(
       edits.map((edit) => {
         const { range, text } = edit;
 
@@ -51,9 +54,8 @@ export class ActionsManager extends Disposable {
           text,
         };
       }),
-      () => null,
+      false,
     );
-    model.pushStackElement();
   }
 
   private pickMapping(range: LineRange): DocumentMapping | undefined {
@@ -129,11 +131,13 @@ export class ActionsManager extends Disposable {
       this.mappingManagerService.revokeActionsTurnRight(range);
     }
 
+    const model = viewEditor.getModel()!;
+    const eol = model.getEOL();
     const { text } = metaData;
 
     // 为 null 则说明是删除文本
     if (text) {
-      this.applyLineRangeEdits([{ range: range.toRange(), text }]);
+      this.applyLineRangeEdits([{ range: range.toRange(), text: text + (range.isEmpty ? eol : '') }]);
     } else {
       this.applyLineRangeEdits([{ range: range.deltaStart(-1).toRange(Number.MAX_SAFE_INTEGER), text: null }]);
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -97,25 +97,25 @@ export class ActionsManager extends Disposable {
     const eol = model.getEOL();
 
     const applyText = model.getValueInRange(range.toRange());
-    const sameRange = mapping.adjacentComputeRangeMap.get(range.id);
+    const oppositeRange = mapping.adjacentComputeRangeMap.get(range.id);
 
-    if (!sameRange) {
+    if (!oppositeRange) {
       return;
     }
 
     this.applyLineRangeEdits([
       {
-        range: range.isEmpty ? sameRange.deltaStart(-1).toRange(Number.MAX_SAFE_INTEGER) : sameRange.toRange(),
-        text: applyText + (sameRange.isEmpty ? eol : ''),
+        range: range.isEmpty ? oppositeRange.deltaStart(-1).toRange(Number.MAX_SAFE_INTEGER) : oppositeRange.toRange(),
+        text: applyText + (oppositeRange.isEmpty ? eol : ''),
       },
     ]);
 
     this.markComplete(range);
 
     /**
-     * 如果 sameRange 是 merge range 合成的，则需要更新 current editor 和 incoming editor 的 actions
+     * 如果 oppositeRange 是 merge range 合成的，则需要更新 current editor 和 incoming editor 的 actions
      */
-    if (sameRange.isMerge) {
+    if (oppositeRange.isMerge) {
       this.currentView?.updateActions();
       this.incomingView?.updateActions();
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -111,8 +111,17 @@ export class ActionsManager extends Disposable {
     ]);
 
     this.markComplete(range);
+
     /**
-     * 操作完 result 视图的 actions 都需要更新一遍
+     * 如果 sameRange 是 merge range 合成的，则需要更新 current editor 和 incoming editor 的 actions
+     */
+    if (sameRange.isMerge) {
+      this.currentView?.updateActions();
+      this.incomingView?.updateActions();
+    }
+
+    /**
+     * accept current 执行完之后都需要更新一遍 result 视图的 actions
      */
     this.resultView?.updateActions();
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -149,7 +149,10 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
       };
 
       if (sameRange) {
-        _exec(range.isTendencyRight(sameRange) ? 'remove' : range.isTendencyLeft(sameRange) ? 'insert' : 'modify');
+        _exec(
+          range.type ??
+            (range.isTendencyRight(sameRange) ? 'remove' : range.isTendencyLeft(sameRange) ? 'insert' : 'modify'),
+        );
       }
     });
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -143,9 +143,8 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
       const sameRange = turnRight[idx];
       const _exec = (type: LineRangeType) => {
         const direction = withBase === 1 ? ETurnDirection.CURRENT : ETurnDirection.INCOMING;
-        // 同时将 sameRange 赋予一样的状态
-        sameRange.setType(type).setTurnDirection(direction);
-        changesResult.push(range.setType(type).setTurnDirection(direction));
+        sameRange.setType(type).setTurnDirection(sameRange.turnDirection ?? direction);
+        changesResult.push(range.setType(type).setTurnDirection(range.turnDirection ?? direction));
         // inner range 先不计算
       };
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -140,18 +140,22 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
     const innerChangesResult: InnerRange[][] = [];
 
     turnLeft.forEach((range, idx) => {
-      const sameRange = turnRight[idx];
+      const oppositeRange = turnRight[idx];
       const _exec = (type: LineRangeType) => {
         const direction = withBase === 1 ? ETurnDirection.CURRENT : ETurnDirection.INCOMING;
-        sameRange.setType(type).setTurnDirection(sameRange.turnDirection ?? direction);
+        oppositeRange.setType(type).setTurnDirection(oppositeRange.turnDirection ?? direction);
         changesResult.push(range.setType(type).setTurnDirection(range.turnDirection ?? direction));
         // inner range 先不计算
       };
 
-      if (sameRange) {
+      if (oppositeRange) {
         _exec(
           range.type ??
-            (range.isTendencyRight(sameRange) ? 'remove' : range.isTendencyLeft(sameRange) ? 'insert' : 'modify'),
+            (range.isTendencyRight(oppositeRange)
+              ? 'remove'
+              : range.isTendencyLeft(oppositeRange)
+              ? 'insert'
+              : 'modify'),
         );
       }
     });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -159,9 +159,17 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
     return [changesResult, innerChangesResult];
   }
 
-  public updateDecorations(): void {
+  protected abstract provideActionsItems(ranges?: LineRange[]): IActionsDescription[];
+
+  public updateActions(): this {
+    this.conflictActions.updateActions(this.provideActionsItems());
+    return this;
+  }
+
+  public updateDecorations(): this {
     const [r, i] = this.prepareRenderDecorations();
     this.decorations.updateDecorations(r, i);
+    return this;
   }
 
   protected registerActionsProvider(provider: IActionsProvider): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -42,8 +42,8 @@ export class CurrentCodeEditor extends BaseCodeEditor {
         const idMark = `${ADDRESSING_TAG_CLASSNAME}${range.id}`;
         let rotataClassName = '';
         if (range.isMerge) {
-          const sameRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
-          if (sameRange && sameRange.isComplete) {
+          const oppositeRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
+          if (oppositeRange && oppositeRange.isComplete) {
             rotataClassName += DECORATIONS_CLASSNAME.rotate_turn_left;
           }
         }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -34,18 +34,27 @@ export class CurrentCodeEditor extends BaseCodeEditor {
     return super.prepareRenderDecorations(1);
   }
 
-  private provideActionsItems(): IActionsDescription[] {
+  protected provideActionsItems(): IActionsDescription[] {
     const ranges = this.documentMapping.getOriginalRange();
     return ranges
       .filter((r) => !r.isComplete)
       .map((range) => {
         const idMark = `${ADDRESSING_TAG_CLASSNAME}${range.id}`;
+        let rotataClassName = '';
+        if (range.isMerge) {
+          const sameRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
+          if (sameRange && sameRange.isComplete) {
+            rotataClassName = DECORATIONS_CLASSNAME.rotate_turn_left;
+          }
+        }
+
         return {
           range,
           decorationOptions: {
             glyphMarginClassName: DECORATIONS_CLASSNAME.combine(
               CONFLICT_ACTIONS_ICON.RIGHT,
               DECORATIONS_CLASSNAME.offset_left,
+              rotataClassName,
               idMark,
             ),
             marginClassName: DECORATIONS_CLASSNAME.combine(CONFLICT_ACTIONS_ICON.CLOSE, idMark),
@@ -71,11 +80,6 @@ export class CurrentCodeEditor extends BaseCodeEditor {
 
   public getEditorViewType(): EditorViewType {
     return EditorViewType.CURRENT;
-  }
-
-  public override updateDecorations(): void {
-    super.updateDecorations();
-    this.conflictActions.updateActions(this.provideActionsItems());
   }
 
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -16,6 +16,7 @@ import {
   ADDRESSING_TAG_CLASSNAME,
   TActionsType,
   IActionsDescription,
+  APPEND_ACTIONS,
 } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
@@ -107,8 +108,14 @@ export class CurrentCodeEditor extends BaseCodeEditor {
             withViewType: EditorViewType.CURRENT,
             action: ACCEPT_CURRENT_ACTIONS,
           });
-        } else if (actionType === IGNORE_ACTIONS) {
+        }
+
+        if (actionType === IGNORE_ACTIONS) {
           this._onDidConflictActions.fire({ range, withViewType: EditorViewType.CURRENT, action: IGNORE_ACTIONS });
+        }
+
+        if (actionType === APPEND_ACTIONS) {
+          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.CURRENT, action: APPEND_ACTIONS });
         }
       },
     });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -44,7 +44,7 @@ export class CurrentCodeEditor extends BaseCodeEditor {
         if (range.isMerge) {
           const sameRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
           if (sameRange && sameRange.isComplete) {
-            rotataClassName = DECORATIONS_CLASSNAME.rotate_turn_left;
+            rotataClassName += DECORATIONS_CLASSNAME.rotate_turn_left;
           }
         }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.tsx
@@ -40,23 +40,19 @@ export class CurrentCodeEditor extends BaseCodeEditor {
       .filter((r) => !r.isComplete)
       .map((range) => {
         const idMark = `${ADDRESSING_TAG_CLASSNAME}${range.id}`;
-        let rotataClassName = '';
+        let iconActions = CONFLICT_ACTIONS_ICON.RIGHT;
+
         if (range.isMerge) {
           const oppositeRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
           if (oppositeRange && oppositeRange.isComplete) {
-            rotataClassName += DECORATIONS_CLASSNAME.rotate_turn_left;
+            iconActions = CONFLICT_ACTIONS_ICON.ROTATE_RIGHT;
           }
         }
 
         return {
           range,
           decorationOptions: {
-            glyphMarginClassName: DECORATIONS_CLASSNAME.combine(
-              CONFLICT_ACTIONS_ICON.RIGHT,
-              DECORATIONS_CLASSNAME.offset_left,
-              rotataClassName,
-              idMark,
-            ),
+            glyphMarginClassName: DECORATIONS_CLASSNAME.combine(iconActions, DECORATIONS_CLASSNAME.offset_left, idMark),
             marginClassName: DECORATIONS_CLASSNAME.combine(CONFLICT_ACTIONS_ICON.CLOSE, idMark),
           },
         };

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -38,7 +38,7 @@ export class IncomingCodeEditor extends BaseCodeEditor {
         if (range.isMerge) {
           const sameRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
           if (sameRange && sameRange.isComplete) {
-            rotataClassName = DECORATIONS_CLASSNAME.rotate_turn_right;
+            rotataClassName += DECORATIONS_CLASSNAME.rotate_turn_right;
           }
         }
 
@@ -48,10 +48,13 @@ export class IncomingCodeEditor extends BaseCodeEditor {
             glyphMarginClassName: DECORATIONS_CLASSNAME.combine(
               CONFLICT_ACTIONS_ICON.CLOSE,
               DECORATIONS_CLASSNAME.offset_right,
+              idMark,
+            ),
+            firstLineDecorationClassName: DECORATIONS_CLASSNAME.combine(
+              CONFLICT_ACTIONS_ICON.LEFT,
               rotataClassName,
               idMark,
             ),
-            firstLineDecorationClassName: DECORATIONS_CLASSNAME.combine(CONFLICT_ACTIONS_ICON.LEFT, idMark),
           },
         };
       });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -36,8 +36,8 @@ export class IncomingCodeEditor extends BaseCodeEditor {
         const idMark = `${ADDRESSING_TAG_CLASSNAME}${range.id}`;
         let rotataClassName = '';
         if (range.isMerge) {
-          const sameRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
-          if (sameRange && sameRange.isComplete) {
+          const oppositeRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
+          if (oppositeRange && oppositeRange.isComplete) {
             rotataClassName += DECORATIONS_CLASSNAME.rotate_turn_right;
           }
         }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -34,11 +34,12 @@ export class IncomingCodeEditor extends BaseCodeEditor {
       .filter((r) => !r.isComplete)
       .map((range) => {
         const idMark = `${ADDRESSING_TAG_CLASSNAME}${range.id}`;
-        let rotataClassName = '';
+        let iconActions = CONFLICT_ACTIONS_ICON.LEFT;
+
         if (range.isMerge) {
           const oppositeRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
           if (oppositeRange && oppositeRange.isComplete) {
-            rotataClassName += DECORATIONS_CLASSNAME.rotate_turn_right;
+            iconActions = CONFLICT_ACTIONS_ICON.ROTATE_LEFT;
           }
         }
 
@@ -52,7 +53,7 @@ export class IncomingCodeEditor extends BaseCodeEditor {
             ),
             firstLineDecorationClassName: DECORATIONS_CLASSNAME.combine(
               CONFLICT_ACTIONS_ICON.LEFT,
-              rotataClassName,
+              iconActions,
               idMark,
             ),
           },

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -14,6 +14,7 @@ import {
   ADDRESSING_TAG_CLASSNAME,
   TActionsType,
   IActionsDescription,
+  APPEND_ACTIONS,
 } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
@@ -51,11 +52,7 @@ export class IncomingCodeEditor extends BaseCodeEditor {
               DECORATIONS_CLASSNAME.offset_right,
               idMark,
             ),
-            firstLineDecorationClassName: DECORATIONS_CLASSNAME.combine(
-              CONFLICT_ACTIONS_ICON.LEFT,
-              iconActions,
-              idMark,
-            ),
+            firstLineDecorationClassName: DECORATIONS_CLASSNAME.combine(iconActions, idMark),
           },
         };
       });
@@ -90,8 +87,14 @@ export class IncomingCodeEditor extends BaseCodeEditor {
             withViewType: EditorViewType.INCOMING,
             action: ACCEPT_CURRENT_ACTIONS,
           });
-        } else if (actionType === IGNORE_ACTIONS) {
+        }
+
+        if (actionType === IGNORE_ACTIONS) {
           this._onDidConflictActions.fire({ range, withViewType: EditorViewType.INCOMING, action: IGNORE_ACTIONS });
+        }
+
+        if (actionType === APPEND_ACTIONS) {
+          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.INCOMING, action: APPEND_ACTIONS });
         }
       },
     });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.tsx
@@ -28,18 +28,27 @@ export class IncomingCodeEditor extends BaseCodeEditor {
     return { readOnly: true, lineDecorationsWidth: 42 };
   }
 
-  private provideActionsItems(): IActionsDescription[] {
+  protected provideActionsItems(): IActionsDescription[] {
     const ranges = this.documentMapping.getModifiedRange();
     return ranges
       .filter((r) => !r.isComplete)
       .map((range) => {
         const idMark = `${ADDRESSING_TAG_CLASSNAME}${range.id}`;
+        let rotataClassName = '';
+        if (range.isMerge) {
+          const sameRange = this.documentMapping.adjacentComputeRangeMap.get(range.id);
+          if (sameRange && sameRange.isComplete) {
+            rotataClassName = DECORATIONS_CLASSNAME.rotate_turn_right;
+          }
+        }
+
         return {
           range,
           decorationOptions: {
             glyphMarginClassName: DECORATIONS_CLASSNAME.combine(
               CONFLICT_ACTIONS_ICON.CLOSE,
               DECORATIONS_CLASSNAME.offset_right,
+              rotataClassName,
               idMark,
             ),
             firstLineDecorationClassName: DECORATIONS_CLASSNAME.combine(CONFLICT_ACTIONS_ICON.LEFT, idMark),
@@ -63,11 +72,6 @@ export class IncomingCodeEditor extends BaseCodeEditor {
 
   public getEditorViewType(): EditorViewType {
     return EditorViewType.INCOMING;
-  }
-
-  public override updateDecorations(): void {
-    super.updateDecorations();
-    this.conflictActions.updateActions(this.provideActionsItems());
   }
 
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -68,8 +68,6 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
     this.addDispose(
       this.editor.onDidChangeModelContent(async (e) => {
-        // console.log('onDidChangeModelContent:::>>> e', e);
-
         const model = this.editor.getModel();
         if (model && model.getLineCount() !== preLineCount) {
           preLineCount = model.getLineCount();
@@ -100,8 +98,6 @@ export class ResultCodeEditor extends BaseCodeEditor {
             });
           });
 
-          // console.log('onDidChangeModelContent:::>>> deltaEdits', deltaEdits);
-
           deltaEdits.forEach((edits) => {
             const { startLineNumber, endLineNumber, offset } = edits;
 
@@ -116,10 +112,6 @@ export class ResultCodeEditor extends BaseCodeEditor {
               this.mappingManagerService.findTouchesRanges(toLineRange, false);
             const { [EditorViewType.CURRENT]: nextTurnLeftRange, [EditorViewType.INCOMING]: nextTurnRightRange } =
               this.mappingManagerService.findNextLineRanges(toLineRange);
-
-            // console.log('onDidChangeModelContent:::>>> include ', includeLeftRange, includeRightRange);
-            // console.log('onDidChangeModelContent:::>>> touch ', touchTurnLeftRange, touchTurnRightRange);
-            // console.log('onDidChangeModelContent:::>>> next ', nextTurnLeftRange, nextTurnRightRange);
 
             if (includeLeftRange) {
               this.documentMappingTurnLeft.deltaEndAdjacentQueue(includeLeftRange, offset);

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -384,7 +384,9 @@ export class ResultCodeEditor extends BaseCodeEditor {
         onActionsClick: (range: LineRange, actionType: TActionsType) => {
           if (actionType === REVOKE_ACTIONS) {
             this._onDidConflictActions.fire({ range, withViewType: EditorViewType.RESULT, action: REVOKE_ACTIONS });
-          } else if (actionType === ACCEPT_COMBINATION_ACTIONS) {
+          }
+
+          if (actionType === ACCEPT_COMBINATION_ACTIONS) {
             this._onDidConflictActions.fire({
               range,
               withViewType: EditorViewType.RESULT,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -158,7 +158,11 @@ export class ResultCodeEditor extends BaseCodeEditor {
   }
 
   protected provideActionsItems(ranges?: LineRange[]): IActionsDescription[] {
-    return (ranges || [])
+    if (!Array.isArray(ranges)) {
+      return [];
+    }
+
+    return ranges
       .filter((r) => r.isComplete || r.isMerge)
       .map((range) => ({
         range,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -249,7 +249,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
        *  3. { startLine: 30，endLine: 40 } // 方向向右
        *
        * 首先这三者的 turn directio 方向一定是左右交替的
-       * 那么第二个 lineRange 的对位关系 sameLineRange 的起点 startLine 就一定会比第一个 lineRange 的起点 startLine 少一个高度
+       * 那么第二个 lineRange 的对位关系 oppositeLineRange 的起点 startLine 就一定会比第一个 lineRange 的起点 startLine 少一个高度
        * 这个高度的差距会影响后续所有的 conflict action 操作（因为缺失的这部分高度会导致 accept 操作后的代码内容丢失）
        *
        * 而我们只需要补齐这第二个和倒数第二个的高度即可，中间部分的所有 lineRange 都会在最终合并到一起

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -67,6 +67,8 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
     this.addDispose(
       this.editor.onDidChangeModelContent((e) => {
+        // console.log('onDidChangeModelContent:::>>> e', e);
+
         const model = this.editor.getModel();
         if (model && model.getLineCount() !== preLineCount) {
           preLineCount = model.getLineCount();
@@ -97,6 +99,8 @@ export class ResultCodeEditor extends BaseCodeEditor {
             });
           });
 
+          // console.log('onDidChangeModelContent:::>>> deltaEdits', deltaEdits);
+
           deltaEdits.forEach((edits) => {
             const { startLineNumber, endLineNumber, offset } = edits;
 
@@ -108,9 +112,13 @@ export class ResultCodeEditor extends BaseCodeEditor {
              * 那么就要以当前 touch range 的结果作为要 delta 的起点
              */
             const { [EditorViewType.CURRENT]: touchTurnLeftRange, [EditorViewType.INCOMING]: touchTurnRightRange } =
-              this.mappingManagerService.findTouchesRanges(toLineRange);
+              this.mappingManagerService.findTouchesRanges(toLineRange, false);
             const { [EditorViewType.CURRENT]: nextTurnLeftRange, [EditorViewType.INCOMING]: nextTurnRightRange } =
               this.mappingManagerService.findNextLineRanges(toLineRange);
+
+            // console.log('onDidChangeModelContent:::>>> include ', includeLeftRange, includeRightRange);
+            // console.log('onDidChangeModelContent:::>>> touch ', touchTurnLeftRange, touchTurnRightRange);
+            // console.log('onDidChangeModelContent:::>>> next ', nextTurnLeftRange, nextTurnRightRange);
 
             if (includeLeftRange) {
               this.documentMappingTurnLeft.deltaEndAdjacentQueue(includeLeftRange, offset);
@@ -284,12 +292,12 @@ export class ResultCodeEditor extends BaseCodeEditor {
       }
 
       if (mergeRangeTurnLeft) {
-        const newLineRange = mergeRangeTurnLeft.setTurnDirection(ETurnDirection.CURRENT);
+        const newLineRange = mergeRangeTurnLeft.setTurnDirection(ETurnDirection.CURRENT).setType('modify');
         this.documentMappingTurnLeft.addRange(newLineRange, mergeRange);
       }
 
       if (mergeRangeTurnRight) {
-        const newLineRange = mergeRangeTurnRight.setTurnDirection(ETurnDirection.INCOMING);
+        const newLineRange = mergeRangeTurnRight.setTurnDirection(ETurnDirection.INCOMING).setType('modify');
         this.documentMappingTurnRight.addRange(newLineRange, mergeRange);
       }
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
@@ -101,11 +101,11 @@
     }
 
     &.rotate-turn-left {
-      transform: rotate(50deg);
+      transform: rotate(-50deg);
     }
 
     &.rotate-turn-right {
-      transform: rotate(-50deg);
+      transform: rotate(50deg);
     }
   }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
@@ -86,6 +86,8 @@
   .conflict-actions {
     cursor: pointer;
     z-index: 1;
+    // 默认图标宽度
+    width: 16px !important;
 
     &.offset-left {
       left: 18px !important;
@@ -96,6 +98,14 @@
       left: initial !important;
       right: 8px !important;
       z-index: 2;
+    }
+
+    &.rotate-turn-left {
+      transform: rotate(50deg);
+    }
+
+    &.rotate-turn-right {
+      transform: rotate(-50deg);
     }
   }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/stickiness-connect-manager.tsx
@@ -114,9 +114,9 @@ export class StickinessConnectManager extends Disposable {
     const { marginWidth, lineHeight } = editorLayoutInfo;
 
     origin.forEach((range, idx) => {
-      const sameModify = modify[idx];
-      const minTop = Math.min(range.startLineNumber, sameModify.startLineNumber);
-      const maxBottom = Math.max(range.endLineNumberExclusive, sameModify.endLineNumberExclusive);
+      const oppositeModify = modify[idx];
+      const minTop = Math.min(range.startLineNumber, oppositeModify.startLineNumber);
+      const maxBottom = Math.max(range.endLineNumberExclusive, oppositeModify.endLineNumberExclusive);
       const width = marginWidth;
       const height = lineHeight * (maxBottom - minTop);
       const position = {
@@ -124,9 +124,9 @@ export class StickinessConnectManager extends Disposable {
       };
       const path = {
         leftTop: Math.abs(minTop - range.startLineNumber) * lineHeight,
-        rightTop: Math.abs(minTop - sameModify.startLineNumber) * lineHeight,
+        rightTop: Math.abs(minTop - oppositeModify.startLineNumber) * lineHeight,
         leftBottom: (range.endLineNumberExclusive - minTop) * lineHeight,
-        rightBottom: (sameModify.endLineNumberExclusive - minTop) * lineHeight,
+        rightBottom: (oppositeModify.endLineNumberExclusive - minTop) * lineHeight,
       };
 
       result.push(
@@ -136,7 +136,7 @@ export class StickinessConnectManager extends Disposable {
           path,
           position,
           range.type,
-          withBase === 0 ? range.isComplete : sameModify.isComplete,
+          withBase === 0 ? range.isComplete : oppositeModify.isComplete,
         ),
       );
     });


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 💄 Style Changes
- [x] 🪚 Refactors

### Background or solution

- [x] 修复 decoration 重复渲染的问题（渲染的时候对 document mapping 里的数据去重）
- [x] 将 pushEditOperations 替换成 applyEdits，暂时不处理文档文本 undo 和 redo 的情况（放在第二期）
- [x] 将 conflict actions 的图标渲染和 decoration diff 区域的渲染分开处理，减少不必要的重复渲染计算
- [x] 修复执行 revoke 之后两边的 diff 区域颜色状态不正确的问题
- [x] 新增 accept append 操作，如果某一块区域两边都有 diff 变更的时候，此时执行某一视图的 accept current 后，另一视图的图标应该发生改变，且操作后是 append 代码内容而不是覆写内容
e.g 
![image](https://user-images.githubusercontent.com/20262815/207537789-73de982d-e1c4-4726-a170-8aa58999429e.png)
- [x] 将 `sameRange` 变量统一改成 `oppositeRange` 变量，更符合语义

### Changelog
改进解决冲突的各种操作交互