### PR TITLE
style: dialog message title center

### DIFF
--- a/packages/components/src/dialog/styles.less
+++ b/packages/components/src/dialog/styles.less
@@ -99,5 +99,4 @@
   align-items: center;
   display: inline-flex;
   user-select: text;
-  flex-direction: column;
 }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

### Changelog
修复 dialog 弹窗标题不居中的问题