### PR TITLE
chore: fix unstable fileServiceClient unit test

### DIFF
--- a/packages/file-service/__tests__/browser/file-service-client.test.ts
+++ b/packages/file-service/__tests__/browser/file-service-client.test.ts
@@ -125,7 +125,6 @@ describe('FileServiceClient should be work', () => {
   });
 
   it('watch file change', async () => {
-    expect.assertions(1);
     const newTempDir = FileUri.create(fs.realpathSync(track.mkdirSync('watch-file-change')));
 
     const watcher = await fileServiceClient.watchFileChanges(newTempDir);
@@ -152,8 +151,6 @@ describe('FileServiceClient should be work', () => {
   });
 
   it('set watchExcludes', async () => {
-    expect.assertions(2);
-
     const targetDir = tempDir.resolve('watch-exclude-temp-dir');
     await fs.ensureDir(targetDir.codeUri.fsPath);
 


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

![image](https://user-images.githubusercontent.com/9823838/209417932-0b3f2d0b-34ec-40af-ba74-5b8369ef777b.png)

### Changelog
