### PR TITLE
fix: update monaco keybindings after keybinding changed

### DIFF
--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -27,7 +27,7 @@ export enum KeybindingScope {
 }
 
 // ref: https://github.com/Microsoft/vscode/blob/97fc588e65bedcb1113baeddd2f67237e52c8c63/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L56
-// 快捷键第一优先级，在开天中将对该值 * 100 作为快捷键的优先级参数 priority
+// 快捷键第一优先级，将对该值 * 100 作为快捷键的优先级参数 priority
 export enum KeybindingWeight {
   Default = 0, // 不传入 priority 则默认为 0
   EditorCore = 1,
@@ -161,6 +161,7 @@ export interface KeybindingRegistry {
   isPseudoCommand(commandId: string): boolean;
   resetKeybindings(): void;
   onKeybindingsChanged: Event<{ affectsCommands: string[] }>;
+  getKeybindingByScope(scope: KeybindingScope): Keybinding[];
 }
 
 export const keybindingServicePath = '/services/keybindings';
@@ -902,6 +903,10 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
       }
     }
     return false;
+  }
+
+  getKeybindingByScope(scope: KeybindingScope) {
+    return this.keymaps[scope];
   }
 }
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -9,51 +9,52 @@ title: 编辑器模块
 
 ![](https://cdn.nlark.com/yuque/0/2021/png/201640/1617938693844-e954f3ea-2888-48e2-8527-683603b15b39.png)
 
-1. 在整个 IDE 全局中，拥有一个唯一的 WorkbenchEditorService 实例，它是全局的编辑器管理服务。我们在打开一个编辑器时，首先要调用它的 open 方法，传入一个对应的uri，如 file://path/to/fileToOpen.ts
-   
+1. 在整个 IDE 全局中，拥有一个唯一的 WorkbenchEditorService 实例，它是全局的编辑器管理服务。我们在打开一个编辑器时，首先要调用它的 open 方法，传入一个对应的 uri，如 file://path/to/fileToOpen.ts
 2. 为了打开这个 uri， 我们需要将其转换为一个在编辑器中可打开的 IResource, 它会拥有更多必要的对编辑器的信息。 这些信息由提前注册的 `IResourceProvider` 提供。
-````typescript
+
+```typescript
+/**
+ * Resource
+ * 一个资源代表了一个能够在编辑器区域被打开的东西
+ */
+export interface IResource<MetaData = any> {
   /**
-   * Resource
-   * 一个资源代表了一个能够在编辑器区域被打开的东西
+   * 是否允许刷新后恢复
    */
-  export interface IResource<MetaData = any> {
-    /**
-     * 是否允许刷新后恢复
-     */
-    supportsRevive?: boolean;
+  supportsRevive?: boolean;
 
-    // 资源名称
-    name: string;
-    // 资源URI
-    uri: URI;
-    // 资源icon的class
-    icon: string;
-    // 资源的额外信息
-    metadata?: MetaData;
-    // 资源已被删除
-    deleted?: any;
-  }
-````
+  // 资源名称
+  name: string;
+  // 资源URI
+  uri: URI;
+  // 资源icon的class
+  icon: string;
+  // 资源的额外信息
+  metadata?: MetaData;
+  // 资源已被删除
+  deleted?: any;
+}
+```
+
 3. 获得 IResource 之后，就可以在 tab 上创建新 tab， 展示对应的名称和 icon 了。
-4. 为了能在编辑器中展示内容，还需要知道如何把这个 IResource 打开。开天的编辑器模块支持一个资源拥有多种打开方式，如 md 文件拥有代码和实时预览的方式。一个打开方式可以是代码编辑器、diff编辑器，或者是一个编辑器富组件（React组件）。这些打开方式和富组件都需要提前在 `EditorComponentRegistry` 中进行注册
-````typescript
-  // 定义一个resource如何被打开
-  export interface IEditorOpenType {
+4. 为了能在编辑器中展示内容，还需要知道如何把这个 IResource 打开，编辑器模块支持一个资源拥有多种打开方式，如 md 文件拥有代码和实时预览的方式。一个打开方式可以是代码编辑器、diff 编辑器，或者是一个编辑器富组件（React 组件）。这些打开方式和富组件都需要提前在 `EditorComponentRegistry` 中进行注册
 
-    type: 'code' | 'diff' | 'component';
+```typescript
+// 定义一个resource如何被打开
+export interface IEditorOpenType {
+  type: 'code' | 'diff' | 'component';
 
-    componentId?: string;
+  componentId?: string;
 
-    title?: string;
+  title?: string;
 
-    readonly?: boolean;
+  readonly?: boolean;
 
-    // 默认0， 大的排在前面
-    weight?: number;
+  // 默认0， 大的排在前面
+  weight?: number;
+}
+```
 
-  }
-````
 5. 获得对应的打开方式后，根据用户选择的类型将对应的内容展现在编辑器的主体中，这样就完成了一个 tab 的打开过程。
 
 # 贡献点
@@ -80,8 +81,7 @@ title: 编辑器模块
 
 **onDidRestoreState**
 
-当进入 IDE 时，编辑器会尝试恢复上一次打开的编辑器组和组内打开的文件
-完成后会执行 onDidRestoreState 这个 hook
+当进入 IDE 时，编辑器会尝试恢复上一次打开的编辑器组和组内打开的文件完成后会执行 onDidRestoreState 这个 hook
 
 **registerEditorFeature**
 
@@ -89,23 +89,16 @@ title: 编辑器模块
 
 #### Example
 
-示例1: 为 example_scheme://exampleTitle 这样的 Uri 注册一个编辑器组件，使得它能在编辑器内被打开。
+示例 1: 为 example_scheme://exampleTitle 这样的 Uri 注册一个编辑器组件，使得它能在编辑器内被打开。
 
 ```tsx
-
-
 const ExampleEditorComponent = () => {
-  return <div> 
-    示例组件内容
-  </div>
-}
-
+  return <div>示例组件内容</div>;
+};
 
 @Domain(BrowserEditorContribution)
 export class ExampleEditorContribution implements BrowserEditorContribution {
-
   registerResource(resourceService: ResourceService): void {
-
     // 注册example_scheme 可以在编辑器打开，并且设定对应的tab icon 和 名字
     resourceService.registerResourceProvider({
       scheme: 'example_scheme',
@@ -113,14 +106,13 @@ export class ExampleEditorContribution implements BrowserEditorContribution {
         return {
           uri,
           name: '示例编辑器组件',
-          icon: 'example-icon-class'
+          icon: 'example-icon-class',
         };
       },
     });
   }
 
   registerEditorComponent(registry: EditorComponentRegistry) {
-    
     // 将组件进行注册
     registry.registerEditorComponent({
       component: ExampleEditorComponent,
@@ -138,14 +130,12 @@ export class ExampleEditorContribution implements BrowserEditorContribution {
       ]);
     });
   }
-
 }
-
 ```
 
-示例2： 为 monaco 编辑器提供额外的能力
+示例 2： 为 monaco 编辑器提供额外的能力
 
-```` ts
+```ts
 
 @Domain(BrowserEditorContribution)
 export class ExampleEditorContribution implements BrowserEditorContribution {
@@ -162,8 +152,7 @@ export class ExampleEditorContribution implements BrowserEditorContribution {
   }
 }
 
-````
-
+```
 
 ## Contributions
 
@@ -171,139 +160,142 @@ export class ExampleEditorContribution implements BrowserEditorContribution {
 
 ### Command
 
-* `file.new.untitled`: 在编辑器创建一个新文件
-* `editor.undo`: 撤销 (编辑器时)
-* `editor.redo`: 重做 (编辑器时)
-* `editor.componentUndo`: 撤销 (富组件时)
-* `editor.componentRedo`: 撤销 (富组件时)
-* `editor.selectAll`: 全选
-* `editor.openUri`: 打开一个 uri
-* `editor.openUris`: 打开多个 uri
-* `editor.saveUri`: 保存某个 uri 指定的文件
-* `editor.compare`: 将两个 uri 进行比较
-* `editor.close`: 关闭当前打开的 tab
-* `editor.closeAllInGroup`: 关闭一组 tab
-* `editor.closeOtherEditorsInGroup`： 在一组tab中关闭除目标以外的其他tab
-* `editor.closeAll`: 关闭全部tab
-* `editor.closeSaved`: 关闭已保存的tab
-* `editor.closeToRight`: 关闭右侧的tab
-* `editor.getCurrent`: 获取当前的 tab 的 uri
-* `editor.getCurrentResource`: 获取当前的 tab 的 resource
-* `editor.splitToLeft`: 向左拆分编辑器组
-* `editor.splitToRight`: 向右拆分编辑器组
-* `editor.splitToTop`: 向上拆分编辑器组
-* `editor.splitToBottom`: 向上拆分编辑器组
-* `editor.changeLanguage`: 修改当前编辑器的语言
-* `editor.changeEol`: 修改当前编辑器的 eol
-* `editor.navigateLeft`: 将光标移到到左边的编辑器组
-* `editor.navigateRight`: 将光标移到到右边的编辑器组
-* `editor.navigateUp`: 将光标移到到上边的编辑器组
-* `editor.navigateDown`: 将光标移到到下边的编辑器组
-* `editor.navigatePrevious`: 将光标移到到上一个编辑器组
-* `editor.navigateNext`: 将光标移到到下一个编辑器组
-* `editor.goToGroup`: 将光标移到指定的编辑器组
-* `editor.previous`: 移动到前一个 tab （如果是组里面第一个，则会移动到上一组）
-* `editor.next`: 移动到后一个 tab （如果是组里面最后一个，则会移动到下一组）
-* `editor.previousInGroup`: 移动到当前编辑器组内前一个 tab
-* `editor.nextInGroup`: 移动到当前编辑器组内后一个 tab
-* `editor.closeOtherGroup`: 关闭其他编辑器组
-* `editor.openEditorAtIndex`: 打开当前编辑器组第 x 个 tab 页
-* `editor.evenEditorGroups`: 重置编辑器组大小
-* `editor.document.revert`: 还原当前 tab 的文档
-* `editor.revertAndClose`: 还原当前 tab 的文档，并关闭当前tab
-* `editor.goForward`: 前进到下一个编辑器光标的历史位置
-* `editor.goBack`: 回到上一个编辑器光标的历史位置
-* `editor.pinCurrent`: 将当前 tab 固定（取消 preview模式）
-* `editor.copyCurrentPath`: 复制当前 tab 的路径 （文件路径）
-* `editor.moveGroup`: 将当前的 tab 移到另外一个编辑器组
-* `editor.reopenClosed`: 重新打开刚刚关闭的 tab
-* `editor.focus`: 编辑器获取焦点
-* `editor.autoSave`: 切换自动保存
+- `file.new.untitled`: 在编辑器创建一个新文件
+- `editor.undo`: 撤销 (编辑器时)
+- `editor.redo`: 重做 (编辑器时)
+- `editor.componentUndo`: 撤销 (富组件时)
+- `editor.componentRedo`: 撤销 (富组件时)
+- `editor.selectAll`: 全选
+- `editor.openUri`: 打开一个 uri
+- `editor.openUris`: 打开多个 uri
+- `editor.saveUri`: 保存某个 uri 指定的文件
+- `editor.compare`: 将两个 uri 进行比较
+- `editor.close`: 关闭当前打开的 tab
+- `editor.closeAllInGroup`: 关闭一组 tab
+- `editor.closeOtherEditorsInGroup`： 在一组 tab 中关闭除目标以外的其他 tab
+- `editor.closeAll`: 关闭全部 tab
+- `editor.closeSaved`: 关闭已保存的 tab
+- `editor.closeToRight`: 关闭右侧的 tab
+- `editor.getCurrent`: 获取当前的 tab 的 uri
+- `editor.getCurrentResource`: 获取当前的 tab 的 resource
+- `editor.splitToLeft`: 向左拆分编辑器组
+- `editor.splitToRight`: 向右拆分编辑器组
+- `editor.splitToTop`: 向上拆分编辑器组
+- `editor.splitToBottom`: 向上拆分编辑器组
+- `editor.changeLanguage`: 修改当前编辑器的语言
+- `editor.changeEol`: 修改当前编辑器的 eol
+- `editor.navigateLeft`: 将光标移到到左边的编辑器组
+- `editor.navigateRight`: 将光标移到到右边的编辑器组
+- `editor.navigateUp`: 将光标移到到上边的编辑器组
+- `editor.navigateDown`: 将光标移到到下边的编辑器组
+- `editor.navigatePrevious`: 将光标移到到上一个编辑器组
+- `editor.navigateNext`: 将光标移到到下一个编辑器组
+- `editor.goToGroup`: 将光标移到指定的编辑器组
+- `editor.previous`: 移动到前一个 tab （如果是组里面第一个，则会移动到上一组）
+- `editor.next`: 移动到后一个 tab （如果是组里面最后一个，则会移动到下一组）
+- `editor.previousInGroup`: 移动到当前编辑器组内前一个 tab
+- `editor.nextInGroup`: 移动到当前编辑器组内后一个 tab
+- `editor.closeOtherGroup`: 关闭其他编辑器组
+- `editor.openEditorAtIndex`: 打开当前编辑器组第 x 个 tab 页
+- `editor.evenEditorGroups`: 重置编辑器组大小
+- `editor.document.revert`: 还原当前 tab 的文档
+- `editor.revertAndClose`: 还原当前 tab 的文档，并关闭当前 tab
+- `editor.goForward`: 前进到下一个编辑器光标的历史位置
+- `editor.goBack`: 回到上一个编辑器光标的历史位置
+- `editor.pinCurrent`: 将当前 tab 固定（取消 preview 模式）
+- `editor.copyCurrentPath`: 复制当前 tab 的路径 （文件路径）
+- `editor.moveGroup`: 将当前的 tab 移到另外一个编辑器组
+- `editor.reopenClosed`: 重新打开刚刚关闭的 tab
+- `editor.focus`: 编辑器获取焦点
+- `editor.autoSave`: 切换自动保存
+
 ### Preference
 
-editor模块中将所有 monaco 的 options 变成了对应含有 `editor.` 前缀的 preference
-详见 src/browser/preference/schema.ts
+editor 模块中将所有 monaco 的 options 变成了对应含有 `editor.` 前缀的 preference 详见 src/browser/preference/schema.ts
 
 其他的 preferences:
 
-* `editor.readonlyFiles`: 只读的文件列表
-* `editor.previewMode`: 是否开启预览模式
-* `editor.tokenColorCustomizations`: 自定义 token 颜色的配置
-* `editor.askIfDiff`: 保存文件时，如果磁盘文件较新，是否弹出提示
-* `editor.showActionWhenGroupEmpty`: 在编辑器组没有tab时，是否显示右上角的 editor/title 菜单
-* `editor.autoSave`: 自动保存的模式
-* `editor.autoSaveDelay`: 当自动保存是 afterDelay 时，保存的延时时长
-* `editor.preferredFormatter`: 针对各个语言的格式化方式选择的配置
-* `editor.forceReadOnly`: 是否强制所有编辑器变成 readOnly
-* `editor.languageFeatureEnabledMaxSize`: 会启用languageFeature的最大文件尺寸
-* `editor.docExtHostSyncMaxSize`:  会同步到extHost的最大文件尺寸
-* `editor.formatOnSave`: 是否在保存时自动格式化
-* `editor.formatOnSaveTimeout`: 保存时自动格式化的最大执行时间
-* `editor.largeFile`: 对于 '大文件' 的大小定义， 单位 B
-* `editor.modelDisposeTime`: 编辑器 tab 关闭后， 没有被引用的文档会被 dispose 的延时
+- `editor.readonlyFiles`: 只读的文件列表
+- `editor.previewMode`: 是否开启预览模式
+- `editor.tokenColorCustomizations`: 自定义 token 颜色的配置
+- `editor.askIfDiff`: 保存文件时，如果磁盘文件较新，是否弹出提示
+- `editor.showActionWhenGroupEmpty`: 在编辑器组没有 tab 时，是否显示右上角的 editor/title 菜单
+- `editor.autoSave`: 自动保存的模式
+- `editor.autoSaveDelay`: 当自动保存是 afterDelay 时，保存的延时时长
+- `editor.preferredFormatter`: 针对各个语言的格式化方式选择的配置
+- `editor.forceReadOnly`: 是否强制所有编辑器变成 readOnly
+- `editor.languageFeatureEnabledMaxSize`: 会启用 languageFeature 的最大文件尺寸
+- `editor.docExtHostSyncMaxSize`: 会同步到 extHost 的最大文件尺寸
+- `editor.formatOnSave`: 是否在保存时自动格式化
+- `editor.formatOnSaveTimeout`: 保存时自动格式化的最大执行时间
+- `editor.largeFile`: 对于 '大文件' 的大小定义， 单位 B
+- `editor.modelDisposeTime`: 编辑器 tab 关闭后， 没有被引用的文档会被 dispose 的延时
+
 ### KeyBinding
 
-* `ctrlcmd+s`: 保存文件
-* `ctrlcmd+w` **Electron**: 关闭当前 tab
-* `alt+shift+w` **Web**: 关闭当前 tab
-* `alt+cmd+left` **Electron**: 前一个tab
-* `ctrlcmd+pageup` **Electron**: 前一个tab
-* `ctrl+shift+tab` **Electron**: 前一个tab
-* `ctrlcmd+shift+[` **Electron** **Mac**: 前一个tab
-* `ctrlcmd+ctrl+left` **Web**: 前一个tab
-* `alt+pageup` **Web**: 前一个tab
-* `alt+cmd+right` **Electron**: 后一个tab
-* `ctrlcmd+pagedown` **Electron**: 后一个tab
-* `ctrl+tab` **Electron**: 后一个tab
-* `ctrlcmd+shift+]` **Electron** **Mac**: 后一个tab
-* `ctrlcmd+ctrl+right` **Web**: 后一个tab
-* `alt+pagedown` **Web**: 后一个tab
-* `alt+right` **Windows** : 下一个光标位置
-* `ctrl+shift+-` **Mac** : 下一个光标位置
-* `alt+left` **Windows** : 上一个光标位置
-* `ctrl+-` **Mac** : 上一个光标位置
-* `ctrlcmd+k m`: 修改当前打开的文件的语言
-* `ctrlcmd+\`: 向右拆分
-* `ctrlcmd+k ctrlcmd+right`: 下一个编辑器组
-* `ctrlcmd+k ctrlcmd+left`: 上一个编辑器组
-* `alt+ctrlcmd+s`：保存全部文件
-* `ctrlcmd+k w`: 关闭全部
-* `ctrlcmd+k enter`: 让当前 tab 退出 preview 状态
-* `ctrlcmd+k p`: 复制当前 tab 路径
-* `ctrlcmd+shift+t` **Electron**: 重新打开已关闭的文件
-* `alt+shift+t` **Web**: 重新打开已关闭的文件
-* `ctrlcmd+n` **Electron**: 创建一个新文件 tab
-* `alt+n` **Web**: 创建一个新文件 tab
-* `ctrlcmd+t` **Electron**: 搜索 workspace symbol
-* `ctrlcmd+o` **Web**: 搜索 workspace symbol
-* `ctrlcmd+1` : 去到第 1 个编辑器组
-* `ctrlcmd+2` : 去到第 2 个编辑器组
-* `ctrlcmd+3` : 去到第 3 个编辑器组
-* `ctrlcmd+4` : 去到第 4 个编辑器组
-* `ctrlcmd+5` : 去到第 5 个编辑器组
-* `ctrlcmd+6` : 去到第 6 个编辑器组
-* `ctrlcmd+7` : 去到第 7 个编辑器组
-* `ctrlcmd+8` : 去到第 8 个编辑器组
-* `ctrlcmd+9` : 去到第 9 个编辑器组
-* `ctrlcmd+k up`: 将当前tab移动到上方编辑器组
-* `ctrlcmd+k left`: 将当前tab移动到左方编辑器组
-* `ctrlcmd+k right`: 将当前tab移动到右方编辑器组
-* `ctrlcmd+k down`: 将当前tab移动到下方编辑器组
+- `ctrlcmd+s`: 保存文件
+- `ctrlcmd+w` **Electron**: 关闭当前 tab
+- `alt+shift+w` **Web**: 关闭当前 tab
+- `alt+cmd+left` **Electron**: 前一个 tab
+- `ctrlcmd+pageup` **Electron**: 前一个 tab
+- `ctrl+shift+tab` **Electron**: 前一个 tab
+- `ctrlcmd+shift+[` **Electron** **Mac**: 前一个 tab
+- `ctrlcmd+ctrl+left` **Web**: 前一个 tab
+- `alt+pageup` **Web**: 前一个 tab
+- `alt+cmd+right` **Electron**: 后一个 tab
+- `ctrlcmd+pagedown` **Electron**: 后一个 tab
+- `ctrl+tab` **Electron**: 后一个 tab
+- `ctrlcmd+shift+]` **Electron** **Mac**: 后一个 tab
+- `ctrlcmd+ctrl+right` **Web**: 后一个 tab
+- `alt+pagedown` **Web**: 后一个 tab
+- `alt+right` **Windows** : 下一个光标位置
+- `ctrl+shift+-` **Mac** : 下一个光标位置
+- `alt+left` **Windows** : 上一个光标位置
+- `ctrl+-` **Mac** : 上一个光标位置
+- `ctrlcmd+k m`: 修改当前打开的文件的语言
+- `ctrlcmd+\`: 向右拆分
+- `ctrlcmd+k ctrlcmd+right`: 下一个编辑器组
+- `ctrlcmd+k ctrlcmd+left`: 上一个编辑器组
+- `alt+ctrlcmd+s`：保存全部文件
+- `ctrlcmd+k w`: 关闭全部
+- `ctrlcmd+k enter`: 让当前 tab 退出 preview 状态
+- `ctrlcmd+k p`: 复制当前 tab 路径
+- `ctrlcmd+shift+t` **Electron**: 重新打开已关闭的文件
+- `alt+shift+t` **Web**: 重新打开已关闭的文件
+- `ctrlcmd+n` **Electron**: 创建一个新文件 tab
+- `alt+n` **Web**: 创建一个新文件 tab
+- `ctrlcmd+t` **Electron**: 搜索 workspace symbol
+- `ctrlcmd+o` **Web**: 搜索 workspace symbol
+- `ctrlcmd+1` : 去到第 1 个编辑器组
+- `ctrlcmd+2` : 去到第 2 个编辑器组
+- `ctrlcmd+3` : 去到第 3 个编辑器组
+- `ctrlcmd+4` : 去到第 4 个编辑器组
+- `ctrlcmd+5` : 去到第 5 个编辑器组
+- `ctrlcmd+6` : 去到第 6 个编辑器组
+- `ctrlcmd+7` : 去到第 7 个编辑器组
+- `ctrlcmd+8` : 去到第 8 个编辑器组
+- `ctrlcmd+9` : 去到第 9 个编辑器组
+- `ctrlcmd+k up`: 将当前 tab 移动到上方编辑器组
+- `ctrlcmd+k left`: 将当前 tab 移动到左方编辑器组
+- `ctrlcmd+k right`: 将当前 tab 移动到右方编辑器组
+- `ctrlcmd+k down`: 将当前 tab 移动到下方编辑器组
+
 ### Menu
 
-#### MenuIds 
-* `editor/title`: 每组编辑器右上角的动作按钮
-* `editor/title/context`: 在 tab 上右键出现的菜单
-* `editor/context`: 在编辑器内 (必须是monaco编辑器内) 右键出现的菜单
+#### MenuIds
+
+- `editor/title`: 每组编辑器右上角的动作按钮
+- `editor/title/context`: 在 tab 上右键出现的菜单
+- `editor/context`: 在编辑器内 (必须是 monaco 编辑器内) 右键出现的菜单
+
 # 类
 
 ### WorkbenchEditorService
 
 外部模块调用编辑器主要通过这个 class 进行对应的操作
 
-````typescript
+```typescript
 export abstract class WorkbenchEditorService {
-
   /**
    * 当前 resource 发生变更
    */
@@ -393,18 +385,17 @@ export abstract class WorkbenchEditorService {
    */
   abstract createUntitledResource(options?: IUntitledOptions): Promise<IOpenResourceResult>;
 }
-````
+```
 
 ### IEditor
 
 monaco 编辑器的包裹概念
 
-````typescript
+```typescript
 /**
  * 一个IEditor代表了一个最小的编辑器单元，可以是CodeEditor中的一个，也可以是DiffEditor中的两个
  */
 export interface IEditor {
-
   /**
    * 获得当前编辑器
    */
@@ -441,9 +432,8 @@ export interface IEditor {
    */
   applyDecoration(key: string, options: IDecorationApplyOptions[]);
 
-
   getSelections(): ISelection[] | null;
-  onSelectionsChanged: Event<{ selections: ISelection[], source: string }>;
+  onSelectionsChanged: Event<{ selections: ISelection[]; source: string }>;
 
   onVisibleRangesChanged: Event<IRange[]>;
 
@@ -464,19 +454,17 @@ export interface IEditor {
 
   onDispose: Event<void>;
 }
-````
-
+```
 
 ### IEditorGroup
 
-````typescript 
+```typescript
 /**
  * 编辑器组
  * 是一组tab和一个展示编辑器或者编辑器富组件的单元，主要用来管理 tab 的生命周期，以及控制编辑器主体的展示。
  * 一个 workbenchEditorService 会拥有多个（至少一个）编辑器组，它会在类似 “向右拆分” 这样的功能被使用时创建，在该组tab完全关闭时销毁。
  */
 export interface IEditorGroup {
-
   /**
    * 当前 editorGroup 在 workbenchEditorService.sortedEditorGroups 中的 index
    */
@@ -561,5 +549,4 @@ export interface IEditorGroup {
    */
   saveResource(resource: IResource, reason: SaveReason): Promise<void>;
 }
-
-````
+```

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -109,7 +109,7 @@ export const EDITOR_DEFAULTS = {
   readOnly: false,
   mouseStyle: 'text',
   disableLayerHinting: false,
-  automaticLayout: true, // 开天修改
+  automaticLayout: true, // Modified
   wordWrap: 'off',
   wordWrapColumn: 80,
   wordWrapMinified: true,
@@ -159,7 +159,7 @@ export const EDITOR_DEFAULTS = {
     renderWhitespace: 'none',
     renderControlCharacters: false,
     fontLigatures: false,
-    renderLineHighlight: 'none', // 开天修改
+    renderLineHighlight: 'none', // Modified
     scrollbar: {
       vertical: 1, // ScrollbarVisibility.Auto,
       horizontal: 1, // ScrollbarVisibility.Auto,
@@ -210,7 +210,7 @@ export const EDITOR_DEFAULTS = {
     suggestOnTriggerCharacters: true,
     acceptSuggestionOnEnter: 'on',
     acceptSuggestionOnCommitCharacter: true,
-    wordBasedSuggestions: false, // 开天修改
+    wordBasedSuggestions: false, // Modified
     suggestSelection: 'recentlyUsed',
     suggestFontSize: 0,
     suggestLineHeight: 0,

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@opensumi/ide-core-common": "workspace:*",
     "@opensumi/ide-core-node": "workspace:*",
-    "@opensumi/ide-utils": "workspace:*",
-    "@opensumi/ide-file-service": "workspace:*"
+    "@opensumi/ide-file-service": "workspace:*",
+    "@opensumi/ide-utils": "workspace:*"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "workspace:*",

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@opensumi/ide-core-common": "workspace:*",
     "@opensumi/ide-core-node": "workspace:*",
-    "@opensumi/ide-utils": "workspace:*"
+    "@opensumi/ide-utils": "workspace:*",
+    "@opensumi/ide-file-service": "workspace:*"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,6 +2810,7 @@ __metadata:
     "@opensumi/ide-core-node": "workspace:*"
     "@opensumi/ide-dev-tool": "workspace:*"
     "@opensumi/ide-editor": "workspace:*"
+    "@opensumi/ide-file-service": "workspace:*"
     "@opensumi/ide-overlay": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #2239 

在快捷键更新之后，需要通过 monaco 内的 `addDynamicKeybinding` 方法去覆盖实现，从而达到卸载对应快捷键的同时，覆盖快捷键在编辑器内的展示。
<img width="276" alt="截屏2023-02-09 10 35 09" src="https://user-images.githubusercontent.com/9823838/217704555-455c99ab-bd75-4034-b617-cbbc080ec3f4.png">
<img width="965" alt="截屏2023-02-09 10 35 17" src="https://user-images.githubusercontent.com/9823838/217704564-8b08499e-19b7-4ece-bae2-16b56d13136e.png">

### Changelog

update monaco keybindings after keybinding changed