### PR TITLE
fix: do not exclude .gitignore

### DIFF
--- a/packages/addons/src/browser/file-search.contribution.ts
+++ b/packages/addons/src/browser/file-search.contribution.ts
@@ -371,7 +371,7 @@ export class FileSearchQuickCommandHandler {
         limit: DEFAULT_FILE_SEARCH_LIMIT,
         useGitIgnore: true,
         noIgnoreParent: true,
-        excludePatterns: ['*.git*', ...this.getPreferenceSearchExcludes()],
+        excludePatterns: this.getPreferenceSearchExcludes(),
       },
       token,
     );

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -1,11 +1,5 @@
 import { Injector } from '@opensumi/di';
-import {
-  localize,
-  getAvailableLanguages,
-  isElectronRenderer,
-  SUPPORTED_ENCODINGS,
-  GeneralSettingsId,
-} from '@opensumi/ide-core-common';
+import { localize, getAvailableLanguages, SUPPORTED_ENCODINGS, GeneralSettingsId } from '@opensumi/ide-core-common';
 
 import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceSchema } from './preferences';
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

默认添加的这个 `*.git*` 不仅排除 git 目录，也会排除所有包含 `.git` 的文件，实际上只需要 `*.git/` 即可

### Changelog
- do not exclude `.gitignore`