### PR TITLE
fix: prefix quick open should trim input

### DIFF
--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -331,7 +331,7 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
     const originLookFor = lookFor;
 
     if (this.options.skipPrefix) {
-      lookFor = lookFor.substr(this.options.skipPrefix);
+      lookFor = lookFor.substring(this.options.skipPrefix).trim();
     }
 
     if (actionProvider && actionProvider.getValidateInput) {


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes


### Background or solution

close: #1958
- https://github.com/opensumi/core/issues/1958

After:
<img width="1013" alt="CleanShot 2023-01-06 at 13 20 35@2x" src="https://user-images.githubusercontent.com/13938334/210935658-53d88b87-1b56-4fd4-86f2-7a14803bb906.png">


### Changelog

trim user input in prefix quickopen
