### PR TITLE
fix: highlight search content when ignore case

### DIFF
--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -204,6 +204,7 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
           search={search}
           replace={replace}
           isUseRegexp={searchBrowserService.UIState.isUseRegexp}
+          isMatchCase={searchBrowserService.UIState.isMatchCase}
         />
       );
     } else {

--- a/packages/search/src/browser/tree/search-node.tsx
+++ b/packages/search/src/browser/tree/search-node.tsx
@@ -26,6 +26,7 @@ export interface ISearchNodeProps {
   onContextMenu: (ev: React.MouseEvent, item: SearchContentNode | SearchFileNode) => void;
   commandService: CommandService;
   isUseRegexp: boolean;
+  isMatchCase: boolean;
 }
 
 export type ISearchNodeRenderedProps = ISearchNodeProps & INodeRendererProps;
@@ -42,6 +43,7 @@ export const SearchNodeRendered: React.FC<ISearchNodeRenderedProps> = ({
   onContextMenu,
   commandService,
   isUseRegexp,
+  isMatchCase,
 }: ISearchNodeRenderedProps) => {
   const handleClick = useCallback(
     (ev: React.MouseEvent) => {
@@ -106,7 +108,7 @@ export const SearchNodeRendered: React.FC<ISearchNodeRenderedProps> = ({
         if (isUseRegexp) {
           let regexp;
           try {
-            regexp = new RegExp(search);
+            regexp = new RegExp(search, isMatchCase ? '' : 'i');
           } catch (e) {
             regexp = null;
           }
@@ -130,12 +132,19 @@ export const SearchNodeRendered: React.FC<ISearchNodeRenderedProps> = ({
             }
           }
         } else {
-          const index = node.description.indexOf(search);
+          let index = -1;
+          if (isMatchCase) {
+            index = node.description.indexOf(search);
+          } else {
+            index = node.description.toLocaleLowerCase().indexOf(search.toLocaleLowerCase());
+          }
           if (index >= 0) {
             return (
               <div className={cls(styles.segment_grow, styles.description)}>
                 {node.description.slice(0, index)}
-                <span className={cls(styles.match, replace && styles.replace)}>{search}</span>
+                <span className={cls(styles.match, replace && styles.replace)}>
+                  {node.description.slice(index, index + search.length)}
+                </span>
                 {replace && <span className={styles.replace}>{replace}</span>}
                 {node.description.slice(index + search.length)}
               </div>
@@ -145,7 +154,7 @@ export const SearchNodeRendered: React.FC<ISearchNodeRenderedProps> = ({
         }
       }
     },
-    [replace, search, isUseRegexp],
+    [replace, search, isUseRegexp, isMatchCase],
   );
 
   const renderStatusTail = useCallback(

--- a/packages/search/src/browser/tree/search-tree.view.tsx
+++ b/packages/search/src/browser/tree/search-tree.view.tsx
@@ -19,6 +19,7 @@ export interface ISearchTreeProp {
   viewState: ViewState;
   state: SEARCH_STATE;
   isUseRegexp: boolean;
+  isMatchCase: boolean;
 }
 
 export interface ISearchResultTotalContent {
@@ -88,7 +89,16 @@ const ResultTotalContent = ({ total, state, model }: ISearchResultTotalContent) 
   return null;
 };
 
-export const SearchTree = ({ offsetTop, total, state, replace, search, viewState, isUseRegexp }: ISearchTreeProp) => {
+export const SearchTree = ({
+  offsetTop,
+  total,
+  state,
+  replace,
+  search,
+  viewState,
+  isUseRegexp,
+  isMatchCase,
+}: ISearchTreeProp) => {
   const [model, setModel] = useState<SearchTreeModel | undefined>();
   const searchModelService = useInjectable<SearchModelService>(SearchModelService);
   const commandService = useInjectable<CommandService>(CommandService);
@@ -136,10 +146,11 @@ export const SearchTree = ({ offsetTop, total, state, replace, search, viewState
         onContextMenu={searchModelService.handleContextMenu}
         leftPadding={8}
         isUseRegexp={isUseRegexp}
+        isMatchCase={isMatchCase}
         commandService={commandService}
       />
     ),
-    [model, search, replace, isUseRegexp],
+    [model, search, replace, isUseRegexp, isMatchCase],
   );
 
   const renderSearchTree = useCallback(() => {
@@ -155,7 +166,7 @@ export const SearchTree = ({ offsetTop, total, state, replace, search, viewState
         </RecycleTree>
       );
     }
-  }, [model, totalHeight, offsetTop, search, replace, isUseRegexp, viewState]);
+  }, [model, totalHeight, offsetTop, search, replace, isUseRegexp, isMatchCase, viewState]);
 
   return (
     <div className={styles.tree} tabIndex={-1} onBlur={handleTreeBlur} onFocus={handleTreeFocus} ref={wrapperRef}>


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

正则及普通字段搜索没有处理大小写情况的搜索高亮

### Changelog

highlight search content when ignore case
