### PR TITLE
fix: show correct i18n text on the settings panel

### DIFF
--- a/packages/core-browser/__tests__/external-preference.test.ts
+++ b/packages/core-browser/__tests__/external-preference.test.ts
@@ -58,8 +58,8 @@ describe('external preference tests', () => {
     registerLocalStorageProvider('general.icon', mockWorkspace);
     registerLocalStorageProvider('general.language');
 
-    getExternalPreferenceProvider('general.theme')!.set('testTheme', PreferenceScope.Workspace);
-    expect(getPreferenceThemeId()).toBe('testTheme');
+    getExternalPreferenceProvider('general.theme')?.set('test-theme', PreferenceScope.Workspace);
+    expect(getPreferenceThemeId()).toBe('test-theme');
 
     // mock localStorage
     const store = new Map();
@@ -69,31 +69,32 @@ describe('external preference tests', () => {
       },
       getItem: (key: string) => store.get(key),
     };
+    const unique_languageId = 'zh-Hans';
 
     // 默认值为 zh-CN
     expect(getPreferenceLanguageId()).toBe('zh-CN');
     // 工作空间级别不生效
-    getExternalPreferenceProvider('general.language')!.set('testLanguage', PreferenceScope.Workspace);
+    getExternalPreferenceProvider('general.language')?.set(unique_languageId, PreferenceScope.Workspace);
     expect(getPreferenceLanguageId()).toBe('zh-CN');
     // 全局级别可生效
-    getExternalPreferenceProvider('general.language')!.set('testLanguage', PreferenceScope.Default);
-    expect(getPreferenceLanguageId()).toBe('testLanguage');
+    getExternalPreferenceProvider('general.language')?.set(unique_languageId, PreferenceScope.Default);
+    expect(getPreferenceLanguageId()).toBe(unique_languageId);
 
-    // getPreferenceLanguageId 可传参 defaultPreference
+    // 传入默认配置的情况下，如果可以通过 `getExternalPreference` 获取配置值，优先采用获取到的配置值
     expect(
       getPreferenceLanguageId({
         'general.language': 'en-US',
       } as IPreferences),
-    ).toBe('en-US');
+    ).toBe(unique_languageId);
 
     // 采用 getExternalPreference 中的值兜底
     expect(
       getPreferenceLanguageId({
         'general.theme': 'vscode-icon',
       } as IPreferences),
-    ).toBe('testLanguage');
+    ).toBe(unique_languageId);
 
-    getExternalPreferenceProvider('general.icon')!.set('testIcon', PreferenceScope.Workspace);
-    expect(getPreferenceIconThemeId()).toBe('testIcon');
+    getExternalPreferenceProvider('general.icon')?.set('test-icon', PreferenceScope.Workspace);
+    expect(getPreferenceIconThemeId()).toBe('test-icon');
   });
 });

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -115,8 +115,6 @@ export class ClientApp implements IClientApp, IDisposable {
   constructor(opts: IClientAppOpts) {
     const {
       modules,
-      contributions,
-      modulesInstances,
       connectionPath,
       connectionProtocols,
       iconStyleSheets,

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -96,7 +96,7 @@ export const corePreferenceSchema: PreferenceSchema = {
       type: 'string',
       enum: ['singleClick', 'doubleClick'],
       default: 'singleClick',
-      description: localize('preference.workbench.list.openMode'),
+      description: '%preference.workbench.list.openMode%',
     },
     'workbench.commandPalette.history': {
       type: 'number',

--- a/packages/core-browser/src/preferences/early-preferences.ts
+++ b/packages/core-browser/src/preferences/early-preferences.ts
@@ -46,10 +46,10 @@ export function getPreferenceIconThemeId(): string {
  * 因为集成方可能会在集成后自己设置后调用 `setLanguageId` 来更新默认语言，所以统一收口到 `getLanguageId`。
  */
 export function getPreferenceLanguageId(defaultPreferences?: IPreferences): string {
-  // 因为语言加载的时机比较早，因此会优先从 defaultPreferences 里面读取
+  // 默认从配置项中获取语言选项，其次从默认配置项中获取 `general.language`, 默认为 `en-US`
   const langFromDefaultPreferences = defaultPreferences && defaultPreferences[GeneralSettingsId.Language];
   return (
-    langFromDefaultPreferences || getExternalPreference<string>(GeneralSettingsId.Language).value || getLanguageId()
+    getExternalPreference<string>(GeneralSettingsId.Language).value || langFromDefaultPreferences || getLanguageId()
   );
 }
 

--- a/packages/core-common/src/localize.ts
+++ b/packages/core-common/src/localize.ts
@@ -107,11 +107,10 @@ class LocalizationRegistry implements ILocalizationRegistry {
 }
 
 /**
- * 获取当前语言别名，默认为中文
- * TODO 临时通过 href 获取
- * @returns 当前语言别名
+ * 获取当前语言 ID，默认为中文
+ * @returns 当前语言 ID
  */
-export function getLanguageId(scope = 'host'): string {
+export function getLanguageId(): string {
   return _currentLanguageId;
 }
 

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -242,86 +242,65 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.ariaLabel': {
     type: 'string',
     default: EDITOR_DEFAULTS.viewInfo.ariaLabel,
-    description: localize('ariaLabel', "The aria label for the editor's textarea (when it is focused)."),
+    description: '%editor.configuration.ariaLabel%',
   },
   'editor.extraEditorClassName': {
     type: 'string',
-    description: localize('extraEditorClassName', 'Class name to be added to the editor.'),
+    description: '%editor.configuration.extraEditorClassName%',
   },
   'editor.fixedOverflowWidgets': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.fixedOverflowWidgets,
-    description: localize('fixedOverflowWidgets', 'Display overflow widgets as fixed.'),
+    description: '%editor.configuration.fixedOverflowWidgets%',
   },
   'editor.revealHorizontalRightPadding': {
     type: 'number',
-    description: localize(
-      'revealHorizontalRightPadding',
-      'When revealing the cursor, a virtual padding (px) is added to the cursor, turning it into a rectangle. This virtual padding ensures that the cursor gets revealed before hitting the edge of the viewport. Defaults to 30 (px).',
-    ),
+    description: '%editor.configuration.revealHorizontalRightPadding%',
   },
   'editor.selectOnLineNumbers': {
     type: 'boolean',
-    description: localize(
-      'selectOnLineNumbers',
-      'Should the corresponding line be selected when clicking on the line number? Defaults to true.',
-    ),
+    description: '%editor.configuration.selectOnLineNumbers%',
   },
   'editor.wordWrapMinified': {
     type: 'boolean',
-    description: localize(
-      'wordWrapMinified',
-      'Force word wrapping when the text appears to be of a minified/generated file. Defaults to true.',
-    ),
+    description: '%editor.configuration.wordWrapMinified%',
   },
   'editor.wordWrapBreakAfterCharacters': {
     type: 'string',
     default:
       ' \t})]?|/&.,;¢°′″‰℃、。｡､￠，．：；？！％・･ゝゞヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻ｧｨｩｪｫｬｭｮｯｰ”〉》」』】〕）］｝｣',
-    description: localize(
-      'wordWrapBreakAfterCharacters',
-      "Configure word wrapping characters. A break will be introduced after these characters. Defaults to ' \t})]?|/&.,;¢°′″‰℃、。｡､￠，．：；？！％・･ゝゞヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻ｧｨｩｪｫｬｭｮｯｰ”〉》」』】〕）］｝｣'.",
-    ),
+    description: '%editor.configuration.wordWrapBreakAfterCharacters%',
   },
   'editor.wrappingStrategy': {
     type: 'string',
     enum: ['advanced', 'simple'],
     default: 'simple',
-    description: localize('wrappingStrategy', 'Controls the algorithm that computes wrapping points.'),
+    description: '%editor.configuration.wrappingStrategy%',
   },
   'editor.wordWrapBreakBeforeCharacters': {
     type: 'string',
     default: '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋',
-    description: localize(
-      'wordWrapBreakBeforeCharacters',
-      "Configure word wrapping characters. A break will be introduced before these characters. Defaults to '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋'.",
-    ),
+    description: '%editor.configuration.wordWrapBreakBeforeCharacters%',
   },
   'editor.lineNumbersMinChars': {
     type: 'number',
     default: EDITOR_DEFAULTS.lineNumbersMinChars,
-    description: localize(
-      'lineNumbersMinChars',
-      'Control the width of line numbers, by reserving horizontal space for rendering at least an amount of digits. Defaults to 5.',
-    ),
+    description: '%editor.configuration.lineNumbersMinChars%',
   },
   'editor.lineDecorationsWidth': {
     type: 'number',
     default: EDITOR_DEFAULTS.lineDecorationsWidth,
-    description: localize(
-      'lineDecorationsWidth',
-      'The width reserved for line decorations (in px). Line decorations are placed between line numbers and the editor content. You can pass in a string in the format floating point followed by "ch". e.g. 1.3ch. Defaults to 10.',
-    ),
+    description: '%editor.configuration.lineDecorationsWidth%',
   },
   'editor.fontFamily': {
     type: 'string',
     default: EDITOR_FONT_DEFAULTS.fontFamily,
-    description: localize('fontFamily', 'Controls the font family.'),
+    description: '%editor.configuration.fontFamily%',
   },
   'editor.fontWeight': {
     type: 'string',
     default: EDITOR_FONT_DEFAULTS.fontWeight,
-    description: localize('editor.configuration.fontWeight'),
+    description: '%editor.configuration.fontWeight%',
   },
   'editor.fontSize': {
     type: 'number',
@@ -340,282 +319,249 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     type: 'string',
     enum: ['insert', 'replace'],
     enumDescriptions: [
-      localize('suggest.insertMode.insert', 'Insert suggestion without overwriting text right of the cursor.'),
-      localize('suggest.insertMode.replace', 'Insert suggestion and overwrite text right of the cursor.'),
+      localize(
+        'editor.configuration.suggest.insertMode.insert',
+        'Insert suggestion without overwriting text right of the cursor.',
+      ),
+      localize(
+        'editor.configuration.suggest.insertMode.replace',
+        'Insert suggestion and overwrite text right of the cursor.',
+      ),
     ],
     default: 'insert',
-    description: localize(
-      'suggest.insertMode',
-      'Controls whether words are overwritten when accepting completions. Note that this depends on extensions opting into this feature.',
-    ),
+    description: '%editor.configuration.suggest.insertMode%',
   },
   'editor.suggest.filterGraceful': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.filterGraceful,
-    description: localize(
-      'suggest.filterGraceful',
-      'Controls whether filtering and sorting suggestions accounts for small typos.',
-    ),
+    description: '%editor.configuration.suggest.filterGraceful%',
   },
   'editor.suggest.localityBonus': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.localityBonus,
-    description: localize(
-      'suggest.localityBonus',
-      'Controls whether sorting favours words that appear close to the cursor.',
-    ),
+    description: '%editor.configuration.suggest.localityBonus%',
   },
   'editor.suggest.shareSuggestSelections': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.shareSuggestSelections,
-    description: localize(
-      'suggest.shareSuggestSelections',
-      'Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).',
-    ),
+    description: '%editor.configuration.suggest.shareSuggestSelections%',
   },
   'editor.suggest.snippetsPreventQuickSuggestions': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.snippetsPreventQuickSuggestions,
-    description: localize(
-      'suggest.snippetsPreventQuickSuggestions',
-      'Controls whether an active snippet prevents quick suggestions.',
-    ),
+    description: '%editor.configuration.suggest.snippetsPreventQuickSuggestions%',
   },
   'editor.suggest.showIcons': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.showIcons,
-    description: localize('suggest.showIcons', 'Controls whether to show or hide icons in suggestions.'),
+    description: '%editor.configuration.suggest.showIcons%',
   },
   'editor.suggest.maxVisibleSuggestions': {
     type: 'number',
     default: EDITOR_SUGGEST_DEFAULTS.maxVisibleSuggestions,
     minimum: 1,
     maximum: 15,
-    description: localize(
-      'editor.suggest.maxVisibleSuggestions',
-      'Controls how many suggestions IntelliSense will show before showing a scrollbar (maximum 15).',
-    ),
+    description: '%editor.configuration.suggest.maxVisibleSuggestions%',
   },
   'editor.suggest.showMethods': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showMethods', 'When enabled IntelliSense shows `method`-suggestions.'),
+    description: '%editor.configuration.suggest.showMethods%',
   },
   'editor.suggest.showFunctions': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showFunctions', 'When enabled IntelliSense shows `function`-suggestions.'),
+    description: '%editor.configuration.suggest.showFunctions%',
   },
   'editor.suggest.showConstructors': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.suggest.showConstructors',
-      'When enabled IntelliSense shows `constructor`-suggestions.',
-    ),
+    description: '%editor.configuration.suggest.showConstructors%',
   },
   'editor.suggest.showFields': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showFields', 'When enabled IntelliSense shows `field`-suggestions.'),
+    description: '%editor.configuration.suggest.showFields%',
   },
   'editor.suggest.showVariables': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showVariables', 'When enabled IntelliSense shows `variable`-suggestions.'),
+    description: '%editor.configuration.suggest.showVariables%',
   },
   'editor.suggest.showClasses': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showClasss', 'When enabled IntelliSense shows `class`-suggestions.'),
+    description: '%editor.configuration.suggest.showClasss%',
   },
   'editor.suggest.showStructs': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showStructs', 'When enabled IntelliSense shows `struct`-suggestions.'),
+    description: '%editor.configuration.suggest.showStructs%',
   },
   'editor.suggest.showInterfaces': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showInterfaces', 'When enabled IntelliSense shows `interface`-suggestions.'),
+    description: '%editor.configuration.suggest.showInterfaces%',
   },
   'editor.suggest.showModules': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showModules', 'When enabled IntelliSense shows `module`-suggestions.'),
+    description: '%editor.configuration.suggest.showModules%',
   },
   'editor.suggest.showProperties': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showPropertys', 'When enabled IntelliSense shows `property`-suggestions.'),
+    description: '%editor.configuration.suggest.showPropertys%',
   },
   'editor.suggest.showEvents': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showEvents', 'When enabled IntelliSense shows `event`-suggestions.'),
+    description: '%editor.configuration.suggest.showEvents%',
   },
   'editor.suggest.showOperators': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showOperators', 'When enabled IntelliSense shows `operator`-suggestions.'),
+    description: '%editor.configuration.suggest.showOperators%',
   },
   'editor.suggest.showUnits': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showUnits', 'When enabled IntelliSense shows `unit`-suggestions.'),
+    description: '%editor.configuration.suggest.showUnits%',
   },
   'editor.suggest.showValues': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showValues', 'When enabled IntelliSense shows `value`-suggestions.'),
+    description: '%editor.configuration.suggest.showValues%',
   },
   'editor.suggest.showConstants': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showConstants', 'When enabled IntelliSense shows `constant`-suggestions.'),
+    description: '%editor.configuration.suggest.showConstants%',
   },
   'editor.suggest.showEnums': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showEnums', 'When enabled IntelliSense shows `enum`-suggestions.'),
+    description: '%editor.configuration.suggest.showEnums%',
   },
   'editor.suggest.showEnumMembers': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.suggest.showEnumMembers',
-      'When enabled IntelliSense shows `enumMember`-suggestions.',
-    ),
+    description: '%editor.configuration.suggest.showEnumMembers%',
   },
   'editor.suggest.showKeywords': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showKeywords', 'When enabled IntelliSense shows `keyword`-suggestions.'),
+    description: '%editor.configuration.suggest.showKeywords%',
   },
   'editor.suggest.showWords': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showTexts', 'When enabled IntelliSense shows `text`-suggestions.'),
+    description: '%editor.configuration.suggest.showTexts%',
   },
   'editor.suggest.showColors': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showColors', 'When enabled IntelliSense shows `color`-suggestions.'),
+    description: '%editor.configuration.suggest.showColors%',
   },
   'editor.suggest.showFiles': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showFiles', 'When enabled IntelliSense shows `file`-suggestions.'),
+    description: '%editor.configuration.suggest.showFiles%',
   },
   'editor.suggest.showReferences': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showReferences', 'When enabled IntelliSense shows `reference`-suggestions.'),
+    description: '%editor.configuration.suggest.showReferences%',
   },
   'editor.suggest.showCustomcolors': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.suggest.showCustomcolors',
-      'When enabled IntelliSense shows `customcolor`-suggestions.',
-    ),
+    description: '%editor.configuration.suggest.showCustomcolors%',
   },
   'editor.suggest.showFolders': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showFolders', 'When enabled IntelliSense shows `folder`-suggestions.'),
+    description: '%editor.configuration.suggest.showFolders%',
   },
   'editor.suggest.showTypeParameters': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.suggest.showTypeParameters',
-      'When enabled IntelliSense shows `typeParameter`-suggestions.',
-    ),
+    description: '%editor.configuration.suggest.showTypeParameters%',
   },
   'editor.suggest.showSnippets': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showSnippets', 'When enabled IntelliSense shows `snippet`-suggestions.'),
