### PR TITLE
fix: update default scroller bar thumb size to 10

### DIFF
--- a/packages/components/src/scrollbars/index.tsx
+++ b/packages/components/src/scrollbars/index.tsx
@@ -132,24 +132,20 @@ export const Scrollbars = ({
       onUpdate={handleUpdate}
       onScroll={onScroll}
       renderTrackHorizontal={({ style, ...props }) => (
-        <div
-          {...props}
-          style={{ ...style, height: thumbSize, left: 0, right: 0, bottom: 0 }}
-          className={'scrollbar-track'}
-        />
+        <div {...props} style={{ ...style, height: thumbSize, left: 0, right: 0, bottom: 1 }} />
       )}
       renderTrackVertical={({ style, ...props }) => (
+        <div {...props} style={{ ...style, width: thumbSize, top: 0, right: 1, bottom: 0 }} />
+      )}
+      renderThumbVertical={({ style, className, ...props }) => (
+        <div {...props} style={{ ...style, width: thumbSize }} className={cls(className, 'scrollbar-thumb-vertical')} />
+      )}
+      renderThumbHorizontal={({ style, className, ...props }) => (
         <div
           {...props}
-          style={{ ...style, width: thumbSize, top: 0, right: 0, bottom: 0 }}
-          className={'scrollbar-track'}
+          style={{ ...style, height: thumbSize }}
+          className={cls(className, 'scrollbar-thumb-horizontal')}
         />
-      )}
-      renderThumbVertical={({ style, ...props }) => (
-        <div {...props} style={{ ...style, width: thumbSize }} className={'scrollbar-thumb-vertical'} />
-      )}
-      renderThumbHorizontal={({ style, ...props }) => (
-        <div {...props} style={{ ...style, height: thumbSize }} className={'scrollbar-thumb-horizontal'} />
       )}
     >
       <div
@@ -171,6 +167,6 @@ export const Scrollbars = ({
 Scrollbars.displayName = 'CustomScrollbars';
 
 export const ScrollbarsVirtualList = React.forwardRef((props, ref) => (
-  <Scrollbars {...props} thumbSize={6} forwardedRef={ref} />
+  <Scrollbars {...props} thumbSize={10} forwardedRef={ref} />
 ));
 ScrollbarsVirtualList.displayName = 'ScrollbarsVirtualList';

--- a/packages/components/src/scrollbars/styles.less
+++ b/packages/components/src/scrollbars/styles.less
@@ -18,11 +18,6 @@
     }
   }
 
-  .scrollbar-track {
-    user-select: none;
-    pointer-events: none;
-  }
-
   .scrollbar-thumb-vertical {
     z-index: 9999;
   }

--- a/packages/components/src/virtual-list/index.tsx
+++ b/packages/components/src/virtual-list/index.tsx
@@ -22,7 +22,7 @@ export const VirtualList = ({
     // 暂时还无法应用这个 Scrollbars 上下边界样式（阴影效果）
     // 因为 Virtuoso 的 scroll 事件没有传给 Scrollbars
     // 此处用于展示虚拟的滑动条而不是浏览器绘制的滑动条
-    <Scrollbars>
+    <Scrollbars thumbSize={0}>
       <Virtuoso
         rangeChanged={(range) => {
           onRangeChanged?.(range);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

修复滚动条无法拖动问题

### Changelog

update default scroller bar thumb size to 10