### PR TITLE
chore: update large file size limit

### DIFF
--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -355,7 +355,7 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
       return;
     }
     const tokenizerOption: TokenizerOption = {
-      lineLimit: this.preferenceService.get('editor.maxTokenizationLineLength') || 10000,
+      lineLimit: this.preferenceService.get('editor.maxTokenizationLineLength') || 20000,
     };
     const configuration = this.textmateRegistry.getGrammarConfiguration(languageId)();
     const initialLanguage = getEncodedLanguageId(languageId);

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1601,7 +1601,7 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   },
   'editor.maxTokenizationLineLength': {
     type: 'integer',
-    default: 20_000,
+    default: 20000,
     description: localize(
       'maxTokenizationLineLength',
       'Lines above this length will not be tokenized for performance reasons',
@@ -1723,16 +1723,16 @@ const customEditorSchema: PreferenceSchemaProperties = {
     default: false,
     description: '%editor.configuration.forceReadOnly%',
   },
-  // 会启用languageFeature的最大文件尺寸
+  // 会启用 languageFeature 的最大文件尺寸
   'editor.languageFeatureEnabledMaxSize': {
     type: 'number',
-    default: 2 * 1024 * 1024, // 2M
+    default: 4 * 1024 * 1024 * 1024, // 4096 MB
     description: '%editor.configuration.languageFeatureEnabledMaxSize%',
   },
-  // 会同步到extHost的最大文件尺寸, 必须大于等于 languageFeatureEnabledMaxSize
+  // 会同步到插件进程的最大文件尺寸, 必须大于等于 languageFeatureEnabledMaxSize
   'editor.docExtHostSyncMaxSize': {
     type: 'number',
-    default: 2 * 1024 * 1024, // 2M
+    default: 4 * 1024 * 1024 * 1024, // 4096 MB
     description: '%editor.configuration.docExtHostSyncMaxSize%',
   },
   'editor.renderLineHighlight': {
@@ -1811,7 +1811,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   },
   'editor.maxTokenizationLineLength': {
     type: 'integer',
-    default: 10000,
+    default: 20000,
     description: '%editor.configuration.maxTokenizationLineLength%',
   },
   'editor.semanticHighlighting.enabled': {
@@ -1837,7 +1837,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   },
   'editor.largeFile': {
     type: 'number',
-    default: 2 * 1024 * 1024,
+    default: 4 * 1024 * 1024 * 1024,
     description: '%editor.configuration.largeFileSize%',
   },
   'editor.quickSuggestionsDelay': {

--- a/packages/extension/src/browser/vscode/api/main.thread.doc.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.doc.ts
@@ -115,12 +115,12 @@ export class MainThreadExtensionDocumentData extends WithEventBus implements IMa
         this.docSyncEnabled.set(
           uriString,
           docRef.instance.getMonacoModel().getValueLength() <
-            (this.preference.get<number>('editor.docExtHostSyncMaxSize') || 2 * 1024 * 1024),
+            (this.preference.get<number>('editor.docExtHostSyncMaxSize') || 4 * 1024 * 1024 * 1024),
         );
         docRef.dispose();
       }
     }
-    return this.docSyncEnabled.get(uriString)!;
+    return this.docSyncEnabled.get(uriString) ?? false;
   }
 
   constructor(@Optional(Symbol()) private rpcProtocol: IRPCProtocol) {

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -171,7 +171,7 @@ export class MainThreadLanguages implements IMainThreadLanguages {
       this.languageFeatureEnabled.set(
         uriString,
         model.getValueLength() <
-          (this.preference.get<number>('editor.languageFeatureEnabledMaxSize') || 2 * 1024 * 1024),
+          (this.preference.get<number>('editor.languageFeatureEnabledMaxSize') || 4 * 1024 * 1024 * 1024),
       );
     }
     return this.languageFeatureEnabled.get(uriString);

--- a/packages/file-scheme/__tests__/browser/contribution.test.ts
+++ b/packages/file-scheme/__tests__/browser/contribution.test.ts
@@ -78,7 +78,7 @@ describe('contribution test', () => {
   });
 
   it('should fallback to LARGE_FILE_PREVENT_COMPONENT_ID if file is too large', async () => {
-    mockFileService.getFileStat.mockReturnValueOnce({ size: 114514 });
+    mockFileService.getFileStat.mockReturnValueOnce({ size: 4 * 1024 * 1024 * 1024 + 1 });
     const openTypes = await registry.resolveEditorComponent(createMockResource('file:///foo/2.js'));
     expect(openTypes[0].type).toBe('component');
     expect(openTypes[0].componentId).toBe('large-file-prevent');

--- a/packages/file-scheme/src/browser/file-scheme.contribution.ts
+++ b/packages/file-scheme/src/browser/file-scheme.contribution.ts
@@ -137,7 +137,7 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
         if (type === 'text') {
           const { metadata, uri } = resource as { uri: URI; metadata: any };
           const stat = await this.fileServiceClient.getFileStat(uri.toString());
-          const maxSize = this.preference.get<number>('editor.largeFile') || 20000;
+          const maxSize = this.preference.get<number>('editor.largeFile') || 4 * 1024 * 1024 * 1024;
 
           if (stat && (stat.size || 0) > maxSize && !(metadata || {}).noPrevent) {
             results.push({


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

调整 OpenSumi 内可打开的最大文件大小以及语法高亮限制。

目前 `editor.languageFeatureEnabledMaxSize`  及 `editor.docExtHostSyncMaxSize` 的设计与 `editor.maxTokenizationLineLength` 存在一些重复性设计，目前调整至与 `editor.largeFile` 保持一致，后续可以考虑移除这两个配置。

### Changelog

update large file size limit