### PR TITLE
fix: reset yTextMap when file updated by system

### DIFF
--- a/packages/collaboration/src/browser/collaboration.contribution.ts
+++ b/packages/collaboration/src/browser/collaboration.contribution.ts
@@ -1,6 +1,7 @@
 import { Autowired } from '@opensumi/di';
 import {
   ClientAppContribution,
+  FsProviderContribution,
   KeybindingContribution,
   KeybindingRegistry,
   KeybindingWeight,
@@ -12,8 +13,10 @@ import { AUTO_SAVE_MODE } from '@opensumi/ide-editor';
 import { ICollaborationService, CollaborationModuleContribution } from '../common';
 import { REDO, UNDO } from '../common/commands';
 
-@Domain(ClientAppContribution, KeybindingContribution, CommandContribution)
-export class CollaborationContribution implements ClientAppContribution, KeybindingContribution, CommandContribution {
+@Domain(ClientAppContribution, KeybindingContribution, CommandContribution, FsProviderContribution)
+export class CollaborationContribution
+  implements ClientAppContribution, KeybindingContribution, CommandContribution, FsProviderContribution
+{
   @Autowired(ICollaborationService)
   private collaborationService: ICollaborationService;
 
@@ -86,5 +89,9 @@ export class CollaborationContribution implements ClientAppContribution, Keybind
         this.collaborationService.redoOnFocusedTextModel();
       },
     });
+  }
+
+  onFileServiceReady() {
+    this.collaborationService.initFileWatch();
   }
 }

--- a/packages/collaboration/src/browser/collaboration.service.ts
+++ b/packages/collaboration/src/browser/collaboration.service.ts
@@ -5,7 +5,7 @@ import { WebsocketProvider } from 'y-websocket';
 import { Doc as YDoc, Map as YMap, YMapEvent, Text as YText } from 'yjs';
 
 import { Injectable, Autowired, Inject, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import { AppConfig } from '@opensumi/ide-core-browser';
+import { AppConfig, DisposableCollection } from '@opensumi/ide-core-browser';
 import { Deferred, ILogger, OnEvent, uuid, WithEventBus } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import {
@@ -16,6 +16,7 @@ import {
   IEditorDocumentModelService,
 } from '@opensumi/ide-editor/lib/browser';
 import { WorkbenchEditorServiceImpl } from '@opensumi/ide-editor/lib/browser/workbench-editor.service';
+import { IFileServiceClient, FileChangeEvent, FileChangeType } from '@opensumi/ide-file-service/lib/common';
 import { ITextModel, ICodeEditor } from '@opensumi/ide-monaco';
 import { ICSSStyleService } from '@opensumi/ide-theme';
 
@@ -54,6 +55,9 @@ export class CollaborationService extends WithEventBus implements ICollaboration
   @Autowired(IEditorDocumentModelService)
   private docModelManager: IEditorDocumentModelService;
 
+  @Autowired(IFileServiceClient)
+  protected readonly fileServiceClient: IFileServiceClient;
+
   @Autowired(AppConfig)
   private appConfig: AppConfig;
 
@@ -74,6 +78,8 @@ export class CollaborationService extends WithEventBus implements ICollaboration
   private yMapReadyMap: Map<string, Deferred<void>> = new Map();
 
   private bindingReadyMap: Map<string, Deferred<void>> = new Map();
+
+  protected readonly toDisposableCollection: DisposableCollection = new DisposableCollection();
 
   private yMapObserver = (event: YMapEvent<YText>) => {
     const changes = event.changes.keys;
@@ -131,6 +137,14 @@ export class CollaborationService extends WithEventBus implements ICollaboration
     this.yWebSocketProvider.awareness.on('update', this.updateCSSManagerWhenAwarenessUpdated);
   }
 
+  initFileWatch() {
+    this.toDisposableCollection.push(
+      this.fileServiceClient.onFilesChanged((e) => {
+        this.handleFileChange(e);
+      }),
+    );
+  }
+
   destroy() {
     this.yWebSocketProvider.awareness.off('update', this.updateCSSManagerWhenAwarenessUpdated);
     this.clientIDStyleAddedSet.forEach((clientID) => {
@@ -141,6 +155,7 @@ export class CollaborationService extends WithEventBus implements ICollaboration
     this.yTextMap.unobserve(this.yMapObserver);
     this.yWebSocketProvider.disconnect();
     this.bindingMap.forEach((binding) => binding.destroy());
+    this.toDisposableCollection.dispose();
   }
 
   registerContribution(contribution: CollaborationModuleContribution) {
@@ -265,6 +280,16 @@ export class CollaborationService extends WithEventBus implements ICollaboration
       });
     }
   };
+
+  private handleFileChange(e: FileChangeEvent) {
+    e.forEach((change) => {
+      // 只有从文件系统更新，并且窗口未打开情况，才重置 yTextMap
+      if (change.type === FileChangeType.UPDATED && !this.bindingMap.get(change.uri) && this.yTextMap.get(change.uri)) {
+        this.yTextMap.delete(change.uri);
+        this.resetDeferredYMapKey(change.uri);
+      }
+    });
+  }
 
   @OnEvent(EditorDocumentModelCreationEvent)
   private async editorDocumentModelCreationHandler(e: EditorDocumentModelCreationEvent) {

--- a/packages/collaboration/src/common/types.ts
+++ b/packages/collaboration/src/common/types.ts
@@ -8,6 +8,7 @@ export const ICollaborationService = Symbol('ICollaborationService');
 
 export interface ICollaborationService {
   initialize(): void;
+  initFileWatch(): void;
   destroy(): void;
   undoOnFocusedTextModel(): void;
   redoOnFocusedTextModel(): void;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

https://github.com/opensumi/core/issues/2238

问题原因是在打开文件时，协同模块会根据 yTextMap 内容更新文档，文件窗口关闭后通过其他方式直接修改文件后，yTextMap 内容未更新，导致打开文件时，依然是上次关闭的内容
