### PR TITLE
style: update the padding at the top/bottom of popover component

### DIFF
--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -17,7 +17,7 @@
       position: absolute;
       left: 0;
       width: 100%;
-      height: 15px;
+      height: 7px;
       border-style: solid;
       background: transparent;
       border: 0;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution
修复 popover 组件顶部/底部的边距

before:

<img width="714" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/2226423/211012855-60f91713-0c7f-4004-abe1-245dfc86e48f.png">

after:

<img width="727" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/2226423/211012866-ca017af1-d9a9-4bc7-87f7-5d0ff58f650b.png">

### Changelog
