### PR TITLE
test: add Javascript Debug Terminal test case

### DIFF
--- a/tools/playwright/src/debug-view.ts
+++ b/tools/playwright/src/debug-view.ts
@@ -1,6 +1,7 @@
 import { OpenSumiApp } from './app';
 import { OpenSumiPanel } from './panel';
 
+type DebugToolbarActionType = 'Continue' | 'Step Over' | 'Step Into' | 'Step Out' | 'Restart' | 'Stop';
 export class OpenSumiDebugView extends OpenSumiPanel {
   private selector = {
     toolbarClass: "[class*='debug_configuration_toolbar___']",
@@ -9,6 +10,10 @@ export class OpenSumiDebugView extends OpenSumiPanel {
 
   constructor(app: OpenSumiApp) {
     super(app, 'DEBUG');
+  }
+
+  async getDebugToolbar() {
+    return this.page.$('[class*="debug_toolbar_wrapper__"]');
   }
 
   async start(): Promise<void> {
@@ -20,5 +25,49 @@ export class OpenSumiDebugView extends OpenSumiPanel {
     const element = await toolbarLocator.elementHandle();
     const startIcon = await element?.$(this.selector.actionStartID);
     await startIcon?.click();
+  }
+
+  async getToobarAction(action: DebugToolbarActionType) {
+    const toolbar = await this.getDebugToolbar();
+    const buttons = await toolbar?.$$('[class*="debug_action__"]');
+    if (!buttons) {
+      return;
+    }
+    for (const button of buttons) {
+      const title = await button.getAttribute('title');
+      if (title === action) {
+        return button;
+      }
+    }
+  }
+
+  async stop() {
+    const action = await this.getToobarAction('Stop');
+    await action?.click();
+  }
+
+  async continue() {
+    const action = await this.getToobarAction('Continue');
+    await action?.click();
+  }
+
+  async restart() {
+    const action = await this.getToobarAction('Restart');
+    await action?.click();
+  }
+
+  async stepInto() {
+    const action = await this.getToobarAction('Step Into');
+    await action?.click();
+  }
+
+  async stepOver() {
+    const action = await this.getToobarAction('Step Over');
+    await action?.click();
+  }
+
+  async stepOut() {
+    const action = await this.getToobarAction('Step Out');
+    await action?.click();
   }
 }

--- a/tools/playwright/src/terminal.ts
+++ b/tools/playwright/src/terminal.ts
@@ -1,5 +1,8 @@
 import { OpenSumiApp } from './app';
+import { OpenSumiContextMenu } from './context-menu';
 import { OpenSumiPanel } from './panel';
+
+type TerminalType = 'bash' | 'zsh' | 'Javascript Debug Terminal';
 
 export class OpenSumiTerminal extends OpenSumiPanel {
   constructor(app: OpenSumiApp) {
@@ -18,5 +21,30 @@ export class OpenSumiTerminal extends OpenSumiPanel {
     }
     await this.page.keyboard.type(text);
     await this.app.page.keyboard.press('Enter');
+  }
+
+  async createTerminalByType(type: TerminalType) {
+    const buttonWrapper = await this.view?.$('[class*="item_wrapper__"]');
+    const buttons = await buttonWrapper?.$$('.kaitian-icon');
+    if (!buttons) {
+      return;
+    }
+    let button;
+    for (const item of buttons) {
+      const title = await item.getAttribute('title');
+      if (title === 'Create terminal by type') {
+        button = item;
+        break;
+      }
+    }
+    if (!button) {
+      return;
+    }
+    await button.click();
+    const menu = new OpenSumiContextMenu(this.app);
+    await menu.waitForVisible();
+    await menu.clickMenuItem(type);
+
+    await this.app.page.waitForTimeout(1000);
   }
 }


### PR DESCRIPTION
### Types

- [x] ⏱ Tests

### Background or solution

新增针对 'Javascript Debug Terminal' 测试案例，同时优化调试面板测试

- [x] 通过 JavaScript Debug Terminal 运行脚本后，脚本在断点位置暂停并正确展示阶段信息

#1475.

### Changelog

add Javascript Debug Terminal test case
