### PR TITLE
fix(editor): add missing edit stack when save

### DIFF
--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -380,11 +380,12 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
     }
     const task = new SaveTask(this.uri, versionId, this.monacoModel.getAlternativeVersionId(), this.getText(), force);
     this.savingTasks.push(task);
-    if (this.savingTasks.length === 1) {
+    if (this.savingTasks.length > 0) {
       this.initSave();
     }
     const res = await task.finished;
     if (res.state === SaveTaskResponseState.SUCCESS) {
+      this.monacoModel.pushStackElement();
       return true;
     } else if (res.state === SaveTaskResponseState.ERROR) {
       if (res.errorMessage !== SaveTaskErrorCause.CANCEL) {

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -29,7 +29,7 @@
     "@playwright/test": "1.29.1"
   },
   "devDependencies": {
-    "@opensumi/ide-utils": "2.21.13",
+    "@opensumi/ide-utils": "workspace:*",
     "allure-commandline": "^2.13.8",
     "allure-playwright": "^2.0.0-beta.14",
     "typescript": "4.9.3"

--- a/tools/playwright/src/editor.ts
+++ b/tools/playwright/src/editor.ts
@@ -69,6 +69,11 @@ export class OpenSumiEditor extends OpenSumiView {
     await this.app.menubar.trigger('File', 'Save File');
     // waiting for saved
     await dirtyIcon?.waitForElementState('hidden');
+    await this.waitForEditorDone();
+  }
+
+  async waitForEditorDone() {
+    await this.page.waitForTimeout(200);
   }
 
   async close() {
@@ -92,7 +97,7 @@ export class OpenSumiEditor extends OpenSumiView {
     await this.activate();
     for (let i = 0; i < times; i++) {
       await this.app.menubar.trigger('Edit', 'Undo');
-      await this.app.page.waitForTimeout(200);
+      await this.waitForEditorDone();
     }
   }
 
@@ -100,7 +105,7 @@ export class OpenSumiEditor extends OpenSumiView {
     await this.activate();
     for (let i = 0; i < times; i++) {
       await this.app.menubar.trigger('Edit', 'Redo');
-      await this.app.page.waitForTimeout(200);
+      await this.waitForEditorDone();
     }
   }
 

--- a/tools/playwright/src/tests/editor/undoRedo.test.ts
+++ b/tools/playwright/src/tests/editor/undoRedo.test.ts
@@ -13,7 +13,7 @@ let explorer: OpenSumiExplorerView;
 let editor: OpenSumiTextEditor;
 let workspace: OpenSumiWorkspace;
 
-test.describe.only('OpenSumi Editor Undo Redo', () => {
+test.describe('OpenSumi Editor Undo Redo', () => {
   test.beforeAll(async () => {
     workspace = new OpenSumiWorkspace([path.resolve('./src/tests/workspaces/default')]);
     app = await OpenSumiApp.load(page, workspace);

--- a/tools/playwright/src/tests/editor/undoRedo.test.ts
+++ b/tools/playwright/src/tests/editor/undoRedo.test.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+
+import { expect } from '@playwright/test';
+
+import { OpenSumiApp } from '../../app';
+import { OpenSumiExplorerView } from '../../explorer-view';
+import { OpenSumiTextEditor } from '../../text-editor';
+import { OpenSumiWorkspace } from '../../workspace';
+import test, { page } from '../hooks';
+
+let app: OpenSumiApp;
+let explorer: OpenSumiExplorerView;
+let editor: OpenSumiTextEditor;
+let workspace: OpenSumiWorkspace;
+
+test.describe.only('OpenSumi Editor Undo Redo', () => {
+  test.beforeAll(async () => {
+    workspace = new OpenSumiWorkspace([path.resolve('./src/tests/workspaces/default')]);
+    app = await OpenSumiApp.load(page, workspace);
+    explorer = await app.open(OpenSumiExplorerView);
+    explorer.initFileTreeView(workspace.workspace.displayName);
+    await explorer.fileTreeView.open();
+  });
+
+  test.afterAll(() => {
+    app.dispose();
+  });
+
+  test('simple editor undo/redo should work', async () => {
+    editor = await app.openEditor(OpenSumiTextEditor, explorer, 'editor-undo-redo.text');
+    const existingLine = await editor.lineByLineNumber(1);
+    await editor.placeCursorInLine(existingLine);
+    await editor.typeText('a');
+    await editor.saveByKeyboard();
+    await editor.typeText('b');
+    await editor.saveByKeyboard();
+    await editor.typeText('c');
+    await editor.saveByKeyboard();
+    await expectLineHasText('abc');
+    await editor.undoByKeyboard();
+    await expectLineHasText('ab');
+    await editor.undoByKeyboard();
+    await expectLineHasText('a');
+    await editor.redoByKeyboard();
+    await expectLineHasText('ab');
+    await editor.redoByKeyboard();
+    await expectLineHasText('abc');
+
+    async function expectLineHasText(text: string) {
+      const line = await editor.lineByLineNumber(1);
+      expect(await line?.innerText()).toEqual(text);
+      await editor.placeCursorInLine(line);
+    }
+  });
+});

--- a/tools/playwright/src/text-editor.ts
+++ b/tools/playwright/src/text-editor.ts
@@ -4,7 +4,7 @@ import { OpenSumiApp } from './app';
 import { OpenSumiContextMenu } from './context-menu';
 import { OpenSumiEditor } from './editor';
 import { OpenSumiTreeNode } from './tree-node';
-import { keypressWithCmdCtrl } from './utils';
+import { keypressWithCmdCtrl, keypressWithCmdCtrlAndShift } from './utils';
 
 abstract class ViewsModel {
   constructor(readonly page: Page) {}
@@ -130,6 +130,22 @@ export class OpenSumiTextEditor extends OpenSumiEditor {
   protected async typeTextAndHitEnter(text: string): Promise<void> {
     await this.page.keyboard.type(text);
     await this.page.keyboard.press('Enter');
+  }
+
+  async typeText(text: string): Promise<void> {
+    await this.page.keyboard.type(text);
+  }
+  async saveByKeyboard(): Promise<void> {
+    await this.page.keyboard.press(keypressWithCmdCtrl('s'));
+    await this.waitForEditorDone();
+  }
+  async undoByKeyboard(): Promise<void> {
+    await this.page.keyboard.press(keypressWithCmdCtrl('z'));
+    await this.waitForEditorDone();
+  }
+  async redoByKeyboard(): Promise<void> {
+    await this.page.keyboard.press(keypressWithCmdCtrlAndShift('z'));
+    await this.waitForEditorDone();
   }
 
   async selectLineWithLineNumber(lineNumber: number): Promise<ElementHandle<SVGElement | HTMLElement> | undefined> {
@@ -271,7 +287,7 @@ export class OpenSumiTextEditor extends OpenSumiEditor {
     await lineElement?.click({ clickCount: 3 });
   }
 
-  protected async placeCursorInLine(
+  async placeCursorInLine(
     lineElement: ElementHandle<SVGElement | HTMLElement> | undefined,
     point: 'start' | 'end' = 'end',
   ): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,7 +3470,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opensumi/ide-utils@2.21.13, @opensumi/ide-utils@workspace:*, @opensumi/ide-utils@workspace:packages/utils":
+"@opensumi/ide-utils@workspace:*, @opensumi/ide-utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@opensumi/ide-utils@workspace:packages/utils"
   dependencies:
@@ -3550,7 +3550,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opensumi/playwright@workspace:tools/playwright"
   dependencies:
-    "@opensumi/ide-utils": 2.21.13
+    "@opensumi/ide-utils": "workspace:*"
     "@playwright/test": 1.29.1
     allure-commandline: ^2.13.8
     allure-playwright: ^2.0.0-beta.14

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,7 +3470,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@opensumi/ide-utils@2.21.12, @opensumi/ide-utils@workspace:*, @opensumi/ide-utils@workspace:packages/utils":
+"@opensumi/ide-utils@2.21.13, @opensumi/ide-utils@workspace:*, @opensumi/ide-utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@opensumi/ide-utils@workspace:packages/utils"
   dependencies:
@@ -3550,7 +3550,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opensumi/playwright@workspace:tools/playwright"
   dependencies:
-    "@opensumi/ide-utils": 2.21.12
+    "@opensumi/ide-utils": 2.21.13
     "@playwright/test": 1.29.1
     allure-commandline: ^2.13.8
     allure-playwright: ^2.0.0-beta.14


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

close: #1906 

研究发现：
输入第二个字符按保存后，monaco editor 并没有把这个变更 push 到 editStack 中。
但是这个时候，点击一下编辑器，这个变更就被 push 到 stack 里了。

也就是说，保存的时候补偿一个 pushStack 应该就好了


### Changelog

add missing edit stack when save
