### PR TITLE
style: improve empty editor component style

### DIFF
--- a/packages/startup/entry/sample-modules/editor-empty-component.module.less
+++ b/packages/startup/entry/sample-modules/editor-empty-component.module.less
@@ -4,7 +4,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border-top: 1px solid var(--sideBar-border);
   img {
     width: 100px;
     height: 100px;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

Before:

<img width="275" alt="image" src="https://user-images.githubusercontent.com/9823838/209531639-1c8b3c88-a142-4770-add2-6112938e81ba.png">

After:

<img width="337" alt="image" src="https://user-images.githubusercontent.com/9823838/209530513-1ae5c75b-e285-4467-8cf9-0a057cd71159.png">

### Changelog

improve empty editor component style
