### PR TITLE
test: add search e2e test case

### DIFF
--- a/packages/search/__tests__/browser/search.service.test.ts
+++ b/packages/search/__tests__/browser/search.service.test.ts
@@ -143,7 +143,6 @@ describe('search.service.ts', () => {
     const service: any = searchService;
     searchService.searchValue = 'value';
     (service.UIState as IUIState) = {
-      isSearchFocus: false,
       isToggleOpen: true,
       isDetailOpen: false,
 

--- a/packages/search/src/browser/search.input.widget.tsx
+++ b/packages/search/src/browser/search.input.widget.tsx
@@ -10,7 +10,6 @@ import styles from './search.module.less';
 export interface SearchInputWidgetProps {
   isDetailOpen: boolean;
   onDetailToggle: () => void;
-  isSearchFocus: boolean;
   onSearchFocus: () => void;
   onSearchBlur: () => void;
   isMatchCase: boolean;
@@ -45,7 +44,6 @@ const SearchRuleCheckout = memo(
 function isSearchInputPropsEqual(prevProps: SearchInputWidgetProps, nextProps: SearchInputWidgetProps) {
   return (
     prevProps.isDetailOpen === nextProps.isDetailOpen &&
-    prevProps.isSearchFocus === nextProps.isSearchFocus &&
     prevProps.isMatchCase === nextProps.isMatchCase &&
     prevProps.isWholeWord === nextProps.isWholeWord &&
     prevProps.isRegex === nextProps.isRegex &&
@@ -61,7 +59,6 @@ export const SearchInputWidget = memo(
       {
         isDetailOpen,
         onDetailToggle,
-        isSearchFocus,
         onSearchFocus,
         onSearchBlur,
         isMatchCase,
@@ -82,7 +79,7 @@ export const SearchInputWidget = memo(
         <div className={styles.search_and_replace_fields}>
           <div className={styles.search_field_container}>
             <SearchRuleCheckout isDetailOpen={isDetailOpen} onDetailToggle={onDetailToggle} />
-            <div className={cls(styles.search_field, { [styles.focus]: isSearchFocus })}>
+            <div className={styles.search_field}>
               <ValidateInput
                 id='search-input-field'
                 title={localize('search.input.placeholder')}

--- a/packages/search/src/browser/search.module.less
+++ b/packages/search/src/browser/search.module.less
@@ -153,7 +153,7 @@
         justify-content: space-between;
       }
 
-      .checkbox_wrap {
+      .use_default_excludes_wrapper {
         display: flex;
         align-items: center;
       }

--- a/packages/search/src/browser/search.rules.widget.tsx
+++ b/packages/search/src/browser/search.rules.widget.tsx
@@ -123,7 +123,7 @@ const ExcludeInput = React.memo(
     <div className={cls(styles.glob_field, styles.search_excludes)}>
       <div className={styles.label}>
         <span className={styles.limit}>{localize('search.excludes')}</span>
-        <div className={styles.checkbox_wrap}>
+        <div className={styles.use_default_excludes_wrapper}>
           <CheckBox
             className={cls(styles.checkbox)}
             label={localize('search.excludes.default.enable')}

--- a/packages/search/src/browser/search.service.ts
+++ b/packages/search/src/browser/search.service.ts
@@ -150,7 +150,6 @@ export class ContentSearchClientService extends Disposable implements IContentSe
   }
 
   public UIState: IUIState = {
-    isSearchFocus: false,
     isToggleOpen: true,
     isDetailOpen: false,
     // Search Options
@@ -601,12 +600,6 @@ export class ContentSearchClientService extends Disposable implements IContentSe
     );
 
   updateUIState = (obj: Partial<typeof this.UIState>) => {
-    if (!isUndefined(obj.isSearchFocus) && obj.isSearchFocus !== this.UIState.isSearchFocus) {
-      // 搜索框状态发现变化，重置搜索历史的当前位置
-      this.searchHistory.reset();
-      this.isShowValidateMessage = false;
-    }
-
     const newUIState = Object.assign({}, this.UIState, obj);
 
     if (this.shouldSearch(obj)) {
@@ -677,11 +670,6 @@ export class ContentSearchClientService extends Disposable implements IContentSe
 
   private async recoverUIState() {
     const UIState = (await this.browserStorageService.getData('search.UIState')) as IUIState | undefined;
-    // 上次关闭时搜索框若处于 focus 状态会导致本次启动恢复现场后 UI 与 Service 不一致 (#1203)
-    // 这里一个非根本性解决方法是在 updateUIState 前将 isSearchFocus 置为 false
-    if (UIState) {
-      UIState.isSearchFocus = false;
-    }
     this.updateUIState(UIState || {});
   }
 

--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -28,6 +28,7 @@ import { SearchInputWidget } from './search.input.widget';
 import styles from './search.module.less';
 import { SearchReplaceWidget } from './search.replace.widget';
 import { SearchRulesWidget } from './search.rules.widget';
+import { SearchTreeService } from './tree/search-tree.service';
 import { SearchTree } from './tree/search-tree.view';
 
 export interface ISearchContentResult {
@@ -43,7 +44,7 @@ export interface ISearchContentResult {
 export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewState }>) => {
   const searchOptionRef = createRef<HTMLDivElement>();
   const wrapperRef = createRef<HTMLDivElement>();
-  const searchTreeService = useInjectable<ISearchTreeService>(ISearchTreeService);
+  const searchTreeService = useInjectable<SearchTreeService>(ISearchTreeService);
   const searchBrowserService = useInjectable<IContentSearchClientService>(IContentSearchClientService);
   const [offsetTop, setOffsetTop] = useState<number>(0);
   const [searchContent, setSearchContent] = useState<ISearchContentResult>({
@@ -72,11 +73,11 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
   }, [searchBrowserService]);
 
   const onSearchFocus = useCallback(() => {
-    updateUIState({ isSearchFocus: true });
-  }, [searchBrowserService]);
+    searchTreeService.contextKey.searchInputBoxFocusedKey.set(true);
+  }, [searchTreeService]);
 
   const onSearchBlur = useCallback(() => {
-    updateUIState({ isSearchFocus: false });
+    searchTreeService.contextKey.searchInputBoxFocusedKey.set(false);
   }, [searchBrowserService]);
 
   const onMatchCaseToggle = useCallback(() => {
@@ -235,7 +236,6 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
           onRegexToggle={onRegexToggle}
           isWholeWord={UIState.isWholeWord}
           onWholeWordToggle={onWholeWordToggle}
-          isSearchFocus={UIState.isSearchFocus}
           isShowValidateMessage={searchContent.isShowValidateMessage}
           validateMessage={searchContent.validateMessage}
           onSearchFocus={onSearchFocus}

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -146,13 +146,6 @@ export class SearchModelService extends Disposable {
         }
         this.refresh();
       }),
-      this.searchService.onDidUIStateChange((state: IUIState) => {
-        if (state.isSearchFocus) {
-          this.searchTreeService.contextKey.searchInputBoxFocusedKey.set(true);
-        } else {
-          this.searchTreeService.contextKey.searchInputBoxFocusedKey.set(false);
-        }
-      }),
     );
 
     this.onDidUpdateTreeModelEmitter.fire(this._treeModel);

--- a/packages/search/src/common/content-search.ts
+++ b/packages/search/src/common/content-search.ts
@@ -110,7 +110,6 @@ export interface ISearchTreeService extends ITree {
 }
 
 export interface IUIState {
-  isSearchFocus: boolean;
   isToggleOpen: boolean;
   isDetailOpen: boolean;
   isMatchCase: boolean;

--- a/tools/playwright/src/scm-view.ts
+++ b/tools/playwright/src/scm-view.ts
@@ -1,5 +1,4 @@
 import { OpenSumiApp } from './app';
-import { OpenSumiFileTreeView } from './filetree-view';
 import { OpenSumiOpenedEditorView } from './opened-editor-view';
 import { OpenSumiPanel } from './panel';
 import { OpenSumiSourceControlView } from './source-control-view';

--- a/tools/playwright/src/search-view.ts
+++ b/tools/playwright/src/search-view.ts
@@ -1,5 +1,54 @@
+import { isDefined } from '@opensumi/ide-utils';
+
 import { OpenSumiApp } from './app';
 import { OpenSumiPanel } from './panel';
+import { OpenSumiTreeNode } from './tree-node';
+
+export interface ISearchOptions {
+  search: string;
+  include?: string;
+  exclude?: string;
+  useDefaultExclude?: boolean;
+  useRegexp?: boolean;
+  isMatchWhileWord?: boolean;
+  isMatchCase?: boolean;
+}
+
+const SEARCH_OPTIONS = {
+  MATCH_CASE: 'Match Case',
+  MATCH_WHOLE_WORD: 'Match Whole Word',
+  USE_REGEXP: 'Use Regular Expression',
+};
+
+export class OpenSumiSearchFileStatNode extends OpenSumiTreeNode {
+  async getFsPath() {
+    return await this.elementHandle.getAttribute('title');
+  }
+
+  async isFile() {
+    const icon = await this.elementHandle.$("[class*='icon__']");
+    if (!icon) {
+      return false;
+    }
+    const className = await icon.getAttribute('class');
+    return className?.includes('file-icon');
+  }
+
+  async getMenuItemByName(name: string) {
+    const contextMenu = await this.openContextMenu();
+    const menuItem = await contextMenu.menuItemByName(name);
+    return menuItem;
+  }
+
+  async open() {
+    await this.elementHandle.click();
+  }
+
+  async getBadge() {
+    const status = await this.elementHandle.$('[class*="status___"]');
+    return await status?.textContent();
+  }
+}
 
 export class OpenSumiSearchView extends OpenSumiPanel {
   constructor(app: OpenSumiApp) {
@@ -41,13 +90,47 @@ export class OpenSumiSearchView extends OpenSumiPanel {
     };
   }
 
+  async getReplaceAllButton() {
+    const button = this.view?.$('[class*="replace_all_button__"]');
+    return button;
+  }
+
   async focusOnSearch() {
     const visible = await this.isVisible();
     if (!visible) {
       await this.open();
     }
-    const $searchInput = await this.app.page.$(this.searchInputSelector);
-    await $searchInput?.focus();
+    const input = await this.app.page.$(this.searchInputSelector);
+    await input?.fill('');
+    await input?.focus();
+  }
+
+  async focusOnReplace() {
+    const visible = await this.isVisible();
+    if (!visible) {
+      await this.open();
+    }
+    const input = await this.app.page.$(this.replaceInputSelector);
+    await input?.focus();
+    return input;
+  }
+
+  async focusOnExclude() {
+    const visible = await this.isVisible();
+    if (!visible) {
+      await this.open();
+    }
+    const input = await this.getExcludeInput();
+    await input?.focus();
+  }
+
+  async focusOnInclude() {
+    const visible = await this.isVisible();
+    if (!visible) {
+      await this.open();
+    }
+    const input = await this.getIncludeInput();
+    await input?.focus();
   }
 
   async getSearchInput() {
@@ -66,13 +149,112 @@ export class OpenSumiSearchView extends OpenSumiPanel {
     return await this.view?.$(this.includeInputSelector);
   }
 
-  async toggleDisplaySearchRules() {
+  async getSearchAction(value: string) {
+    const searchField = await this.view?.$('[class*="search_field__"]');
+    if (searchField) {
+      const options = await searchField.$$('[class*="search_option__"]');
+      for (const option of options) {
+        const title = await option.getAttribute('title');
+        if (title === value) {
+          return option;
+        }
+      }
+    }
+  }
+
+  async activeSearchAction(value: string) {
+    const action = await this.getSearchAction(value);
+    const classname = await action?.getAttribute('class');
+    if (classname?.includes('select___')) {
+      return;
+    }
+    await action?.click();
+  }
+
+  async deactiveSearchAction(value: string) {
+    const action = await this.getSearchAction(value);
+    const classname = await action?.getAttribute('class');
+    if (classname?.includes('select___')) {
+      await action?.click();
+    }
+  }
+
+  async toggleDisplaySearchRules(expected?: boolean) {
     const visible = await this.isVisible();
     if (!visible) {
       await this.open();
     }
     const titleBar = await this.view?.$('[class*="search_input_title_"]');
     const checkbox = await titleBar?.$('.kt-checkbox');
+    const checked = await checkbox?.isChecked();
+    if (isDefined(expected) && expected === checked) {
+      return;
+    }
     await checkbox?.click();
+  }
+
+  async toggleUseDefaultExclude(expected?: boolean) {
+    const visible = await this.isVisible();
+    if (!visible) {
+      await this.open();
+    }
+    const wrapper = await this.view?.$('[class*="use_default_excludes_wrapper_"]');
+    const checkbox = await wrapper?.$('.kt-checkbox');
+    const checked = await checkbox?.isChecked();
+    if (isDefined(expected) && expected === checked) {
+      return;
+    }
+    await checkbox?.click();
+  }
+
+  async search(options: ISearchOptions) {
+    if (!(await this.isVisible())) {
+      await this.open();
+    }
+    if (!options.search) {
+      return;
+    }
+    if (isDefined(options.isMatchCase)) {
+      (await options.isMatchCase)
+        ? this.activeSearchAction(SEARCH_OPTIONS.MATCH_CASE)
+        : this.deactiveSearchAction(SEARCH_OPTIONS.MATCH_CASE);
+    }
+    if (isDefined(options.isMatchWhileWord)) {
+      (await options.isMatchWhileWord)
+        ? this.activeSearchAction(SEARCH_OPTIONS.MATCH_WHOLE_WORD)
+        : this.deactiveSearchAction(SEARCH_OPTIONS.MATCH_WHOLE_WORD);
+    }
+    if (isDefined(options.useRegexp)) {
+      (await options.useRegexp)
+        ? this.activeSearchAction(SEARCH_OPTIONS.USE_REGEXP)
+        : this.deactiveSearchAction(SEARCH_OPTIONS.USE_REGEXP);
+    }
+    if (options.exclude || options.include || isDefined(options.useDefaultExclude)) {
+      await this.toggleDisplaySearchRules(true);
+      if (options.exclude) {
+        await this.focusOnExclude();
+        await this.page.keyboard.type(options.exclude);
+      }
+      if (options.include) {
+        await this.focusOnInclude();
+        await this.page.keyboard.type(options.include);
+      }
+      const useDefaultExlude = isDefined(options.useDefaultExclude) ? options.useDefaultExclude : true;
+      await this.toggleUseDefaultExclude(useDefaultExlude);
+    }
+    // Search on the end.
+    await this.focusOnSearch();
+    await this.page.keyboard.type(options.search);
+  }
+
+  async getTreeNodeByIndex(index: number) {
+    const treeItems = await this.view?.$$('[class*="search_node___"]');
+    if (!treeItems) {
+      return;
+    }
+    const node = treeItems[index];
+    if (node) {
+      return new OpenSumiSearchFileStatNode(node, this.app);
+    }
   }
 }

--- a/tools/playwright/src/tests/search-view.test.ts
+++ b/tools/playwright/src/tests/search-view.test.ts
@@ -3,17 +3,24 @@ import path from 'path';
 import { expect } from '@playwright/test';
 
 import { OpenSumiApp } from '..';
+import { OpenSumiDiffEditor } from '../diff-editor';
+import { OpenSumiExplorerView } from '../explorer-view';
 import { OpenSumiSearchView } from '../search-view';
+import { OpenSumiTextEditor } from '../text-editor';
+import { keypressWithCmdCtrlAndShift } from '../utils/key';
 import { OpenSumiWorkspace } from '../workspace';
 
 import test, { page } from './hooks';
 
 let app: OpenSumiApp;
 let search: OpenSumiSearchView;
+let editor: OpenSumiTextEditor;
+let explorer: OpenSumiExplorerView;
+let workspace: OpenSumiWorkspace;
 
 test.describe('OpenSumi Search Panel', () => {
   test.beforeAll(async () => {
-    const workspace = new OpenSumiWorkspace([path.resolve('./src/tests/workspaces/default')]);
+    workspace = new OpenSumiWorkspace([path.resolve('./src/tests/workspaces/search')]);
     app = await OpenSumiApp.load(page, workspace);
     search = await app.open(OpenSumiSearchView);
   });
@@ -21,13 +28,73 @@ test.describe('OpenSumi Search Panel', () => {
   test('Can search files by simple text', async () => {
     const searchText = 'hello';
     expect(await search.isVisible()).toBeTruthy();
-    await search.focusOnSearch();
-    await page.keyboard.type(searchText);
-    // search panel should searched after typing
-    await app.page.keyboard.press('Enter');
-    const { results, files } = await search.getSearchResult();
-    expect(results).toBe(1);
-    expect(files).toBe(1);
+    await search.search({
+      search: searchText,
+    });
+    await app.page.waitForTimeout(1000);
+    const result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(1);
+      expect(files).toBe(1);
+    }
+  });
+
+  test('Open file with editor', async () => {
+    const searchText = 'hello';
+    expect(await search.isVisible()).toBeTruthy();
+    await search.search({
+      search: searchText,
+    });
+    await app.page.waitForTimeout(1000);
+    const result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(1);
+      expect(files).toBe(1);
+    }
+
+    const fileNode = await search.getTreeNodeByIndex(0);
+    const contentNode = await search.getTreeNodeByIndex(1);
+
+    expect(await fileNode?.isFile()).toBeTruthy();
+    expect(await contentNode?.isFile()).toBeFalsy();
+
+    expect(contentNode).toBeDefined();
+    if (contentNode) {
+      await contentNode?.open();
+      await app.page.waitForTimeout(1000);
+
+      const editor = new OpenSumiTextEditor(app, contentNode);
+      const currentTab = await editor.getCurrentTab();
+      const dataUri = await currentTab?.getAttribute('data-uri');
+      expect(dataUri?.startsWith('file')).toBeTruthy();
+    }
+  });
+
+  test('Open file with diffEditor', async () => {
+    const searchText = 'hello';
+    const replaceText = 'Hello';
+    expect(await search.isVisible()).toBeTruthy();
+    await search.search({
+      search: searchText,
+    });
+    const input = await search.focusOnReplace();
+    await page.keyboard.type(replaceText);
+
+    const contentNode = await search.getTreeNodeByIndex(1);
+    expect(contentNode).toBeDefined();
+    if (contentNode) {
+      await contentNode.open();
+      await app.page.waitForTimeout(1000);
+      const editor = new OpenSumiDiffEditor(app, contentNode);
+      const currentTab = await editor.getCurrentTab();
+      const dataUri = await currentTab?.getAttribute('data-uri');
+      expect(dataUri?.startsWith('file')).toBeFalsy();
+    }
+    await input?.fill('');
   });
 
   test('Open search rules view', async () => {
@@ -39,5 +106,134 @@ test.describe('OpenSumi Search Panel', () => {
     await search.toggleDisplaySearchRules();
     expect((await search.getIncludeInput())?.isVisible()).toBeFalsy();
     expect((await search.getExcludeInput())?.isVisible()).toBeFalsy();
+  });
+
+  test('Replace search result with RegExp', async () => {
+    const searchText = 'const (.+) = require((.*))';
+    const replaceText = '$1...$2';
+
+    await search.search({
+      search: searchText,
+      useRegexp: true,
+    });
+
+    await app.page.waitForTimeout(1000);
+    let result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(1);
+      expect(files).toBe(1);
+    }
+
+    const input = await search.focusOnReplace();
+    await page.keyboard.type(replaceText);
+
+    const replaceButton = await search.getReplaceAllButton();
+
+    expect(await replaceButton?.isEnabled()).toBeTruthy();
+    await replaceButton?.click();
+    const confirmed = await app.getDialogButton('Replace');
+    await confirmed?.click();
+    await app.page.waitForTimeout(1000);
+
+    await search.search({
+      search: "fs...('fs')",
+      useRegexp: false,
+    });
+    await app.page.waitForTimeout(1000);
+    result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(1);
+      expect(files).toBe(1);
+    }
+    await input?.fill('');
+  });
+
+  test('Search content with MatchCase', async () => {
+    const searchText = 'abcd';
+
+    await search.search({
+      search: searchText,
+      isMatchCase: true,
+    });
+    await app.page.waitForTimeout(1000);
+    let result = await search.getSearchResult();
+    await app.page.waitForTimeout(1000);
+
+    expect(result.results).toBe(1);
+    expect(result.files).toBe(1);
+
+    await search.search({
+      search: searchText,
+      isMatchCase: false,
+    });
+    await app.page.waitForTimeout(1000);
+
+    result = await search.getSearchResult();
+    expect(result.results).toBe(2);
+    expect(result.files).toBe(1);
+  });
+
+  test('Search content with editor selection', async () => {
+    explorer = await app.open(OpenSumiExplorerView);
+    explorer.initFileTreeView(workspace.workspace.displayName);
+    editor = await app.openEditor(OpenSumiTextEditor, explorer, 'index.js');
+    await editor.selectLineContainingText('hello');
+    await app.page.keyboard.press(keypressWithCmdCtrlAndShift('KeyF'), { delay: 200 });
+
+    await app.page.waitForTimeout(1000);
+    const result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(1);
+      expect(files).toBe(1);
+    }
+  });
+
+  test('File content can not be search after deleted', async () => {
+    const searchText = 'console.log';
+    await search.search({
+      search: searchText,
+      useRegexp: false,
+    });
+    await app.page.waitForTimeout(1000);
+    let result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(4);
+      expect(files).toBe(2);
+    }
+
+    // Delete `index2.js` file
+    if (!(await explorer.isVisible())) {
+      await explorer.open();
+    }
+    const file = await explorer.getFileStatTreeNodeByPath('index2.js');
+    expect(file).toBeDefined();
+    const menu = await file?.openContextMenu();
+    const deleteMenu = await menu?.menuItemByName('Delete');
+    await deleteMenu?.click();
+    await app.page.waitForTimeout(200);
+    const confirmed = await app.getDialogButton('Move to trash');
+    await confirmed?.click();
+    await app.page.waitForTimeout(2000);
+
+    await search.search({
+      search: searchText,
+      useRegexp: false,
+    });
+    await app.page.waitForTimeout(1000);
+    result = await search.getSearchResult();
+    expect(result).toBeDefined();
+    if (result) {
+      const { results, files } = result;
+      expect(results).toBe(3);
+      expect(files).toBe(1);
+    }
   });
 });

--- a/tools/playwright/src/tests/workspaces/search/index.js
+++ b/tools/playwright/src/tests/workspaces/search/index.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+
+console.log('hello');
+console.log('abcde');
+console.log('ABCDE');

--- a/tools/playwright/src/tests/workspaces/search/index2.js
+++ b/tools/playwright/src/tests/workspaces/search/index2.js
@@ -1,0 +1,1 @@
+console.log('This file will be deleted');

--- a/tools/playwright/src/utils/key.ts
+++ b/tools/playwright/src/utils/key.ts
@@ -4,3 +4,8 @@ export const keypressWithCmdCtrl = (key: string) => {
   const modifier = isMacintosh ? 'Meta' : isWindows ? 'Ctrl' : 'Control';
   return `${modifier}+${key}`;
 };
+
+export const keypressWithCmdCtrlAndShift = (key: string) => {
+  const modifier = isMacintosh ? 'Meta' : isWindows ? 'Ctrl' : 'Control';
+  return `${modifier}+Shift+${key}`;
+};


### PR DESCRIPTION
### Types

- [x] ⏱ Tests

### Background or solution

新增如下测试：

- [x] 搜索文本后进行批量替换
- [x] 通过正则搜索内容
- [x] 进行区分大小写的内容搜索，能得到正确结果
- [x] 在编辑器中选中内容后，通过 CMD+SHIFT+F 可以在搜索面板进行快速搜索，正常展示搜索结果
- [x] 已删除的文件不会再次出现在搜索内容中
- [x] 点击搜索结果，在右侧编辑器展示响应内容


https://user-images.githubusercontent.com/9823838/210079329-a1f0eb04-1076-43da-966a-3567407a4159.mp4

同时移除了搜索面板状态中冗余且无效的 `isSearchFocus` 状态存储，从根源处解决 #1203 问题。

#1475.

### Changelog

add search e2e test case