+    description: '%editor.configuration.suggest.showSnippets%',
   },
   'editor.suggest.showUsers': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showUsers', 'When enabled IntelliSense shows `user`-suggestions.'),
+    description: '%editor.configuration.suggest.showUsers%',
   },
   'editor.suggest.showIssues': {
     type: 'boolean',
     default: true,
-    description: localize('editor.suggest.showIssues', 'When enabled IntelliSense shows `issues`-suggestions.'),
+    description: '%editor.configuration.suggest.showIssues%',
   },
   'editor.suggest.statusBar.visible': {
     type: 'boolean',
     default: false,
-    description: localize(
-      'editor.suggest.statusBar.visible',
-      'Controls the visibility of the status bar at the bottom of the suggest widget.',
-    ),
+    description: '%editor.configuration.suggest.statusBar.visible%',
   },
   'editor.suggest.preview': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.preview,
-    description: localize('editor.suggest.preview', 'Enable or disable the rendering of the suggestion preview.'),
+    description: '%editor.configuration.suggest.preview%',
   },
   'editor.suggest.details.visible': {
     type: 'boolean',
     default: EDITOR_SUGGEST_DEFAULTS.detailsVisible,
-    description: localize('editor.suggest.details.visible'),
+    description: '%editor.configuration.suggest.details.visible%',
   },
   'editor.inlineSuggest.enabled': {
     type: 'boolean',
     default: EDITOR_INLINE_SUGGEST_DEFAULTS.enabled,
-    description: localize('inlineSuggest.enabled', 'Enable or disable the rendering of automatic inline completions.'),
+    description: '%editor.configuration.inlineSuggest.enabled%',
   },
   'editor.experimental.stickyScroll.enabled': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.experimental.stickyScroll',
-      'Shows the nested current scopes during the scroll at the top of the editor.',
-    ),
+    description: '%editor.configuration.experimental.stickyScroll%',
   },
   'editor.customCodeActionMenu.showHeaders': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.customCodeActionMenu.showHeaders',
-      'Enabling this will show the code action menu with group headers, if the custom code action menu is enabled.',
-    ),
+    description: '%editor.configuration.customCodeActionMenu.showHeaders',
   },
   'editor.useCustomCodeActionMenu': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'editor.useCustomCodeActionMenu',
-      'Enabling this adjusts how the code action menu is rendered.',
-    ),
+    description: '%editor.configuration.useCustomCodeActionMenu%',
   },
   'editor.letterSpacing': {
     type: 'number',
     default: EDITOR_FONT_DEFAULTS.letterSpacing,
-    description: localize('letterSpacing', 'Controls the letter spacing in pixels.'),
+    description: '%editor.configuration.letterSpacing%',
   },
   'editor.lineNumbers': {
     type: 'string',
     enum: ['off', 'on', 'relative', 'interval'],
     enumDescriptions: [
-      localize('lineNumbers.off', 'Line numbers are not rendered.'),
-      localize('lineNumbers.on', 'Line numbers are rendered as absolute number.'),
-      localize('lineNumbers.relative', 'Line numbers are rendered as distance in lines to cursor position.'),
-      localize('lineNumbers.interval', 'Line numbers are rendered every 10 lines.'),
+      localize('editor.configuration.lineNumbers.off', 'Line numbers are not rendered.'),
+      localize('editor.configuration.lineNumbers.on', 'Line numbers are rendered as absolute number.'),
+      localize(
+        'editor.configuration.lineNumbers.relative',
+        'Line numbers are rendered as distance in lines to cursor position.',
+      ),
+      localize('editor.configuration.lineNumbers.interval', 'Line numbers are rendered every 10 lines.'),
     ],
     default: 'on',
-    description: localize('lineNumbers', 'Controls the display of line numbers.'),
+    description: '%editor.configuration.lineNumbers%',
   },
   'editor.renderFinalNewline': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.renderFinalNewline,
-    description: localize('renderFinalNewline', 'Render last line number when the file ends with a newline.'),
+    description: '%editor.configuration.renderFinalNewline%',
   },
   'editor.rulers': {
     type: 'array',
@@ -623,27 +569,18 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
       type: 'number',
     },
     default: EDITOR_DEFAULTS.viewInfo.rulers,
-    description: localize(
-      'rulers',
-      'Render vertical rulers after a certain number of monospace characters. Use multiple values for multiple rulers. No rulers are drawn if array is empty.',
-    ),
+    description: '%editor.configuration.rulers%',
   },
   'editor.wordSeparators': {
     type: 'string',
     default: EDITOR_DEFAULTS.wordSeparators,
-    description: localize(
-      'wordSeparators',
-      'Characters that will be used as word separators when doing word related navigations or operations.',
-    ),
+    description: '%editor.configuration.wordSeparators%',
   },
   'editor.tabSize': {
     type: 'number',
     default: EDITOR_MODEL_DEFAULTS.tabSize,
     minimum: 1,
-    markdownDescription: localize(
-      'tabSize',
-      'The number of spaces a tab is equal to. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.',
-    ),
+    markdownDescription: '%editor.configuration.tabSize%',
   },
   // 'editor.indentSize': {
   // 	'anyOf': [
@@ -662,79 +599,64 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.insertSpaces': {
     type: 'boolean',
     default: EDITOR_MODEL_DEFAULTS.insertSpaces,
-    markdownDescription: localize(
-      'insertSpaces',
-      'Insert spaces when pressing `Tab`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.',
-    ),
+    markdownDescription: '%editor.configuration.insertSpaces%',
   },
   'editor.detectIndentation': {
     type: 'boolean',
     default: EDITOR_MODEL_DEFAULTS.detectIndentation,
-    markdownDescription: localize(
-      'detectIndentation',
-      'Controls whether `#editor.tabSize#` and `#editor.insertSpaces#` will be automatically detected when a file is opened based on the file contents.',
-    ),
+    markdownDescription: '%editor.configuration.detectIndentation%',
   },
   'editor.roundedSelection': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.roundedSelection,
-    description: localize('roundedSelection', 'Controls whether selections should have rounded corners.'),
+    description: '%editor.configuration.roundedSelection%',
   },
   'editor.scrollBeyondLastLine': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.scrollBeyondLastLine,
-    description: localize('scrollBeyondLastLine', 'Controls whether the editor will scroll beyond the last line.'),
+    description: '%editor.configuration.scrollBeyondLastLine%',
   },
   'editor.scrollBeyondLastColumn': {
     type: 'number',
     default: EDITOR_DEFAULTS.viewInfo.scrollBeyondLastColumn,
-    description: localize(
-      'scrollBeyondLastColumn',
-      'Controls the number of extra characters beyond which the editor will scroll horizontally.',
-    ),
+    description: '%editor.configuration.scrollBeyondLastColumn%',
   },
   'editor.smoothScrolling': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.smoothScrolling,
-    description: localize('smoothScrolling', 'Controls whether the editor will scroll using an animation.'),
+    description: '%editor.configuration.smoothScrolling%',
   },
   'editor.minimap.enabled': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.minimap.enabled,
-    description: localize('minimap.enabled', 'Controls whether the minimap is shown.'),
+    description: '%editor.configuration.minimap.enabled%',
   },
   'editor.minimap.side': {
     type: 'string',
     enum: ['left', 'right'],
     default: EDITOR_DEFAULTS.viewInfo.minimap.side,
-    description: localize('minimap.side', 'Controls the side where to render the minimap.'),
+    description: '%editor.configuration.minimap.side%',
   },
   'editor.minimap.showSlider': {
     type: 'string',
     enum: ['always', 'mouseover'],
     default: EDITOR_DEFAULTS.viewInfo.minimap.showSlider,
-    description: localize('minimap.showSlider', 'Controls whether the minimap slider is automatically hidden.'),
+    description: '%editor.configuration.minimap.showSlider%',
   },
   'editor.minimap.renderCharacters': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.minimap.renderCharacters,
-    description: localize(
-      'minimap.renderCharacters',
-      'Render the actual characters on a line as opposed to color blocks.',
-    ),
+    description: '%editor.configuration.minimap.renderCharacters%',
   },
   'editor.minimap.maxColumn': {
     type: 'number',
     default: EDITOR_DEFAULTS.viewInfo.minimap.maxColumn,
-    description: localize(
-      'minimap.maxColumn',
-      'Limit the width of the minimap to render at most a certain number of columns.',
-    ),
+    description: '%editor.configuration.minimap.maxColumn%',
   },
   'editor.hover.enabled': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.hover.enabled,
-    description: localize('hover.enabled', 'Controls whether the hover is shown.'),
+    description: '%editor.configuration.hover.enabled%',
   },
   'editor.hover.delay': {
     type: 'number',
@@ -744,96 +666,84 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.hover.sticky': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.hover.sticky,
-    description: localize(
-      'hover.sticky',
-      'Controls whether the hover should remain visible when mouse is moved over it.',
-    ),
+    description: '%editor.configuration.hover.sticky%',
   },
   'editor.find.seedSearchStringFromSelection': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.find.seedSearchStringFromSelection,
-    description: localize(
-      'find.seedSearchStringFromSelection',
-      'Controls whether the search string in the Find Widget is seeded from the editor selection.',
-    ),
+    description: '%editor.configuration.find.seedSearchStringFromSelection%',
   },
   'editor.find.autoFindInSelection': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.find.autoFindInSelection,
-    description: localize(
-      'find.autoFindInSelection',
-      'Controls whether the find operation is carried out on selected text or the entire file in the editor.',
-    ),
+    description: '%editor.configuration.find.autoFindInSelection%',
   },
   'editor.find.globalFindClipboard': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.find.globalFindClipboard,
-    description: localize(
-      'find.globalFindClipboard',
-      'Controls whether the Find Widget should read or modify the shared find clipboard on macOS.',
-    ),
+    description: '%editor.configuration.find.globalFindClipboard%',
     included: isOSX,
   },
   'editor.find.addExtraSpaceOnTop': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'find.addExtraSpaceOnTop',
-      'Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.',
-    ),
+    description: '%editor.configuration.find.addExtraSpaceOnTop%',
   },
   'editor.wordWrap': {
     type: 'string',
     enum: ['off', 'on', 'wordWrapColumn', 'bounded'],
     markdownEnumDescriptions: [
-      localize('wordWrap.off', 'Lines will never wrap.'),
-      localize('wordWrap.on', 'Lines will wrap at the viewport width.'),
-      localize('wordWrap.wordWrapColumn', 'Lines will wrap at `#editor.wordWrapColumn#`.'),
-      localize('wordWrap.bounded', 'Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.'),
+      localize('editor.configuration.wordWrap.off', 'Lines will never wrap.'),
+      localize('editor.configuration.wordWrap.on', 'Lines will wrap at the viewport width.'),
+      localize('editor.configuration.wordWrap.wordWrapColumn', 'Lines will wrap at `#editor.wordWrapColumn#`.'),
+      localize(
+        'editor.configuration.wordWrap.bounded',
+        'Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.',
+      ),
     ],
     default: EDITOR_DEFAULTS.wordWrap,
-    description: localize('wordWrap', 'Controls how lines should wrap.'),
+    description: '%editor.configuration.wordWrap%',
   },
   'editor.wordWrapColumn': {
     type: 'integer',
     default: EDITOR_DEFAULTS.wordWrapColumn,
     minimum: 1,
-    markdownDescription: localize(
-      'wordWrapColumn',
-      'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.',
-    ),
+    markdownDescription: '%editor.configuration.wordWrapColumn%',
   },
   'editor.wrappingIndent': {
     type: 'string',
     enum: ['none', 'same', 'indent', 'deepIndent'],
     enumDescriptions: [
-      localize('wrappingIndent.none', 'No indentation. Wrapped lines begin at column 1.'),
-      localize('wrappingIndent.same', 'Wrapped lines get the same indentation as the parent.'),
-      localize('wrappingIndent.indent', 'Wrapped lines get +1 indentation toward the parent.'),
-      localize('wrappingIndent.deepIndent', 'Wrapped lines get +2 indentation toward the parent.'),
+      localize('editor.configuration.wrappingIndent.none', 'No indentation. Wrapped lines begin at column 1.'),
+      localize('editor.configuration.wrappingIndent.same', 'Wrapped lines get the same indentation as the parent.'),
+      localize('editor.configuration.wrappingIndent.indent', 'Wrapped lines get +1 indentation toward the parent.'),
+      localize('editor.configuration.wrappingIndent.deepIndent', 'Wrapped lines get +2 indentation toward the parent.'),
     ],
     default: 'same',
-    description: localize('wrappingIndent', 'Controls the indentation of wrapped lines.'),
+    description: '%editor.configuration.wrappingIndent%',
   },
   'editor.mouseWheelScrollSensitivity': {
     type: 'number',
     default: EDITOR_DEFAULTS.viewInfo.scrollbar.mouseWheelScrollSensitivity,
-    markdownDescription: localize(
-      'mouseWheelScrollSensitivity',
-      'A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.',
-    ),
+    markdownDescription: '%editor.configuration.mouseWheelScrollSensitivity%',
   },
   'editor.fastScrollSensitivity': {
     type: 'number',
     default: EDITOR_DEFAULTS.viewInfo.scrollbar.fastScrollSensitivity,
-    markdownDescription: localize('fastScrollSensitivity', 'Scrolling speed multiplier when pressing `Alt`.'),
+    markdownDescription: '%editor.configuration.fastScrollSensitivity%',
   },
   'editor.multiCursorModifier': {
     type: 'string',
     enum: ['ctrlCmd', 'alt'],
     markdownEnumDescriptions: [
-      localize('multiCursorModifier.ctrlCmd', 'Maps to `Control` on Windows and Linux and to `Command` on macOS.'),
-      localize('multiCursorModifier.alt', 'Maps to `Alt` on Windows and Linux and to `Option` on macOS.'),
+      localize(
+        'editor.configuration.multiCursorModifier.ctrlCmd',
+        'Maps to `Control` on Windows and Linux and to `Command` on macOS.',
+      ),
+      localize(
+        'editor.configuration.multiCursorModifier.alt',
+        'Maps to `Alt` on Windows and Linux and to `Option` on macOS.',
+      ),
     ],
     default: 'alt',
     markdownDescription: localize(
@@ -844,7 +754,7 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.multiCursorMergeOverlapping': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.multiCursorMergeOverlapping,
-    description: localize('multiCursorMergeOverlapping', 'Merge multiple cursors when they are overlapping.'),
+    description: '%editor.configuration.multiCursorMergeOverlapping%',
   },
   'editor.quickSuggestions': {
     anyOf: [
@@ -857,54 +767,45 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
           strings: {
             type: 'boolean',
             default: false,
-            description: localize('quickSuggestions.strings', 'Enable quick suggestions inside strings.'),
+            description: localize(
+              'editor.configuration.quickSuggestions.strings',
+              'Enable quick suggestions inside strings.',
+            ),
           },
           comments: {
             type: 'boolean',
             default: false,
-            description: localize('quickSuggestions.comments', 'Enable quick suggestions inside comments.'),
+            description: localize(
+              'editor.configuration.quickSuggestions.comments',
+              'Enable quick suggestions inside comments.',
+            ),
           },
           other: {
             type: 'boolean',
             default: true,
-            description: localize(
-              'quickSuggestions.other',
-              'Enable quick suggestions outside of strings and comments.',
-            ),
+            description: '%editor.configuration.quickSuggestions.other%',
           },
         },
       },
     ],
     default: EDITOR_DEFAULTS.contribInfo.quickSuggestions,
-    description: localize(
-      'quickSuggestions',
-      'Controls whether suggestions should automatically show up while typing.',
-    ),
+    description: '%editor.configuration.quickSuggestions%',
   },
   'editor.quickSuggestionsDelay': {
     type: 'integer',
     default: EDITOR_DEFAULTS.contribInfo.quickSuggestionsDelay,
     minimum: 0,
-    description: localize(
-      'quickSuggestionsDelay',
-      'Controls the delay in milliseconds after which quick suggestions will show up.',
-    ),
+    description: '%editor.configuration.quickSuggestionsDelay%',
   },
   'editor.parameterHints.enabled': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.parameterHints.enabled,
-    description: localize(
-      'parameterHints.enabled',
-      'Enables a pop-up that shows parameter documentation and type information as you type.',
-    ),
+    description: '%editor.configuration.parameterHints.enabled%',
   },
   'editor.parameterHints.cycle': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.parameterHints.cycle,
