### PR TITLE
fix: disable some keybindings on filetree filter mode

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -1037,7 +1037,7 @@ export class FileTreeContribution
     bindings.registerKeybinding({
       command: FILE_COMMANDS.COPY_FILE.id,
       keybinding: 'ctrlcmd+c',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
@@ -1049,24 +1049,24 @@ export class FileTreeContribution
     bindings.registerKeybinding({
       command: FILE_COMMANDS.CUT_FILE.id,
       keybinding: 'ctrlcmd+x',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
     bindings.registerKeybinding({
       command: FILE_COMMANDS.SELECT_CURRENT_NODE.id,
       keybinding: 'ctrlcmd+a',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
       command: FILE_COMMANDS.RENAME_FILE.id,
       keybinding: 'enter',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
       command: FILE_COMMANDS.DELETE_FILE.id,
       keybinding: 'ctrlcmd+backspace',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
@@ -1084,31 +1084,31 @@ export class FileTreeContribution
     bindings.registerKeybinding({
       command: FILE_COMMANDS.NEXT.id,
       keybinding: 'down',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
       command: FILE_COMMANDS.PREV.id,
       keybinding: 'up',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
       command: FILE_COMMANDS.EXPAND.id,
       keybinding: 'right',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
       command: FILE_COMMANDS.COLLAPSE.id,
       keybinding: 'left',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({
       command: FILE_COMMANDS.TOGGLE_OR_OPEN.id,
       keybinding: 'space',
-      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw}`,
+      when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
 
     bindings.registerKeybinding({


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

该问题会导致筛选输入框无法正常编辑的问题

### Changelog

disable some keybindings on filetree filter mode