### PR TITLE
refactor: remove DeprecatedRecycleTree on comment module

### DIFF
--- a/packages/comments/__test__/browser/comment-thread.test.ts
+++ b/packages/comments/__test__/browser/comment-thread.test.ts
@@ -47,7 +47,7 @@ describe('comment service test', () => {
         {
           mode: CommentMode.Editor,
           author: {
-            name: '蛋总',
+            name: 'User',
           },
           body: '评论内容1',
         },
@@ -64,7 +64,7 @@ describe('comment service test', () => {
         {
           mode: CommentMode.Editor,
           author: {
-            name: '蛋总',
+            name: 'User',
           },
           body: '评论内容1',
           data: {
@@ -87,14 +87,14 @@ describe('comment service test', () => {
       {
         mode: CommentMode.Preview,
         author: {
-          name: '蛋总',
+          name: 'User',
         },
         body: '评论内容1',
       },
       {
         mode: CommentMode.Editor,
         author: {
-          name: '蛋总',
+          name: 'User',
         },
         body: '评论内容2',
       },
@@ -110,14 +110,14 @@ describe('comment service test', () => {
       {
         mode: CommentMode.Preview,
         author: {
-          name: '蛋总',
+          name: 'User',
         },
         body: '评论内容1',
       },
       {
         mode: CommentMode.Editor,
         author: {
-          name: '蛋总',
+          name: 'User',
         },
         body: '评论内容2',
       },

--- a/packages/comments/__test__/browser/comments-feature.registry.test.ts
+++ b/packages/comments/__test__/browser/comments-feature.registry.test.ts
@@ -1,6 +1,5 @@
 import { Injector } from '@opensumi/di';
 import { IContextKeyService } from '@opensumi/ide-core-browser';
-import { URI, positionToRange } from '@opensumi/ide-core-common';
 import { IIconService } from '@opensumi/ide-theme';
 import { IconService } from '@opensumi/ide-theme/lib/browser';
 
@@ -9,11 +8,10 @@ import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 import { createMockedMonaco } from '../../../monaco/__mocks__/monaco';
 import { MockContextKeyService } from '../../../monaco/__mocks__/monaco.context-key.service';
 import { CommentsModule } from '../../src/browser';
-import { ICommentsService, CommentMode, ICommentsFeatureRegistry } from '../../src/common';
+import { ICommentsService, ICommentsFeatureRegistry } from '../../src/common';
 
 describe('comment service test', () => {
   let injector: MockInjector;
-  let commentsService: ICommentsService;
   let commentsFeatureRegistry: ICommentsFeatureRegistry;
   beforeAll(() => {
     (global as any).monaco = createMockedMonaco() as any;
@@ -30,7 +28,6 @@ describe('comment service test', () => {
         },
       ]),
     );
-    commentsService = injector.get<ICommentsService>(ICommentsService);
     commentsFeatureRegistry = injector.get<ICommentsFeatureRegistry>(ICommentsFeatureRegistry);
   });
 
@@ -66,31 +63,5 @@ describe('comment service test', () => {
     const registryOptions = commentsFeatureRegistry.getCommentsPanelOptions();
 
     expect(registryOptions).toEqual(options);
-  });
-
-  it('registerPanelTreeNodeHandler', () => {
-    // 先绑定 node 节点处理函数
-    commentsFeatureRegistry.registerPanelTreeNodeHandler((nodes) =>
-      nodes.map((node) => {
-        node.name = '111';
-        return node;
-      }),
-    );
-    const uri = URI.file('/test');
-    commentsService.createThread(uri, positionToRange(1), {
-      comments: [
-        {
-          mode: CommentMode.Editor,
-          author: {
-            name: '蛋总',
-          },
-          body: '评论内容1',
-        },
-      ],
-    });
-    const nodes = commentsService.commentsTreeNodes;
-    // name 不会是 test，而是被 handler 处理过的 111
-    expect(nodes[0].name).toBe('111');
-    expect(nodes[1].name).toBe('111');
   });
 });

--- a/packages/comments/src/browser/comments-feature.registry.ts
+++ b/packages/comments/src/browser/comments-feature.registry.ts
@@ -17,8 +17,6 @@ export class CommentsFeatureRegistry implements ICommentsFeatureRegistry {
 
   private options: CommentsPanelOptions = {};
 
-  private panelTreeNodeHandlers: PanelTreeNodeHandler[] = [];
-
   private fileUploadHandler: FileUploadHandler;
 
   private mentionsOptions: MentionsOptions = {};
@@ -32,10 +30,6 @@ export class CommentsFeatureRegistry implements ICommentsFeatureRegistry {
       ...this.config,
       ...config,
     };
-  }
-
-  registerPanelTreeNodeHandler(handler: PanelTreeNodeHandler): void {
-    this.panelTreeNodeHandlers.push(handler);
   }
 
   registerPanelOptions(options: CommentsPanelOptions): void {
@@ -63,10 +57,6 @@ export class CommentsFeatureRegistry implements ICommentsFeatureRegistry {
 
   getCommentsPanelOptions(): CommentsPanelOptions {
     return this.options;
-  }
-
-  getCommentsPanelTreeNodeHandlers(): PanelTreeNodeHandler[] {
-    return this.panelTreeNodeHandlers;
   }
 
   getFileUploadHandler() {

--- a/packages/comments/src/browser/comments-zone.view.tsx
+++ b/packages/comments/src/browser/comments-zone.view.tsx
@@ -135,7 +135,7 @@ const CommentsZone: React.FC<ICommentProps> = observer(({ thread, widget }) => {
 
 @Injectable({ multiple: true })
 export class CommentsZoneWidget extends ResizeZoneWidget implements ICommentsZoneWidget {
-  protected _fillContainer(container: HTMLElement): void {}
+  protected _fillContainer(): void {}
   @Autowired(AppConfig)
   appConfig: AppConfig;
 

--- a/packages/comments/src/browser/comments.contribution.ts
+++ b/packages/comments/src/browser/comments.contribution.ts
@@ -33,6 +33,8 @@ import {
   CommentReactionClick,
 } from '../common';
 
+import { CommentModelService } from './tree/tree-model.service';
+
 @Domain(
   ClientAppContribution,
   BrowserEditorContribution,
@@ -64,6 +66,9 @@ export class CommentsBrowserContribution
   @Autowired(IEventBus)
   private readonly eventBus: IEventBus;
 
+  @Autowired(CommentModelService)
+  private commentModelService: CommentModelService;
+
   onStart() {
     this.registerCommentsFeature();
     this.listenToCreateCommentsPanel();
@@ -84,7 +89,7 @@ export class CommentsBrowserContribution
       },
       {
         execute: () => {
-          this.eventBus.fire(new CommentPanelCollapse());
+          this.commentModelService.collapsedAll();
         },
       },
     );

--- a/packages/comments/src/browser/comments.service.ts
+++ b/packages/comments/src/browser/comments.service.ts
@@ -1,7 +1,6 @@
 import debounce from 'lodash/debounce';
 import flattenDeep from 'lodash/flattenDeep';
 import groupBy from 'lodash/groupBy';
-import { observable, computed, action } from 'mobx';
 
 import { INJECTOR_TOKEN, Injector, Injectable, Autowired } from '@opensumi/di';
 import {
@@ -19,6 +18,10 @@ import {
   Deferred,
   path,
   LRUCache,
+  MaybePromise,
+  LabelService,
+  formatLocalize,
+  getExternalIcon,
 } from '@opensumi/ide-core-browser';
 import { IEditor } from '@opensumi/ide-editor';
 import {
@@ -36,7 +39,6 @@ import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import {
   ICommentsService,
   ICommentsThread,
-  ICommentsTreeNode,
   ICommentsFeatureRegistry,
   CommentPanelId,
   ICommentRangeProvider,
@@ -45,8 +47,7 @@ import {
 
 import { CommentsPanel } from './comments-panel.view';
 import { CommentsThread } from './comments-thread';
-
-const { dirname } = path;
+import { CommentContentNode, CommentFileNode, CommentReplyNode, CommentRoot } from './tree/tree-node.defined';
 
 @Injectable()
 export class CommentsService extends Disposable implements ICommentsService {
@@ -61,6 +62,9 @@ export class CommentsService extends Disposable implements ICommentsService {
 
   @Autowired(IIconService)
   private readonly iconService: IIconService;
+
+  @Autowired(LabelService)
+  private readonly labelService: LabelService;
 
   @Autowired(ICommentsFeatureRegistry)
   private readonly commentsFeatureRegistry: ICommentsFeatureRegistry;
@@ -79,10 +83,11 @@ export class CommentsService extends Disposable implements ICommentsService {
 
   private decorationChangeEmitter = new Emitter<URI>();
 
-  @observable
   private threads = new Map<string, ICommentsThread>();
 
   private threadsChangeEmitter = new Emitter<ICommentsThread>();
+
+  private threadsCommentChangeEmitter = new Emitter<ICommentsThread>();
 
   private threadsCreatedEmitter = new Emitter<ICommentsThread>();
 
@@ -97,10 +102,6 @@ export class CommentsService extends Disposable implements ICommentsService {
 
   private decorationProviderDisposer = Disposable.NULL;
 
-  @observable
-  private forceUpdateCount = 0;
-
-  @computed
   get commentsThreads() {
     return [...this.threads.values()];
   }
@@ -122,6 +123,10 @@ export class CommentsService extends Disposable implements ICommentsService {
 
   get onThreadsChanged(): Event<ICommentsThread> {
     return this.threadsChangeEmitter.event;
+  }
+
+  get onThreadsCommentChange(): Event<ICommentsThread> {
+    return this.threadsCommentChangeEmitter.event;
   }
 
   get onThreadsCreated(): Event<ICommentsThread> {
@@ -153,7 +158,7 @@ export class CommentsService extends Disposable implements ICommentsService {
   private createHoverDecoration(): model.IModelDecorationOptions {
     const decorationOptions: model.IModelDecorationOptions = {
       description: 'comments-hover-decoration',
-      linesDecorationsClassName: ['comments-decoration', 'comments-add', getIcon('message')].join(' '),
+      linesDecorationsClassName: ['comments-decoration', 'comments-add', getIcon('add-comments')].join(' '),
     };
     return textModel.ModelDecorationOptions.createDynamic(decorationOptions);
   }
@@ -300,6 +305,9 @@ export class CommentsService extends Disposable implements ICommentsService {
       this.threadsChangeEmitter.fire(thread);
       this.decorationChangeEmitter.fire(uri);
     });
+    thread.onDidChange(() => {
+      this.threadsChangeEmitter.fire(thread);
+    });
     this.threads.set(thread.id, thread);
     this.addDispose(thread);
     this.threadsChangeEmitter.fire(thread);
@@ -317,91 +325,71 @@ export class CommentsService extends Disposable implements ICommentsService {
     );
   }
 
-  @action
-  public forceUpdateTreeNodes() {
-    this.forceUpdateCount++;
-  }
-
-  @computed
-  get commentsTreeNodes(): ICommentsTreeNode[] {
-    let treeNodes: ICommentsTreeNode[] = [];
-    const commentThreads = [...this.threads.values()].filter((thread) => thread.comments.length);
-    const threadUris = groupBy(commentThreads, (thread: ICommentsThread) => thread.uri);
-    Object.keys(threadUris).forEach((uri) => {
-      const threads: ICommentsThread[] = threadUris[uri];
-      if (threads.length === 0) {
-        return;
-      }
-      const firstThread = threads[0];
-      const firstThreadUri = firstThread.uri;
-      const filePath = dirname(firstThreadUri.path.toString().replace(this.appConfig.workspaceDir, ''));
-      const rootNode: ICommentsTreeNode = {
-        id: uri,
-        name: firstThreadUri.displayName,
-        uri: firstThreadUri,
-        description: filePath.replace(/^\//, ''),
-        parent: undefined,
-        thread: firstThread,
-        ...(threads.length && {
-          expanded: true,
-          children: [],
-        }),
-        // 跳过 mobx computed， 强制在走一次 getCommentsPanelTreeNodeHandlers 逻辑
-        _forceUpdateCount: this.forceUpdateCount,
-      };
-      treeNodes.push(rootNode);
-      threads.forEach((thread) => {
-        if (thread.comments.length === 0) {
-          return;
-        }
-        const [firstComment, ...otherComments] = thread.comments;
-        const firstCommentNode: ICommentsTreeNode = {
-          id: firstComment.id,
-          name: firstComment.author.name,
-          iconStyle: {
-            marginRight: 5,
-            backgroundSize: '14px 14px',
-          },
-          icon: this.iconService.fromIcon('', firstComment.author.iconPath?.toString(), IconType.Background),
-          description: typeof firstComment.body === 'string' ? firstComment.body : firstComment.body.value,
-          uri: thread.uri,
-          parent: rootNode,
-          depth: 1,
-          thread,
-          ...(otherComments.length && {
-            expanded: true,
-            children: [],
-          }),
-          comment: firstComment,
-        };
-        const firstCommentChildren = otherComments.map((comment) => {
-          const otherCommentNode: ICommentsTreeNode = {
-            id: comment.id,
-            name: comment.author.name,
-            description: typeof comment.body === 'string' ? comment.body : comment.body.value,
-            uri: thread.uri,
-            iconStyle: {
-              marginRight: 5,
-              backgroundSize: '14px 14px',
-            },
-            icon: this.iconService.fromIcon('', comment.author.iconPath?.toString(), IconType.Background),
-            parent: firstCommentNode,
-            depth: 2,
-            thread,
-            comment,
-          };
-          return otherCommentNode;
+  async resolveChildren(parent?: CommentRoot | CommentFileNode | CommentContentNode) {
+    const childs: (CommentRoot | CommentFileNode | CommentContentNode | CommentReplyNode)[] = [];
+    if (!parent) {
+      childs.push(new CommentRoot(this));
+    } else {
+      if (CommentRoot.isRoot(parent)) {
+        const commentThreads = [...this.threads.values()].filter((thread) => thread.comments.length);
+        const threadUris = groupBy(commentThreads, (thread: ICommentsThread) => thread.uri);
+        Object.keys(threadUris).map((uri) => {
+          const threads: ICommentsThread[] = threadUris[uri];
+          if (threads.length === 0) {
+            return;
+          }
+          const workspaceDir = new URI(this.appConfig.workspaceDir);
+          const resource = new URI(uri);
+          const description = workspaceDir.relative(resource)?.toString();
+          childs.push(
+            new CommentFileNode(
+              this,
+              threads,
+              description,
+              resource.codeUri.fsPath,
+              this.labelService.getIcon(resource),
+              resource,
+              parent,
+            ),
+          );
         });
-        treeNodes.push(firstCommentNode);
-        treeNodes.push(...firstCommentChildren);
-      });
-    });
-
-    for (const handler of this.commentsFeatureRegistry.getCommentsPanelTreeNodeHandlers()) {
-      treeNodes = handler(treeNodes);
+      } else if (CommentFileNode.is(parent)) {
+        for (const thread of (parent as CommentFileNode).threads) {
+          const [first] = thread.comments;
+          const comment = typeof first.body === 'string' ? first.body : first.body.value;
+          childs.push(
+            new CommentContentNode(
+              this,
+              thread,
+              comment,
+              `[Ln ${thread.range.startLineNumber}]`,
+              first.author.iconPath
+                ? (this.iconService.fromIcon('', first.author.iconPath.toString(), IconType.Background) as string)
+                : getIcon('message'),
+              first.author,
+              parent.resource,
+              parent as CommentFileNode,
+            ),
+          );
+        }
+      } else if (CommentContentNode.is(parent)) {
+        const thread = parent.thread;
+        const [_, ...others] = thread.comments;
+        const lastReply = others[others.length - 1].author.name;
+        childs.push(
+          new CommentReplyNode(
+            this,
+            thread,
+            formatLocalize('comment.reply.count', others?.length || 0),
+            formatLocalize('comment.reply.lastReply', lastReply),
+            getExternalIcon('indent'),
+            parent.resource,
+            parent,
+          ),
+        );
+      }
     }
-
-    return treeNodes;
+    return childs;
   }
 
   public async getContributionRanges(uri: URI): Promise<IRange[]> {
@@ -436,6 +424,10 @@ export class CommentsService extends Disposable implements ICommentsService {
     const flattenRange: IRange[] = flattenDeep(res).filter(Boolean) as IRange[];
     deferredRes.resolve(flattenRange);
     return flattenRange;
+  }
+
+  public fireThreadCommentChange(thread: ICommentsThread) {
+    this.threadsCommentChangeEmitter.fire(thread);
   }
 
   private registerDecorationProvider() {

--- a/packages/comments/src/browser/index.ts
+++ b/packages/comments/src/browser/index.ts
@@ -6,8 +6,7 @@ import { CommentsContribution, ICommentsService, ICommentsFeatureRegistry } from
 import { CommentsFeatureRegistry } from './comments-feature.registry';
 import { CommentsBrowserContribution } from './comments.contribution';
 import { CommentsService } from './comments.service';
-
-import './comments.module.less';
+import { CommentModelService } from './tree/tree-model.service';
 
 @Injectable()
 export class CommentsModule extends BrowserModule {
@@ -16,6 +15,10 @@ export class CommentsModule extends BrowserModule {
     {
       token: ICommentsService,
       useClass: CommentsService,
+    },
+    {
+      token: CommentModelService,
+      useClass: CommentModelService,
     },
     {
       token: ICommentsFeatureRegistry,

--- a/packages/comments/src/browser/tree/comment-node.tsx
+++ b/packages/comments/src/browser/tree/comment-node.tsx
@@ -1,0 +1,122 @@
+import cls from 'classnames';
+import React, { useCallback } from 'react';
+
+import { INodeRendererProps, ClasslistComposite } from '@opensumi/ide-components';
+import { getIcon } from '@opensumi/ide-core-browser';
+
+import { CommentContentNode, CommentFileNode, CommentReplyNode } from './tree-node.defined';
+import styles from './tree-node.module.less';
+
+export interface ICommentNodeProps {
+  item: any;
+  defaultLeftPadding?: number;
+  leftPadding?: number;
+  decorations?: ClasslistComposite;
+  onClick: (ev: React.MouseEvent, item: CommentContentNode | CommentFileNode) => void;
+}
+
+export type ICommentNodeRenderedProps = ICommentNodeProps & INodeRendererProps;
+
+export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
+  item,
+  defaultLeftPadding = 8,
+  leftPadding = 8,
+  decorations,
+  onClick,
+}: ICommentNodeRenderedProps) => {
+  const handleClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onClick(ev, item as CommentContentNode);
+    },
+    [onClick],
+  );
+
+  const paddingLeft = `${
+    defaultLeftPadding +
+    (item.depth || 0) * (leftPadding || 0) +
+    (CommentContentNode.is(item) ? 16 : CommentReplyNode.is(item) ? 28 : 0)
+  }px`;
+
+  const renderedNodeStyle = {
+    height: COMMENT_TREE_NODE_HEIGHT,
+    lineHeight: `${COMMENT_TREE_NODE_HEIGHT}px`,
+    paddingLeft,
+  } as React.CSSProperties;
+
+  const renderIcon = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+    if (CommentReplyNode.is(node)) {
+      return null;
+    }
+    return (
+      <div
+        className={cls(styles.icon, !CommentReplyNode.is(node) ? node.icon : '')}
+        style={{
+          height: COMMENT_TREE_NODE_HEIGHT,
+          lineHeight: `${COMMENT_TREE_NODE_HEIGHT}px`,
+        }}
+      ></div>
+    );
+  }, []);
+
+  const renderDisplayName = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+    if (CommentContentNode.is(node)) {
+      return (
+        <div className={cls(styles.segment, styles.displayname)}>
+          {node.comment}
+          <span className={styles.separator}>·</span>
+          {node.author.name}
+        </div>
+      );
+    } else {
+      return <div className={cls(styles.segment, styles.displayname)}>{node.displayName}</div>;
+    }
+  }, []);
+
+  const renderDescription = useCallback(
+    (node: CommentFileNode | CommentContentNode | CommentReplyNode) => (
+      <div className={cls(styles.segment_grow, styles.description)}>{node.description}</div>
+    ),
+    [],
+  );
+
+  const renderFolderToggle = useCallback(
+    (node: CommentFileNode) => (
+      <div
+        className={cls(styles.segment, styles.expansion_toggle, getIcon('arrow-right'), {
+          [`${styles.mod_collapsed}`]: !(node as CommentFileNode).expanded,
+        })}
+      />
+    ),
+    [],
+  );
+
+  const renderTwice = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+    if (CommentFileNode.is(node)) {
+      return renderFolderToggle(node as CommentFileNode);
+    }
+  }, []);
+
+  const getItemTooltip = useCallback(() => item.tooltip, [item]);
+
+  return (
+    <div
+      key={item.id}
+      onClick={handleClick}
+      title={getItemTooltip()}
+      className={cls(styles.search_node, decorations ? decorations.classlist : null)}
+      style={renderedNodeStyle}
+      data-id={item.id}
+    >
+      <div className={styles.content}>
+        {renderTwice(item)}
+        {renderIcon(item)}
+        <div className={styles.overflow_wrap}>
+          {renderDisplayName(item)}
+          {renderDescription(item)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const COMMENT_TREE_NODE_HEIGHT = 22;

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -1,0 +1,173 @@
+/* eslint-disable import/order */
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
+import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeModel } from '@opensumi/ide-components';
+import { DisposableCollection, Emitter, Event, Disposable } from '@opensumi/ide-core-browser';
+import { ICommentsService } from '../../common/index';
+
+import { CommentContentNode, CommentFileNode, CommentReplyNode, CommentRoot } from './tree-node.defined';
+import styles from './tree-node.module.less';
+
+export interface IEditorTreeHandle extends IRecycleTreeHandle {
+  hasDirectFocus: () => boolean;
+}
+
+@Injectable({ multiple: true })
+export class CommentTreeModel extends TreeModel {
+  constructor(@Optional() root: CommentRoot) {
+    super();
+    this.init(root);
+  }
+}
+
+@Injectable()
+export class CommentModelService extends Disposable {
+  @Autowired(ICommentsService)
+  private readonly commentService: ICommentsService;
+
+  @Autowired(INJECTOR_TOKEN)
+  private readonly injector: Injector;
+
+  private _treeModel: CommentTreeModel;
+
+  private _whenReady: Promise<void>;
+
+  private _decorations: DecorationsManager;
+  private _commentTreeHandle: IRecycleTreeHandle;
+
+  // All decoration
+  private selectedDecoration: Decoration = new Decoration(styles.mod_selected); // selected
+  private focusedDecoration: Decoration = new Decoration(styles.mod_focused); // focused
+
+  private _focusedNode: CommentFileNode | CommentContentNode | CommentReplyNode | null;
+  private _selectedNodes: (CommentFileNode | CommentContentNode | CommentReplyNode)[] = [];
+
+  private onDidUpdateTreeModelEmitter: Emitter<CommentTreeModel | undefined> = new Emitter();
+
+  private disposableCollection: DisposableCollection = new DisposableCollection();
+
+  constructor() {
+    super();
+    this._whenReady = this.initTreeModel();
+  }
+
+  get onDidUpdateTreeModel(): Event<CommentTreeModel | undefined> {
+    return this.onDidUpdateTreeModelEmitter.event;
+  }
+
+  get whenReady() {
+    return this._whenReady;
+  }
+
+  get commentTreeHandle() {
+    return this._commentTreeHandle;
+  }
+
+  get decorations() {
+    return this._decorations;
+  }
+
+  get treeModel() {
+    return this._treeModel;
+  }
+
+  get focusedNode() {
+    return this._focusedNode;
+  }
+
+  get selectedNodes() {
+    return this._selectedNodes;
+  }
+
+  async initTreeModel() {
+    const childs = await this.commentService.resolveChildren();
+    if (!childs) {
+      return;
+    }
+    const root = childs[0];
+    if (!root) {
+      return;
+    }
+    this._treeModel = this.injector.get<any>(CommentTreeModel, [root]);
+    await this._treeModel.ensureReady;
+
+    this.initDecorations(root);
+
+    this.disposables.push(
+      this.commentService.onThreadsCommentChange(() => {
+        this.refresh();
+      }),
+    );
+
+    this.onDidUpdateTreeModelEmitter.fire(this._treeModel);
+  }
+
+  initDecorations(root) {
+    this._decorations = new DecorationsManager(root as any);
+    this._decorations.addDecoration(this.selectedDecoration);
+    this._decorations.addDecoration(this.focusedDecoration);
+    return this._decorations;
+  }
+
+  handleTreeHandler(handle: IRecycleTreeHandle) {
+    this._commentTreeHandle = handle;
+  }
+
+  applyFocusedDecoration = (target: CommentFileNode | CommentContentNode | CommentReplyNode, dispatch = true) => {
+    if (target) {
+      for (const target of this._selectedNodes) {
+        this.selectedDecoration.removeTarget(target);
+      }
+      if (this.focusedNode) {
+        this.focusedDecoration.removeTarget(this.focusedNode);
+      }
+      this.selectedDecoration.addTarget(target);
+      this.focusedDecoration.addTarget(target);
+      this._focusedNode = target;
+      this._selectedNodes = [target];
+
+      dispatch && this.treeModel?.dispatchChange();
+    }
+  };
+
+  removeFocusedDecoration = () => {
+    if (this.focusedNode) {
+      this.focusedDecoration.removeTarget(this.focusedNode);
+      this.treeModel?.dispatchChange();
+    }
+    this._focusedNode = null;
+  };
+
+  handleTreeBlur = () => {
+    this.removeFocusedDecoration();
+  };
+
+  handleItemClick = async (ev: React.MouseEvent, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+    this.applyFocusedDecoration(node);
+    if (CommentFileNode.is(node)) {
+      this.toggleDirectory(node);
+    } else if (node) {
+    }
+  };
+
+  toggleDirectory = (item: CommentFileNode | CommentContentNode) => {
+    if (item.expanded) {
+      this.commentTreeHandle.collapseNode(item);
+    } else {
+      this.commentTreeHandle.expandNode(item);
+    }
+  };
+
+  async refresh() {
+    await this.whenReady;
+    this.treeModel.root.refresh();
+  }
+
+  async collapsedAll() {
+    await this.whenReady;
+    return this.treeModel.root.collapsedAll();
+  }
+
+  dispose() {
+    this.disposableCollection.dispose();
+  }
+}

--- a/packages/comments/src/browser/tree/tree-node.defined.ts
+++ b/packages/comments/src/browser/tree/tree-node.defined.ts
@@ -1,0 +1,90 @@
+import { TreeNode, CompositeTreeNode, ITree } from '@opensumi/ide-components';
+import { URI } from '@opensumi/ide-core-common';
+
+import { ICommentAuthorInformation, ICommentsService, ICommentsThread } from '../../common/index';
+
+export class CommentRoot extends CompositeTreeNode {
+  static is(node: CommentFileNode | CommentRoot): node is CommentRoot {
+    return !!node && !node.parent;
+  }
+
+  constructor(tree: ICommentsService) {
+    super(tree as ITree, undefined);
+  }
+
+  get expanded() {
+    return true;
+  }
+}
+
+export class CommentFileNode extends CompositeTreeNode {
+  public static is(node: any): node is CommentFileNode {
+    return CompositeTreeNode.is(node) && 'threads' in node;
+  }
+
+  constructor(
+    tree: ICommentsService,
+    public threads: ICommentsThread[],
+    public description: string = '',
+    public tooltip: string,
+    public icon: string,
+    public resource: URI,
+    parent: CommentRoot,
+  ) {
+    super(tree as ITree, parent);
+    this.isExpanded = true;
+  }
+
+  get displayName() {
+    return this.resource.displayName;
+  }
+
+  get badge() {
+    return this.branchSize;
+  }
+}
+
+export class CommentContentNode extends CompositeTreeNode {
+  public static is(node: any): node is CommentContentNode {
+    return CompositeTreeNode.is(node) && 'author' in node;
+  }
+
+  constructor(
+    tree: ICommentsService,
+    public thread: ICommentsThread,
+    public comment: string,
+    public description: string = '',
+    public icon: string,
+    public author: ICommentAuthorInformation,
+    public resource: URI,
+    parent: CommentFileNode | undefined,
+  ) {
+    super(tree as ITree, parent);
+  }
+
+  get expanded() {
+    return true;
+  }
+}
+
+export class CommentReplyNode extends TreeNode {
+  public static is(node: any): node is CommentReplyNode {
+    return TreeNode.is(node) && 'label' in node;
+  }
+
+  constructor(
+    tree: ICommentsService,
+    public thread: ICommentsThread,
+    public label: string,
+    public description: string = '',
+    public icon: string,
+    public resource: URI,
+    parent: CommentContentNode | undefined,
+  ) {
+    super(tree as ITree, parent);
+  }
+
+  get displayName() {
+    return this.label;
+  }
+}

--- a/packages/comments/src/browser/tree/tree-node.module.less
+++ b/packages/comments/src/browser/tree/tree-node.module.less
@@ -1,0 +1,156 @@
+.search_node {
+  height: 22px;
+  line-height: 22px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  cursor: pointer;
+
+  .displayname {
+    color: var(--foreground);
+    margin-right: 6px;
+    display: inline;
+    white-space: pre;
+  }
+
+  .description {
+    display: inline;
+    color: var(--descriptionForeground);
+  }
+
+  .separator {
+    margin: 0 3px;
+  }
+
+  .content {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .status {
+    text-align: center;
+    font-size: 12px;
+  }
+
+  .segment {
+    flex-grow: 0;
+    white-space: nowrap;
+    color: inherit;
+    &_grow {
+      flex-grow: 1 !important;
+      text-align: left;
+      z-index: 10;
+      padding-right: 5px;
+
+      &.overflow_visible {
+        overflow: visible !important;
+      }
+    }
+  }
+
+  .segment_grow {
+    flex-grow: 1 !important;
+    text-align: left;
+    z-index: 10;
+    padding-right: 5px;
+
+    &.overflow_visible {
+      overflow: visible !important;
+    }
+  }
+
+  .tail {
+    text-align: center;
+    margin-right: 10px;
+    position: relative;
+    height: 22px;
+    display: flex;
+    align-items: center;
+  }
+
+  .overflow_wrap {
+    flex: 1;
+    flex-shrink: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
+    color: var(--foreground);
+  }
+
+  .flex_wrap {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .icon {
+    position: relative;
+    color: var(--icon-foreground);
+    margin-right: 4px;
+    &:before {
+      font-size: 16px;
+      text-align: center;
+    }
+  }
+  &:hover {
+    color: var(--kt-tree-hoverForeground);
+    background: var(--kt-tree-hoverBackground);
+    .action_bar {
+      display: block;
+    }
+    &::before {
+      display: none;
+    }
+  }
+
+  &.mod_selected {
+    color: var(--kt-tree-inactiveSelectionForeground);
+    background: var(--kt-tree-inactiveSelectionBackground);
+    .expansion_toggle,
+    .description {
+      color: var(--kt-tree-inactiveSelectionForeground);
+    }
+  }
+
+  &.mod_focused {
+    outline: 1px solid var(--list-focusOutline);
+    outline-offset: -1px;
+    color: var(--kt-tree-activeSelectionForeground);
+    background: var(--kt-tree-activeSelectionBackground);
+    .expansion_toggle,
+    .description {
+      color: var(--kt-tree-activeSelectionForeground);
+    }
+  }
+
+  &.mod_actived {
+    outline: 1px solid var(--list-focusOutline);
+    outline-offset: -1px;
+    .expansion_toggle {
+      color: var(--kt-tree-activeSelectionForeground);
+    }
+  }
+}
+
+.expansion_toggle {
+  min-width: 20px;
+  display: flex;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 16px;
+  color: var(--foreground);
+  &.mod_collapsed {
+    &:before {
+      display: block;
+    }
+  }
+
+  &:not(.mod_collapsed) {
+    &:before {
+      display: block;
+      transform: rotate(90deg);
+    }
+  }
+}

--- a/packages/comments/src/common/index.ts
+++ b/packages/comments/src/common/index.ts
@@ -1,3 +1,4 @@
+import type { ITree } from '@opensumi/ide-components';
 import {
   IRange,
   URI,
@@ -393,11 +394,6 @@ export interface ICommentsFeatureRegistry {
    */
   registerPanelOptions(options: CommentsPanelOptions): void;
   /**
-   * 注册底部面板评论树的处理函数，可以在渲染前重新再定义一次树的数据结构
-   * @param handler
-   */
-  registerPanelTreeNodeHandler(handler: PanelTreeNodeHandler): void;
-  /**
    * 注册提及相关功能的能力
    * @param options
    */
@@ -420,10 +416,6 @@ export interface ICommentsFeatureRegistry {
    * 获取底部面板参数
    */
   getCommentsPanelOptions(): CommentsPanelOptions;
-  /**
-   * 获取底部面板评论树的处理函数
-   */
-  getCommentsPanelTreeNodeHandlers(): PanelTreeNodeHandler[];
   /**
    * 获取文件上传处理函数
    */
@@ -615,15 +607,11 @@ export interface ICommentsThreadOptions {
 }
 
 export const ICommentsService = Symbol('ICommentsService');
-export interface ICommentsService {
+export interface ICommentsService extends ITree {
   /**
    * 评论节点
    */
   commentsThreads: ICommentsThread[];
-  /**
-   * 评论树节点
-   */
-  commentsTreeNodes: ICommentsTreeNode[];
   /**
    * 初始化函数
    */
@@ -655,17 +643,21 @@ export interface ICommentsService {
    */
   onThreadsCreated: Event<ICommentsThread>;
   /**
-   * 强制更新 tree node，再走一次 TreeNodeHandler 逻辑
+   * thread 下评论更新
    */
-  forceUpdateTreeNodes(): void;
-  /**
-   * 触发 左侧 decoration 的渲染
-   */
-  forceUpdateDecoration(): void;
+  onThreadsCommentChange: Event<ICommentsThread>;
   /**
    * 注册插件底部面板
    */
   registerCommentPanel(): void;
+  /**
+   * 通知对应 thread 下评论内容更新
+   */
+  fireThreadCommentChange(thread: ICommentsThread): void;
+  /**
+   * 触发左侧 decoration 的渲染
+   */
+  forceUpdateDecoration(): void;
   /**
    * 外部注册可评论的行号提供者
    */

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.statusbar.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.statusbar.test.ts
@@ -134,13 +134,13 @@ describe('vscode MainThreadStatusBar Test', () => {
 
     const statusbar = extHost.createStatusBarItem(mockExtensionDescription);
     statusbar.accessibilityInformation = {
-      label: '蛋总',
+      label: 'User',
       role: 'danzong',
     };
     statusbar.show();
     // statusbar host 调用 main 有一个 定时器
     setTimeout(() => {
-      expect($setMessage.mock.calls[0][9]).toStrictEqual({ label: '蛋总', role: 'danzong' });
+      expect($setMessage.mock.calls[0][9]).toStrictEqual({ label: 'User', role: 'danzong' });
       done();
     }, 100);
   });

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1005,6 +1005,9 @@ export const localizationBundle = {
     'task.contribute': 'Contribute',
     'task.cannotFindTask': 'Cannot find task for {0}. Press Enter key to return.',
 
+    'comment.reply.count': '{0} comments',
+    'comment.reply.lastReply': 'Last reply from {0}',
+
     // extension contribute
 
     // #region walkthrough

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1047,6 +1047,9 @@ export const localizationBundle = {
 
     'task.contribute': '贡献',
     'task.cannotFindTask': '未找到 {0} 的任务，按回车键返回',
+
+    'comment.reply.count': '{0} 个评论',
+    'comment.reply.lastReply': '最后由 {0} 评论',
     // extension contribute
 
     // #region walkthrough

--- a/tools/playwright/src/tests/explorer-view.test.ts
+++ b/tools/playwright/src/tests/explorer-view.test.ts
@@ -289,7 +289,7 @@ console.log(a);`,
       await input.type(newFileName, { delay: 200 });
       await app.page.keyboard.press('Enter');
     }
-    await app.page.waitForTimeout(1000);
+    await app.page.waitForTimeout(2000);
     // |- test
     // |----a
     // |------b


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

统一评论面板 Tree 组件样式，修复部分样式问题，同时移除废弃的 DeprecatedRecycleTree 组件

相关 Issue: https://github.com/opensumi/core/issues/592

Before：

![image](https://user-images.githubusercontent.com/9823838/209120023-8eedb6b8-7c13-4d6c-8ed0-23d0c9190b4a.png)

After:
![image](https://user-images.githubusercontent.com/9823838/209120064-4288171c-7c2a-4b15-83d4-f7f5debff132.png)


### Changelog

remove DeprecatedRecycleTree on comment module