### PR TITLE
fix: unregister default monaco keybindings

### DIFF
--- a/packages/components/src/dropdown/dropdown.tsx
+++ b/packages/components/src/dropdown/dropdown.tsx
@@ -1,6 +1,6 @@
 import RightOutlined from '@ant-design/icons/RightOutlined';
 import classNames from 'classnames';
-import RcDropdown from 'rc-dropdown';
+import RCDropdown from 'rc-dropdown';
 import React from 'react';
 
 import { tuple } from '../utils/type';
@@ -124,7 +124,7 @@ export default class Dropdown extends React.Component<DropDownProps, any> {
     }
 
     return (
-      <RcDropdown
+      <RCDropdown
         alignPoint={alignPoint}
         {...this.props}
         prefixCls={prefixCls}
@@ -134,7 +134,7 @@ export default class Dropdown extends React.Component<DropDownProps, any> {
         overlay={() => this.renderOverlay(prefixCls)}
       >
         {dropdownTrigger}
-      </RcDropdown>
+      </RCDropdown>
     );
   };
 

--- a/packages/core-browser/__tests__/external-preference.test.ts
+++ b/packages/core-browser/__tests__/external-preference.test.ts
@@ -1,3 +1,5 @@
+import { LOCALE_TYPES } from '@opensumi/ide-i18n/lib/common/types';
+
 import { IPreferences } from '../src';
 import {
   registerExternalPreferenceProvider,
@@ -83,7 +85,7 @@ describe('external preference tests', () => {
     // 传入默认配置的情况下，如果可以通过 `getExternalPreference` 获取配置值，优先采用获取到的配置值
     expect(
       getPreferenceLanguageId({
-        'general.language': 'en-US',
+        'general.language': LOCALE_TYPES.EN_US,
       } as IPreferences),
     ).toBe(unique_languageId);
 

--- a/packages/core-browser/__tests__/external-preference.test.ts
+++ b/packages/core-browser/__tests__/external-preference.test.ts
@@ -1,4 +1,4 @@
-import { LOCALE_TYPES } from '@opensumi/ide-i18n/lib/common/types';
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
 
 import { IPreferences } from '../src';
 import {

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -44,7 +44,6 @@ import {
   DEFAULT_URI_SCHEME,
 } from '@opensumi/ide-core-common/lib/const/application';
 import { IElectronMainLifeCycleService } from '@opensumi/ide-core-common/lib/electron';
-import { LocaleType, setLocale } from '@opensumi/ide-monaco/lib/browser/monaco-localize';
 
 import { createElectronClientConnection } from '..';
 import { ClientAppStateService } from '../application';

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -6,7 +6,7 @@ import {
   GeneralSettingsId,
   PreferenceSchema,
 } from '@opensumi/ide-core-common';
-import { LOCALE_TYPES } from '@opensumi/ide-i18n/lib/common/types';
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
 
 import { createPreferenceProxy, PreferenceProxy, PreferenceService } from './preferences';
 

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -41,7 +41,7 @@ export const corePreferenceSchema: PreferenceSchema = {
     'general.language': {
       type: 'string',
       enum: getAvailableLanguages().map((l) => l.languageId),
-      default: 'zh-CN',
+      default: 'en-US',
     },
     'general.theme': {
       type: 'string',

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -6,6 +6,7 @@ import {
   GeneralSettingsId,
   PreferenceSchema,
 } from '@opensumi/ide-core-common';
+import { LOCALE_TYPES } from '@opensumi/ide-i18n/lib/common/types';
 
 import { createPreferenceProxy, PreferenceProxy, PreferenceService } from './preferences';
 
@@ -41,7 +42,7 @@ export const corePreferenceSchema: PreferenceSchema = {
     'general.language': {
       type: 'string',
       enum: getAvailableLanguages().map((l) => l.languageId),
-      default: 'en-US',
+      default: LOCALE_TYPES.EN_US,
     },
     'general.theme': {
       type: 'string',

--- a/packages/core-common/src/const/index.ts
+++ b/packages/core-common/src/const/index.ts
@@ -1,1 +1,2 @@
 export * from './application';
+export * from './locale-types';

--- a/packages/core-common/src/const/locale-types.ts
+++ b/packages/core-common/src/const/locale-types.ts
@@ -1,0 +1,6 @@
+export type LocaleType = 'en-US' | 'zh-CN';
+
+export const LOCALE_TYPES = {
+  EN_US: 'en-US' as LocaleType,
+  ZH_CN: 'zh-CN' as LocaleType,
+};

--- a/packages/debug/src/browser/view/console/debug-console.contribution.ts
+++ b/packages/debug/src/browser/view/console/debug-console.contribution.ts
@@ -173,7 +173,6 @@ export class DebugConsoleContribution
       command: DEBUG_COMMANDS.CONSOLE_FILTER_FOCUS.id,
       keybinding: 'ctrlcmd+f',
       when: `${CONTEXT_IN_DEBUG_REPL.raw}`,
-      priority: Number.MAX_SAFE_INTEGER,
     });
   }
 }

--- a/packages/extension/src/browser/extension.ts
+++ b/packages/extension/src/browser/extension.ts
@@ -9,6 +9,7 @@ import {
   Deferred,
   URI,
 } from '@opensumi/ide-core-browser';
+import { LOCALE_TYPES } from '@opensumi/ide-i18n/lib/common/types';
 import { StaticResourceService } from '@opensumi/ide-static-resource/lib/browser';
 
 import {
@@ -167,7 +168,7 @@ export class Extension extends WithEventBus implements IExtension {
         registerLocalizationBundle(
           {
             languageId: 'default',
-            languageName: 'en-US',
+            languageName: LOCALE_TYPES.EN_US,
             localizedLanguageName: 'English',
             contents: this.defaultPkgNlsJSON as any,
           },

--- a/packages/extension/src/browser/extension.ts
+++ b/packages/extension/src/browser/extension.ts
@@ -9,7 +9,7 @@ import {
   Deferred,
   URI,
 } from '@opensumi/ide-core-browser';
-import { LOCALE_TYPES } from '@opensumi/ide-i18n/lib/common/types';
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
 import { StaticResourceService } from '@opensumi/ide-static-resource/lib/browser';
 
 import {

--- a/packages/file-service/__tests__/node/file-service-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-service-watcher.test.ts
@@ -1,7 +1,7 @@
 import * as fse from 'fs-extra';
 import temp from 'temp';
 
-import { URI } from '@opensumi/ide-core-common';
+import { URI, isMacintosh } from '@opensumi/ide-core-common';
 import { FileUri } from '@opensumi/ide-core-node';
 
 import { createNodeInjector } from '../../../../tools/dev-tool/src/injector-helper';
@@ -17,7 +17,7 @@ jest.setTimeout(10000);
 
 let seed = 1;
 
-describe('ParceWatcher Test', () => {
+(isMacintosh ? describe.skip : describe)('ParceWatcher Test', () => {
   const track = temp.track();
   const sleepTime = 1000;
   let injector: MockInjector;
@@ -144,7 +144,7 @@ describe('ParceWatcher Test', () => {
   });
 });
 
-describe('Watch file rename/move/new', () => {
+(isMacintosh ? describe.skip : describe)('Watch file rename/move/new', () => {
   jest.setTimeout(10000);
 
   const track = temp.track();

--- a/packages/file-service/__tests__/node/file-service-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-service-watcher.test.ts
@@ -1,10 +1,10 @@
 import * as fse from 'fs-extra';
 import temp from 'temp';
 
-import { URI, isMacintosh } from '@opensumi/ide-core-common';
+import { URI } from '@opensumi/ide-core-common';
 import { FileUri } from '@opensumi/ide-core-node';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
+import { createNodeInjector } from '../../../../tools/dev-tool/src/injector-helper';
 import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 import { DidFilesChangedParams, FileChangeType } from '../../src/common';
 import { FileSystemWatcherServer } from '../../src/node/file-service-watcher';
@@ -13,20 +13,21 @@ function sleep(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time));
 }
 
+jest.setTimeout(10000);
+
 let seed = 1;
 
-(isMacintosh ? describe.skip : describe)('ParceWatcher Test', () => {
+describe('ParceWatcher Test', () => {
   const track = temp.track();
-  const sleepTime = 500;
+  const sleepTime = 1000;
   let injector: MockInjector;
   let root: URI;
   let watcherServer: FileSystemWatcherServer;
   let watcherId: number;
-  jest.setTimeout(10000);
 
   beforeEach(async () => {
-    injector = createBrowserInjector([]);
-    root = FileUri.create(await temp.mkdir('node-fs-root'));
+    injector = createNodeInjector([]);
+    root = FileUri.create(fse.realpathSync(await temp.mkdir('parce-watcher-test')));
     // @ts-ignore
     injector.mock(FileSystemWatcherServer, 'isEnableNSFW', () => false);
     watcherServer = injector.get(FileSystemWatcherServer);
@@ -143,17 +144,18 @@ let seed = 1;
   });
 });
 
-(isMacintosh ? describe.skip : describe)('Watch file rename/move/new', () => {
+describe('Watch file rename/move/new', () => {
+  jest.setTimeout(10000);
+
   const track = temp.track();
-  const sleepTime = 500;
+  const sleepTime = 1000;
   let root: URI;
   let watcherServer: FileSystemWatcherServer;
   let injector: MockInjector;
-  jest.setTimeout(10000);
 
   beforeEach(async () => {
-    injector = createBrowserInjector([]);
-    root = FileUri.create(fse.realpathSync(temp.mkdirSync('node-fs-root')));
+    injector = createNodeInjector([]);
+    root = FileUri.create(fse.realpathSync(temp.mkdirSync('nsfw-test')));
     fse.mkdirpSync(FileUri.fsPath(root.resolve('for_rename_folder')));
     fse.writeFileSync(FileUri.fsPath(root.resolve('for_rename')), 'rename');
     // @ts-ignore

--- a/packages/i18n/__tests__/dataValidity.test.ts
+++ b/packages/i18n/__tests__/dataValidity.test.ts
@@ -1,4 +1,6 @@
-const languages = ['en-US', 'zh-CN'];
+import { LOCALE_TYPES, LocaleType } from '@opensumi/ide-core-common/lib/const';
+
+const languages = [LOCALE_TYPES.EN_US, LOCALE_TYPES.ZH_CN];
 
 describe.skip('check data validity', () => {
   const i18nMap = new Map<string, Record<string, string>>();
@@ -14,7 +16,7 @@ describe.skip('check data validity', () => {
     const thisLength = Object.keys(data).length;
     if (thisLength > maxNumber) {
       maxNumber = thisLength;
-      maxLengthKey = key;
+      maxLengthKey = key as LocaleType;
     }
   }
 

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1,7 +1,8 @@
 import { browserViews } from './contributes/en-US.lang';
+import { LOCALE_TYPES } from './types';
 
 export const localizationBundle = {
-  languageId: 'en-US',
+  languageId: LOCALE_TYPES.EN_US,
   languageName: 'english',
   localizedLanguageName: 'English',
   contents: {

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1,5 +1,6 @@
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
+
 import { browserViews } from './contributes/en-US.lang';
-import { LOCALE_TYPES } from './types';
 
 export const localizationBundle = {
   languageId: LOCALE_TYPES.EN_US,

--- a/packages/i18n/src/common/types.ts
+++ b/packages/i18n/src/common/types.ts
@@ -1,0 +1,4 @@
+export const LOCALE_TYPES = {
+  EN_US: 'en-US',
+  ZH_CN: 'zh-CN',
+};

--- a/packages/i18n/src/common/types.ts
+++ b/packages/i18n/src/common/types.ts
@@ -1,4 +1,0 @@
-export const LOCALE_TYPES = {
-  EN_US: 'en-US',
-  ZH_CN: 'zh-CN',
-};

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1,5 +1,6 @@
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
+
 import { browserViews } from './contributes/zh-CN.lang';
-import { LOCALE_TYPES } from './types';
 
 export const localizationBundle = {
   languageId: LOCALE_TYPES.ZH_CN,

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1,7 +1,8 @@
 import { browserViews } from './contributes/zh-CN.lang';
+import { LOCALE_TYPES } from './types';
 
 export const localizationBundle = {
-  languageId: 'zh-CN',
+  languageId: LOCALE_TYPES.ZH_CN,
   languageName: 'Chinese',
   localizedLanguageName: '中文(中国)',
   contents: {

--- a/packages/startup/entry/sample-modules/editor-empty-component.contribution.tsx
+++ b/packages/startup/entry/sample-modules/editor-empty-component.contribution.tsx
@@ -13,6 +13,7 @@ import {
 import { KeybindingRegistry } from '@opensumi/ide-core-browser/lib/keybinding/keybinding';
 import { useInjectable } from '@opensumi/ide-core-browser/lib/react-hooks';
 import { localize, registerLocalizationBundle } from '@opensumi/ide-core-common';
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
 import { IKeymapService } from '@opensumi/ide-keymaps/lib/common/keymaps';
 import { KeybindingView } from '@opensumi/ide-quick-open/lib/browser/components/keybinding';
 
@@ -21,7 +22,7 @@ import styles from './editor-empty-component.module.less';
 // 集成侧自定义多语言
 export const localizationBundle = {
   'zh-CN': {
-    languageId: 'zh-CN',
+    languageId: LOCALE_TYPES.ZH_CN,
     languageName: 'Chinese',
     localizedLanguageName: '中文(中国)',
     contents: {
@@ -32,7 +33,7 @@ export const localizationBundle = {
     },
   },
   'en-US': {
-    languageId: 'en-US',
+    languageId: LOCALE_TYPES.EN_US,
     languageName: 'English',
     localizedLanguageName: 'English',
     contents: {
@@ -43,8 +44,8 @@ export const localizationBundle = {
     },
   },
 };
-registerLocalizationBundle(localizationBundle['zh-CN']);
-registerLocalizationBundle(localizationBundle['en-US']);
+registerLocalizationBundle(localizationBundle[LOCALE_TYPES.ZH_CN]);
+registerLocalizationBundle(localizationBundle[LOCALE_TYPES.EN_US]);
 
 /**
  * 单行快捷键信息

--- a/packages/startup/entry/web-lite/app.tsx
+++ b/packages/startup/entry/web-lite/app.tsx
@@ -2,6 +2,7 @@ import '@opensumi/ide-i18n/lib/browser';
 import * as React from 'react';
 
 import { SlotLocation } from '@opensumi/ide-core-browser';
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
 
 import { SampleModule } from '../sample-modules';
 
@@ -53,7 +54,7 @@ renderApp({
     'editor.quickSuggestionsDelay': 100,
     'editor.quickSuggestionsMaxCount': 50,
     'editor.scrollBeyondLastLine': false,
-    'general.language': 'en-US',
+    'general.language': LOCALE_TYPES.EN_US,
   },
   workspaceDir: '/test',
   extraContextProvider: (props) => (

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,3 +1,10 @@
+// eslint-disable-next-line import/order
+import { setLocale } from '@opensumi/ide-monaco/lib/browser/monaco-localize';
+// 请注意，集成方在这里需要自己传一个正确的 locale 进去
+// FIXME: 如果不传则首次访问默认为 'zh-CN' 语言，后续才会根据 PreferenceScope 的优先级从 LocalStorage 取值
+// 见 https://github.com/opensumi/monaco-editor-core/blob/478a796f4a04fe3a436d3e30c39e1693d3e7d686/src/vs/nls.mock.ts#L37
+setLocale('en-US');
+
 import '@opensumi/ide-i18n';
 import '@opensumi/ide-core-browser/lib/style/index.less';
 import { SlotLocation } from '@opensumi/ide-core-browser';

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,4 +1,7 @@
-const defaultLanguage = 'en-US';
+// eslint-disable-next-line import/order
+import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
+
+const defaultLanguage = LOCALE_TYPES.EN_US;
 // eslint-disable-next-line import/order
 import { setLocale } from '@opensumi/ide-monaco/lib/browser/monaco-localize';
 // 请注意，集成方在这里需要自己传一个正确的 locale 进去

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,9 +1,9 @@
+const defaultLanguage = 'en-US';
 // eslint-disable-next-line import/order
 import { setLocale } from '@opensumi/ide-monaco/lib/browser/monaco-localize';
 // 请注意，集成方在这里需要自己传一个正确的 locale 进去
-// FIXME: 如果不传则首次访问默认为 'zh-CN' 语言，后续才会根据 PreferenceScope 的优先级从 LocalStorage 取值
-// 见 https://github.com/opensumi/monaco-editor-core/blob/478a796f4a04fe3a436d3e30c39e1693d3e7d686/src/vs/nls.mock.ts#L37
-setLocale('en-US');
+// 如果不传则默认会根据 PreferenceScope 的优先级从 LocalStorage 取值
+setLocale(defaultLanguage);
 
 import '@opensumi/ide-i18n';
 import '@opensumi/ide-core-browser/lib/style/index.less';
@@ -37,7 +37,7 @@ renderApp({
   useCdnIcon: true,
   useExperimentalShadowDom: true,
   defaultPreferences: {
-    'general.language': 'en-US',
+    'general.language': defaultLanguage,
     'general.theme': 'opensumi-dark',
     'general.icon': 'vscode-icons',
     'application.confirmExit': 'never',

--- a/tools/dev-tool/src/injector-helper.ts
+++ b/tools/dev-tool/src/injector-helper.ts
@@ -1,7 +1,8 @@
 import { Injector, Injectable } from '@opensumi/di';
-import { IContextKeyService, RecentFilesManager } from '@opensumi/ide-core-browser';
 import { ClientApp } from '@opensumi/ide-core-browser/lib/bootstrap/app';
 import { BrowserModule } from '@opensumi/ide-core-browser/lib/browser-module';
+import { IContextKeyService } from '@opensumi/ide-core-browser/lib/context-key';
+import { RecentFilesManager } from '@opensumi/ide-core-browser/lib/quick-open';
 import {
   CommonServerPath,
   ConstructorOf,

--- a/tools/dev-tool/src/mock-injector.ts
+++ b/tools/dev-tool/src/mock-injector.ts
@@ -1,4 +1,4 @@
-import { Injector, Token, TokenResult, InstanceOpts, ConstructorOf, CreatorStatus, Provider } from '@opensumi/di';
+import { Injector, Token, TokenResult, InstanceOpts, ConstructorOf, CreatorStatus } from '@opensumi/di';
 import { CommandRegistry } from '@opensumi/ide-core-common';
 
 export class MockInjector extends Injector {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原有 KeybindingRegistry 实例存在问题，同时修改卸载 Monaco 默认快捷键的逻辑

### Changelog

unregister default monaco keybindings