### PR TITLE
fix: duplicate search results

### DIFF
--- a/packages/core-common/src/reference.ts
+++ b/packages/core-common/src/reference.ts
@@ -25,11 +25,17 @@ export class ReferenceManager<T> {
 
   constructor(private factory: (key: string) => MaybePromise<T>) {}
 
-  async getReference(key: string, reason?: string): Promise<IRef<T>> {
+  private getReferenceKey(uri: string) {
+    // 部分情况下可能出现类似 `file:///a//b.js` 的路径，此时需要替换路径中的 `//` 为 `/`
+    return uri.replace(/\w+\/\/\w+/gi, (match) => match.replace('//', '/'));
+  }
+
+  async getReference(uri: string, reason?: string): Promise<IRef<T>> {
+    const key = this.getReferenceKey(uri);
     if (!this.instances.has(key)) {
-      // 由于创建过程可能为异步，此处标注为creating， 防止重复创建。
+      // 由于创建过程可能为异步，此处标注为 creating， 防止重复创建。
       if (!this._creating.has(key)) {
-        const promise = (async (resolve) => {
+        const promise = (async () => {
           const instance = await this.factory(key);
           this.instances.set(key, instance);
           this._onInstanceCreated.fire(instance);
@@ -37,7 +43,7 @@ export class ReferenceManager<T> {
         this._creating.set(key, promise);
       }
       try {
-        await this._creating.get(key)!;
+        await this._creating.get(key);
       } catch (e) {
         // 出错时需要清除创建中状态
         this._creating.delete(key);
@@ -45,12 +51,12 @@ export class ReferenceManager<T> {
       }
     }
     const ref = this.createRef(key, reason);
-    // 需要在ref被创建后再结束creating状态，否则如果在onInstanceCreated事件中触发了removeRef至0,
-    // 可能导致instance 意外被删除。
+    // 需要在 ref 被创建后再结束 creating 状态，否则如果在 onInstanceCreated 事件中触发了 removeRef 至 0,
+    // 可能导致 instance 意外被删除。
     if (this._creating.get(key)) {
-      const creatingPromise = this._creating.get(key)!;
+      const creatingPromise = this._creating.get(key);
       this._creating.delete(key);
-      creatingPromise.then(() => {
+      creatingPromise?.then(() => {
         // 再触发一次空remove，防止被保护的instance意外残留
         this.removeRef(key, undefined);
       });

--- a/packages/search/src/browser/search.service.ts
+++ b/packages/search/src/browser/search.service.ts
@@ -759,9 +759,15 @@ export class ContentSearchClientService extends Disposable implements IContentSe
   } {
     let matcherList: ParsedPattern[] = [];
     const uriString = docModel.uri.toString();
+
     const result: ContentSearchResult[] = [];
     const searchedList: string[] = [];
-
+    if (!rootDirs.some((root) => uriString.startsWith(root))) {
+      return {
+        result,
+        searchedList,
+      };
+    }
     if (searchOptions.include && searchOptions.include.length > 0) {
       // include 设置时，若匹配不到则返回空
       searchOptions.include.forEach((str: string) => {

--- a/packages/search/src/node/content-search.service.ts
+++ b/packages/search/src/node/content-search.service.ts
@@ -228,7 +228,7 @@ export class ContentSearchService extends RPCService<IRPCContentSearchService> i
 
           if (opts && opts.maxResults && searchInfo.resultLength >= opts.maxResults) {
             // 达到设置上限，停止搜索
-            this.logger.debug('达到设置上限，停止搜索');
+            this.logger.debug('Reached the set upper limit, stop searching.');
             this.cancel(searchInfo.searchId);
             return true;
           }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

部分插件可能存在不正确的文档打开路径，导致在 DocManager 中创建了不合理路径（如  `file:///a//b.js` ） 的 docRef，导致文档中搜索出的结果出现重复。

如 Bookmarks 插件中存在明显的字段拼接错误问题，极易复现该问题
![image](https://user-images.githubusercontent.com/9823838/209566634-5b5a15cf-826c-4233-b895-7025767ad64f.png)

通过对 Reference 引用 Key 的唯一化处理解决该问题

### Changelog

fix duplicate search results
