### PR TITLE
fix: merge editor state restore

### DIFF
--- a/packages/core-browser/src/monaco/merge-editor-widget.ts
+++ b/packages/core-browser/src/monaco/merge-editor-widget.ts
@@ -67,6 +67,7 @@ export interface IOpenMergeEditorArgs {
   ancestor: {
     uri: URI;
     textModel: IEditorModel;
+    baseContent: string;
   };
   input1: MergeEditorInputData;
   input2: MergeEditorInputData;

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -74,6 +74,7 @@ import {
   getSplitActionFromDragDrop,
 } from '../common';
 
+import { EditorDocumentModel } from './doc-model/editor-document-model';
 import { IEditorDocumentModelService, IEditorDocumentModelRef } from './doc-model/types';
 import { EditorTabChangedError, isEditorError } from './error';
 import { IGridEditorGroup, EditorGrid, SplitDirection, IEditorGridState } from './grid/grid.service';
@@ -1632,6 +1633,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
         ancestor: {
           uri: URI.parse(metadata.ancestor),
           textModel: ancestorRef.instance.getMonacoModel(),
+          baseContent: (ancestorRef.instance as EditorDocumentModel).baseContent || '',
         },
         input1: input1Data.setTextModel(input1Ref.instance.getMonacoModel()),
         input2: input2Data.setTextModel(input2Ref.instance.getMonacoModel()),

--- a/packages/monaco/__tests__/browser/merge-editor/merge-editor.service.test.ts
+++ b/packages/monaco/__tests__/browser/merge-editor/merge-editor.service.test.ts
@@ -52,6 +52,12 @@ a += 1;
 a += 1;
 a += 1;
 a += 1;`),
+        baseContent: `let a = 123456789;
+a += 1;
+a += 1;
+a += 1;
+a += 1;
+a += 1;`,
       },
       input1: new MergeEditorInputData(URI.parse('b')).setTextModel(
         monaco.editor.createModel(`let a = 123456789;

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor-widget.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor-widget.tsx
@@ -57,13 +57,33 @@ export class MergeEditorWidget extends Disposable implements IMergeEditorEditor 
     this._id = ++MERGE_EDITOR_ID;
 
     this.layout();
+
+    this.addDispose(
+      this.mergeEditorService.onRestoreState((uri) => {
+        if (uri) {
+          const key = uri.toString();
+          this.viewStateMap.delete(key);
+          this.outputUri = undefined;
+
+          /**
+           * 解决完成后重置回原来的文档内容
+           */
+          const nutrition = this.mergeEditorService.getNutrition();
+          if (nutrition) {
+            const { ancestor } = nutrition;
+            const { baseContent, textModel } = ancestor!;
+            (textModel as ITextModel).setValue(baseContent);
+          }
+        }
+      }),
+    );
   }
 
   async open(args: IOpenMergeEditorArgs): Promise<void> {
     const { ancestor, input1, input2, output } = args;
     this.mergeEditorService.setNutritionAndLaunch(args);
 
-    // 保存上一次状态
+    // 保存上一个 uri 的状态
     this.saveViewState(this.outputUri);
 
     this.outputUri = output.uri;

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -9,6 +9,7 @@ import {
   MonacoService,
 } from '@opensumi/ide-core-browser';
 import { IOpenMergeEditorArgs } from '@opensumi/ide-core-browser/lib/monaco/merge-editor-widget';
+import { URI } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { IDialogService } from '@opensumi/ide-overlay';
 
@@ -57,6 +58,10 @@ export class MergeEditorService extends Disposable {
 
   private readonly _onDidInputNutrition = new Emitter<IOpenMergeEditorArgs>();
   public readonly onDidInputNutrition: Event<IOpenMergeEditorArgs> = this._onDidInputNutrition.event;
+
+  private readonly _onRestoreState = new Emitter<URI>();
+  public readonly onRestoreState: Event<URI> = this._onRestoreState.event;
+
   private nutrition: IOpenMergeEditorArgs | undefined;
 
   constructor() {
@@ -80,6 +85,10 @@ export class MergeEditorService extends Disposable {
   public setNutritionAndLaunch(data: IOpenMergeEditorArgs): void {
     this.nutrition = data;
     this._onDidInputNutrition.fire(data);
+  }
+
+  public getNutrition(): IOpenMergeEditorArgs | undefined {
+    return this.nutrition;
   }
 
   public instantiationCodeEditor(current: HTMLDivElement, result: HTMLDivElement, incoming: HTMLDivElement): void {
@@ -131,6 +140,7 @@ export class MergeEditorService extends Disposable {
        */
       const resultValue = this.resultView.getEditor().getValue();
       await this.fileServiceClient.setContent(stat, resultValue);
+      this.fireRestoreState(uri);
 
       await this.commandService.executeCommand(EDITOR_COMMANDS.CLOSE.id);
     };
@@ -153,6 +163,10 @@ export class MergeEditorService extends Disposable {
     } else {
       await saveApply();
     }
+  }
+
+  public fireRestoreState(uri: URI): void {
+    this._onRestoreState.fire(uri);
   }
 
   public getCurrentEditor(): ICodeEditor {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -169,6 +169,7 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
       minimap: {
         enabled: false,
       },
+      codeLens: false,
       scrollBeyondLastLine: false,
       ...this.getMonacoEditorOptions(),
     });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.ts
@@ -120,7 +120,9 @@ export class CurrentCodeEditor extends BaseCodeEditor {
       },
     });
 
-    this.layout();
+    requestAnimationFrame(() => {
+      this.layout();
+    });
   }
 
   /**

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -96,6 +96,8 @@
     z-index: 1;
     // 默认图标宽度
     width: 16px !important;
+    display: flex;
+    align-items: center;
 
     &.offset_left {
       left: 18px !important;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- [x] 清理文档状态残留问题（如 git reset 操作）
- [x] 关闭 result 视图的 codelens 配置
- [x] 修复 conflict icon 图标错位的问题

![image](https://user-images.githubusercontent.com/20262815/216923106-7c928d29-9ead-420e-b21e-5c72f04b2b97.png)


### Changelog
修复 merge editor 文档状态会残留的问题
