### PR TITLE
fix: merge editor conflict action error

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/document-mapping.ts
@@ -175,7 +175,14 @@ export class DocumentMapping extends Disposable {
     const values = this.ensureSort(this.adjacentComputeRangeMap.values());
 
     for (const range of values) {
-      if (range.isTouches(oppositeRange) && (isAllowContact ? true : !range.isContact(oppositeRange))) {
+      const condition = () => {
+        if (isAllowContact) {
+          return range.isTouches(oppositeRange) || range.isContact(oppositeRange);
+        }
+        return range.isTouches(oppositeRange) && !range.isContact(oppositeRange);
+      };
+
+      if (condition()) {
         return range;
       }
     }

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -1,5 +1,5 @@
-import { uuid } from '@opensumi/ide-core-common';
-import { IRange } from '@opensumi/monaco-editor-core';
+import { Constants, uuid } from '@opensumi/ide-core-common';
+import { IRange, Position } from '@opensumi/monaco-editor-core';
 import { LineRange as MonacoLineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 
 import { ETurnDirection, IRangeContrast, LineRangeType } from '../types';
@@ -228,14 +228,23 @@ export class LineRange extends MonacoLineRange implements IRangeContrast {
     return this.retainState(child).setId(preId);
   }
 
-  public toRange(startColumn = 0, endColumn: number = Number.MAX_SAFE_INTEGER): IRange {
-    if (this.isEmpty) {
-      return InnerRange.fromPositions({ lineNumber: this.startLineNumber, column: startColumn }).setType(this._type);
-    }
-
+  public toRange(): IRange {
     return InnerRange.fromPositions(
-      { lineNumber: this.startLineNumber, column: startColumn },
-      { lineNumber: this.endLineNumberExclusive - 1, column: endColumn },
+      new Position(this.startLineNumber, 1),
+      new Position(this.endLineNumberExclusive, 1),
+    ).setType(this._type);
+  }
+
+  public toInclusiveRange(startColumn?: number, endColumn?: number): IRange {
+    if (this.isEmpty) {
+      return InnerRange.fromPositions(
+        new Position(this.startLineNumber, startColumn ?? 1),
+        new Position(this.startLineNumber, endColumn ?? 1),
+      ).setType(this._type);
+    }
+    return InnerRange.fromPositions(
+      new Position(this.startLineNumber, startColumn ?? 1),
+      new Position(this.endLineNumberExclusive - 1, endColumn ?? Constants.MAX_SAFE_SMALL_INTEGER),
     ).setType(this._type);
   }
 

--- a/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/model/line-range.ts
@@ -1,5 +1,6 @@
 import { Constants, uuid } from '@opensumi/ide-core-common';
-import { IRange, Position } from '@opensumi/monaco-editor-core';
+import { IRange } from '@opensumi/monaco-editor-core';
+import { Position } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/position';
 import { LineRange as MonacoLineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputer';
 
 import { ETurnDirection, IRangeContrast, LineRangeType } from '../types';

--- a/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/actions-manager.ts
@@ -1,9 +1,7 @@
 import { Disposable, Event } from '@opensumi/ide-core-common';
-import { Position } from '@opensumi/monaco-editor-core';
 import { IEditorMouseEvent, MouseTargetType } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
-import { ISingleEditOperation } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/editOperation';
+import { Position } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/position';
 
-import { ITextModel } from '../../../monaco-api/types';
 import { MappingManagerService } from '../mapping-manager.service';
 import { DocumentMapping } from '../model/document-mapping';
 import { InnerRange } from '../model/inner-range';
@@ -300,7 +298,9 @@ export class ActionsManager extends Disposable {
         this.incomingView.onDidConflictActions,
       )(({ range, action }) => {
         if (action === ACCEPT_CURRENT_ACTIONS) {
-          this.handleAcceptChange(range, (_range, oppositeRange, { applyText }) => [{ range: oppositeRange, text: applyText }]);
+          this.handleAcceptChange(range, (_range, oppositeRange, { applyText }) => [
+            { range: oppositeRange, text: applyText },
+          ]);
         }
 
         if (action === IGNORE_ACTIONS) {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.ts
@@ -99,7 +99,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
           deltaEdits.forEach((edits) => {
             const { startLineNumber, endLineNumber, offset } = edits;
 
-            const toLineRange = LineRange.fromPositions(startLineNumber, endLineNumber);
+            const toLineRange = LineRange.fromPositions(startLineNumber, endLineNumber + Math.max(0, offset));
             const { [EditorViewType.CURRENT]: includeLeftRange, [EditorViewType.INCOMING]: includeRightRange } =
               this.mappingManagerService.findIncludeRanges(toLineRange);
             /**
@@ -107,13 +107,13 @@ export class ResultCodeEditor extends BaseCodeEditor {
              * 那么就要以当前 touch range 的结果作为要 delta 的起点
              */
             const { [EditorViewType.CURRENT]: touchTurnLeftRange, [EditorViewType.INCOMING]: touchTurnRightRange } =
-              this.mappingManagerService.findTouchesRanges(toLineRange, false);
+              this.mappingManagerService.findTouchesRanges(toLineRange);
             const { [EditorViewType.CURRENT]: nextTurnLeftRange, [EditorViewType.INCOMING]: nextTurnRightRange } =
               this.mappingManagerService.findNextLineRanges(toLineRange);
 
             if (includeLeftRange) {
               this.documentMappingTurnLeft.deltaEndAdjacentQueue(includeLeftRange, offset);
-            } else if (touchTurnLeftRange && !toLineRange.isAfter(touchTurnLeftRange)) {
+            } else if (touchTurnLeftRange) {
               this.documentMappingTurnLeft.deltaEndAdjacentQueue(touchTurnLeftRange, offset);
             } else if (nextTurnLeftRange) {
               const reverse = this.documentMappingTurnLeft.reverse(nextTurnLeftRange);
@@ -124,7 +124,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
             if (includeRightRange) {
               this.documentMappingTurnRight.deltaEndAdjacentQueue(includeRightRange, offset);
-            } else if (touchTurnRightRange && !toLineRange.isAfter(touchTurnRightRange)) {
+            } else if (touchTurnRightRange) {
               this.documentMappingTurnRight.deltaEndAdjacentQueue(touchTurnRightRange, offset);
             } else if (nextTurnRightRange) {
               const reverse = this.documentMappingTurnRight.reverse(nextTurnRightRange);
@@ -400,7 +400,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
     diffRanges.forEach((range) => {
       this.timeMachineDocument.record(range.id, {
         range,
-        text: range.isEmpty ? null : this.editor.getModel()!.getValueInRange(range.toRange()),
+        text: range.isEmpty ? null : this.editor.getModel()!.getValueInRange(range.toInclusiveRange()),
       });
     });
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

例如: 如果 diff 区域是在编辑器的最后一行，就会出现如下情况

https://user-images.githubusercontent.com/20262815/210696384-29f02f88-c31f-420b-ba01-6c060bdd2ee6.mp4

现在调整了 applyEdits 时的 range 计算方式

https://user-images.githubusercontent.com/20262815/210696556-5bf37922-6629-4b26-83b1-667b0e17e6c6.mp4


### Changelog
修复合并编辑器的解决冲突操作不正确的问题