-    description: localize(
-      'parameterHints.cycle',
-      'Controls whether the parameter hints menu cycles or closes when reaching the end of the list.',
-    ),
+    description: '%editor.configuration.parameterHints.cycle%',
   },
   'editor.autoClosingBrackets': {
     type: 'string',
@@ -912,20 +813,17 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     enumDescriptions: [
       '',
       localize(
-        'editor.autoClosingBrackets.languageDefined',
+        'editor.configuration.autoClosingBrackets.languageDefined',
         'Use language configurations to determine when to autoclose brackets.',
       ),
       localize(
-        'editor.autoClosingBrackets.beforeWhitespace',
+        'editor.configuration.autoClosingBrackets.beforeWhitespace',
         'Autoclose brackets only when the cursor is to the left of whitespace.',
       ),
       '',
     ],
     default: EDITOR_DEFAULTS.autoClosingBrackets,
-    description: localize(
-      'autoClosingBrackets',
-      'Controls whether the editor should automatically close brackets after the user adds an opening bracket.',
-    ),
+    description: '%editor.configuration.autoClosingBrackets%',
   },
   'editor.autoClosingQuotes': {
     type: 'string',
@@ -933,67 +831,52 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     enumDescriptions: [
       '',
       localize(
-        'editor.autoClosingQuotes.languageDefined',
+        'editor.configuration.autoClosingQuotes.languageDefined',
         'Use language configurations to determine when to autoclose quotes.',
       ),
       localize(
-        'editor.autoClosingQuotes.beforeWhitespace',
+        'editor.configuration.autoClosingQuotes.beforeWhitespace',
         'Autoclose quotes only when the cursor is to the left of whitespace.',
       ),
       '',
     ],
     default: EDITOR_DEFAULTS.autoClosingQuotes,
-    description: localize(
-      'autoClosingQuotes',
-      'Controls whether the editor should automatically close quotes after the user adds an opening quote.',
-    ),
+    description: '%editor.configuration.autoClosingQuotes%',
   },
   'editor.autoSurround': {
     type: 'string',
     enum: ['languageDefined', 'brackets', 'quotes', 'never'],
     enumDescriptions: [
       localize(
-        'editor.autoSurround.languageDefined',
+        'editor.configuration.autoSurround.languageDefined',
         'Use language configurations to determine when to automatically surround selections.',
       ),
-      localize('editor.autoSurround.brackets', 'Surround with brackets but not quotes.'),
-      localize('editor.autoSurround.quotes', 'Surround with quotes but not brackets.'),
+      localize('editor.configuration.autoSurround.brackets', 'Surround with brackets but not quotes.'),
+      localize('editor.configuration.autoSurround.quotes', 'Surround with quotes but not brackets.'),
       '',
     ],
     default: EDITOR_DEFAULTS.autoSurround,
-    description: localize('autoSurround', 'Controls whether the editor should automatically surround selections.'),
+    description: '%editor.configuration.autoSurround%',
   },
   'editor.formatOnType': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.formatOnType,
-    description: localize(
-      'formatOnType',
-      'Controls whether the editor should automatically format the line after typing.',
-    ),
+    description: '%editor.configuration.formatOnType%',
   },
   'editor.formatOnPaste': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.formatOnPaste,
-    description: localize(
-      'formatOnPaste',
-      'Controls whether the editor should automatically format the pasted content. A formatter must be available and the formatter should be able to format a range in a document.',
-    ),
+    description: '%editor.configuration.formatOnPaste%',
   },
   'editor.autoIndent': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.autoIndent,
-    description: localize(
-      'autoIndent',
-      'Controls whether the editor should automatically adjust the indentation when users type, paste or move lines. Extensions with indentation rules of the language must be available.',
-    ),
+    description: '%editor.configuration.autoIndent%',
   },
   'editor.suggestOnTriggerCharacters': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.suggestOnTriggerCharacters,
-    description: localize(
-      'suggestOnTriggerCharacters',
-      'Controls whether suggestions should automatically show up when typing trigger characters.',
-    ),
+    description: '%editor.configuration.suggestOnTriggerCharacters%',
   },
   'editor.acceptSuggestionOnEnter': {
     type: 'string',
@@ -1001,11 +884,14 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     default: EDITOR_DEFAULTS.contribInfo.acceptSuggestionOnEnter,
     markdownEnumDescriptions: [
       '',
-      localize('acceptSuggestionOnEnterSmart', 'Only accept a suggestion with `Enter` when it makes a textual change.'),
+      localize(
+        'editor.configuration.acceptSuggestionOnEnterSmart',
+        'Only accept a suggestion with `Enter` when it makes a textual change.',
+      ),
       '',
     ],
     markdownDescription: localize(
-      'acceptSuggestionOnEnter',
+      'editor.configuration.acceptSuggestionOnEnter',
       'Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.',
     ),
   },
@@ -1013,7 +899,7 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.acceptSuggestionOnCommitCharacter,
     markdownDescription: localize(
-      'acceptSuggestionOnCommitCharacter',
+      'editor.configuration.acceptSuggestionOnCommitCharacter',
       'Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.',
     ),
   },
@@ -1021,324 +907,228 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     type: 'string',
     enum: ['top', 'bottom', 'inline', 'none'],
     enumDescriptions: [
-      localize('snippetSuggestions.top', 'Show snippet suggestions on top of other suggestions.'),
-      localize('snippetSuggestions.bottom', 'Show snippet suggestions below other suggestions.'),
-      localize('snippetSuggestions.inline', 'Show snippets suggestions with other suggestions.'),
-      localize('snippetSuggestions.none', 'Do not show snippet suggestions.'),
+      localize('editor.configuration.snippetSuggestions.top', 'Show snippet suggestions on top of other suggestions.'),
+      localize('editor.configuration.snippetSuggestions.bottom', 'Show snippet suggestions below other suggestions.'),
+      localize('editor.configuration.snippetSuggestions.inline', 'Show snippets suggestions with other suggestions.'),
+      localize('editor.configuration.snippetSuggestions.none', 'Do not show snippet suggestions.'),
     ],
     default: 'inline',
-    description: localize(
-      'snippetSuggestions',
-      'Controls whether snippets are shown with other suggestions and how they are sorted.',
-    ),
+    description: '%editor.configuration.snippetSuggestions%',
   },
   'editor.emptySelectionClipboard': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.emptySelectionClipboard,
-    description: localize(
-      'emptySelectionClipboard',
-      'Controls whether copying without a selection copies the current line.',
-    ),
+    description: '%editor.configuration.emptySelectionClipboard%',
   },
   'editor.copyWithSyntaxHighlighting': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.copyWithSyntaxHighlighting,
-    description: localize(
-      'copyWithSyntaxHighlighting',
-      'Controls whether syntax highlighting should be copied into the clipboard.',
-    ),
+    description: '%editor.configuration.copyWithSyntaxHighlighting%',
   },
   'editor.wordBasedSuggestions': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.wordBasedSuggestions,
-    description: localize(
-      'wordBasedSuggestions',
-      'Controls whether completions should be computed based on words in the document.',
-    ),
+    description: '%editor.configuration.wordBasedSuggestions%',
   },
   'editor.suggestSelection': {
     type: 'string',
     enum: ['first', 'recentlyUsed', 'recentlyUsedByPrefix'],
     markdownEnumDescriptions: [
-      localize('suggestSelection.first', 'Always select the first suggestion.'),
+      localize('editor.configuration.suggestSelection.first', 'Always select the first suggestion.'),
       localize(
-        'suggestSelection.recentlyUsed',
+        'editor.configuration.suggestSelection.recentlyUsed',
         'Select recent suggestions unless further typing selects one, e.g. `console.| -> console.log` because `log` has been completed recently.',
       ),
       localize(
-        'suggestSelection.recentlyUsedByPrefix',
+        'editor.configuration.suggestSelection.recentlyUsedByPrefix',
         'Select suggestions based on previous prefixes that have completed those suggestions, e.g. `co -> console` and `con -> const`.',
       ),
     ],
     default: 'recentlyUsed',
-    description: localize(
-      'suggestSelection',
-      'Controls how suggestions are pre-selected when showing the suggest list.',
-    ),
+    description: '%editor.configuration.suggestSelection%',
   },
   'editor.suggestFontSize': {
     type: 'integer',
     default: 0,
     minimum: 0,
-    markdownDescription: localize(
-      'suggestFontSize',
-      'Font size for the suggest widget. When set to `0`, the value of `#editor.fontSize#` is used.',
-    ),
+    markdownDescription: '%editor.configuration.suggestFontSize%',
   },
   'editor.suggestLineHeight': {
     type: 'integer',
     default: 0,
     minimum: 0,
-    markdownDescription: localize(
-      'suggestLineHeight',
-      'Line height for the suggest widget. When set to `0`, the value of `#editor.lineHeight#` is used.',
-    ),
+    markdownDescription: '%editor.configuration.suggestLineHeight%',
   },
   'editor.tabCompletion': {
     type: 'string',
     default: 'off',
     enum: ['on', 'off', 'onlySnippets'],
     enumDescriptions: [
-      localize('tabCompletion.on', 'Tab complete will insert the best matching suggestion when pressing tab.'),
-      localize('tabCompletion.off', 'Disable tab completions.'),
       localize(
-        'tabCompletion.onlySnippets',
+        'editor.configuration.tabCompletion.on',
+        'Tab complete will insert the best matching suggestion when pressing tab.',
+      ),
+      localize('editor.configuration.tabCompletion.off', 'Disable tab completions.'),
+      localize(
+        'editor.configuration.tabCompletion.onlySnippets',
         "Tab complete snippets when their prefix match. Works best when 'quickSuggestions' aren't enabled.",
       ),
     ],
-    description: localize('tabCompletion', 'Enables tab completions.'),
+    description: '%editor.configuration.tabCompletion%',
   },
   'editor.suggest.filteredTypes': {
     type: 'object',
     default: { keyword: true, snippet: true },
-    markdownDescription: localize(
-      'suggest.filtered',
-      'Controls whether some suggestion types should be filtered from IntelliSense. A list of suggestion types can be found here: https://code.visualstudio.com/docs/editor/intellisense#_types-of-completions.',
-    ),
+    markdownDescription: '%editor.configuration.suggest.filtered%',
     properties: {
       method: {
         type: 'boolean',
         default: true,
         markdownDescription: localize(
-          'suggest.filtered.method',
+          'editor.configuration.suggest.filtered.method',
           'When set to `false` IntelliSense never shows `method` suggestions.',
         ),
       },
       function: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.function',
-          'When set to `false` IntelliSense never shows `function` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.function%',
       },
       constructor: {
         type: 'boolean' as const,
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.constructor',
-          'When set to `false` IntelliSense never shows `constructor` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.constructor%',
       },
       field: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.field',
-          'When set to `false` IntelliSense never shows `field` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.field%',
       },
       variable: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.variable',
-          'When set to `false` IntelliSense never shows `variable` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.variable%',
       },
       class: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.class',
-          'When set to `false` IntelliSense never shows `class` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.class%',
       },
       struct: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.struct',
-          'When set to `false` IntelliSense never shows `struct` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.struct%',
       },
       interface: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.interface',
-          'When set to `false` IntelliSense never shows `interface` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.interface%',
       },
       module: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.module',
-          'When set to `false` IntelliSense never shows `module` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.module%',
       },
       property: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.property',
-          'When set to `false` IntelliSense never shows `property` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.property%',
       },
       event: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.event',
-          'When set to `false` IntelliSense never shows `event` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.event%',
       },
       operator: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.operator',
-          'When set to `false` IntelliSense never shows `operator` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.operator%',
       },
       unit: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.unit',
-          'When set to `false` IntelliSense never shows `unit` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.unit%',
       },
       value: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.value',
-          'When set to `false` IntelliSense never shows `value` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.value',
       },
       constant: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.constant',
-          'When set to `false` IntelliSense never shows `constant` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.constant%',
       },
       enum: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.enum',
-          'When set to `false` IntelliSense never shows `enum` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.enum%',
       },
       enumMember: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.enumMember',
-          'When set to `false` IntelliSense never shows `enumMember` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.enumMember%',
       },
       keyword: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.keyword',
-          'When set to `false` IntelliSense never shows `keyword` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.keyword%',
       },
       text: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.text',
-          'When set to `false` IntelliSense never shows `text` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.text%',
       },
       color: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.color',
-          'When set to `false` IntelliSense never shows `color` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.color%',
       },
       file: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.file',
-          'When set to `false` IntelliSense never shows `file` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.file%',
       },
       reference: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.reference',
-          'When set to `false` IntelliSense never shows `reference` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.reference%',
       },
       customcolor: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.customcolor',
-          'When set to `false` IntelliSense never shows `customcolor` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.customcolor%',
       },
       folder: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.folder',
-          'When set to `false` IntelliSense never shows `folder` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.folder%',
       },
       typeParameter: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.typeParameter',
-          'When set to `false` IntelliSense never shows `typeParameter` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.typeParameter%',
       },
       snippet: {
         type: 'boolean',
         default: true,
-        markdownDescription: localize(
-          'suggest.filtered.snippet',
-          'When set to `false` IntelliSense never shows `snippet` suggestions.',
-        ),
+        markdownDescription: '%editor.configuration.suggest.filtered.snippet%',
       },
     },
   },
   'editor.gotoLocation.multiple': {
-    description: localize(
-      'editor.gotoLocation.multiple',
-      "Controls the behavior of 'Go To' commands, like Go To Definition, when multiple target locations exist.",
-    ),
+    description: '%editor.configuration.editor.gotoLocation.multiple%',
     type: 'string',
     enum: ['peek', 'gotoAndPeek', 'goto'],
     default: EDITOR_DEFAULTS.contribInfo.gotoLocation.multiple,
     enumDescriptions: [
-      localize('editor.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
-      localize('editor.gotoLocation.multiple.gotoAndPeek', 'Go to the primary result and show a peek view'),
+      localize('editor.configuration.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
       localize(
-        'editor.gotoLocation.multiple.goto',
+        'editor.configuration.gotoLocation.multiple.gotoAndPeek',
+        'Go to the primary result and show a peek view',
+      ),
+      localize(
+        'editor.configuration.gotoLocation.multiple.goto',
         'Go to the primary result and enable peek-less navigation to others',
       ),
     ],
@@ -1346,126 +1136,102 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.selectionHighlight': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.selectionHighlight,
-    description: localize(
-      'selectionHighlight',
-      'Controls whether the editor should highlight matches similar to the selection.',
-    ),
+    description: '%editor.configuration.selectionHighlight%',
   },
   'editor.occurrencesHighlight': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.occurrencesHighlight,
-    description: localize(
-      'occurrencesHighlight',
-      'Controls whether the editor should highlight semantic symbol occurrences.',
-    ),
+    description: '%editor.configuration.occurrencesHighlight%',
   },
   'editor.overviewRulerLanes': {
     type: 'integer',
     default: 3,
-    description: localize(
-      'overviewRulerLanes',
-      'Controls the number of decorations that can show up at the same position in the overview ruler.',
-    ),
+    description: '%editor.configuration.overviewRulerLanes%',
   },
   'editor.overviewRulerBorder': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.overviewRulerBorder,
-    description: localize(
-      'overviewRulerBorder',
-      'Controls whether a border should be drawn around the overview ruler.',
-    ),
+    description: '%editor.configuration.overviewRulerBorder%',
   },
   'editor.cursorBlinking': {
     type: 'string',
     enum: ['blink', 'smooth', 'phase', 'expand', 'solid'],
     default: 'blink',
-    description: localize('cursorBlinking', 'Control the cursor animation style.'),
+    description: '%editor.configuration.cursorBlinking%',
   },
   'editor.mouseWheelZoom': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.mouseWheelZoom,
-    markdownDescription: localize(
-      'mouseWheelZoom',
-      'Zoom the font of the editor when using mouse wheel and holding `Ctrl`.',
-    ),
+    markdownDescription: '%editor.configuration.mouseWheelZoom%',
   },
   'editor.cursorSmoothCaretAnimation': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.cursorSmoothCaretAnimation,
-    description: localize(
-      'cursorSmoothCaretAnimation',
-      'Controls whether the smooth caret animation should be enabled.',
-    ),
+    description: '%editor.configuration.cursorSmoothCaretAnimation%',
   },
   'editor.cursorStyle': {
     type: 'string',
     enum: ['block', 'block-outline', 'line', 'line-thin', 'underline', 'underline-thin'],
     default: EDITOR_FONT_DEFAULTS.cursorStyle,
-    description: localize('cursorStyle', 'Controls the cursor style.'),
+    description: '%editor.configuration.cursorStyle%',
   },
   'editor.cursorWidth': {
     type: 'integer',
     default: EDITOR_DEFAULTS.viewInfo.cursorWidth,
-    markdownDescription: localize(
-      'cursorWidth',
-      'Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.',
-    ),
+    markdownDescription: '%editor.configuration.cursorWidth%',
   },
   'editor.fontLigatures': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.fontLigatures,
-    description: localize('fontLigatures', 'Enables/Disables font ligatures.'),
+    description: '%editor.configuration.fontLigatures%',
   },
   'editor.hideCursorInOverviewRuler': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.hideCursorInOverviewRuler,
-    description: localize(
-      'hideCursorInOverviewRuler',
-      'Controls whether the cursor should be hidden in the overview ruler.',
-    ),
+    description: '%editor.configuration.hideCursorInOverviewRuler%',
   },
   'editor.renderWhitespace': {
     type: 'string',
     enum: ['none', 'boundary', 'selection', 'all'],
     enumDescriptions: [
       '',
-      localize('renderWhitespace.boundary', 'Render whitespace characters except for single spaces between words.'),
-      localize('renderWhitespace.selection', 'Render whitespace characters only on selected text.'),
+      localize(
+        'editor.configuration.renderWhitespace.boundary',
+        'Render whitespace characters except for single spaces between words.',
+      ),
+      localize(
+        'editor.configuration.renderWhitespace.selection',
+        'Render whitespace characters only on selected text.',
+      ),
       '',
     ],
     default: EDITOR_DEFAULTS.viewInfo.renderWhitespace,
-    description: localize('renderWhitespace', 'Controls how the editor should render whitespace characters.'),
+    description: '%editor.configuration.renderWhitespace%',
   },
   'editor.rename.enablePreview': {
     type: 'boolean',
     default: true,
-    description: 'Enable/disable the ability to preview changes before renaming',
+    description: '%editor.configuration.rename.enablePreview%',
   },
   'editor.renderControlCharacters': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.renderControlCharacters,
