### PR TITLE
fix: webview cspSource

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.api.webview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.webview.ts
@@ -99,7 +99,7 @@ export class ExtHostWebview implements Webview {
   public get cspSource() {
     let cspSource = this.cspResourceRoots.join(' ');
     if (this.extensionLocation) {
-      cspSource += ` ${this.asWebviewUri(this.extensionLocation).toString()}`;
+      cspSource += `'self' vscode-resource:/${this.extensionLocation.path}/`.toLowerCase();
     }
     return cspSource;
   }

--- a/packages/extension/src/hosted/api/vscode/ext.host.api.webview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.webview.ts
@@ -41,7 +41,13 @@ export class ExtHostWebview implements Webview {
   public readonly _onMessageEmitter = new Emitter<any>();
   public readonly onDidReceiveMessage: Event<any> = this._onMessageEmitter.event;
 
-  constructor(handle: string, proxy: IMainThreadWebview, options: IWebviewOptions, private cspResourceRoots: string[]) {
+  constructor(
+    handle: string,
+    proxy: IMainThreadWebview,
+    options: IWebviewOptions,
+    private cspResourceRoots: string[],
+    private extensionLocation?: Uri,
+  ) {
     this._handle = handle;
     this._proxy = proxy;
     this._options = options;
@@ -91,7 +97,11 @@ export class ExtHostWebview implements Webview {
   }
 
   public get cspSource() {
-    return this.cspResourceRoots.join(' ');
+    let cspSource = this.cspResourceRoots.join(' ');
+    if (this.extensionLocation) {
+      cspSource += ` ${this.asWebviewUri(this.extensionLocation).toString()}`;
+    }
+    return cspSource;
   }
 
   public toWebviewResource(resource: Uri): Uri {
@@ -315,7 +325,7 @@ export class ExtHostWebviewService implements IExtHostWebview {
     const handle = this.getNextHandle();
     this._proxy.$createWebviewPanel(handle, viewType, title, webviewShowOptions, options, extension);
 
-    const webview = new ExtHostWebview(handle, this._proxy, options, this.resourceRoots);
+    const webview = new ExtHostWebview(handle, this._proxy, options, this.resourceRoots, extensionLocation);
     const panel = new ExtHostWebviewPanel(handle, this._proxy, viewType, title, viewColumn, options, webview);
     this._webviewPanels.set(handle, panel);
     return panel;

--- a/packages/extension/src/hosted/api/vscode/ext.host.window.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.window.api.impl.ts
@@ -200,7 +200,7 @@ export function createWindowApiFactory(
       options?: IWebviewPanelOptions & IWebviewOptions,
     ): WebviewPanel {
       return extHostWebviews.createWebview(
-        Uri.parse('not-implemented://'),
+        extension.extensionLocation,
         viewType,
         title,
         showOptions,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

部分插件在加载 webview 资源时会指定 style-src 属性，基于 webview 的 cspSource 计算得出，但默认没有加入当前插件的路径，导致在 electron 端会因为 csp 错误加载失败

![image](https://user-images.githubusercontent.com/17701805/209526645-e51b2986-9854-4063-943e-f42c18021e1a.png)

![image](https://user-images.githubusercontent.com/17701805/209526708-6ed4c660-0940-4b39-b943-41db485fd9ce.png)

因插件 webview 中资源都会被转换为 vscode-resource 协议，所以需要将 vscode-resource 协议下的插件路径加入到 style-src 中

![image](https://user-images.githubusercontent.com/17701805/209527072-58533d17-80ef-4f34-8c71-2ea4c482bfde.png)


### Changelog
- fix webview cspSrouce value