### PR TITLE
feat: show title head info & implement the apply actions

### DIFF
--- a/packages/core-browser/src/monaco/merge-editor-widget.ts
+++ b/packages/core-browser/src/monaco/merge-editor-widget.ts
@@ -13,8 +13,8 @@ export interface IMergeEditorEditor extends IEditor {
 export interface IMergeEditorInputData {
   uri: URI;
   title?: string;
-  detail?: string;
-  description?: string;
+  detail?: string; // 分支名
+  description?: string; // commit
 }
 
 export class MergeEditorInputData implements IMergeEditorInputData {

--- a/packages/core-browser/src/monaco/merge-editor-widget.ts
+++ b/packages/core-browser/src/monaco/merge-editor-widget.ts
@@ -116,14 +116,14 @@ export namespace IRelaxedOpenMergeEditorArgs {
 
   const toInputData = (args: unknown): MergeEditorInputData => {
     if (typeof args === 'string') {
-      return new MergeEditorInputData(URI.parse(args), undefined, undefined, undefined);
+      return new MergeEditorInputData(URI.parse(args));
     }
     if (!args || typeof args !== 'object') {
       throw new TypeError('invalid argument');
     }
 
     if (isUriComponents(args)) {
-      return new MergeEditorInputData(URI.from(args), undefined, undefined, undefined);
+      return new MergeEditorInputData(URI.from(args));
     }
 
     const obj = args as MergeEditorInputData;

--- a/packages/core-browser/src/monaco/merge-editor-widget.ts
+++ b/packages/core-browser/src/monaco/merge-editor-widget.ts
@@ -8,14 +8,20 @@ export interface IMergeEditorEditor extends IEditor {
   getResultEditor(): ICodeEditor;
   getTheirsEditor(): ICodeEditor;
   open(openMergeEditorArgs: IOpenMergeEditorArgs): Promise<void>;
-  compare(): Promise<void>;
 }
 
-export class MergeEditorInputData {
+export interface IMergeEditorInputData {
+  uri: URI;
+  title?: string;
+  detail?: string;
+  description?: string;
+}
+
+export class MergeEditorInputData implements IMergeEditorInputData {
   static from(data: string): MergeEditorInputData {
     try {
       const obj: MergeEditorInputData = JSON.parse(data);
-      return new MergeEditorInputData(obj.uri, obj.detail, obj.description);
+      return new MergeEditorInputData(obj.uri, obj.title, obj.detail, obj.description);
     } catch (error) {
       throw Error('invalid MergeEditorInputData parse');
     }
@@ -26,11 +32,26 @@ export class MergeEditorInputData {
     return this._textModel;
   }
 
-  constructor(readonly uri: URI, readonly detail?: string | undefined, readonly description?: string | undefined) {}
+  constructor(
+    readonly uri: URI,
+    readonly title?: string,
+    readonly detail?: string | undefined,
+    readonly description?: string | undefined,
+  ) {}
+
+  public getRaw(): IMergeEditorInputData {
+    return {
+      uri: this.uri,
+      title: this.title,
+      detail: this.detail,
+      description: this.description,
+    };
+  }
 
   public toString(): string {
     return JSON.stringify({
       uri: this.uri.toString(),
+      title: this.title,
       detail: this.detail,
       description: this.description,
     });
@@ -71,8 +92,14 @@ export namespace IRelaxedOpenMergeEditorArgs {
     const obj = args as IValidateOpenArgs;
     const ancestor = toUri(obj.ancestor);
     const output = toUri(obj.output);
-    const input1 = toInputData(obj.input1);
-    const input2 = toInputData(obj.input2);
+    const input1 = toInputData({
+      ...obj.input1,
+      title: obj.input1.title ?? 'Current',
+    });
+    const input2 = toInputData({
+      ...obj.input2,
+      title: obj.input2.title ?? 'Incoming',
+    });
     return { ancestor, input1, input2, output };
   };
 
@@ -89,21 +116,22 @@ export namespace IRelaxedOpenMergeEditorArgs {
 
   const toInputData = (args: unknown): MergeEditorInputData => {
     if (typeof args === 'string') {
-      return new MergeEditorInputData(URI.parse(args), undefined, undefined);
+      return new MergeEditorInputData(URI.parse(args), undefined, undefined, undefined);
     }
     if (!args || typeof args !== 'object') {
       throw new TypeError('invalid argument');
     }
 
     if (isUriComponents(args)) {
-      return new MergeEditorInputData(URI.from(args), undefined, undefined);
+      return new MergeEditorInputData(URI.from(args), undefined, undefined, undefined);
     }
 
     const obj = args as MergeEditorInputData;
     const uri = toUri(obj.uri);
+    const title = obj.title;
     const detail = obj.detail;
     const description = obj.description;
-    return new MergeEditorInputData(uri, detail, description);
+    return new MergeEditorInputData(uri, title, detail, description);
   };
 
   const toUri = (args: unknown): URI => {

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1018,6 +1018,7 @@ export const localizationBundle = {
       'The file has unresolved conflicts or changes, whether to apply and save the changes?',
     'mergeEditor.conflict.action.apply.confirm.continue': 'Continue Merge',
     'mergeEditor.conflict.action.apply.confirm.complete': 'Apply Changes',
+    'mergeEditor.button.apply': 'Apply',
     // #endregion merge editor
     ...browserViews,
   },

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1014,6 +1014,10 @@ export const localizationBundle = {
 
     // #region merge editor
     'mergeEditor.workbench.tab.name': 'Merging: {0}',
+    'mergeEditor.conflict.action.apply.confirm.title':
+      'The file has unresolved conflicts or changes, whether to apply and save the changes?',
+    'mergeEditor.conflict.action.apply.confirm.continue': 'Continue Merge',
+    'mergeEditor.conflict.action.apply.confirm.complete': 'Apply Changes',
     // #endregion merge editor
     ...browserViews,
   },

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1056,6 +1056,9 @@ export const localizationBundle = {
 
     // #region merge editor
     'mergeEditor.workbench.tab.name': '正在合并: {0}',
+    'mergeEditor.conflict.action.apply.confirm.title': '当前文件还有未处理的冲突或变更，是否应用并保存更改？',
+    'mergeEditor.conflict.action.apply.confirm.continue': '继续合并',
+    'mergeEditor.conflict.action.apply.confirm.complete': '确认保存并更改',
     // #endregion merge editor
     ...browserViews,
   },

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1059,6 +1059,7 @@ export const localizationBundle = {
     'mergeEditor.conflict.action.apply.confirm.title': '当前文件还有未处理的冲突或变更，是否应用并保存更改？',
     'mergeEditor.conflict.action.apply.confirm.continue': '继续合并',
     'mergeEditor.conflict.action.apply.confirm.complete': '确认保存并更改',
+    'mergeEditor.button.apply': '应用更改',
     // #endregion merge editor
     ...browserViews,
   },

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@opensumi/ide-dev-tool": "^1.3.1",
     "@opensumi/ide-file-service": "2.21.6",
+    "@opensumi/ide-overlay": "2.21.6",
     "@opensumi/ide-theme": "2.21.6",
     "@opensumi/ide-workspace": "2.21.6"
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/mapping-manager.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/mapping-manager.service.ts
@@ -100,6 +100,11 @@ export class MappingManagerService extends Disposable {
     this.revokeActionsFactory(EDiffRangeTurn.MODIFIED)(oppositeRange);
   }
 
+  public clearMapping(): void {
+    this.documentMappingTurnLeft.clear();
+    this.documentMappingTurnRight.clear();
+  }
+
   /**
    * 分别找出离目标 lineRange 最近的 documentMappingTurnLeft 和 documentMappingTurnRight 里的 lineRange
    * 其中 target 只能是 result view 视图中的 range

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -31,6 +31,23 @@ export class DocumentMapping extends Disposable {
     return Array.from(values).sort((a, b) => a.startLineNumber - b.startLineNumber);
   }
 
+  public getMetaLineRangeMapping(): LineRangeMapping[] {
+    const result: LineRangeMapping[] = [];
+
+    this.computeRangeMap.forEach((range) => {
+      if (this.diffRangeTurn === EDiffRangeTurn.ORIGIN) {
+        result.push(new LineRangeMapping(range, this.adjacentComputeRangeMap.get(range.id)!, []));
+      } else if (this.diffRangeTurn === EDiffRangeTurn.MODIFIED) {
+        const adjacentRange = this.adjacentComputeRangeMap.get(range.id)!;
+        const reverse = this.reverse(adjacentRange);
+        if (reverse) {
+          result.push(new LineRangeMapping(adjacentRange, range, []));
+        }
+      }
+    });
+    return result;
+  }
+
   public getOriginalRange(): LineRange[] {
     return this.ensureSort(
       this.diffRangeTurn === EDiffRangeTurn.ORIGIN
@@ -105,6 +122,11 @@ export class DocumentMapping extends Disposable {
         this.adjacentComputeRangeMap.set(key, pick.delta(offset));
       }
     }
+  }
+
+  public clear(): void {
+    this.computeRangeMap.clear();
+    this.adjacentComputeRangeMap.clear();
   }
 
   public deleteRange(range: LineRange): void {

--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -38,11 +38,7 @@ export class DocumentMapping extends Disposable {
       if (this.diffRangeTurn === EDiffRangeTurn.ORIGIN) {
         result.push(new LineRangeMapping(range, this.adjacentComputeRangeMap.get(range.id)!, []));
       } else if (this.diffRangeTurn === EDiffRangeTurn.MODIFIED) {
-        const adjacentRange = this.adjacentComputeRangeMap.get(range.id)!;
-        const reverse = this.reverse(adjacentRange);
-        if (reverse) {
-          result.push(new LineRangeMapping(adjacentRange, range, []));
-        }
+        result.push(new LineRangeMapping(this.adjacentComputeRangeMap.get(range.id)!, range, []));
       }
     });
     return result;

--- a/packages/monaco/src/browser/contrib/merge-editor/model/time-machine.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/time-machine.ts
@@ -13,7 +13,9 @@ export class TimeMachineDocument {
   }
 
   public record(rangeId: string, data: ITimeMachineMetaData): void {
-    this.collectMap.set(rangeId, data);
+    if (!this.collectMap.has(rangeId)) {
+      this.collectMap.set(rangeId, data);
+    }
   }
 
   public getMetaData(rangeId: string): ITimeMachineMetaData | undefined {

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -1,9 +1,11 @@
 import { getExternalIcon, getIcon } from '@opensumi/ide-core-browser';
 import { IEditorMouseEvent } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
+import { ICodeEditorViewState } from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorCommon';
 
 import { IModelDecorationOptions } from '../../monaco-api/editor';
 
 import { LineRange } from './model/line-range';
+import { LineRangeMapping } from './model/line-range-mapping';
 
 export interface IRangeContrast {
   type: LineRangeType;
@@ -146,4 +148,15 @@ export interface IConflictActionsEvent {
 export interface ITimeMachineMetaData {
   range: LineRange;
   text: string | null;
+}
+
+/**
+ * View State
+ */
+export interface IMergeEditorViewState {
+  [EditorViewType.CURRENT]: ICodeEditorViewState | null;
+  [EditorViewType.RESULT]: ICodeEditorViewState | null;
+  [EditorViewType.INCOMING]: ICodeEditorViewState | null;
+  turnLeft: LineRangeMapping[];
+  turnRight: LineRangeMapping[];
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.tsx
@@ -44,7 +44,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
     return this.mappingManagerService.documentMappingTurnRight;
   }
 
-  public isFirstInputComputeDiff = true;
+  private isFirstInputComputeDiff = true;
 
   constructor(container: HTMLDivElement, monacoService: MonacoService, injector: Injector) {
     super(container, monacoService, injector);
@@ -141,6 +141,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
   }
 
   private getAllDiffRanges(): LineRange[] {
+    // 去重相同 id 或位置一样的 line range
     return distinct(
       this.documentMappingTurnLeft.getModifiedRange().concat(this.documentMappingTurnRight.getOriginalRange()),
       (range) => range.id,
@@ -345,6 +346,10 @@ export class ResultCodeEditor extends BaseCodeEditor {
     };
   }
 
+  public reset(): void {
+    this.isFirstInputComputeDiff = true;
+  }
+
   public getEditorViewType(): EditorViewType {
     return EditorViewType.RESULT;
   }
@@ -356,6 +361,16 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
   public getContentInTimeMachineDocument(rangeId: string): ITimeMachineMetaData | undefined {
     return this.timeMachineDocument.getMetaData(rangeId);
+  }
+
+  public completeSituation(): { completeCount: number; shouldCount: number } {
+    const allRanges = this.getAllDiffRanges();
+    const completeCount = allRanges.reduce((pre: number, cur: LineRange) => pre + (cur.isComplete ? 1 : 0), 0);
+
+    return {
+      completeCount,
+      shouldCount: allRanges.length,
+    };
   }
 
   /**

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { useInjectable } from '@opensumi/ide-core-browser';
+import { localize, useInjectable } from '@opensumi/ide-core-browser';
 import { Button, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 import {
   IMergeEditorInputData,
@@ -116,7 +116,7 @@ export const Grid = () => {
       </SplitPanel>
       <div className={'merge-actions'}>
         <Button size='large' onClick={handleApply}>
-          Apply
+          {localize('mergeEditor.button.apply')}
         </Button>
       </div>
     </div>

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -1,12 +1,63 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useInjectable } from '@opensumi/ide-core-browser';
-import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
+import { Button, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
+import {
+  IMergeEditorInputData,
+  IOpenMergeEditorArgs,
+  MergeEditorInputData,
+} from '@opensumi/ide-core-browser/lib/monaco/merge-editor-widget';
 
 import { MergeEditorService } from '../merge-editor.service';
 import { EditorViewType } from '../types';
 
 import { WithViewStickinessConnectComponent } from './stickiness-connect-manager';
+
+const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType }) => {
+  const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
+  const [head, setHead] = useState<IMergeEditorInputData>();
+
+  React.useEffect(() => {
+    const disposable = mergeEditorService.onDidInputNutrition((nutrition: IOpenMergeEditorArgs) => {
+      /**
+       * input1: current
+       * input2: incoming
+       * output: result
+       */
+      const { input1, input2, output } = nutrition;
+      if (contrastType === EditorViewType.CURRENT) {
+        setHead(input1.getRaw());
+      } else if (contrastType === EditorViewType.INCOMING) {
+        setHead(input2.getRaw());
+      } else if (contrastType === EditorViewType.RESULT) {
+        setHead(new MergeEditorInputData(output.uri, 'Result', output.uri.toString(), '').getRaw());
+      }
+    });
+
+    return () => {
+      disposable.dispose();
+    };
+  }, [mergeEditorService]);
+
+  return (
+    <div className='title-head-container'>
+      {head && (
+        <div className='content'>
+          <span className='title' title={head.title}>
+            {head.title}
+          </span>
+          <span className='description' title={head.description}>
+            {head.description}
+          </span>
+          <span className='detail' title={head.detail}>
+            {head.detail}
+          </span>
+        </div>
+      )}
+      {/* more actions */}
+    </div>
+  );
+};
 
 export const Grid = () => {
   const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
@@ -24,7 +75,10 @@ export const Grid = () => {
     if (current && result && incoming) {
       mergeEditorService.instantiationCodeEditor(current, result, incoming);
     }
-    return () => mergeEditorService.dispose();
+
+    return () => {
+      mergeEditorService.dispose();
+    };
   }, [
     incomingEditorContainer.current,
     currentEditorContainer.current,
@@ -36,19 +90,24 @@ export const Grid = () => {
     <div className={'merge-editor-container'}>
       <SplitPanel overflow='hidden' id='merge-editor-container' flex={2}>
         <div className={'editor-container-arrange'}>
-          <div className={'currentEditorContainer'} ref={currentEditorContainer}></div>
+          <TitleHead contrastType={EditorViewType.CURRENT}></TitleHead>
+          <div className={'editorContainer'} ref={currentEditorContainer}></div>
         </div>
         <div className={'editor-container-arrange'}>
-          <WithViewStickinessConnectComponent
-            contrastType={EditorViewType.CURRENT}
-          ></WithViewStickinessConnectComponent>
-          <div className={'resultEditorContainer'} ref={resultEditorContainer}></div>
-          <WithViewStickinessConnectComponent
-            contrastType={EditorViewType.INCOMING}
-          ></WithViewStickinessConnectComponent>
+          <TitleHead contrastType={EditorViewType.RESULT}></TitleHead>
+          <div className={'editorContainer'}>
+            <WithViewStickinessConnectComponent
+              contrastType={EditorViewType.CURRENT}
+            ></WithViewStickinessConnectComponent>
+            <div className={'editorContainer'} ref={resultEditorContainer}></div>
+            <WithViewStickinessConnectComponent
+              contrastType={EditorViewType.INCOMING}
+            ></WithViewStickinessConnectComponent>
+          </div>
         </div>
         <div className={'editor-container-arrange'}>
-          <div className={'incomingEditorContainer'} ref={incomingEditorContainer}></div>
+          <TitleHead contrastType={EditorViewType.INCOMING}></TitleHead>
+          <div className={'editorContainer'} ref={incomingEditorContainer}></div>
         </div>
       </SplitPanel>
     </div>

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -86,6 +86,10 @@ export const Grid = () => {
     mergeEditorService,
   ]);
 
+  const handleApply = () => {
+    mergeEditorService.accept();
+  };
+
   return (
     <div className={'merge-editor-container'}>
       <SplitPanel overflow='hidden' id='merge-editor-container' flex={2}>
@@ -110,6 +114,11 @@ export const Grid = () => {
           <div className={'editorContainer'} ref={incomingEditorContainer}></div>
         </div>
       </SplitPanel>
+      <div className={'merge-actions'}>
+        <Button size='large' onClick={handleApply}>
+          Apply
+        </Button>
+      </div>
     </div>
   );
 };

--- a/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/guideline-widget.ts
@@ -24,6 +24,11 @@ export class GuidelineWidget extends ZoneWidget {
     });
   }
 
+  // 覆写 revealLine 函数，使其在 show 的时候编辑器不会定位到对应位置
+  protected override revealLine(lineNumber: number, isLastLine: boolean): void {
+    // not implement
+  }
+
   public getRecordLine(): number {
     return this.recordLine;
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.less
@@ -1,10 +1,16 @@
 .merge-editor-container {
   height: 100%;
   overflow: hidden;
+  position: relative;
 
-  .currentEditorContainer,
-  .resultEditorContainer,
-  .incomingEditorContainer {
+  .merge-actions {
+    position: absolute;
+    right: 50px;
+    bottom: 30px;
+  }
+
+  .editorContainer {
+    display: flex;
     height: inherit;
     width: 100%;
   }
@@ -55,6 +61,8 @@
   .editor-container-arrange {
     height: 100%;
     display: flex;
+    flex-direction: column;
+
     .stickiness-connect-container {
       height: 100%;
       position: relative;
@@ -145,6 +153,57 @@
 
     &.stretch-bottom {
       border-bottom: transparent;
+    }
+  }
+
+  .title-head-container {
+    padding: 0 10px;
+    height: 30px;
+    min-height: 30px;
+    z-index: 2;
+
+    & span {
+      align-self: center;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      padding-right: 6px;
+      white-space: nowrap;
+    }
+
+    .content {
+      display: flex;
+      align-content: center;
+      height: inherit;
+      max-width: calc(100% - 80px);
+      display: flex;
+
+      .title {
+        flex-shrink: 0;
+      }
+
+      .description {
+        display: flex;
+        font-size: 12px;
+        align-items: center;
+        color: var(--descriptionForeground);
+      }
+
+      .detail {
+        margin-left: 0;
+        flex-shrink: 0;
+        font-size: 12px;
+        color: var(--descriptionForeground);
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        flex: 1;
+
+        &:before {
+          content: '•';
+          opacity: 0.5;
+          padding-right: 3px;
+        }
+      }
     }
   }
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/scroll-synchronizer.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/scroll-synchronizer.ts
@@ -16,11 +16,7 @@ export class ScrollSynchronizer extends Disposable {
 
   public mount(currentView: BaseCodeEditor, resultView: BaseCodeEditor, incomingView: BaseCodeEditor): void {
     this.addDispose(
-      Event.debounce<{ event: IScrollEvent; editor: BaseCodeEditor }>(
-        this.onScrollChange,
-        (_, e) => e,
-        1,
-      )(({ event, editor }) => {
+      Event.buffer<{ event: IScrollEvent; editor: BaseCodeEditor }>(this.onScrollChange)(({ event, editor }) => {
         if (!event.scrollTopChanged && !event.scrollLeftChanged && !event.scrollHeightChanged) {
           return;
         }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

- [x] 修复上下滚动视图时的顿感问题
- [x] 修复点击 conflict action 操作后视图页面会滚动的问题
- [x] 修复切换 tab 后，decoration 状态会重复渲染的问题
- [x] 新增 title head 展示
![image](https://user-images.githubusercontent.com/20262815/208340114-b4502ce5-852a-4c4d-8e99-1e1e169c93f3.png)
- [x] 实现 apply 操作，点击后将 result 视图的代码覆写到真实的本地磁盘文件，表示冲突已解决完成

https://user-images.githubusercontent.com/20262815/208357850-ab817832-a8e4-4a7b-b40b-8539ebc69f85.mp4


### Changelog
新增 title head 展示分支信息和 commit 以及新增 apply 按钮
