### PR TITLE
feat: support electron titlebar string template

### DIFF
--- a/packages/core-browser/src/preferences/preference-service.ts
+++ b/packages/core-browser/src/preferences/preference-service.ts
@@ -112,7 +112,7 @@ export class PreferenceServiceImpl implements PreferenceService {
     this.toDispose.dispose();
   }
 
-  public onSpecificPreferenceChange(preferenceName, listener) {
+  public onSpecificPreferenceChange(preferenceName: string, listener: (change: PreferenceChange) => void) {
     if (!this.specificEmitters.has(preferenceName)) {
       this.specificEmitters.set(preferenceName, new Emitter());
     }

--- a/packages/core-browser/src/preferences/types.ts
+++ b/packages/core-browser/src/preferences/types.ts
@@ -110,9 +110,8 @@ export interface PreferenceService extends IDisposable {
   /**
    * 都走 onPreferenceChanged 再用if判断性能太差了
    * TODO: 将只监听一个偏好的使用这个方法
-   * @param preferenceName
    */
-  onSpecificPreferenceChange(preferenceName, listener: (change: PreferenceChange) => void): IDisposable;
+  onSpecificPreferenceChange(preferenceName: string, listener: (change: PreferenceChange) => void): IDisposable;
 }
 
 export const PreferenceProviderProvider = Symbol('PreferenceProviderProvider');

--- a/packages/electron-basic/__mocks__/index.ts
+++ b/packages/electron-basic/__mocks__/index.ts
@@ -5,7 +5,7 @@ import { IMessageService } from '@opensumi/ide-overlay/lib/common';
 
 import { createBrowserInjector } from '../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../tools/dev-tool/src/mock-injector';
-import { IElectronHeaderService } from '../src/common/header';
+// import { IElectronHeaderService } from '../src/common/header';
 
 import { mockService } from './utils';
 

--- a/packages/electron-basic/__mocks__/index.ts
+++ b/packages/electron-basic/__mocks__/index.ts
@@ -5,7 +5,6 @@ import { IMessageService } from '@opensumi/ide-overlay/lib/common';
 
 import { createBrowserInjector } from '../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../tools/dev-tool/src/mock-injector';
-// import { IElectronHeaderService } from '../src/common/header';
 
 import { mockService } from './utils';
 

--- a/packages/electron-basic/src/browser/electron-preference.contribution.ts
+++ b/packages/electron-basic/src/browser/electron-preference.contribution.ts
@@ -7,7 +7,6 @@ export const electronPreferencesSchema: PreferenceSchema = {
   properties: {
     'window.title': {
       type: 'string',
-      default: DEFAULT_TEMPLATE,
       description: localize('window.title'),
     },
   },

--- a/packages/electron-basic/src/browser/electron-preference.contribution.ts
+++ b/packages/electron-basic/src/browser/electron-preference.contribution.ts
@@ -1,7 +1,5 @@
 import { PreferenceSchema, PreferenceContribution, localize, Domain } from '@opensumi/ide-core-browser';
 
-import { DEFAULT_TEMPLATE } from './header/header.service';
-
 export const electronPreferencesSchema: PreferenceSchema = {
   type: 'object',
   properties: {

--- a/packages/electron-basic/src/browser/electron-preference.contribution.ts
+++ b/packages/electron-basic/src/browser/electron-preference.contribution.ts
@@ -1,0 +1,21 @@
+import { PreferenceSchema, PreferenceContribution, localize, Domain } from '@opensumi/ide-core-browser';
+
+import { DEFAULT_TEMPLATE } from './header/header.service';
+
+export const electronPreferencesSchema: PreferenceSchema = {
+  type: 'object',
+  properties: {
+    'window.title': {
+      type: 'string',
+      default: DEFAULT_TEMPLATE,
+      description: localize('window.title'),
+    },
+  },
+};
+
+export const ElectronPreferences = Symbol('ElectronPreferences');
+
+@Domain(PreferenceContribution)
+export class ElectronPreferenceContribution implements PreferenceContribution {
+  schema: PreferenceSchema = electronPreferencesSchema;
+}

--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -73,7 +73,7 @@ export class ElectronHeaderService implements IElectronHeaderService {
         if (e.newValue) {
           this.titleTemplate = e.newValue;
         }
-        // window.title is deteled
+        // window.title is deleted
         if (!e.newValue && this.titleTemplate !== DEFAULT_TEMPLATE) {
           this.titleTemplate = DEFAULT_TEMPLATE;
         }

--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -6,6 +6,7 @@ import {
   Emitter,
   DisposableCollection,
   isMacintosh,
+  PreferenceService,
 } from '@opensumi/ide-core-browser';
 import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/browser';
 import { basename, dirname, relative } from '@opensumi/ide-utils/lib/path';
@@ -28,13 +29,13 @@ export class ElectronHeaderService implements IElectronHeaderService {
   disposableCollection = new DisposableCollection();
 
   @Autowired(WorkbenchEditorService)
-  editorService: WorkbenchEditorService;
+  private readonly editorService: WorkbenchEditorService;
 
-  @Autowired(INJECTOR_TOKEN)
-  injector: Injector;
+  @Autowired(PreferenceService)
+  private readonly preferenceService: PreferenceService;
 
   @Autowired(AppConfig)
-  appConfig: AppConfig;
+  private readonly appConfig: AppConfig;
 
   private _onTitleChanged = new Emitter<string>();
   onTitleChanged = this._onTitleChanged.event;
@@ -45,7 +46,7 @@ export class ElectronHeaderService implements IElectronHeaderService {
 
   private _titleTemplate = DEFAULT_TEMPLATE;
   get titleTemplate() {
-    return this._titleTemplate;
+    return this.preferenceService.get('window.title', this._titleTemplate);
   }
 
   set titleTemplate(value: string) {

--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -46,7 +46,7 @@ export class ElectronHeaderService implements IElectronHeaderService {
 
   private _titleTemplate = DEFAULT_TEMPLATE;
   get titleTemplate() {
-    return this.preferenceService.get('window.title', this._titleTemplate);
+    return this._titleTemplate;
   }
 
   set titleTemplate(value: string) {
@@ -60,6 +60,8 @@ export class ElectronHeaderService implements IElectronHeaderService {
   }
 
   constructor() {
+    this._titleTemplate = this.preferenceService.get('window.title', this._titleTemplate);
+
     this.disposableCollection.push(
       this.editorService.onActiveResourceChange(() => {
         this.updateAppTitle();

--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -60,7 +60,7 @@ export class ElectronHeaderService implements IElectronHeaderService {
   }
 
   constructor() {
-    this._titleTemplate = this.preferenceService.get('window.title', this._titleTemplate);
+    this._titleTemplate = this.preferenceService.getValid('window.title', this._titleTemplate);
 
     this.disposableCollection.push(
       this.editorService.onActiveResourceChange(() => {
@@ -70,7 +70,13 @@ export class ElectronHeaderService implements IElectronHeaderService {
 
     this.disposableCollection.push(
       this.preferenceService.onSpecificPreferenceChange('window.title', async (e) => {
-        this.titleTemplate = e.newValue;
+        if (e.newValue) {
+          this.titleTemplate = e.newValue;
+        }
+        // window.title is deteled
+        if (!e.newValue && this.titleTemplate !== DEFAULT_TEMPLATE) {
+          this.titleTemplate = DEFAULT_TEMPLATE;
+        }
       }),
     );
   }

--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -8,7 +8,6 @@ import {
   isMacintosh,
   PreferenceService,
 } from '@opensumi/ide-core-browser';
-import { Event } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/browser';
 import { basename, dirname, relative } from '@opensumi/ide-utils/lib/path';
 import { template } from '@opensumi/ide-utils/lib/strings';
@@ -24,8 +23,6 @@ export let DEFAULT_TEMPLATE = '${dirty}${activeEditorShort}${separator}${rootNam
 if (isMacintosh) {
   DEFAULT_TEMPLATE = '${activeEditorShort}${separator}${rootName}';
 }
-
-const PREFERENCE_CHANGED_EVENT_DELAY = 100;
 
 @Injectable()
 export class ElectronHeaderService implements IElectronHeaderService {
@@ -69,16 +66,9 @@ export class ElectronHeaderService implements IElectronHeaderService {
       }),
     );
 
-    const onPreferenceChangedEvent = Event.debounce(
-      this.preferenceService.onPreferenceChanged,
-      (_, e) => e,
-      PREFERENCE_CHANGED_EVENT_DELAY,
-    );
     this.disposableCollection.push(
-      onPreferenceChangedEvent(async (e) => {
-        if (e.preferenceName === 'window.title') {
-          this.titleTemplate = e.newValue;
-        }
+      this.preferenceService.onSpecificPreferenceChange('window.title', async (e) => {
+        this.titleTemplate = e.newValue;
       }),
     );
   }

--- a/packages/electron-basic/src/browser/index.ts
+++ b/packages/electron-basic/src/browser/index.ts
@@ -39,9 +39,12 @@ import { IElectronHeaderService } from '../common/header';
 
 import { ElectronClipboardService } from './clipboard';
 import { ElectronNativeDialogService } from './dialog';
+import { ElectronPreferenceContribution } from './electron-preference.contribution';
 import { ElectronHeaderService } from './header/header.service';
 import { ElectronHeaderBar } from './header/header.view';
 import { WelcomeContribution } from './welcome/contribution';
+
+import '../common/i18n/setup';
 
 @Injectable()
 export class ElectronBasicModule extends BrowserModule {
@@ -55,6 +58,7 @@ export class ElectronBasicModule extends BrowserModule {
       useClass: ElectronHeaderService,
     },
     ElectronBasicContribution,
+    ElectronPreferenceContribution,
     WelcomeContribution,
   ];
 }

--- a/packages/electron-basic/src/common/header.ts
+++ b/packages/electron-basic/src/common/header.ts
@@ -31,7 +31,7 @@ export interface IElectronHeaderService {
    * - `${folderPath}`: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder).
    * - `${rootName}`: name of the opened workspace or folder (e.g. myFolder or myWorkspace).
    * - `${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace).
-   * - `${appName}`: e.g. VS Code.
+   * - `${appName}`: e.g. OpenSumi.
    * - `${remoteName}`: e.g. SSH
    * - `${dirty}`: an indicator for when the active editor has unsaved changes.
    * - `${separator}`: a conditional separator (" - ") that only shows when surrounded by variables with values or static text.

--- a/packages/electron-basic/src/common/i18n/en-US.lang.ts
+++ b/packages/electron-basic/src/common/i18n/en-US.lang.ts
@@ -3,7 +3,22 @@ export const localizationBundle = {
   languageName: 'english',
   localizedLanguageName: 'English',
   contents: {
-    // custom window title
-    'wiindow.title': 'Window Title Template',
+    'window.title': [
+      'Controls the window title based on the active editor. Variables are substituted based on the context:',
+      '`${activeEditorShort}`: the file name (e.g. myFile.txt).',
+      '`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).',
+      '`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).',
+      '`${activeFolderShort}`: the name of the folder the file is contained in (e.g. myFileFolder).',
+      '`${activeFolderMedium}`: the path of the folder the file is contained in, relative to the workspace folder (e.g. myFolder/myFileFolder).',
+      '`${activeFolderLong}`: the full path of the folder the file is contained in (e.g. /Users/Development/myFolder/myFileFolder).',
+      '`${folderName}`: name of the workspace folder the file is contained in (e.g. myFolder).',
+      '`${folderPath}`: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder).',
+      '`${rootName}`: name of the opened workspace or folder (e.g. myFolder or myWorkspace).',
+      '`${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace).',
+      '`${appName}`: e.g. OpenSumi.',
+      '`${remoteName}`: e.g. SSH',
+      '`${dirty}`: an indicator for when the active editor has unsaved changes.',
+      '`${separator}`: a conditional separator (" - ") that only shows when surrounded by variables with values or static text.',
+    ].join('\n- '),
   },
 };

--- a/packages/electron-basic/src/common/i18n/en-US.lang.ts
+++ b/packages/electron-basic/src/common/i18n/en-US.lang.ts
@@ -1,0 +1,9 @@
+export const localizationBundle = {
+  languageId: 'en-US',
+  languageName: 'english',
+  localizedLanguageName: 'English',
+  contents: {
+    // custom window title
+    'wiindow.title': 'Window Title Template',
+  },
+};

--- a/packages/electron-basic/src/common/i18n/setup.ts
+++ b/packages/electron-basic/src/common/i18n/setup.ts
@@ -1,0 +1,7 @@
+import { registerLocalizationBundle } from '@opensumi/ide-core-common/lib/localize';
+
+import { localizationBundle as en } from './en-US.lang';
+import { localizationBundle as zh } from './zh-CN.lang';
+
+registerLocalizationBundle(zh);
+registerLocalizationBundle(en);

--- a/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
+++ b/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
@@ -17,7 +17,7 @@ export const localizationBundle = {
       '`${rootPath}`: 工作区绝对路径 (例如: /Users/Development/myWorkspace).',
       '`${appName}`: 例如: OpenSumi.',
       '`${remoteName}`: 例如: SSH',
-      '`${dirty}`: 有文件被修改的',
+      '`${dirty}`: 有文件被修改的标记',
       '`${separator}`: 分隔符只在两边都有值的变量中出现',
     ].join('\n- '),
   },

--- a/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
+++ b/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
@@ -1,0 +1,9 @@
+export const localizationBundle = {
+  languageId: 'zh-CN',
+  languageName: 'Chinese',
+  localizedLanguageName: '中文(中国)',
+  contents: {
+    // custom window title
+    'wiindow.title': '窗口标题模板',
+  },
+};

--- a/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
+++ b/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
@@ -3,7 +3,22 @@ export const localizationBundle = {
   languageName: 'Chinese',
   localizedLanguageName: '中文(中国)',
   contents: {
-    // custom window title
-    'wiindow.title': '窗口标题模板',
+    'window.title': [
+      '基于活动文件控制窗口标题。变量根据上下文替换：',
+      '`${activeEditorShort}`: 活跃文件标题 (例如: myFile.txt).',
+      '`${activeEditorMedium}`: 活跃文件相对工作区的路径 (例如: myFolder/myFileFolder/myFile.txt).',
+      '`${activeEditorLong}`: 活跃文件的绝对路径 (例如: /Users/Development/myFolder/myFileFolder/myFile.txt).',
+      '`${activeFolderShort}`: 活跃文件的父目录 (例如: myFileFolder).',
+      '`${activeFolderMedium}`: 活跃文件的父目录相约对工作区的路径 (例如: myFolder/myFileFolder).',
+      '`${activeFolderLong}`: 活跃文件的父目录相约对工作区的绝对路径 (例如: /Users/Development/myFolder/myFileFolder).',
+      '`${folderName}`: 目录名称 (例如: myFolder).',
+      '`${folderPath}`: 目录绝对路径 (例如: /Users/Development/myFolder).',
+      '`${rootName}`: 工作区名称 (例如: myFolder or myWorkspace).',
+      '`${rootPath}`: 工作区绝对路径 (例如: /Users/Development/myWorkspace).',
+      '`${appName}`: 例如: OpenSumi.',
+      '`${remoteName}`: 例如: SSH',
+      '`${dirty}`: 有文件被修改的',
+      '`${separator}`: 分隔符只在两边都有值的变量中出现',
+    ].join('\n- '),
   },
 };

--- a/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
+++ b/packages/electron-basic/src/common/i18n/zh-CN.lang.ts
@@ -4,7 +4,7 @@ export const localizationBundle = {
   localizedLanguageName: '中文(中国)',
   contents: {
     'window.title': [
-      '基于活动文件控制窗口标题。变量根据上下文替换：',
+      '基于活跃文件控制窗口标题。变量根据上下文替换：',
       '`${activeEditorShort}`: 活跃文件标题 (例如: myFile.txt).',
       '`${activeEditorMedium}`: 活跃文件相对工作区的路径 (例如: myFolder/myFileFolder/myFile.txt).',
       '`${activeEditorLong}`: 活跃文件的绝对路径 (例如: /Users/Development/myFolder/myFileFolder/myFile.txt).',


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

支持 setting.json 设置 window.title 标题模板，比如 `${dirty}${activeEditorShort}${separator}${rootName}` 或者`${dirty}${activeEditorShort}${separator}${appName}`


https://user-images.githubusercontent.com/2226423/211964057-4fc2330d-9cb9-4f9b-a643-d6a640217b8a.mov


### Changelog
支持通过 window.title 控制窗口标题
