### PR TITLE
fix: collaboration initialize

### DIFF
--- a/packages/collaboration/src/browser/collaboration.contribution.ts
+++ b/packages/collaboration/src/browser/collaboration.contribution.ts
@@ -26,6 +26,10 @@ export class CollaborationContribution implements ClientAppContribution, Keybind
   private prevSetAskIfDiff: boolean;
   private prevSetAutoChange: string;
 
+  initialize() {
+    this.collaborationService.initialize();
+  }
+
   onDidStart() {
     if (this.preferenceService.get('editor.askIfDiff') === true) {
       this.prevSetAskIfDiff = true;
@@ -43,7 +47,7 @@ export class CollaborationContribution implements ClientAppContribution, Keybind
       this.collaborationService.registerContribution(provider);
     }
 
-    this.collaborationService.initialize();
+    this.collaborationService.registerUserInfo();
   }
 
   onStop() {

--- a/packages/collaboration/src/browser/collaboration.service.ts
+++ b/packages/collaboration/src/browser/collaboration.service.ts
@@ -118,6 +118,10 @@ export class CollaborationService extends WithEventBus implements ICollaboration
 
     this.yTextMap.observe(this.yMapObserver);
 
+    this.yWebSocketProvider.awareness.on('update', this.updateCSSManagerWhenAwarenessUpdated);
+  }
+
+  registerUserInfo() {
     if (this.userInfo === undefined) {
       // fallback
       this.userInfo = {
@@ -127,8 +131,6 @@ export class CollaborationService extends WithEventBus implements ICollaboration
     }
     // add userInfo to awareness field
     this.yWebSocketProvider.awareness.setLocalStateField('user-info', this.userInfo);
-
-    this.yWebSocketProvider.awareness.on('update', this.updateCSSManagerWhenAwarenessUpdated);
   }
 
   destroy() {

--- a/packages/collaboration/src/common/types.ts
+++ b/packages/collaboration/src/common/types.ts
@@ -12,6 +12,7 @@ export interface ICollaborationService {
   undoOnFocusedTextModel(): void;
   redoOnFocusedTextModel(): void;
   registerContribution(contribution: CollaborationModuleContribution): void;
+  registerUserInfo(): void;
 }
 
 export interface ITextModelBinding {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

由于 initialize 的时序太靠后了（在 onDidStart 里）
导致在刷新之后，监听不到首次打开的文件发出的 EditorDocumentModelCreationEvent 事件

### Changelog
修复协同编辑模块的初始化时序问题
