### PR TITLE
fix: unnecessary editor update options

### DIFF
--- a/packages/editor/__tests__/browser/editor.collection.test.ts
+++ b/packages/editor/__tests__/browser/editor.collection.test.ts
@@ -147,6 +147,9 @@ describe('editor collection service test', () => {
 
     open(new URI('file:///test/test.js'));
 
+    setPref('editor.fontSize', 20);
+    setPref('editor.readOnly', false);
+
     expect(options['fontSize']).toBe(20);
 
     testEditor.updateOptions({ fontSize: 40 });
@@ -158,7 +161,7 @@ describe('editor collection service test', () => {
 
     // 切换后仍然有这个option
     expect(options['fontSize']).toBe(40);
-
+    setPref('editor.readOnly', true);
     expect(options['readOnly']).toBeTruthy();
 
     testEditor.updateOptions({ fontSize: undefined });
@@ -170,6 +173,7 @@ describe('editor collection service test', () => {
     expect(options['fontSize']).toBe(35);
 
     open(new URI('file:///test/test3.js'));
+    setPref('editor.readOnly', false);
     expect(options['readOnly']).toBeFalsy();
 
     setPref('editor.forceReadOnly', true);

--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -279,7 +279,6 @@ export abstract class BaseMonacoEditorWrapper extends Disposable implements IEdi
   }
 
   private async onDidChangeModel() {
-    const now = Date.now();
     this._editorOptionsFromContribution = {};
     const uri = this.currentUri;
     if (uri) {

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -123,7 +123,7 @@ export interface ICodeEditor extends IEditor, IDisposable {
    * 打开一个 document
    * @param uri
    */
-  open(documentModelRef: IEditorDocumentModelRef, range?: IRange): Promise<void>;
+  open(documentModelRef: IEditorDocumentModelRef, range?: IRange): void;
 
   focus(): void;
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

`onDidChangeModel` 中即使没有来自 contribution 提供的 options 也会调用一次 `updateOptions`,

![upate-options](https://user-images.githubusercontent.com/17701805/209763719-011e68c4-a52f-4f33-be74-890afcf89fe0.jpg)


after

![20221228133929](https://user-images.githubusercontent.com/17701805/209763885-aeeebc32-8763-4775-96be-4b1bfc5169bc.jpg)

### Changelog
- fix: unnecessary editor update options