### PR TITLE
fix: debug condition breakpoint style

### DIFF
--- a/packages/debug/src/browser/editor/debug-breakpoint.module.less
+++ b/packages/debug/src/browser/editor/debug-breakpoint.module.less
@@ -10,7 +10,6 @@
   border-top-width: 1px;
   border-bottom-width: 1px;
   overflow: hidden;
-  align-items: center;
   background: var(--editor-background);
 }
 
@@ -18,13 +17,13 @@
   padding: 0 10px;
   flex: 1;
   min-width: 120px;
+  margin: auto;
 }
 
 .debug_breakpoint_input {
   width: 100%;
-  height: 28px;
-  // (36 - 21) / 2 = 7.5
-  margin-top: 7.5px;
+  height: inherit;
+  margin-top: 7px;
   .input_placeholder {
     position: relative;
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before: 
![image](https://user-images.githubusercontent.com/20262815/209918994-a67e261b-6c57-4129-a9f9-5882df0ecaa0.png)

after:
![image](https://user-images.githubusercontent.com/20262815/209919064-74ce76f1-2d7f-4505-a227-9d73f7e139f6.png)


### Changelog
修复多行表达式断点的样式问题