### PR TITLE
style: remove some useless tree style

### DIFF
--- a/packages/comments/src/browser/tree/tree-node.module.less
+++ b/packages/comments/src/browser/tree/tree-node.module.less
@@ -117,8 +117,6 @@
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground);
-    background: var(--kt-tree-activeSelectionBackground);
     .expansion_toggle,
     .description {
       color: var(--kt-tree-activeSelectionForeground);

--- a/packages/components/src/recycle-tree/basic/styles.less
+++ b/packages/components/src/recycle-tree/basic/styles.less
@@ -27,8 +27,6 @@
     &.mod_focused {
       outline: 1px solid var(--list-focusOutline);
       outline-offset: -1px;
-      color: var(--kt-tree-activeSelectionForeground) !important;
-      background: var(--kt-tree-activeSelectionBackground);
       .expansion_toggle {
         color: var(--kt-tree-activeSelectionForeground) !important;
       }

--- a/packages/debug/src/browser/view/console/debug-console.module.less
+++ b/packages/debug/src/browser/view/console/debug-console.module.less
@@ -139,8 +139,6 @@
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
     .expansion_toggle {
       color: var(--kt-tree-activeSelectionForeground) !important;
     }

--- a/packages/debug/src/browser/view/variables/debug-variables.module.less
+++ b/packages/debug/src/browser/view/variables/debug-variables.module.less
@@ -14,26 +14,16 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground) !important;
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle {
-      color: var(--kt-tree-inactiveSelectionForeground) !important;
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_actived {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_loading {

--- a/packages/debug/src/browser/view/watch/debug-watch.module.less
+++ b/packages/debug/src/browser/view/watch/debug-watch.module.less
@@ -39,27 +39,16 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground) !important;
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle {
-      color: var(--kt-tree-inactiveSelectionForeground) !important;
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_actived {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_loading {

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view-node.module.less
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view-node.module.less
@@ -34,20 +34,11 @@
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
-
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_actived {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_invalid {

--- a/packages/file-tree-next/src/browser/file-tree-node.module.less
+++ b/packages/file-tree-next/src/browser/file-tree-node.module.less
@@ -38,17 +38,11 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground) !important;
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle {
-      color: var(--kt-tree-inactiveSelectionForeground) !important;
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
     .file_tree_node_displayname {
       .compact_name {
         &.active {
@@ -61,9 +55,6 @@
   &.mod_actived {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
     .file_tree_node_displayname {
       .compact_name {
         &.active {

--- a/packages/markers/src/browser/markers-tree.view.tsx
+++ b/packages/markers/src/browser/markers-tree.view.tsx
@@ -95,8 +95,30 @@ const Empty: FC = () => {
 /**
  * marker panel
  */
-export const MarkerPanel = ({ viewState }: { viewState: ViewState }) => (
-  <div className={styles.markersContent}>
-    <MarkerList viewState={viewState} />
-  </div>
-);
+export const MarkerPanel = ({ viewState }: { viewState: ViewState }) => {
+  const markerModelService = useInjectable(MarkerModelService);
+  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+
+  const handleOuterClick = useCallback(() => {
+    // 空白区域点击，取消焦点状态
+    const { enactiveFileDecoration } = markerModelService;
+    enactiveFileDecoration();
+  }, []);
+
+  useEffect(() => {
+    const handleBlur = () => {
+      markerModelService.handleTreeBlur();
+    };
+    wrapperRef.current?.addEventListener('blur', handleBlur, true);
+    return () => {
+      wrapperRef.current?.removeEventListener('blur', handleBlur, true);
+      markerModelService.handleTreeBlur();
+    };
+  }, [wrapperRef.current]);
+
+  return (
+    <div className={styles.markersContent} tabIndex={-1} ref={wrapperRef} onClick={handleOuterClick}>
+      <MarkerList viewState={viewState} />
+    </div>
+  );
+};

--- a/packages/markers/src/browser/tree/tree-node.module.less
+++ b/packages/markers/src/browser/tree/tree-node.module.less
@@ -153,35 +153,16 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground) !important;
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle,
-    .description {
-      color: var(--kt-tree-inactiveSelectionForeground) !important;
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
-    .expansion_toggle,
-    .description {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
-  &.mod_dirty {
-    &::before {
-      content: '';
-      display: block;
-      width: 8px;
-      height: 8px;
-      border-radius: 4px;
-      margin: 7px 5px;
-      background: var(--kt-dirtyDot-foreground);
-      position: absolute;
-      left: 18px;
-    }
+  &.mod_actived {
+    outline: 1px solid var(--list-focusOutline);
+    outline-offset: -1px;
   }
 }
 

--- a/packages/opened-editor/src/browser/opened-editor-node.module.less
+++ b/packages/opened-editor/src/browser/opened-editor-node.module.less
@@ -25,8 +25,6 @@
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
   }
 
   &.mod_actived {

--- a/packages/outline/src/browser/outline-node.module.less
+++ b/packages/outline/src/browser/outline-node.module.less
@@ -20,35 +20,16 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground) !important;
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle,
-    .outline_node_description {
-      color: var(--kt-tree-inactiveSelectionForeground) !important;
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
-    .expansion_toggle,
-    .outline_node_description {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
-  &.mod_dirty {
-    &::before {
-      content: '';
-      display: block;
-      width: 8px;
-      height: 8px;
-      border-radius: 4px;
-      margin: 7px 5px;
-      background: var(--kt-dirtyDot-foreground);
-      position: absolute;
-      left: 18px;
-    }
+  &.mod_actived {
+    outline: 1px solid var(--list-focusOutline);
+    outline-offset: -1px;
   }
 }
 

--- a/packages/outline/src/browser/services/outline-model.service.ts
+++ b/packages/outline/src/browser/services/outline-model.service.ts
@@ -87,7 +87,6 @@ export class OutlineModelService {
   // 装饰器
   private selectedDecoration: Decoration = new Decoration(styles.mod_selected); // 选中态
   private focusedDecoration: Decoration = new Decoration(styles.mod_focused); // 焦点态
-  private dirtyDecoration: Decoration = new Decoration(styles.mod_dirty); // 修改态
   // 即使选中态也是焦点态的节点
   private _focusedNode: OutlineCompositeTreeNode | OutlineTreeNode | undefined;
   // 选中态的节点
@@ -276,7 +275,6 @@ export class OutlineModelService {
     this._decorations = new DecorationsManager(root as any);
     this._decorations.addDecoration(this.selectedDecoration);
     this._decorations.addDecoration(this.focusedDecoration);
-    this._decorations.addDecoration(this.dirtyDecoration);
     return this._decorations;
   }
 

--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -129,8 +129,6 @@
         &.focused {
           outline: 1px solid var(--list-focusOutline);
           outline-offset: -1px;
-          color: var(--kt-tree-activeSelectionForeground) !important;
-          background: var(--kt-tree-activeSelectionBackground);
         }
       }
       .key {

--- a/packages/scm/src/browser/components/scm-resource-tree/index.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/index.tsx
@@ -142,7 +142,7 @@ export const SCMResourceTree: FC<{
       ref={wrapperRef}
       data-name={TREE_FIELD_NAME}
     >
-      <TreeView
+      <SCMTreeView
         isReady={isReady}
         model={model}
         height={height}
@@ -177,7 +177,7 @@ function isTreeViewPropsEqual(prevProps: TreeViewProps, nextProps: TreeViewProps
   );
 }
 
-const TreeView = memo(
+const SCMTreeView = memo(
   ({
     isReady,
     model,
@@ -190,7 +190,6 @@ const TreeView = memo(
   }: TreeViewProps) => {
     const scmTreeModelService = useInjectable<SCMTreeModelService>(SCMTreeModelService);
     const scmTreeService = useInjectable<SCMTreeService>(SCMTreeService);
-
     const renderSCMTreeNode = useCallback(
       (props: ISCMTreeNodeProps) => (
         <SCMTreeNode
@@ -230,4 +229,4 @@ const TreeView = memo(
   isTreeViewPropsEqual,
 );
 
-TreeView.displayName = 'SCMResourceTreeView';
+SCMTreeView.displayName = 'SCMResourceTreeView';

--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-model.ts
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-model.ts
@@ -12,17 +12,9 @@ export class SCMTreeModel extends TreeModel {
   @Autowired(SCMTreeDecorationService)
   public readonly decorationService: SCMTreeDecorationService;
 
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
-
-  private flushDispatchChangeDelayer = new ThrottledDelayer<void>(SCMTreeModel.DEFAULT_FLUSH_DELAY);
-
   constructor(@Optional() root: SCMResourceFolder | SCMResourceRoot) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {

--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.module.less
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.module.less
@@ -10,36 +10,23 @@
     color: var(--kt-tree-hoverForeground);
     background: var(--kt-tree-hoverBackground);
     &::before {
-      display: none !important;
+      display: none;
     }
   }
 
   &.mod_selected {
-    color: var(--kt-tree-inactiveSelectionForeground) !important;
+    color: var(--kt-tree-inactiveSelectionForeground);
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle,
-    .scm_tree_node_description {
-      color: var(--kt-tree-inactiveSelectionForeground) !important;
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground) !important;
-    background: var(--kt-tree-activeSelectionBackground);
-    .expansion_toggle,
-    .scm_tree_node_description {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &.mod_actived {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground) !important;
-    }
   }
 
   &_description {

--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.view.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.view.tsx
@@ -1,5 +1,5 @@
 import clx from 'classnames';
-import React, { memo } from 'react';
+import React, { useCallback } from 'react';
 
 import {
   Badge,
@@ -87,44 +87,59 @@ export const SCMResourceGroupNode: React.FC<ISCMResourceGroupRenderProps> = ({
     );
   }, [scmResourceGroup /* 依赖项是 SCMResourceGroup 指针 */]);
 
-  const handleContextMenu = (ev: React.MouseEvent) => {
-    if (ev.nativeEvent.which === 0) {
-      return;
-    }
-    onContextMenu(ev, item, itemType);
-  };
-
-  const handleClick = (ev: React.MouseEvent) => {
-    onClick(ev, item, itemType);
-  };
-
-  const handleDoubleClick = (ev: React.MouseEvent) => {
-    onDoubleClick(ev, item, itemType);
-  };
-
-  const renderFolderToggle = (node: SCMResourceGroup, clickHandler: any) => {
-    if (decorations && decorations?.classlist.indexOf(styles.mod_loading) > -1) {
-      return <Loading />;
-    }
-    return (
-      <div
-        onClick={clickHandler}
-        className={clx(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
-          [`${styles.mod_collapsed}`]: !(node as SCMResourceGroup).expanded,
-        })}
-      />
-    );
-  };
-
-  const handleTwistierClick = (ev: React.MouseEvent) => {
-    if (itemType === TreeNodeType.TreeNode || itemType === TreeNodeType.CompositeTreeNode) {
-      if (onTwistierClick) {
-        onTwistierClick(ev, item, itemType);
-      } else {
-        onClick(ev, item, itemType);
+  const handleContextMenu = useCallback(
+    (ev: React.MouseEvent) => {
+      if (ev.nativeEvent.which === 0) {
+        return;
       }
-    }
-  };
+      onContextMenu(ev, item, itemType);
+    },
+    [onContextMenu],
+  );
+
+  const handleClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onClick(ev, item, itemType);
+    },
+    [onClick],
+  );
+
+  const handleDoubleClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onDoubleClick(ev, item, itemType);
+    },
+    [onDoubleClick],
+  );
+
+  const renderFolderToggle = useCallback(
+    (node: SCMResourceGroup, clickHandler: any) => {
+      if (decorations && decorations?.classlist.indexOf(styles.mod_loading) > -1) {
+        return <Loading />;
+      }
+      return (
+        <div
+          onClick={clickHandler}
+          className={clx(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
+            [`${styles.mod_collapsed}`]: !(node as SCMResourceGroup).expanded,
+          })}
+        />
+      );
+    },
+    [decorations],
+  );
+
+  const handleTwistierClick = useCallback(
+    (ev: React.MouseEvent) => {
+      if (itemType === TreeNodeType.TreeNode || itemType === TreeNodeType.CompositeTreeNode) {
+        if (onTwistierClick) {
+          onTwistierClick(ev, item, itemType);
+        } else {
+          onClick(ev, item, itemType);
+        }
+      }
+    },
+    [onTwistierClick, onClick],
+  );
 
   return (
     <div
@@ -179,7 +194,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
 
   const scmResource = item.resource as ISCMResource;
 
-  const renderActionBar = React.useCallback(() => {
+  const renderActionBar = useCallback(() => {
     const repoMenus = viewModel.menus.getRepositoryMenus(scmResource.resourceGroup.provider);
     let menus: IContextMenu;
     let context: ISCMResource[];
@@ -199,20 +214,29 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
     /* 当进行 stage/unstage 操作后 resourceGroup 会产生变化需要更新 ActionBar */
   }, [itemType, scmResource.resourceGroup /* 依赖项是 SCMResourceGroup 指针 */]);
 
-  const handleClick = (ev: React.MouseEvent) => {
-    onClick(ev, item, itemType);
-  };
+  const handleClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onClick(ev, item, itemType);
+    },
+    [onClick],
+  );
 
-  const handleDoubleClick = (ev: React.MouseEvent) => {
-    onDoubleClick(ev, item, itemType);
-  };
+  const handleDoubleClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onDoubleClick(ev, item, itemType);
+    },
+    [onDoubleClick],
+  );
 
-  const handleContextMenu = (ev: React.MouseEvent) => {
-    if (ev.nativeEvent.which === 0) {
-      return;
-    }
-    onContextMenu(ev, item, itemType);
-  };
+  const handleContextMenu = useCallback(
+    (ev: React.MouseEvent) => {
+      if (ev.nativeEvent.which === 0) {
+        return;
+      }
+      onContextMenu(ev, item, itemType);
+    },
+    [onContextMenu],
+  );
 
   const isDirectory = SCMResourceFolder.is(item);
   const { hidesExplorerArrows, hasFolderIcons } = iconTheme;
@@ -232,14 +256,20 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
     );
   };
 
-  const renderDisplayName = (node: SCMResourceFolder | SCMResourceFile) => (
-    <div className={clx(styles.scm_tree_node_segment, styles.scm_tree_node_displayname)}>
-      {SCMResourceFolder.is(node) ? node.displayName : labelService.getName(node.uri)}
-    </div>
+  const renderDisplayName = useCallback(
+    (node: SCMResourceFolder | SCMResourceFile) => (
+      <div className={clx(styles.scm_tree_node_segment, styles.scm_tree_node_displayname)}>
+        {SCMResourceFolder.is(node) ? node.displayName : labelService.getName(node.uri)}
+      </div>
+    ),
+    [labelService],
   );
 
-  const renderDescription = (node: SCMResourceFile | SCMResourceFolder) => (
-    <div className={clx(styles.scm_tree_node_segment_grow, styles.scm_tree_node_description)}>{node.description}</div>
+  const renderDescription = useCallback(
+    (node: SCMResourceFile | SCMResourceFolder) => (
+      <div className={clx(styles.scm_tree_node_segment_grow, styles.scm_tree_node_description)}>{node.description}</div>
+    ),
+    [],
   );
 
   const themeService = useInjectable<IThemeService>(IThemeService);
@@ -259,41 +289,47 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
     );
   };
 
-  const getItemTooltip = () => {
+  const getItemTooltip = useCallback(() => {
     let tooltip = item.tooltip;
     if (decoration && decoration.badge) {
       tooltip += ` • ${decoration.tooltip || item.resource.decorations.tooltip || ''}`;
     }
     return tooltip;
-  };
+  }, [item]);
 
-  const handleTwistierClick = (ev: React.MouseEvent) => {
-    if (itemType === TreeNodeType.TreeNode || itemType === TreeNodeType.CompositeTreeNode) {
-      if (onTwistierClick) {
-        onTwistierClick(ev, item, itemType);
-      } else {
-        onClick(ev, item, itemType);
+  const handleTwistierClick = useCallback(
+    (ev: React.MouseEvent) => {
+      if (itemType === TreeNodeType.TreeNode || itemType === TreeNodeType.CompositeTreeNode) {
+        if (onTwistierClick) {
+          onTwistierClick(ev, item, itemType);
+        } else {
+          onClick(ev, item, itemType);
+        }
       }
-    }
-  };
+    },
+    [onTwistierClick, onClick],
+  );
 
-  const renderFolderToggle = (node: SCMResourceFolder | SCMResourceFile, clickHandler: any) => {
-    if (!SCMResourceFolder.is(node)) {
-      return null;
-    }
+  const renderFolderToggle = useCallback(
+    (node: SCMResourceFolder | SCMResourceFile, clickHandler: any) => {
+      if (!SCMResourceFolder.is(node)) {
+        return null;
+      }
 
-    if (decorations && decorations?.classlist.indexOf(styles.mod_loading) > -1) {
-      return <Loading />;
-    }
-    return (
-      <div
-        onClick={clickHandler}
-        className={clx(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
-          [`${styles.mod_collapsed}`]: !(node as SCMResourceFolder).expanded,
-        })}
-      />
-    );
-  };
+      if (decorations && decorations?.classlist.indexOf(styles.mod_loading) > -1) {
+        return <Loading />;
+      }
+      return (
+        <div
+          onClick={clickHandler}
+          className={clx(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
+            [`${styles.mod_collapsed}`]: !(node as SCMResourceFolder).expanded,
+          })}
+        />
+      );
+    },
+    [decorations],
+  );
 
   return (
     <div
@@ -331,10 +367,10 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
   );
 };
 
-export const SCMTreeNode: React.FC<ISCMTreeNodeProps> = memo((props) => {
+export const SCMTreeNode: React.FC<ISCMTreeNodeProps> = (props) => {
   const { item, ...restProps } = props;
   if (SCMResourceGroup.is(item)) {
     return <SCMResourceGroupNode item={item} {...restProps} />;
   }
   return <SCMResourceNode {...props} item={item} />;
-});
+};

--- a/packages/search/src/browser/tree/tree-node.module.less
+++ b/packages/search/src/browser/tree/tree-node.module.less
@@ -140,29 +140,16 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground);
     background: var(--kt-tree-inactiveSelectionBackground);
-    .expansion_toggle,
-    .description {
-      color: var(--kt-tree-inactiveSelectionForeground);
-    }
   }
 
   &.mod_focused {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    color: var(--kt-tree-activeSelectionForeground);
-    background: var(--kt-tree-activeSelectionBackground);
-    .expansion_toggle,
-    .description {
-      color: var(--kt-tree-activeSelectionForeground);
-    }
   }
 
   &.mod_actived {
     outline: 1px solid var(--list-focusOutline);
     outline-offset: -1px;
-    .expansion_toggle {
-      color: var(--kt-tree-activeSelectionForeground);
-    }
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

移除了不同视图下的冗余样式，修复 Marker / OpenedEditor 等面板在 Light+ 主题下异常展示问题
<img width="529" alt="image" src="https://user-images.githubusercontent.com/9823838/211560373-97535025-44bb-4b91-8503-04e6656932c0.png">

fixed #2179 

### Changelog

remove some useless tree style