-    description: localize('renderControlCharacters', 'Controls whether the editor should render control characters.'),
+    description: '%editor.configuration.renderControlCharacters%',
   },
   'editor.guides.indentation': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.guides.indentation,
-    description: localize('editor.guides.indentation', 'Controls whether the editor should render indent guides.'),
+    description: '%editor.configuration.guides.indentation%',
   },
   'editor.guides.highlightActiveIndentation': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.guides.highlightActiveIndentGuide,
-    description: localize(
-      'editor.guides.highlightActiveIndentation',
-      'Controls whether the editor should highlight the active indent guide.',
-    ),
+    description: '%editor.configuration.guides.highlightActiveIndentation%',
   },
   'editor.guides.bracketPairs': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.guides.bracketPairs,
-    description: localize(
-      'editor.configuration.guides.bracketPairs',
-      'Controls whether bracket pair guides are enabled or not.',
-    ),
+    description: '%editor.configuration.guides.bracketPairs%',
   },
   'editor.renderLineHighlight': {
     type: 'string',
@@ -1474,88 +1240,79 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
       '',
       '',
       '',
-      localize('renderLineHighlight.all', 'Highlights both the gutter and the current line.'),
+      localize('editor.configuration.renderLineHighlight.all', 'Highlights both the gutter and the current line.'),
     ],
     default: EDITOR_DEFAULTS.viewInfo.renderLineHighlight,
-    description: localize('renderLineHighlight', 'Controls how the editor should render the current line highlight.'),
+    description: '%editor.configuration.renderLineHighlight%',
   },
   'editor.codeLens': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.codeLens,
-    description: localize('codeLens', 'Controls whether the editor shows CodeLens.'),
+    description: '%editor.configuration.codeLens%',
   },
   'editor.folding': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.folding,
-    description: localize('folding', 'Controls whether the editor has code folding enabled.'),
+    description: '%editor.configuration.folding%',
   },
   'editor.foldingStrategy': {
     type: 'string',
     enum: ['auto', 'indentation'],
     default: EDITOR_DEFAULTS.contribInfo.foldingStrategy,
-    markdownDescription: localize(
-      'foldingStrategy',
-      'Controls the strategy for computing folding ranges. `auto` uses a language specific folding strategy, if available. `indentation` uses the indentation based folding strategy.',
-    ),
+    markdownDescription: '%editor.configuration.foldingStrategy%',
   },
   'editor.showFoldingControls': {
     type: 'string',
     enum: ['always', 'mouseover'],
     default: EDITOR_DEFAULTS.contribInfo.showFoldingControls,
-    description: localize(
-      'showFoldingControls',
-      'Controls whether the fold controls on the gutter are automatically hidden.',
-    ),
+    description: '%editor.configuration.showFoldingControls%',
   },
   'editor.matchBrackets': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.matchBrackets,
-    description: localize('matchBrackets', 'Highlight matching brackets when one of them is selected.'),
+    description: '%editor.configuration.matchBrackets%',
   },
   'editor.glyphMargin': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.viewInfo.glyphMargin,
-    description: localize(
-      'glyphMargin',
-      'Controls whether the editor should render the vertical glyph margin. Glyph margin is mostly used for debugging.',
-    ),
+    description: '%editor.configuration.glyphMargin%',
   },
   'editor.useTabStops': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.useTabStops,
-    description: localize('useTabStops', 'Inserting and deleting whitespace follows tab stops.'),
+    description: '%editor.configuration.useTabStops%',
   },
   'editor.trimAutoWhitespace': {
     type: 'boolean',
     default: EDITOR_MODEL_DEFAULTS.trimAutoWhitespace,
-    description: localize('trimAutoWhitespace', 'Remove trailing auto inserted whitespace.'),
+    description: '%editor.configuration.trimAutoWhitespace%',
   },
   'editor.stablePeek': {
     type: 'boolean',
     default: false,
-    markdownDescription: localize(
-      'stablePeek',
-      'Keep peek editors open even when double clicking their content or when hitting `Escape`.',
-    ),
+    markdownDescription: '%editor.configuration.stablePeek%',
   },
   'editor.dragAndDrop': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.dragAndDrop,
-    description: localize(
-      'dragAndDrop',
-      'Controls whether the editor should allow moving selections via drag and drop.',
-    ),
+    description: '%editor.configuration.dragAndDrop%',
   },
   'editor.accessibilitySupport': {
     type: 'string',
     enum: ['auto', 'on', 'off'],
     enumDescriptions: [
       localize(
-        'accessibilitySupport.auto',
+        'editor.configuration.accessibilitySupport.auto',
         'The editor will use platform APIs to detect when a Screen Reader is attached.',
       ),
-      localize('accessibilitySupport.on', 'The editor will be permanently optimized for usage with a Screen Reader.'),
-      localize('accessibilitySupport.off', 'The editor will never be optimized for usage with a Screen Reader.'),
+      localize(
+        'editor.configuration.accessibilitySupport.on',
+        'The editor will be permanently optimized for usage with a Screen Reader.',
+      ),
+      localize(
+        'editor.configuration.accessibilitySupport.off',
+        'The editor will never be optimized for usage with a Screen Reader.',
+      ),
     ],
     default: EDITOR_DEFAULTS.accessibilitySupport,
     description: localize(
@@ -1566,111 +1323,87 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.showUnused': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.showUnused,
-    description: localize('showUnused', 'Controls fading out of unused code.'),
+    description: '%editor.configuration.showUnused%',
   },
   'editor.comments.insertSpace': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'insertSpace',
-      'Insert a space after the line comment token and inside the block comments tokens.',
-    ),
+    description: '%editor.configuration.comments.insertSpace%',
   },
   'editor.comments.ignoreEmptyLines': {
     type: 'boolean',
     default: true,
-    description: localize('insertSpace', 'Ignore empty lines when inserting line comments.'),
+    description: '%editor.configuration.comments.ignoreEmptyLines%',
   },
   'editor.links': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.links,
-    description: localize('links', 'Controls whether the editor should detect links and make them clickable.'),
+    description: '%editor.configuration.links%',
   },
   'editor.colorDecorators': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.colorDecorators,
-    description: localize(
-      'colorDecorators',
-      'Controls whether the editor should render the inline color decorators and color picker.',
-    ),
+    description: '%editor.configuration.colorDecorators%',
   },
   'editor.lightbulb.enabled': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.lightbulbEnabled,
-    description: localize('codeActions', 'Enables the code action lightbulb in the editor.'),
+    description: '%editor.configuration.lightbulb.enabled%',
   },
   'editor.maxTokenizationLineLength': {
     type: 'integer',
     default: 20000,
-    description: localize(
-      'maxTokenizationLineLength',
-      'Lines above this length will not be tokenized for performance reasons',
-    ),
+    description: '%editor.configuration.maxTokenizationLineLength%',
   },
   'editor.codeActionsOnSave': {
     type: 'object',
     properties: {
       'source.organizeImports': {
         type: 'boolean',
-        description: localize(
-          'codeActionsOnSave.organizeImports',
-          'Controls whether organize imports action should be run on file save.',
-        ),
+        description: '%editor.configuration.codeActionsOnSave.organizeImports%',
       },
       'source.fixAll': {
         type: 'boolean',
-        description: localize(
-          'codeActionsOnSave.fixAll',
-          'Controls whether auto fix action should be run on file save.',
-        ),
+        description: '%editor.configuration.codeActionsOnSave.fixAll%',
       },
     },
     additionalProperties: {
       type: 'boolean',
     },
     default: EDITOR_DEFAULTS.contribInfo.codeActionsOnSave,
-    description: localize('codeActionsOnSave', 'Code action kinds to be run on save.'),
+    description: '%editor.configuration.codeActionsOnSave%',
   },
   'editor.codeActionsOnSaveTimeout': {
     type: 'number',
     default: EDITOR_DEFAULTS.contribInfo.codeActionsOnSaveTimeout,
-    description: localize(
-      'codeActionsOnSaveTimeout',
-      'Timeout in milliseconds after which the code actions that are run on save are cancelled.',
-    ),
+    description: '%editor.configuration.codeActionsOnSaveTimeout%',
   },
   'editor.selectionClipboard': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.selectionClipboard,
