### PR TITLE
feat: support submenus on editor/title

### DIFF
--- a/packages/components/src/menu/style.less
+++ b/packages/components/src/menu/style.less
@@ -42,11 +42,6 @@
     color: @menu-highlight-color;
   }
 
-  &-item:active,
-  &-submenu-title:active {
-    background: @menu-item-active-bg;
-  }
-
   &-submenu &-sub {
     cursor: initial;
     transition: background 0.3s @ease-in-out, padding 0.3s @ease-in-out;

--- a/packages/core-browser/src/bootstrap/inner-providers.ts
+++ b/packages/core-browser/src/bootstrap/inner-providers.ts
@@ -265,7 +265,7 @@ export function injectInnerProviders(injector: Injector) {
   injector.addProviders(...providers);
 
   const appConfig: AppConfig = injector.get(AppConfig);
-  // 为electron添加独特的api服务，主要是向electron-main进行调用的服务
+  // Add special API services for Electron, mainly services that make calls to `Electron Main` process.
   if (appConfig.isElectronRenderer) {
     injector.addProviders(
       {

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -28,7 +28,7 @@ import {
   DisposableCollection,
   Event,
 } from '@opensumi/ide-core-browser';
-import { InlineActionBar } from '@opensumi/ide-core-browser/lib/components/actions';
+import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { LAYOUT_VIEW_SIZE } from '@opensumi/ide-core-browser/lib/layout/constants';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
 import { IMenuRegistry, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
@@ -494,12 +494,11 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
         className={classnames(styles.editor_actions, className)}
         style={{ height: LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT }}
       >
-        <InlineActionBar<URI, IEditorGroup, MaybeNull<URI>>
+        <InlineMenuBar<URI, IEditorGroup, MaybeNull<URI>>
           menus={menu}
-          context={args as any /* 这个推断过不去.. */}
+          context={args as any}
           // 不 focus 的时候只展示 more 菜单
           regroup={(nav, more) => (hasFocus ? [nav, more] : [[], more])}
-          debounce={{ delay: 100, maxWait: 300 }}
         />
       </div>
     );

--- a/packages/editor/src/browser/types.ts
+++ b/packages/editor/src/browser/types.ts
@@ -8,7 +8,7 @@ import {
   URI,
   Event,
 } from '@opensumi/ide-core-browser';
-import { IMenu } from '@opensumi/ide-core-browser/lib/menu/next';
+import { IContextMenu } from '@opensumi/ide-core-browser/lib/menu/next';
 import { IThemeColor } from '@opensumi/ide-core-common';
 import { editor } from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
@@ -340,7 +340,7 @@ export interface IEditorActionRegistry {
    */
   registerEditorAction(action: IEditorActionItem): IDisposable;
 
-  getMenu(group: IEditorGroup): IMenu;
+  getMenu(group: IEditorGroup): IContextMenu;
 }
 
 export interface IEditorActionItem {

--- a/packages/extension/src/browser/vscode/contributes/menu.ts
+++ b/packages/extension/src/browser/vscode/contributes/menu.ts
@@ -280,7 +280,6 @@ export class MenusContributionPoint extends VSCodeContributePoint<MenusSchema> {
             }
 
             const [group, order] = parseMenuGroup(item.group);
-
             this.addDispose(
               this.menuRegistry.registerMenuItem(menuId, {
                 submenu: item.submenu,


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

fixed #2067.

在编辑器顶部 `...` 菜单支持插件 `submenus` 注册及展示，效果如下：

Web：
![image](https://user-images.githubusercontent.com/9823838/207815633-59a05a83-7e02-4a28-8cde-8c81738a16e1.png)

Electron:

![image](https://user-images.githubusercontent.com/9823838/207815670-78982b94-9ad8-4527-b651-93fdc18c2740.png)

### Changelog

support submenus on editor/title