-    description: localize('selectionClipboard', 'Controls whether the Linux primary clipboard should be supported.'),
+    description: '%editor.configuration.selectionClipboard%',
     included: isLinux,
   },
   'editor.largeFileOptimizations': {
     type: 'boolean',
     default: EDITOR_MODEL_DEFAULTS.largeFileOptimizations,
-    description: localize(
-      'largeFileOptimizations',
-      'Special handling for large files to disable certain memory intensive features.',
-    ),
+    description: '%editor.configuration.largeFileOptimizations%',
   },
   'diffEditor.renderIndicators': {
     type: 'boolean',
     default: true,
-    description: localize(
-      'renderIndicators',
-      'Controls whether the diff editor shows +/- indicators for added/removed changes.',
-    ),
+    description: '%editor.configuration.renderIndicators%',
   },
   'editor.defaultFormatter': {
     type: 'string',
-    description: localize('defaultFormatter', 'Default code formatter'),
+    description: '%editor.configuration.defaultFormatter%',
   },
 };
 
 const customEditorSchema: PreferenceSchemaProperties = {
   'editor.tokenColorCustomizations': {
     type: 'object',
-    description: '%preference.editor.tokenColorCustomizations%',
+    description: '%editor.configuration.tokenColorCustomizations%',
     default: {},
   },
   'editor.askIfDiff': {
@@ -1797,7 +1530,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.formatOnSave': {
     type: 'boolean',
     default: false,
-    description: '%preference.editor.formatOnSave%',
+    description: '%editor.configuration.formatOnSave%',
   },
   'editor.formatOnSaveTimeout': {
     type: 'number',
@@ -1817,18 +1550,18 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.semanticHighlighting.enabled': {
     enum: [true, false, 'configuredByTheme'],
     enumDescriptions: [
-      localize('semanticHighlighting.true', 'Semantic highlighting enabled for all color themes.'),
-      localize('semanticHighlighting.false', 'Semantic highlighting disabled for all color themes.'),
+      localize('editor.configuration.semanticHighlighting.true', 'Semantic highlighting enabled for all color themes.'),
       localize(
-        'semanticHighlighting.configuredByTheme',
+        'editor.configuration.semanticHighlighting.false',
+        'Semantic highlighting disabled for all color themes.',
+      ),
+      localize(
+        'editor.configuration.semanticHighlighting.configuredByTheme',
         "Semantic highlighting is configured by the current color theme's `semanticHighlighting` setting.",
       ),
     ],
     default: true,
-    description: localize(
-      'semanticHighlighting.enabled',
-      'Controls whether the semanticHighlighting is shown for the languages that support it.',
-    ),
+    description: '%editor.configuration.semanticHighlighting.enabled%',
   },
   'editor.bracketPairColorization.enabled': {
     type: 'boolean',
@@ -1851,7 +1584,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   },
   'workbench.editorAssociations': {
     type: 'object',
-    markdownDescription: '%preference.workbench.editorAssociations%',
+    markdownDescription: '%editor.configuration.workbench.editorAssociations%',
     default: {},
     additionalProperties: {
       type: 'string',
@@ -1870,7 +1603,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   'editor.experimental.stickyScroll.enabled': {
     type: 'boolean',
     default: false,
-    description: '%editor.experimental.stickyScroll.enabled.description%',
+    description: '%editor.configuration.experimental.stickyScroll.enabled%',
   },
   'editor.mouseBackForwardToNavigate': {
     type: 'boolean',

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -122,15 +122,6 @@ export const localizationBundle = {
     'editor.changeEol': 'Select End Of Line Sequence',
     'editor.failToOpen': 'Failed to open {0}. Error message: {1}',
     'editor.changeLanguageId': 'Select Language Mode',
-    'editor.configuration.preferredFormatter': 'Preferred formatter for files',
-    'editor.configuration.maxTokenizationLineLength':
-      'Lines above this length will not be tokenized for performance reasons',
-    'editor.configuration.quickSuggestionsDelay': 'Quick suggestions show delay (in ms) Defaults to 100 (ms)',
-    'editor.configuration.bracketPairColorization.enabled':
-      "Controls whether bracket pair colorization is enabled or not. Use 'workbench.colorCustomizations' to override the bracket highlight colors.",
-    'editor.configuration.guides.bracketPairs': 'Controls whether bracket pair guides are enabled or not.',
-    'editor.configuration.mouseBackForwardToNavigate':
-      "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'.",
     'editor.lineHeight': 'Line Height',
     'editor.lineHeight.description':
       'Controls the line height.\r\nUse 0 to automatically compute the line height from the font size.\r\nValues between 0 and 8 will be used as a multiplier with the font size.\r\nValues greater than or equal to 8 will be used as effective values.',
@@ -501,7 +492,6 @@ export const localizationBundle = {
     'preference.general.theme': 'Theme',
     'preference.general.icon': 'Icon Theme',
     'preference.workbench.colorCustomizations': 'Overwrite colors of current color theme',
-    'preference.editor.tokenColorCustomizations': 'Overwrite token colors of current color theme',
     'preference.general.language': 'Language',
     'preference.general.language.change.refresh.info':
       'After changing the language, it should be restarted to take effect. Will it be refreshed immediately?',
@@ -525,9 +515,6 @@ export const localizationBundle = {
     'preference.workbench.refactoringChanges.showPreviewStrategy':
       'Show preview confirm when triggering some refactoring changes',
     'preference.workbench.refactoringChanges.showPreviewStrategy.title': 'Refactor Confirm',
-    'preference.workbench.editorAssociations':
-      'Configure glob patterns to editors (e.g. `"*.hex": "hexEditor.hexEdit"`). These have precedence over the default behavior.',
-
     'preference.tab.name': 'Settings',
     'preference.noResults': "No Setting Found Containing '{0}'",
     'preference.empty': 'Loading Settings...',
@@ -544,13 +531,15 @@ export const localizationBundle = {
     'preference.editor.quickSuggestionsDelay': 'Quick suggestions show delay (in ms) Defaults to 10 (ms)',
     'preference.editor.largeFile': 'Large File Size',
     'preference.editor.formatOnPaste': 'Format On Paste',
-    'preference.files.eol': 'Files EOL',
+    'preference.files.eol': 'EOL',
+    'preference.files.trimFinalNewlines': 'Trim Final Newlines',
+    'preference.files.trimTrailingWhitespace': 'Trim Trailing Whitespace',
+    'preference.editor.lineHeight': 'Line Height',
 
     'keymaps.tab.name': 'Keyboard Shortcuts',
 
     'preference.editor.wrapTab': 'Wrap Editor Tabs',
     'preference.editor.preferredFormatter': 'Default Formatter',
-    'editor.configuration.previewMode': 'Enable Preview Mode',
     'preference.editor.fontFamily': 'Font Family',
     'preference.editor.minimap': 'minimap',
     'preference.editor.forceReadOnly': 'readOnly',
@@ -567,9 +556,9 @@ export const localizationBundle = {
 
     'preference.item.notValid': '{0} is not a valid option',
 
+    // Editor Configurations
     'editor.configuration.formatOnSaveTimeout':
       'Control the timeout time of formatting (ms). Effective Only when `#editor.formatOnSave#` enables.',
-    'editor.configuration.renderLineHighlight': "Control the highlight of the editor's current line",
     'editor.configuration.enablePreviewFromCodeNavigation':
       'Controls whether editors remain in preview when a code navigation is started from them. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled.',
     'editor.configuration.wrapTab':
@@ -579,17 +568,361 @@ export const localizationBundle = {
     'editor.configuration.autoSaveDelay':
       "Controls the delay in ms after which a dirty file is saved automatically. Only applies when `#editor.formatOnSave#` is set to 'Save After Delay'.",
     'editor.configuration.forceReadOnly': 'If Enable readOnly',
-    'editor.configuration.tabSize':
-      'The number of spaces a tab is equal to. This setting is overridden based on the file contents when Detect Indentation is on.',
     'editor.configuration.largeFileSize': 'Custom size of the large file',
+    'editor.configuration.fontFamily': 'Controls the font family.',
+    'editor.configuration.fontWeight':
+      'Controls the font weight. Accepts "normal" and "bold" keywords or numbers between 1 and 1000.',
+    'editor.configuration.lineDecorationsWidth':
+      'The width reserved for line decorations (in px). Line decorations are placed between line numbers and the editor content. You can pass in a string in the format floating point followed by "ch". e.g. 1.3ch. Defaults to 10.',
+    'editor.configuration.lineNumbersMinChars':
+      'Control the width of line numbers, by reserving horizontal space for rendering at least an amount of digits. Defaults to 5.',
+    'editor.configuration.wordWrapBreakBeforeCharacters':
+      "Configure word wrapping characters. A break will be introduced before these characters. Defaults to '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋'.",
+    'editor.configuration.wrappingStrategy': 'Controls the algorithm that computes wrapping points.',
+    'editor.configuration.wordWrapBreakAfterCharacters':
+      "Configure word wrapping characters. A break will be introduced after these characters. Defaults to ' \t})]?|/&.,;¢°′″‰℃、。｡､￠，．：；？！％・･ゝゞヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻ｧｨｩｪｫｬｭｮｯｰ”〉》」』】〕）］｝｣'.",
+    'editor.configuration.wordWrapMinified':
+      'Force word wrapping when the text appears to be of a minified/generated file. Defaults to true.',
+    'editor.configuration.selectOnLineNumbers':
+      'Should the corresponding line be selected when clicking on the line number? Defaults to true.',
+    'editor.configuration.revealHorizontalRightPadding':
+      'When revealing the cursor, a virtual padding (px) is added to the cursor, turning it into a rectangle. This virtual padding ensures that the cursor gets revealed before hitting the edge of the viewport. Defaults to 30 (px).',
+    'editor.configuration.fixedOverflowWidgets': 'Display overflow widgets as fixed.',
+    'editor.configuration.extraEditorClassName': 'Class name to be added to the editor.',
+    'editor.configuration.ariaLabel': "The aria label for the editor's textarea (when it is focused).",
+    'editor.configuration.suggest.insertMode':
+      'Controls whether words are overwritten when accepting completions. Note that this depends on extensions opting into this feature.',
+    'editor.configuration.suggest.filterGraceful':
+      'Controls whether filtering and sorting suggestions accounts for small typos.',
+    'editor.configuration.suggest.localityBonus':
+      'Controls whether sorting favours words that appear close to the cursor.',
+    'editor.configuration.suggest.shareSuggestSelections':
+      'Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).',
+    'editor.configuration.suggest.snippetsPreventQuickSuggestions':
+      'Controls whether an active snippet prevents quick suggestions.',
+    'editor.configuration.suggest.showIcons': 'Controls whether to show or hide icons in suggestions.',
+    'editor.configuration.suggest.maxVisibleSuggestions':
+      'Controls how many suggestions IntelliSense will show before showing a scrollbar (maximum 15).',
+    'editor.configuration.suggest.showMethods': 'When enabled IntelliSense shows `method`-suggestions.',
+    'editor.configuration.suggest.showFunctions': 'When enabled IntelliSense shows `function`-suggestions.',
+    'editor.configuration.suggest.showConstructors': 'When enabled IntelliSense shows `constructor`-suggestions.',
+    'editor.configuration.suggest.showFields': 'When enabled IntelliSense shows `field`-suggestions.',
+    'editor.configuration.suggest.showVariables': 'When enabled IntelliSense shows `variable`-suggestions.',
+    'editor.configuration.suggest.showClasss': 'When enabled IntelliSense shows `class`-suggestions.',
+    'editor.configuration.suggest.showStructs': 'When enabled IntelliSense shows `struct`-suggestions.',
+    'editor.configuration.suggest.showInterfaces': 'When enabled IntelliSense shows `interface`-suggestions.',
+    'editor.configuration.suggest.showModules': 'When enabled IntelliSense shows `module`-suggestions.',
+    'editor.configuration.suggest.showPropertys': 'When enabled IntelliSense shows `property`-suggestions.',
+    'editor.configuration.suggest.showEvents': 'When enabled IntelliSense shows `event`-suggestions.',
+    'editor.configuration.suggest.showOperators': 'When enabled IntelliSense shows `operator`-suggestions.',
+    'editor.configuration.suggest.showUnits': 'When enabled IntelliSense shows `unit`-suggestions.',
+    'editor.configuration.suggest.showValues': 'When enabled IntelliSense shows `value`-suggestions.',
+    'editor.configuration.suggest.showConstants': 'When enabled IntelliSense shows `constant`-suggestions.',
+    'editor.configuration.suggest.showEnums': 'When enabled IntelliSense shows `enum`-suggestions.',
+    'editor.configuration.suggest.showEnumMembers': 'When enabled IntelliSense shows `enumMember`-suggestions.',
+    'editor.configuration.suggest.showKeywords': 'When enabled IntelliSense shows `keyword`-suggestions.',
+    'editor.configuration.suggest.showTexts': 'When enabled IntelliSense shows `text`-suggestions.',
+    'editor.configuration.suggest.showColors': 'When enabled IntelliSense shows `color`-suggestions.',
+    'editor.configuration.suggest.showFiles': 'When enabled IntelliSense shows `file`-suggestions.',
+    'editor.configuration.suggest.showReferences': 'When enabled IntelliSense shows `reference`-suggestions.',
+    'editor.configuration.suggest.showCustomcolors': 'When enabled IntelliSense shows `customcolor`-suggestions.',
+    'editor.configuration.suggest.showFolders': 'When enabled IntelliSense shows `folder`-suggestions.',
+    'editor.configuration.suggest.showTypeParameters': 'When enabled IntelliSense shows `typeParameter`-suggestions.',
+    'editor.configuration.suggest.showSnippets': 'When enabled IntelliSense shows `snippet`-suggestions.',
+    'editor.configuration.suggest.showUsers': 'When enabled IntelliSense shows `user`-suggestions.',
+    'editor.configuration.suggest.showIssues': 'When enabled IntelliSense shows `issues`-suggestions.',
+    'editor.configuration.suggest.statusBar.visible':
+      'Controls the visibility of the status bar at the bottom of the suggest widget.',
+    'editor.configuration.suggest.preview': 'Enable or disable the rendering of the suggestion preview.',
+    'editor.configuration.suggest.details.visible':
+      'Controls whether editor code completion expands details by default',
+    'editor.configuration.inlineSuggest.enabled': 'Enable or disable the rendering of automatic inline completions.',
+    'editor.configuration.experimental.stickyScroll':
+      'Shows the nested current scopes during the scroll at the top of the editor.',
+    'editor.configuration.customCodeActionMenu.showHeaders':
+      'Enabling this will show the code action menu with group headers, if the custom code action menu is enabled.',
+    'editor.configuration.useCustomCodeActionMenu': 'Enabling this adjusts how the code action menu is rendered.',
+    'editor.configuration.letterSpacing': 'Controls the letter spacing in pixels.',
+    'editor.configuration.lineNumbers': 'Controls the display of line numbers.',
+    'editor.configuration.lineNumbers.off': 'Line numbers are not rendered.',
+    'editor.configuration.lineNumbers.on': 'Line numbers are rendered as absolute number.',
+    'editor.configuration.lineNumbers.relative': 'Line numbers are rendered as distance in lines to cursor position.',
+    'editor.configuration.lineNumbers.interval': 'Line numbers are rendered every 10 lines.',
+    'editor.configuration.renderFinalNewline': 'Render last line number when the file ends with a newline.',
+    'editor.configuration.rulers':
+      'Render vertical rulers after a certain number of monospace characters. Use multiple values for multiple rulers. No rulers are drawn if array is empty.',
+    'editor.configuration.wordSeparators':
+      'Characters that will be used as word separators when doing word related navigations or operations.',
+    'editor.configuration.tabSize':
+      'The number of spaces a tab is equal to. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.',
+    'editor.configuration.insertSpaces':
+      'Insert spaces when pressing `Tab`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.',
+    'editor.configuration.detectIndentation':
+      'Controls whether `#editor.tabSize#` and `#editor.insertSpaces#` will be automatically detected when a file is opened based on the file contents.',
+    'editor.configuration.roundedSelection': 'Controls whether selections should have rounded corners.',
+    'editor.configuration.scrollBeyondLastLine': 'Controls whether the editor will scroll beyond the last line.',
+    'editor.configuration.scrollBeyondLastColumn':
+      'Controls the number of extra characters beyond which the editor will scroll horizontally.',
+    'editor.configuration.smoothScrolling': 'Controls whether the editor will scroll using an animation.',
+    'editor.configuration.minimap.enabled': 'Controls whether the minimap is shown.',
+    'editor.configuration.minimap.side': 'Controls the side where to render the minimap.',
+    'editor.configuration.minimap.showSlider': 'Controls whether the minimap slider is automatically hidden.',
+    'editor.configuration.minimap.renderCharacters':
+      'Render the actual characters on a line as opposed to color blocks.',
+    'editor.configuration.minimap.maxColumn':
+      'Limit the width of the minimap to render at most a certain number of columns.',
+    'editor.configuration.hover.enabled': 'Controls whether the hover is shown.',
+    'editor.configuration.hover.sticky':
+      'Controls whether the hover should remain visible when mouse is moved over it.',
+    'editor.configuration.find.seedSearchStringFromSelection':
+      'Controls whether the search string in the Find Widget is seeded from the editor selection.',
+    'editor.configuration.find.autoFindInSelection':
+      'Controls whether the find operation is carried out on selected text or the entire file in the editor.',
+    'editor.configuration.find.globalFindClipboard':
+      'Controls whether the Find Widget should read or modify the shared find clipboard on macOS.',
+    'editor.configuration.find.addExtraSpaceOnTop':
+      'Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.',
+    'editor.configuration.wordWrap.off': 'Lines will never wrap.',
+    'editor.configuration.wordWrap.on': 'Lines will wrap at the viewport width.',
+    'editor.configuration.wordWrap.wordWrapColumn': 'Lines will wrap at `#editor.wordWrapColumn#`.',
+    'editor.configuration.wordWrap.bounded':
+      'Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.',
+    'editor.configuration.wordWrap': 'Controls how lines should wrap.',
+    'editor.configuration.wordWrapColumn':
+      'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.',
+    'editor.configuration.wrappingIndent.none': 'No indentation. Wrapped lines begin at column 1.',
+    'editor.configuration.wrappingIndent.same': 'Wrapped lines get the same indentation as the parent.',
+    'editor.configuration.wrappingIndent.indent': 'Wrapped lines get +1 indentation toward the parent.',
+    'editor.configuration.wrappingIndent.deepIndent': 'Wrapped lines get +2 indentation toward the parent.',
+    'editor.configuration.wrappingIndent': 'Controls the indentation of wrapped lines.',
+    'editor.configuration.mouseWheelScrollSensitivity':
+      'A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.',
+    'editor.configuration.fastScrollSensitivity': 'Scrolling speed multiplier when pressing `Alt`.',
+    'editor.configuration.multiCursorModifier.ctrlCmd':
+      'Maps to `Control` on Windows and Linux and to `Command` on macOS.',
+    'editor.configuration.multiCursorModifier.alt': 'Maps to `Alt` on Windows and Linux and to `Option` on macOS.',
+    'editor.configuration.multiCursorMergeOverlapping': 'Merge multiple cursors when they are overlapping.',
+    'editor.configuration.quickSuggestions.strings': 'Enable quick suggestions inside strings.',
+    'editor.configuration.quickSuggestions.comments': 'Enable quick suggestions inside comments.',
+    'editor.configuration.quickSuggestions.other': 'Enable quick suggestions outside of strings and comments.',
+    'editor.configuration.quickSuggestions': 'Controls whether suggestions should automatically show up while typing.',
+    'editor.configuration.quickSuggestionsDelay':
+      'Controls the delay in milliseconds after which quick suggestions will show up.',
+    'editor.configuration.parameterHints.enabled':
+      'Enables a pop-up that shows parameter documentation and type information as you type.',
+    'editor.configuration.parameterHints.cycle':
+      'Controls whether the parameter hints menu cycles or closes when reaching the end of the list.',
+    'editor.configuration.autoClosingBrackets.languageDefined':
+      'Use language configurations to determine when to autoclose brackets.',
+    'editor.configuration.autoClosingBrackets.beforeWhitespace':
+      'Autoclose brackets only when the cursor is to the left of whitespace.',
+    'editor.configuration.autoClosingBrackets':
+      'Controls whether the editor should automatically close brackets after the user adds an opening bracket.',
+    'editor.configuration.autoClosingQuotes.languageDefined':
+      'Use language configurations to determine when to autoclose quotes.',
+    'editor.configuration.autoClosingQuotes.beforeWhitespace':
+      'Autoclose quotes only when the cursor is to the left of whitespace.',
+    'editor.configuration.autoClosingQuotes':
+      'Controls whether the editor should automatically close quotes after the user adds an opening quote.',
+    'editor.configuration.autoSurround.languageDefined':
+      'Use language configurations to determine when to automatically surround selections.',
+    'editor.configuration.autoSurround.brackets': 'Surround with brackets but not quotes.',
+    'editor.configuration.autoSurround.quotes': 'Surround with quotes but not brackets.',
+    'editor.configuration.autoSurround': 'Controls whether the editor should automatically surround selections.',
+    'editor.configuration.formatOnType':
+      'Controls whether the editor should automatically format the line after typing.',
+    'editor.configuration.formatOnPaste':
+      'Controls whether the editor should automatically format the pasted content. A formatter must be available and the formatter should be able to format a range in a document.',
+    'editor.configuration.autoIndent':
+      'Controls whether the editor should automatically adjust the indentation when users type, paste or move lines. Extensions with indentation rules of the language must be available.',
+    'editor.configuration.suggestOnTriggerCharacters':
+      'Controls whether suggestions should automatically show up when typing trigger characters.',
+    'editor.configuration.acceptSuggestionOnEnterSmart':
+      'Only accept a suggestion with `Enter` when it makes a textual change.',
+    'editor.configuration.acceptSuggestionOnEnter':
+      'Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.',
+    'editor.configuration.acceptSuggestionOnCommitCharacter':
+      'Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.',
+    'editor.configuration.snippetSuggestions.top': 'Show snippet suggestions on top of other suggestions.',
+    'editor.configuration.snippetSuggestions.bottom': 'Show snippet suggestions below other suggestions.',
+    'editor.configuration.snippetSuggestions.inline': 'Show snippets suggestions with other suggestions.',
+    'editor.configuration.snippetSuggestions.none': 'Do not show snippet suggestions.',
+    'editor.configuration.snippetSuggestions':
+      'Controls whether snippets are shown with other suggestions and how they are sorted.',
+    'editor.configuration.emptySelectionClipboard':
+      'Controls whether copying without a selection copies the current line.',
+    'editor.configuration.copyWithSyntaxHighlighting':
+      'Controls whether syntax highlighting should be copied into the clipboard.',
+    'editor.configuration.wordBasedSuggestions':
+      'Controls whether completions should be computed based on words in the document.',
+    'editor.configuration.suggestSelection.first': 'Always select the first suggestion.',
+    'editor.configuration.suggestSelection.recentlyUsed':
+      'Select recent suggestions unless further typing selects one, e.g. `console.| -> console.log` because `log` has been completed recently.',
+    'editor.configuration.suggestSelection.recentlyUsedByPrefix':
+      'Select suggestions based on previous prefixes that have completed those suggestions, e.g. `co -> console` and `con -> const`.',
+    'editor.configuration.suggestSelection': 'Controls how suggestions are pre-selected when showing the suggest list.',
+    'editor.configuration.suggestFontSize':
+      'Font size for the suggest widget. When set to `0`, the value of `#editor.fontSize#` is used.',
+    'editor.configuration.suggestLineHeight':
+      'Line height for the suggest widget. When set to `0`, the value of `#editor.lineHeight#` is used.',
+    'editor.configuration.tabCompletion.on': 'Tab complete will insert the best matching suggestion when pressing tab.',
+    'editor.configuration.tabCompletion.off': 'Disable tab completions.',
+    'editor.configuration.tabCompletion.onlySnippets':
+      "Tab complete snippets when their prefix match. Works best when 'quickSuggestions' aren't enabled.",
+    'editor.configuration.tabCompletion': 'Enables tab completions.',
+    'editor.configuration.suggest.filtered':
+      'Controls whether some suggestion types should be filtered from IntelliSense. A list of suggestion types can be found here: https://code.visualstudio.com/docs/editor/intellisense#_types-of-completions.',
+    'editor.configuration.suggest.filtered.method':
+      'When set to `false` IntelliSense never shows `method` suggestions.',
+    'editor.configuration.suggest.filtered.function':
+      'When set to `false` IntelliSense never shows `function` suggestions.',
+    'editor.configuration.suggest.filtered.constructor':
+      'When set to `false` IntelliSense never shows `constructor` suggestions.',
+    'editor.configuration.suggest.filtered.field': 'When set to `false` IntelliSense never shows `field` suggestions.',
+    'editor.configuration.suggest.filtered.variable':
+      'When set to `false` IntelliSense never shows `variable` suggestions.',
+    'editor.configuration.suggest.filtered.class': 'When set to `false` IntelliSense never shows `class` suggestions.',
+    'editor.configuration.suggest.filtered.struct':
+      'When set to `false` IntelliSense never shows `struct` suggestions.',
+    'editor.configuration.suggest.filtered.interface':
+      'When set to `false` IntelliSense never shows `interface` suggestions.',
+    'editor.configuration.suggest.filtered.module':
+      'When set to `false` IntelliSense never shows `module` suggestions.',
+    'editor.configuration.suggest.filtered.property':
+      'When set to `false` IntelliSense never shows `property` suggestions.',
+    'editor.configuration.suggest.filtered.event': 'When set to `false` IntelliSense never shows `event` suggestions.',
+    'editor.configuration.suggest.filtered.operator':
+      'When set to `false` IntelliSense never shows `operator` suggestions.',
+    'editor.configuration.suggest.filtered.unit': 'When set to `false` IntelliSense never shows `unit` suggestions.',
+    'editor.configuration.suggest.filtered.value': 'When set to `false` IntelliSense never shows `value` suggestions.',
+    'editor.configuration.suggest.filtered.constant':
+      'When set to `false` IntelliSense never shows `constant` suggestions.',
+    'editor.configuration.suggest.filtered.enum': 'When set to `false` IntelliSense never shows `enum` suggestions.',
+    'editor.configuration.suggest.filtered.enumMember':
+      'When set to `false` IntelliSense never shows `enumMember` suggestions.',
+    'editor.configuration.suggest.filtered.keyword':
+      'When set to `false` IntelliSense never shows `keyword` suggestions.',
+    'editor.configuration.suggest.filtered.text': 'When set to `false` IntelliSense never shows `text` suggestions.',
+    'editor.configuration.suggest.filtered.color': 'When set to `false` IntelliSense never shows `color` suggestions.',
+    'editor.configuration.suggest.filtered.file': 'When set to `false` IntelliSense never shows `file` suggestions.',
+    'editor.configuration.suggest.filtered.reference':
+      'When set to `false` IntelliSense never shows `reference` suggestions.',
+    'editor.configuration.suggest.filtered.customcolor':
+      'When set to `false` IntelliSense never shows `customcolor` suggestions.',
+    'editor.configuration.suggest.filtered.folder':
+      'When set to `false` IntelliSense never shows `folder` suggestions.',
+    'editor.configuration.suggest.filtered.typeParameter':
+      'When set to `false` IntelliSense never shows `typeParameter` suggestions.',
+    'editor.configuration.suggest.filtered.snippet':
+      'When set to `false` IntelliSense never shows `snippet` suggestions.',
+    'editor.configuration.editor.gotoLocation.multiple':
+      "Controls the behavior of 'Go To' commands, like Go To Definition, when multiple target locations exist.",
+    'editor.configuration.gotoLocation.multiple.peek': 'Show peek view of the results (default)',
+    'editor.configuration.gotoLocation.multiple.gotoAndPeek': 'Go to the primary result and show a peek view',
+    'editor.configuration.gotoLocation.multiple.goto':
+      'Go to the primary result and enable peek-less navigation to others',
+    'editor.configuration.selectionHighlight':
+      'Controls whether the editor should highlight matches similar to the selection.',
+    'editor.configuration.occurrencesHighlight':
+      'Controls whether the editor should highlight semantic symbol occurrences.',
+    'editor.configuration.overviewRulerLanes':
+      'Controls the number of decorations that can show up at the same position in the overview ruler.',
+    'editor.configuration.overviewRulerBorder': 'Controls whether a border should be drawn around the overview ruler.',
+    'editor.configuration.cursorBlinking': 'Control the cursor animation style.',
+    'editor.configuration.mouseWheelZoom': 'Zoom the font of the editor when using mouse wheel and holding `Ctrl`.',
+    'editor.configuration.cursorSmoothCaretAnimation': 'Controls whether the smooth caret animation should be enabled.',
+    'editor.configuration.cursorStyle': 'Controls the cursor style.',
+    'editor.configuration.cursorWidth':
+      'Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.',
+    'editor.configuration.fontLigatures': 'Enables/Disables font ligatures.',
+    'editor.configuration.hideCursorInOverviewRuler':
+      'Controls whether the cursor should be hidden in the overview ruler.',
+    'editor.configuration.renderWhitespace.boundary':
+      'Render whitespace characters except for single spaces between words.',
+    'editor.configuration.renderWhitespace.selection': 'Render whitespace characters only on selected text.',
+    'editor.configuration.renderWhitespace': 'Controls how the editor should render whitespace characters.',
+    'editor.configuration.rename.enablePreview': 'Enable/disable the ability to preview changes before renaming',
+    'editor.configuration.renderControlCharacters': 'Controls whether the editor should render control characters.',
+    'editor.configuration.guides.indentation': 'Controls whether the editor should render indent guides.',
+    'editor.configuration.guides.highlightActiveIndentation':
+      'Controls whether the editor should highlight the active indent guide.',
+    'editor.configuration.guides.bracketPairs': 'Controls whether bracket pair guides are enabled or not.',
+    'editor.configuration.renderLineHighlight.all': 'Highlights both the gutter and the current line.',
+    'editor.configuration.renderLineHighlight': 'Controls how the editor should render the current line highlight.',
+    'editor.configuration.codeLens': 'Controls whether the editor shows CodeLens.',
+    'editor.configuration.folding': 'Controls whether the editor has code folding enabled.',
+    'editor.configuration.foldingStrategy':
+      'Controls the strategy for computing folding ranges. `auto` uses a language specific folding strategy, if available. `indentation` uses the indentation based folding strategy.',
+    'editor.configuration.showFoldingControls':
+      'Controls whether the fold controls on the gutter are automatically hidden.',
+    'editor.configuration.matchBrackets': 'Highlight matching brackets when one of them is selected.',
+    'editor.configuration.glyphMargin':
+      'Controls whether the editor should render the vertical glyph margin. Glyph margin is mostly used for debugging.',
+    'editor.configuration.useTabStops': 'Inserting and deleting whitespace follows tab stops.',
+    'editor.configuration.trimAutoWhitespace': 'Remove trailing auto inserted whitespace.',
+    'editor.configuration.stablePeek':
+      'Keep peek editors open even when double clicking their content or when hitting `Escape`.',
+    'editor.configuration.dragAndDrop': 'Controls whether the editor should allow moving selections via drag and drop.',
+    'editor.configuration.accessibilitySupport.auto':
+      'The editor will use platform APIs to detect when a Screen Reader is attached.',
+    'editor.configuration.accessibilitySupport.on':
+      'The editor will be permanently optimized for usage with a Screen Reader.',
+    'editor.configuration.accessibilitySupport.off':
+      'The editor will never be optimized for usage with a Screen Reader.',
+    'editor.configuration.accessibilitySupport':
+      'Controls whether the editor should run in a mode where it is optimized for screen readers.',
+    'editor.configuration.showUnused': 'Controls fading out of unused code.',
+    'editor.configuration.comments.insertSpace':
+      'Insert a space after the line comment token and inside the block comments tokens.',
+    'editor.configuration.comments.ignoreEmptyLines': 'Ignore empty lines when inserting line comments.',
+    'editor.configuration.links': 'Controls whether the editor should detect links and make them clickable.',
+    'editor.configuration.colorDecorators':
+      'Controls whether the editor should render the inline color decorators and color picker.',
+    'editor.configuration.lightbulb.enabled': 'Enables the code action lightbulb in the editor.',
+    'editor.configuration.maxTokenizationLineLength':
+      'Lines above this length will not be tokenized for performance reasons',
+    'editor.configuration.codeActionsOnSave.organizeImports':
+      'Controls whether organize imports action should be run on file save.',
+    'editor.configuration.codeActionsOnSave.fixAll': 'Controls whether auto fix action should be run on file save.',
+    'editor.configuration.codeActionsOnSave': 'Code action kinds to be run on save.',
+    'editor.configuration.codeActionsOnSaveTimeout':
+      'Timeout in milliseconds after which the code actions that are run on save are cancelled.',
+    'editor.configuration.selectionClipboard': 'Controls whether the Linux primary clipboard should be supported.',
+    'editor.configuration.largeFileOptimizations':
+      'Special handling for large files to disable certain memory intensive features.',
+    'editor.configuration.renderIndicators':
+      'Controls whether the diff editor shows +/- indicators for added/removed changes.',
+    'editor.configuration.defaultFormatter': 'Default code formatter',
+    'editor.configuration.tokenColorCustomizations': 'Overwrite token colors of current color theme',
+    'editor.configuration.semanticHighlighting.enabled':
+      'Controls whether the semanticHighlighting is shown for the languages that support it.',
+    'editor.configuration.semanticHighlighting.true': 'Semantic highlighting enabled for all color themes.',
+    'editor.configuration.semanticHighlighting.false': 'Semantic highlighting disabled for all color themes.',
+    'editor.configuration.semanticHighlighting.configuredByTheme':
+      "Semantic highlighting is configured by the current color theme's `semanticHighlighting` setting.",
+    'editor.configuration.experimental.stickyScroll.enabled':
+      'Shows the nested current scopes during the scroll at the top of the editor.',
+    'editor.configuration.previewMode': 'Enable Preview Mode',
+    'editor.configuration.workbench.editorAssociations':
+      'Configure glob patterns to editors (e.g. `"*.hex": "hexEditor.hexEdit"`). These have precedence over the default behavior.',
+    'editor.configuration.preferredFormatter': 'Preferred formatter for files',
+    'editor.configuration.bracketPairColorization.enabled':
+      "Controls whether bracket pair colorization is enabled or not. Use 'workbench.colorCustomizations' to override the bracket highlight colors.",
+    'editor.configuration.mouseBackForwardToNavigate':
+      "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'.",
+    'editor.configuration.suggest.insertMode.insert': 'Insert suggestion without overwriting text right of the cursor.',
+    'editor.configuration.suggest.insertMode.replace': 'Insert suggestion and overwrite text right of the cursor.',
+
+    'diffEditor.configuration.renderSideBySide':
+      'Controls whether the diff editor shows the diff side by side or inline.',
+    'diffEditor.configuration.ignoreTrimWhitespace':
+      'Controls whether the diff editor shows changes in leading or trailing whitespace as diffs.',
+
+    'editor.largeFile.prevent': 'The file is too large, continuing to open it may cause it to jam or crash.',
     'editor.autoSave.enum.off': 'OFF',
     'editor.autoSave.enum.editorFocusChange': 'When editor focus changed',
     'editor.autoSave.enum.afterDelay': 'Save after delay',
     'editor.autoSave.enum.windowLostFocus': 'When window lost focus',
-    'editor.configuration.fontWeight':
-      'Controls the font weight. Accepts "normal" and "bold" keywords or numbers between 1 and 1000.',
-
-    'editor.largeFile.prevent': 'The file is too large, continuing to open it may cause it to jam or crash.',
     'editor.largeFile.prevent.stillOpen': 'Still open it.',
 
     'editor.workspaceSymbol.quickopen': 'Search Workspace Symbol',
@@ -600,16 +933,8 @@ export const localizationBundle = {
     'editor.workspaceSymbol.notfound': 'No symbols matching',
     'editor.workspaceSymbolClass.notfound': 'No class symbols matching',
 
-    'editor.experimental.stickyScroll.enabled.description':
-      'Shows the nested current scopes during the scroll at the top of the editor.',
-
     'preference.diffEditor.renderSideBySide': 'Render Side By Side',
     'preference.diffEditor.ignoreTrimWhitespace': 'Ignore Trim Whitespace',
-    'diffEditor.configuration.renderSideBySide':
-      'Controls whether the diff editor shows the diff side by side or inline.',
-    'diffEditor.configuration.ignoreTrimWhitespace':
-      'Controls whether the diff editor shows changes in leading or trailing whitespace as diffs.',
-
     'validate.tree.emptyFileNameError': 'Please provide a file or folder name',
     'validate.tree.fileNameStartsWithSlashError': 'File or folder name cannot start with /',
     'validate.tree.fileNameFollowOrStartWithSpaceWarning': 'Leading or trailing spaces detected in file or folder name',
@@ -893,8 +1218,7 @@ export const localizationBundle = {
     'TaskService.pickRunTask': 'Select the task to run',
     'TerminalTaskSystem.terminalName': 'Task - {0}',
     'terminal.integrated.exitedWithCode': 'The terminal process terminated with exit code: {0}',
-    // reuseTerminal: "Terminal will be reused by tasks, press 'r' to rerun task. press any other key to close it.",
-    reuseTerminal: 'Terminal will be reused by tasks, press any key to close it.',
+    'terminal.reuseTerminal': 'Terminal will be reused by tasks, press any key to close it.',
 
     'toolbar-customize.buttonDisplay.description': 'Button Style',
     'toolbar-customize.buttonDisplay.icon': 'Icon Only',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -454,7 +454,6 @@ export const localizationBundle = {
     'preference.general.theme': '主题',
     'preference.general.icon': '图标主题',
     'preference.workbench.colorCustomizations': '覆盖当前所选颜色主题的颜色',
-    'preference.editor.tokenColorCustomizations': '覆盖当前所选颜色主题中的编辑器颜色和字体样式',
     'preference.general.language': '语言',
     'preference.general.language.change.refresh.info': '更改语言后需重启后生效，是否立即刷新?',
     'preference.general.language.change.refresh.now': '立即刷新',
@@ -463,11 +462,7 @@ export const localizationBundle = {
     // workbench
     'preference.workbench.refactoringChanges.showPreviewStrategy': '触发一些重构变更时，是否需要弹窗确认',
     'preference.workbench.refactoringChanges.showPreviewStrategy.title': '重构确认方式',
-    'preference.workbench.editorAssociations':
-      '将 glob 模式配置到编辑器(例如 `"*十六进制": "hexEditor.hexEdit"`)。这些优先顺序高于默认行为。',
-
     'preference.editor.wrapTab': '编辑器 Tab 自动换行',
-    'editor.configuration.previewMode': '使用预览模式打开',
     'preference.editor.fontFamily': '字体',
     'preference.editor.minimap': '显示 Minimap',
     'preference.editor.forceReadOnly': '只读模式',
@@ -483,8 +478,7 @@ export const localizationBundle = {
     'preference.editor.wordWrapColumn': '自动换行长度',
     'preference.editor.askIfDiff': '保存文件冲突时提示',
     'preference.editor.readonlyFiles': '只读文件列表',
-    'preference.editor.formatOnSave': '在保存时格式化文件',
-    'preference.editor.formatOnSaveTimeout': '保存时格式化超时',
+    'preference.editor.formatOnSaveTimeout': '格式化超时时间',
     'preference.editor.formatOnSaveTimeoutError': '格式化时间超过 {0} 毫秒，终止格式化',
     'preference.editor.autoSave': '自动保存文件',
     'preference.editor.autoSaveDelay': '自动保存延迟',
@@ -492,10 +486,13 @@ export const localizationBundle = {
     'preference.editor.quickSuggestionsDelay': '智能提示延迟（毫秒）',
     'preference.editor.largeFile': '超大文件尺寸',
     'preference.files.eol': '文件行尾字符',
+    'preference.files.trimFinalNewlines': '移除最后的换行符',
+    'preference.files.trimTrailingWhitespace': '移除结尾空格',
     'preference.editor.formatOnPaste': '粘贴时自动格式化',
     'preference.editor.preferredFormatter': '默认格式化器',
     'preference.editor.bracketPairColorization.enabled': '括号着色',
     'preference.array.additem': '添加',
+    'preference.editor.lineHeight': '行高',
 
     'preference.item.notValid': '{0} 不是有效选项',
 
@@ -503,20 +500,6 @@ export const localizationBundle = {
     'editor.saveCodeActions.getting': '从 {0} 中获取 CodeAction',
     'editor.saveCodeActions.saving': '保存 "{0}"',
 
-    'editor.configuration.wrapTab': '控制当编辑器 Tab 超过可用空间时，是否使用换行来代替滚动模式。',
-    'editor.configuration.enablePreviewFromCodeNavigation': '控制当代码导航从其出发时，编辑器是否仍处于预览模式。',
-    'editor.configuration.renderLineHighlight': '控制编辑器的当前行突出显示方式。',
-    'editor.configuration.formatOnSaveTimeout':
-      '控制保存时格式化的超时时间（毫秒）。仅当 `#editor.formatOnSave#` 启用时生效。',
-    'editor.configuration.autoSave': '控制如何自动保存文件。',
-    'editor.configuration.autoSaveDelay':
-      '控制自动保存的延迟时长（毫秒）。仅当 `#editor.autoSave#` 设置为“编辑后自动保存”时生效。',
-    'editor.configuration.askIfDiff': '保存文件时如果磁盘上的文件较新，进行提示手动解决保存冲突。',
-    'editor.configuration.forceReadOnly': '是否启用 只读模式',
-    'editor.configuration.bracketPairColorization.enabled':
-      '控制是否启用括号对着色。使用 “workbench.colorCustomizations” 替代括号突出显示颜色。',
-    'editor.configuration.guides.bracketPairs': '控制是否启用括号对指南。',
-    'editor.configuration.mouseBackForwardToNavigate': '允许使用鼠标按钮 4 和 5 来执行命令“Go Back”和“Go Forward”。',
     'editor.autoSave.enum.off': '不启用',
     'editor.files.eol': '文件行尾字符',
     'editor.files.eolDesc': '控制文件默认行尾字符。',
@@ -528,18 +511,10 @@ export const localizationBundle = {
     'editor.format.chooseFormatter': '选择要使用的格式化扩展。',
     'editor.formatDocument.label.multiple': '使用...格式化文档',
     'editor.formatSelection.label.multiple': '格式化选定内容的方式...',
-    'editor.configuration.preferredFormatter': '配置优先使用的格式化器。',
     'editor.chooseEncoding': '用编码重新打开(会丢失未保存内容)',
     'editor.guessEncodingFromContent': '通过内容猜测',
     'editor.changeEol': '选择行尾序列',
     'editor.changeLanguageId': '选择语言模式',
-    'editor.configuration.maxTokenizationLineLength': '由于性能原因，超过这个长度的行将不会被标识。',
-    'editor.configuration.quickSuggestionsDelay': '控制显示智能提示的延迟时长 (毫秒)。',
-    'editor.configuration.tabSize':
-      '控制 Tab 缩进等于的空格数。若启用 `#editor.detectIndentation#`，该设置可能会被覆盖',
-    'editor.configuration.fontWeight': '控制字体粗细，接收 "normal" 和 "bold" 关键词或者 1 到 1000 数值。',
-
-    'editor.configuration.largeFileSize': '控制超大文件的自定义体积。',
     'editor.tokenize.test': '获取选中字符串的Tokenize结果(console)',
 
     'editor.largeFile.prevent': '文件过大，继续打开可能会导致卡顿或者崩溃。',
@@ -547,12 +522,9 @@ export const localizationBundle = {
     'editor.closeEditorsInOtherGroups': '关闭其他组中的编辑器',
     'editor.resetEditorGroups': '重置编辑器组大小',
     'editor.revert': '还原文档',
-    'editor.experimental.stickyScroll.enabled.description': '在编辑器顶部的滚动过程中显示嵌套的当前作用域。',
 
     'preference.diffEditor.renderSideBySide': '显示并排差异编辑器',
     'preference.diffEditor.ignoreTrimWhitespace': '忽略差异编辑器的前导和尾随空白字符',
-    'diffEditor.configuration.renderSideBySide': '控制差异编辑器的显示方式。',
-    'diffEditor.configuration.ignoreTrimWhitespace': '启用后，差异编辑器的前导和尾随空白字符将会忽略',
 
     'status.editor.chooseLanguage': '选择语言模式',
     'status.editor.goToLineCol': '转到行/列',
@@ -864,8 +836,7 @@ export const localizationBundle = {
     'TaskService.pickRunTask': '选择要运行的任务',
     'TerminalTaskSystem.terminalName': '任务 - {0}',
     'terminal.integrated.exitedWithCode': '终端进程已终止，退出代码: {0}',
-    // reuseTerminal: '终端将被任务重用，按 r 键重新执行该任务，按其他任意键关闭。',
-    reuseTerminal: '终端将被任务重用，按任意键关闭。',
+    'terminal.reuseTerminal': '终端将被任务重用，按任意键关闭。',
 
     'toolbar-customize.buttonDisplay.description': '按钮展示形式',
     'toolbar-customize.buttonDisplay.icon': '仅图标',
@@ -949,85 +920,119 @@ export const localizationBundle = {
     'keyboard.autoDetect.description': "（当前：'{0} '）",
     'keyboard.autoDetect.detail': '尝试通过浏览器及按键信息进行布局自动检测',
 
-    // 仅引用部分编辑器国际化文案
+    // Editor Configurations
+    // Only import part of the editor's i18n text, and you can import it according to the needs of the Settings panel
     // ref: https://github.com/microsoft/vscode-loc/blob/main/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
-    'suggest.filterGraceful': '控制对建议的筛选和排序是否考虑小的拼写错误。',
-    'suggest.insertMode': '控制接受补全时是否覆盖单词。请注意，这取决于扩展选择使用此功能。',
-    'suggest.insertMode.insert': '插入建议而不覆盖光标右侧的文本。',
-    'suggest.insertMode.replace': '插入建议并覆盖光标右侧的文本。',
-    'suggest.localityBonus': '控制排序时是否首选光标附近的字词。',
-    'suggest.maxVisibleSuggestions.dep': '此设置已弃用。现在可以调整建议小组件的大小。',
-    'suggest.preview': '控制是否在编辑器中预览建议结果。',
-    'suggest.shareSuggestSelections':
+    'editor.configuration.suggest.filterGraceful': '控制对建议的筛选和排序是否考虑小的拼写错误。',
+    'editor.configuration.suggest.insertMode': '控制接受补全时是否覆盖单词。请注意，这取决于扩展选择使用此功能。',
+    'editor.configuration.suggest.insertMode.insert': '插入建议而不覆盖光标右侧的文本。',
+    'editor.configuration.suggest.insertMode.replace': '插入建议并覆盖光标右侧的文本。',
+    'editor.configuration.suggest.localityBonus': '控制排序时是否首选光标附近的字词。',
+    'editor.configuration.suggest.maxVisibleSuggestions.dep': '此设置已弃用。现在可以调整建议小组件的大小。',
+    'editor.configuration.suggest.preview': '控制是否在编辑器中预览建议结果。',
+    'editor.configuration.suggest.shareSuggestSelections':
       '控制是否在多个工作区和窗口间共享记忆的建议选项(需要 `#editor.suggestSelection#`)。',
-    'suggest.showIcons': '控制是否在建议中显示或隐藏图标。',
-    'suggest.showInlineDetails': '控制建议详细信息是随标签一起显示还是仅显示在详细信息小组件中',
-    'suggest.showStatusBar': '控制建议小部件底部的状态栏的可见性。',
-    'suggest.snippetsPreventQuickSuggestions': '控制活动代码段是否阻止快速建议。',
-    suggestFontSize: '建议小部件的字号。如果设置为 `0`，则使用 `#editor.fontSize#` 的值。',
-    suggestLineHeight: '建议小部件的行高。如果设置为 `0`，则使用 `#editor.lineHeight#` 的值。最小值为 8。',
-    suggestOnTriggerCharacters: '控制在键入触发字符后是否自动显示建议。',
-    suggestSelection: '控制在建议列表中如何预先选择建议。',
-    'suggestSelection.first': '始终选择第一个建议。',
-    'suggestSelection.recentlyUsed':
+    'editor.configuration.suggest.showIcons': '控制是否在建议中显示或隐藏图标。',
+    'editor.configuration.suggest.showInlineDetails': '控制建议详细信息是随标签一起显示还是仅显示在详细信息小组件中',
+    'editor.configuration.suggest.showStatusBar': '控制建议小部件底部的状态栏的可见性。',
+    'editor.configuration.suggest.snippetsPreventQuickSuggestions': '控制活动代码段是否阻止快速建议。',
+    'editor.configuration.suggestFontSize': '建议小部件的字号。如果设置为 `0`，则使用 `#editor.fontSize#` 的值。',
+    'editor.configuration.suggestLineHeight':
+      '建议小部件的行高。如果设置为 `0`，则使用 `#editor.lineHeight#` 的值。最小值为 8。',
+    'editor.configuration.suggestOnTriggerCharacters': '控制在键入触发字符后是否自动显示建议。',
+    'editor.configuration.suggestSelection': '控制在建议列表中如何预先选择建议。',
+    'editor.configuration.suggestSelection.first': '始终选择第一个建议。',
+    'editor.configuration.suggestSelection.recentlyUsed':
       '选择最近的建议，除非进一步键入选择其他项。例如 `console. -> console.log`，因为最近补全过 `log`。',
-    'suggestSelection.recentlyUsedByPrefix':
+    'editor.configuration.suggestSelection.recentlyUsedByPrefix':
       '根据之前补全过的建议的前缀来进行选择。例如，`co -> console`、`con -> const`。',
-    tabCompletion: '启用 Tab 补全。',
-    'tabCompletion.off': '禁用 Tab 补全。',
-    'tabCompletion.on': '在按下 Tab 键时进行 Tab 补全，将插入最佳匹配建议。',
-    'tabCompletion.onlySnippets': '在前缀匹配时进行 Tab 补全。在 "quickSuggestions" 未启用时体验最好。',
-    'editor.guides.bracketPairs': '控制是否启用括号对指南。',
-    'editor.guides.bracketPairsHorizontal': '控制是否启用水平括号对指南。',
-    renderLineHighlight: '控制编辑器的当前行进行高亮显示的方式。',
-    'renderLineHighlight.all': '同时突出显示导航线和当前行。',
-    renderLineHighlightOnlyWhenFocus: '控制编辑器是否仅在焦点在编辑器时突出显示当前行。',
-    codeLens: '控制是否在编辑器中显示 CodeLens。',
-    'editor.suggest.showClasss': '启用后，IntelliSense 将显示“类”建议。',
-    'editor.suggest.showColors': '启用后，IntelliSense 将显示“颜色”建议。',
-    'editor.suggest.showConstants': '启用后，IntelliSense 将显示“常量”建议。',
-    'editor.suggest.showConstructors': '启用后，IntelliSense 将显示“构造函数”建议。',
-    'editor.suggest.showCustomcolors': '启用后，IntelliSense 将显示“自定义颜色”建议。',
-    'editor.suggest.showDeprecated': '启用后，IntelliSense 将显示“已启用”建议。',
-    'editor.suggest.showEnumMembers': '启用后，IntelliSense 将显示 "enumMember" 建议。',
-    'editor.suggest.showEnums': '启用后，IntelliSense 将显示“枚举”建议。',
-    'editor.suggest.showEvents': '启用后，IntelliSense 将显示“事件”建议。',
-    'editor.suggest.showFields': '启用后，IntelliSense 将显示“字段”建议。',
-    'editor.suggest.showFiles': '启用后，IntelliSense 将显示“文件”建议。',
-    'editor.suggest.showFolders': '启用后，IntelliSense 将显示“文件夹”建议。',
-    'editor.suggest.showFunctions': '启用后，IntelliSense 将显示“函数”建议。',
-    'editor.suggest.showInterfaces': '启用后，IntelliSense 将显示“接口”建议。',
-    'editor.suggest.showIssues': '启用后，IntelliSense 将显示"问题"建议。',
-    'editor.suggest.showKeywords': '启用后，IntelliSense 将显示“关键字”建议。',
-    'editor.suggest.showMethods': '启用后，IntelliSense 将显示“方法”建议。',
-    'editor.suggest.showModules': '启用后，IntelliSense 将显示“模块”建议。',
-    'editor.suggest.showOperators': '启用后，IntelliSense 将显示“操作符”建议。',
-    'editor.suggest.showPropertys': '启用后，IntelliSense 将显示“属性”建议。',
-    'editor.suggest.showReferences': '启用后，IntelliSense 将显示“参考”建议。',
-    'editor.suggest.showSnippets': '启用后，IntelliSense 将显示“片段”建议。',
-    'editor.suggest.showStructs': '启用后，IntelliSense 将显示“结构”建议。',
-    'editor.suggest.showTexts': '启用后，IntelliSense 将显示“文本”建议。',
-    'editor.suggest.showTypeParameters': '启用后，IntelliSense 将显示 "typeParameter" 建议。',
-    'editor.suggest.showUnits': '启用后，IntelliSense 将显示“单位”建议。',
-    'editor.suggest.showUsers': '启用后，IntelliSense 将显示"用户"建议。',
-    'editor.suggest.showValues': '启用后，IntelliSense 将显示“值”建议。',
-    'editor.suggest.showVariables': '启用后，IntelliSense 将显示“变量”建议。',
-    'editor.suggest.maxVisibleSuggestions': '控制 IntelliSense 在显示滚动条之前将显示的建议数量（最多 15 个）。',
-    'editor.suggest.preview': '启用或禁用建议预览的呈现。',
-    'editor.suggest.details.visible': '控制编辑器代码补全是否默认展开详情信息',
-    'editor.guides.indentation': '控制编辑器是否显示缩进参考线。',
-    'editor.guides.highlightActiveIndentation': '控制是否突出显示编辑器中活动的缩进参考线。',
+    'editor.configuration.tabCompletion': '启用 Tab 补全。',
+    'editor.configuration.tabCompletion.off': '禁用 Tab 补全。',
+    'editor.configuration.tabCompletion.on': '在按下 Tab 键时进行 Tab 补全，将插入最佳匹配建议。',
+    'editor.configuration.tabCompletion.onlySnippets':
+      '在前缀匹配时进行 Tab 补全。在 "quickSuggestions" 未启用时体验最好。',
+    'editor.configuration.editor.guides.bracketPairs': '控制是否启用括号对指南。',
+    'editor.configuration.editor.guides.bracketPairsHorizontal': '控制是否启用水平括号对指南。',
+    'editor.configuration.renderLineHighlight': '控制编辑器的当前行进行高亮显示的方式。',
+    'editor.configuration.renderLineHighlight.all': '同时突出显示导航线和当前行。',
+    'editor.configuration.renderLineHighlightOnlyWhenFocus': '控制编辑器是否仅在焦点在编辑器时突出显示当前行。',
+    'editor.configuration.codeLens': '控制是否在编辑器中显示 CodeLens。',
+    'editor.configuration.suggest.showClasss': '启用后，IntelliSense 将显示“类”建议。',
+    'editor.configuration.suggest.showColors': '启用后，IntelliSense 将显示“颜色”建议。',
+    'editor.configuration.suggest.showConstants': '启用后，IntelliSense 将显示“常量”建议。',
+    'editor.configuration.suggest.showConstructors': '启用后，IntelliSense 将显示“构造函数”建议。',
+    'editor.configuration.suggest.showCustomcolors': '启用后，IntelliSense 将显示“自定义颜色”建议。',
+    'editor.configuration.suggest.showDeprecated': '启用后，IntelliSense 将显示“已启用”建议。',
+    'editor.configuration.suggest.showEnumMembers': '启用后，IntelliSense 将显示 "enumMember" 建议。',
+    'editor.configuration.suggest.showEnums': '启用后，IntelliSense 将显示“枚举”建议。',
+    'editor.configuration.suggest.showEvents': '启用后，IntelliSense 将显示“事件”建议。',
+    'editor.configuration.suggest.showFields': '启用后，IntelliSense 将显示“字段”建议。',
+    'editor.configuration.suggest.showFiles': '启用后，IntelliSense 将显示“文件”建议。',
+    'editor.configuration.suggest.showFolders': '启用后，IntelliSense 将显示“文件夹”建议。',
+    'editor.configuration.suggest.showFunctions': '启用后，IntelliSense 将显示“函数”建议。',
+    'editor.configuration.suggest.showInterfaces': '启用后，IntelliSense 将显示“接口”建议。',
+    'editor.configuration.suggest.showIssues': '启用后，IntelliSense 将显示"问题"建议。',
+    'editor.configuration.suggest.showKeywords': '启用后，IntelliSense 将显示“关键字”建议。',
+    'editor.configuration.suggest.showMethods': '启用后，IntelliSense 将显示“方法”建议。',
+    'editor.configuration.suggest.showModules': '启用后，IntelliSense 将显示“模块”建议。',
+    'editor.configuration.suggest.showOperators': '启用后，IntelliSense 将显示“操作符”建议。',
+    'editor.configuration.suggest.showPropertys': '启用后，IntelliSense 将显示“属性”建议。',
+    'editor.configuration.suggest.showReferences': '启用后，IntelliSense 将显示“参考”建议。',
+    'editor.configuration.suggest.showSnippets': '启用后，IntelliSense 将显示“片段”建议。',
+    'editor.configuration.suggest.showStructs': '启用后，IntelliSense 将显示“结构”建议。',
+    'editor.configuration.suggest.showTexts': '启用后，IntelliSense 将显示“文本”建议。',
+    'editor.configuration.suggest.showTypeParameters': '启用后，IntelliSense 将显示 "typeParameter" 建议。',
+    'editor.configuration.suggest.showUnits': '启用后，IntelliSense 将显示“单位”建议。',
+    'editor.configuration.suggest.showUsers': '启用后，IntelliSense 将显示"用户"建议。',
+    'editor.configuration.suggest.showValues': '启用后，IntelliSense 将显示“值”建议。',
+    'editor.configuration.suggest.showVariables': '启用后，IntelliSense 将显示“变量”建议。',
+    'editor.configuration.suggest.maxVisibleSuggestions':
+      '控制 IntelliSense 在显示滚动条之前将显示的建议数量（最多 15 个）。',
+    'editor.configuration.suggest.details.visible': '控制编辑器代码补全是否默认展开详情信息',
+    'editor.configuration.experimental.stickyScroll.enabled': '在编辑器顶部的滚动过程中显示嵌套的当前作用域。',
+    'editor.configuration.maxTokenizationLineLength': '由于性能原因，超过这个长度的行将不会被标识。',
+    'editor.configuration.quickSuggestionsDelay': '控制显示智能提示的延迟时长 (毫秒)。',
+    'editor.configuration.tabSize':
+      '控制 Tab 缩进等于的空格数。若启用 `#editor.detectIndentation#`，该设置可能会被覆盖',
+    'editor.configuration.fontWeight': '控制字体粗细，接收 "normal" 和 "bold" 关键词或者 1 到 1000 数值。',
+    'editor.configuration.largeFileSize': '控制超大文件的自定义体积。',
+    'editor.configuration.preferredFormatter': '配置优先使用的格式化器。',
+    'editor.configuration.wrapTab': '控制当编辑器 Tab 超过可用空间时，是否使用换行来代替滚动模式。',
+    'editor.configuration.enablePreviewFromCodeNavigation': '控制当代码导航从其出发时，编辑器是否仍处于预览模式。',
+    'editor.configuration.formatOnSaveTimeout':
+      '控制保存时格式化的超时时间（毫秒）。仅当 `#editor.formatOnSave#` 启用时生效。',
+    'editor.configuration.autoSave': '控制如何自动保存文件。',
+    'editor.configuration.formatOnSave': '在保存时格式化文件',
+    'editor.configuration.autoSaveDelay':
+      '控制自动保存的延迟时长（毫秒）。仅当 `#editor.autoSave#` 设置为“编辑后自动保存”时生效。',
+    'editor.configuration.askIfDiff': '保存文件时如果磁盘上的文件较新，进行提示手动解决保存冲突。',
+    'editor.configuration.forceReadOnly': '是否启用 只读模式',
+    'editor.configuration.bracketPairColorization.enabled':
+      '控制是否启用括号对着色。使用 “workbench.colorCustomizations” 替代括号突出显示颜色。',
+    'editor.configuration.guides.bracketPairs': '控制是否启用括号对指南。',
+    'editor.configuration.mouseBackForwardToNavigate': '允许使用鼠标按钮 4 和 5 来执行命令“Go Back”和“Go Forward”。',
+    'editor.configuration.previewMode': '使用预览模式打开',
+    'editor.configuration.tokenColorCustomizations': '覆盖当前所选颜色主题中的编辑器颜色和字体样式',
+    'editor.configuration.workbench.editorAssociations':
+      '将 glob 模式配置到编辑器(例如 `"*十六进制": "hexEditor.hexEdit"`)。这些优先顺序高于默认行为。',
+    'editor.configuration.guides.indentation': '控制编辑器是否显示缩进参考线。',
+    'editor.configuration.guides.highlightActiveIndentation': '控制是否突出显示编辑器中活动的缩进参考线。',
+    'editor.configuration.trimAutoWhitespace': '删除自动插入的尾随空白符号。',
+
+    'diffEditor.configuration.renderSideBySide': '控制差异编辑器的显示方式。',
+    'diffEditor.configuration.ignoreTrimWhitespace': '启用后，差异编辑器的前导和尾随空白字符将会忽略',
+
     'inlineSuggest.enabled': '控制是否在编辑器中自动显示内联建议。',
 
     'view.component.renderedError': '视图组件渲染异常',
     'view.component.tryAgain': '重新加载',
 
-    // #region Testing
+    // Testing
     'test.title': '测试管理器',
     'test.result.runFinished': '测试运行完成于 {0}',
     'test.task.unnamed': '未命名任务',
-    // #endregion
 
+    // Menu
     'menu.missing.command': '菜单{0} 要执行的命令不存在：{1}',
     'menu.missing.altCommand': '菜单{0} 要执行的命令(altCommand)不存在：{1}',
     'menu.dupe.command': '菜单{0} command({1}) 和 alt({2}) 注册重复',
@@ -1049,23 +1054,21 @@ export const localizationBundle = {
     'task.contribute': '贡献',
     'task.cannotFindTask': '未找到 {0} 的任务，按回车键返回',
 
+    // Comment
     'comment.reply.count': '{0} 个评论',
     'comment.reply.lastReply': '最后由 {0} 评论',
-    // extension contribute
 
-    // #region walkthrough
+    // Walkthrough
     'walkthroughs.welcome': '欢迎使用',
     'walkthroughs.get.started': '打开 `入门` 演示',
-    // #endregion walkthrough
 
-    // #region merge editor
+    // Merge Editor
     'mergeEditor.workbench.tab.name': '正在合并: {0}',
     'mergeEditor.conflict.action.apply.confirm.title': '当前文件还有未处理的冲突或变更，是否应用并保存更改？',
     'mergeEditor.conflict.action.apply.confirm.continue': '继续合并',
     'mergeEditor.conflict.action.apply.confirm.complete': '确认保存并更改',
     'mergeEditor.button.apply': '应用更改',
     'workbench.quickOpen.preserveInput': '是否在 QuickOpen 的输入框（包括命令面板）中保留上次输入的内容',
-    // #endregion merge editor
     ...browserViews,
   },
 };

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -1,8 +1,7 @@
-import debounce from 'lodash/debounce';
-import { observable, action, computed, autorun, trace } from 'mobx';
+import { observable, action, computed } from 'mobx';
 
 import { Injectable, Autowired } from '@opensumi/di';
-import { IBasicRecycleTreeHandle, IRecycleTreeHandle } from '@opensumi/ide-components';
+import { IBasicRecycleTreeHandle } from '@opensumi/ide-components';
 import { IVirtualListHandle } from '@opensumi/ide-components/lib/virtual-list/types';
 import {
   IPreferenceViewDesc,
@@ -13,7 +12,6 @@ import {
   Emitter,
   Event,
   CommandService,
-  getDebugLogger,
   isString,
   getIcon,
   PreferenceScope,
@@ -660,10 +658,10 @@ export const defaultSettingSections: {
       preferences: [
         { id: 'files.autoGuessEncoding', localized: 'preference.files.autoGuessEncoding.title' },
         { id: 'files.encoding', localized: 'preference.files.encoding.title' },
-        { id: 'files.eol' },
-        { id: 'files.trimFinalNewlines' },
-        { id: 'files.trimTrailingWhitespace' },
-        { id: 'files.insertFinalNewline' },
+        { id: 'files.eol', localized: 'preference.files.eol' },
+        { id: 'files.trimFinalNewlines', localized: 'preference.files.trimFinalNewlines' },
+        { id: 'files.trimTrailingWhitespace', localized: 'preference.files.trimTrailingWhitespace' },
+        { id: 'files.insertFinalNewline', localized: 'preference.files.trimFinalNewlines' },
         { id: 'files.exclude', localized: 'preference.files.exclude.title' },
         { id: 'files.watcherExclude', localized: 'preference.files.watcherExclude.title' },
         { id: 'files.associations', localized: 'preference.files.associations.title' },

--- a/packages/search/src/browser/search-preferences.ts
+++ b/packages/search/src/browser/search-preferences.ts
@@ -37,17 +37,17 @@ export const searchPreferenceSchema: PreferenceSchema = {
     },
     [SearchSettingId.UseReplacePreview]: {
       type: 'boolean',
-      description: localize('preference.search.useReplacePreview'),
+      description: '%preference.search.useReplacePreview%',
       default: true,
     },
     [SearchSettingId.SearchOnType]: {
       type: 'boolean',
-      description: localize('preference.search.searchOnType'),
+      description: '%preference.search.searchOnType%',
       default: true,
     },
     [SearchSettingId.SearchOnTypeDebouncePeriod]: {
       type: 'number',
-      description: localize('preference.search.searchOnTypeDebouncePeriod'),
+      description: '%preference.search.searchOnTypeDebouncePeriod%',
       default: 300,
     },
   },

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,9 +1,3 @@
-// eslint-disable-next-line import/order
-import { setLocale } from '@opensumi/ide-monaco/lib/browser/monaco-localize';
-// 请注意，集成方在这里需要自己传一个正确的 locale 进去
-// 如果不传则默认会根据 PreferenceScope 的优先级从 LocalStorage 取值
-setLocale('en-US');
-
 import '@opensumi/ide-i18n';
 import '@opensumi/ide-core-browser/lib/style/index.less';
 import { SlotLocation } from '@opensumi/ide-core-browser';

--- a/packages/task/src/browser/task-executor.ts
+++ b/packages/task/src/browser/task-executor.ts
@@ -148,7 +148,7 @@ export class TerminalTaskExecutor extends Disposable implements ITaskExecutor {
     const { id, term } = this.terminalClient;
     term.options.disableStdin = true;
     term.writeln(`\r\n${formatLocalize('terminal.integrated.exitedWithCode', code)}`);
-    term.writeln(`\r\n\x1b[1m${formatLocalize('reuseTerminal')}\x1b[0m\r\n`);
+    term.writeln(`\r\n\x1b[1m${formatLocalize('terminal.reuseTerminal')}\x1b[0m\r\n`);
     this._onDidTaskProcessExit.fire(code);
 
     // 按任意键退出

--- a/packages/types/manifest.json
+++ b/packages/types/manifest.json
@@ -1,296 +1,296 @@
 {
   "meta": {
     "@opensumi/ide-addons": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-collaboration": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-comments": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-components": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-connection": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-core-browser": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["common"]
     },
     "@opensumi/ide-core-common": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-core-electron-main": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-core-node": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-debug": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-decoration": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-editor": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-electron-basic": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/ide-explorer": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/ide-express-file-server": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-manager": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-storage": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-file-scheme": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-search": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-file-service": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-tree-next": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-i18n": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-keymaps": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-logs": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-main-layout": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markdown": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markers": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-menu-bar": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/ide-monaco": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-monaco-enhance": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-opened-editor": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/ide-outline": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-output": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-overlay": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-preferences": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-process": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-quick-open": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/remote-cli": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-remote-opener": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-scm": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-search": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-startup": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/ide-static-resource": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/ide-status-bar": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-storage": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-task": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-terminal-next": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-testing": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-theme": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-toolbar": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser"]
     },
     "@opensumi/sumi": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-userstorage": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-utils": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": []
     },
     "@opensumi/ide-variable": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-webview": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace-edit": {
-      "version": "2.22.0",
+      "version": "2.22.1",
       "entry": ["browser", "common"]
     }
   },
   "packages": {
-    "@opensumi/ide-addons": "2.22.0",
-    "@opensumi/ide-collaboration": "2.22.0",
-    "@opensumi/ide-comments": "2.22.0",
-    "@opensumi/ide-components": "2.22.0",
-    "@opensumi/ide-connection": "2.22.0",
-    "@opensumi/ide-core-browser": "2.22.0",
-    "@opensumi/ide-core-common": "2.22.0",
-    "@opensumi/ide-core-electron-main": "2.22.0",
-    "@opensumi/ide-core-node": "2.22.0",
-    "@opensumi/ide-debug": "2.22.0",
-    "@opensumi/ide-decoration": "2.22.0",
-    "@opensumi/ide-editor": "2.22.0",
-    "@opensumi/ide-electron-basic": "2.22.0",
-    "@opensumi/ide-explorer": "2.22.0",
-    "@opensumi/ide-express-file-server": "2.22.0",
-    "@opensumi/ide-extension": "2.22.0",
-    "@opensumi/ide-extension-manager": "2.22.0",
-    "@opensumi/ide-extension-storage": "2.22.0",
-    "@opensumi/ide-file-scheme": "2.22.0",
-    "@opensumi/ide-file-search": "2.22.0",
-    "@opensumi/ide-file-service": "2.22.0",
-    "@opensumi/ide-file-tree-next": "2.22.0",
-    "@opensumi/ide-i18n": "2.22.0",
-    "@opensumi/ide-keymaps": "2.22.0",
-    "@opensumi/ide-logs": "2.22.0",
-    "@opensumi/ide-main-layout": "2.22.0",
-    "@opensumi/ide-markdown": "2.22.0",
-    "@opensumi/ide-markers": "2.22.0",
-    "@opensumi/ide-menu-bar": "2.22.0",
-    "@opensumi/ide-monaco": "2.22.0",
-    "@opensumi/ide-monaco-enhance": "2.22.0",
-    "@opensumi/ide-opened-editor": "2.22.0",
-    "@opensumi/ide-outline": "2.22.0",
-    "@opensumi/ide-output": "2.22.0",
-    "@opensumi/ide-overlay": "2.22.0",
-    "@opensumi/ide-preferences": "2.22.0",
-    "@opensumi/ide-process": "2.22.0",
-    "@opensumi/ide-quick-open": "2.22.0",
-    "@opensumi/remote-cli": "2.22.0",
-    "@opensumi/ide-remote-opener": "2.22.0",
-    "@opensumi/ide-scm": "2.22.0",
-    "@opensumi/ide-search": "2.22.0",
-    "@opensumi/ide-startup": "2.22.0",
-    "@opensumi/ide-static-resource": "2.22.0",
-    "@opensumi/ide-status-bar": "2.22.0",
-    "@opensumi/ide-storage": "2.22.0",
-    "@opensumi/ide-task": "2.22.0",
-    "@opensumi/ide-terminal-next": "2.22.0",
-    "@opensumi/ide-testing": "2.22.0",
-    "@opensumi/ide-theme": "2.22.0",
-    "@opensumi/ide-toolbar": "2.22.0",
-    "@opensumi/sumi": "2.22.0",
-    "@opensumi/ide-userstorage": "2.22.0",
-    "@opensumi/ide-utils": "2.22.0",
-    "@opensumi/ide-variable": "2.22.0",
-    "@opensumi/ide-webview": "2.22.0",
-    "@opensumi/ide-workspace": "2.22.0",
-    "@opensumi/ide-workspace-edit": "2.22.0"
+    "@opensumi/ide-addons": "2.22.1",
+    "@opensumi/ide-collaboration": "2.22.1",
+    "@opensumi/ide-comments": "2.22.1",
+    "@opensumi/ide-components": "2.22.1",
+    "@opensumi/ide-connection": "2.22.1",
+    "@opensumi/ide-core-browser": "2.22.1",
+    "@opensumi/ide-core-common": "2.22.1",
+    "@opensumi/ide-core-electron-main": "2.22.1",
+    "@opensumi/ide-core-node": "2.22.1",
+    "@opensumi/ide-debug": "2.22.1",
+    "@opensumi/ide-decoration": "2.22.1",
+    "@opensumi/ide-editor": "2.22.1",
+    "@opensumi/ide-electron-basic": "2.22.1",
+    "@opensumi/ide-explorer": "2.22.1",
+    "@opensumi/ide-express-file-server": "2.22.1",
+    "@opensumi/ide-extension": "2.22.1",
+    "@opensumi/ide-extension-manager": "2.22.1",
+    "@opensumi/ide-extension-storage": "2.22.1",
+    "@opensumi/ide-file-scheme": "2.22.1",
+    "@opensumi/ide-file-search": "2.22.1",
+    "@opensumi/ide-file-service": "2.22.1",
+    "@opensumi/ide-file-tree-next": "2.22.1",
+    "@opensumi/ide-i18n": "2.22.1",
+    "@opensumi/ide-keymaps": "2.22.1",
+    "@opensumi/ide-logs": "2.22.1",
+    "@opensumi/ide-main-layout": "2.22.1",
+    "@opensumi/ide-markdown": "2.22.1",
+    "@opensumi/ide-markers": "2.22.1",
+    "@opensumi/ide-menu-bar": "2.22.1",
+    "@opensumi/ide-monaco": "2.22.1",
+    "@opensumi/ide-monaco-enhance": "2.22.1",
+    "@opensumi/ide-opened-editor": "2.22.1",
+    "@opensumi/ide-outline": "2.22.1",
+    "@opensumi/ide-output": "2.22.1",
+    "@opensumi/ide-overlay": "2.22.1",
+    "@opensumi/ide-preferences": "2.22.1",
+    "@opensumi/ide-process": "2.22.1",
+    "@opensumi/ide-quick-open": "2.22.1",
+    "@opensumi/remote-cli": "2.22.1",
+    "@opensumi/ide-remote-opener": "2.22.1",
+    "@opensumi/ide-scm": "2.22.1",
+    "@opensumi/ide-search": "2.22.1",
+    "@opensumi/ide-startup": "2.22.1",
+    "@opensumi/ide-static-resource": "2.22.1",
+    "@opensumi/ide-status-bar": "2.22.1",
+    "@opensumi/ide-storage": "2.22.1",
+    "@opensumi/ide-task": "2.22.1",
+    "@opensumi/ide-terminal-next": "2.22.1",
+    "@opensumi/ide-testing": "2.22.1",
+    "@opensumi/ide-theme": "2.22.1",
+    "@opensumi/ide-toolbar": "2.22.1",
+    "@opensumi/sumi": "2.22.1",
+    "@opensumi/ide-userstorage": "2.22.1",
+    "@opensumi/ide-utils": "2.22.1",
+    "@opensumi/ide-variable": "2.22.1",
+    "@opensumi/ide-webview": "2.22.1",
+    "@opensumi/ide-workspace": "2.22.1",
+    "@opensumi/ide-workspace-edit": "2.22.1"
   }
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

Before:
![image](https://user-images.githubusercontent.com/9823838/215447213-d6eddc6f-6956-4ddc-b96a-e248ed6ac36d.png)

- 修复部分设置面板文案无正确国际化问题
- 移除 Web 实例中对于编辑器语言的默认设置，让启动案例可正常响应中英文语言切换效果
- 调整编辑器内的 Scheme 定义，让定义更规范，同时支持动态化展示

### Changelog

show correct i18n text on the settings panel