### PR TITLE
fix: quick open hightlight label whitespace

### DIFF
--- a/packages/quick-open/src/browser/components/highlight-label/index.tsx
+++ b/packages/quick-open/src/browser/components/highlight-label/index.tsx
@@ -6,9 +6,10 @@ import { strings } from '@opensumi/ide-core-common';
 
 const { escape } = strings;
 
-const labelWithIcons = (str: string) => parseLabel(escape(str)).reduce((pre: string | LabelPart, cur: LabelPart) => {
+const labelWithIcons = (str: string, iconClassName?: string) =>
+  parseLabel(escape(str)).reduce((pre: string | LabelPart, cur: LabelPart) => {
     if (!(typeof cur === 'string') && LabelIcon.is(cur)) {
-      return pre + `<span class='${getExternalIcon(cur.name)}'></span>`;
+      return pre + `<span class='${getExternalIcon(cur.name)} ${iconClassName || ''}'></span>`;
     }
     return pre + cur;
   }, '');
@@ -18,6 +19,7 @@ export interface HighlightLabelProp {
   highlights?: Highlight[];
   className?: string;
   labelClassName?: string;
+  labelIconClassName?: string;
   hightLightClassName?: string;
   OutElementType?: string;
 }
@@ -27,6 +29,7 @@ export const HighlightLabel: React.FC<HighlightLabelProp> = ({
   highlights = [],
   className = '',
   labelClassName = '',
+  labelIconClassName = '',
   hightLightClassName = '',
   OutElementType = 'span',
 }) => {
@@ -40,17 +43,17 @@ export const HighlightLabel: React.FC<HighlightLabelProp> = ({
       }
       if (pos < highlight.start) {
         const substring = text.substring(pos, highlight.start);
-        children.push(`<span class='${labelClassName}'>${labelWithIcons(substring)}</span>`);
+        children.push(`<span class='${labelClassName}'>${labelWithIcons(substring, labelIconClassName)}</span>`);
         pos = highlight.end;
       }
       const substring = text.substring(highlight.start, highlight.end);
-      children.push(`<span class='${hightLightClassName}'>${labelWithIcons(substring)}</span>`);
+      children.push(`<span class='${hightLightClassName}'>${labelWithIcons(substring, labelIconClassName)}</span>`);
       pos = highlight.end;
     }
 
     if (pos < text.length) {
       const substring = text.substring(pos);
-      children.push(`<span class='${labelClassName}'>${labelWithIcons(substring)}</span>`);
+      children.push(`<span class='${labelClassName}'>${labelWithIcons(substring, labelIconClassName)}</span>`);
     }
     return children.join('');
   }, [text, highlights]);

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -257,7 +257,6 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           {iconClass && <span className={clx(styles.item_icon, iconClass)}></span>}
           <HighlightLabel
             className={styles.item_label_name}
-            labelClassName={styles.label_icon_container}
             hightLightClassName={clx(styles.item_label_highlight)}
             text={label}
             highlights={labelHighlights}
@@ -266,6 +265,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
             <HighlightLabel
               className={styles.item_label_description}
               labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
+              labelIconClassName={styles.label_has_icon}
               hightLightClassName={clx(styles.item_label_description_highlight)}
               text={description}
               highlights={descriptionHighlights}
@@ -277,6 +277,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
             OutElementType='div'
             className={styles.item_label_detail}
             labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
+            labelIconClassName={styles.label_has_icon}
             hightLightClassName={clx(styles.item_label_description_highlight)}
             text={detail}
             highlights={detailHighlights}

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -155,6 +155,7 @@
   .label_icon_container {
     display: flex;
     align-items: center;
+    white-space: pre;
   }
 
   .input {

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -86,7 +86,7 @@
 
   .item_icon {
     align-self: center;
-    margin-right: 8px;
+    margin-right: 6px;
   }
 
   .item_label_highlight {
@@ -110,8 +110,11 @@
 
   .item_label_name,
   .item_label_description,
-  .item_label_detail {
+  .item_label_detail,
+  .item_label_description_label,
+  .item_label_description_highlight {
     display: flex;
+    white-space: pre;
   }
 
   .item_label_description_label {
@@ -155,7 +158,10 @@
   .label_icon_container {
     display: flex;
     align-items: center;
-    white-space: pre;
+  }
+
+  .label_has_icon {
+    vertical-align: middle;
   }
 
   .input {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before:
![image](https://user-images.githubusercontent.com/20262815/218014409-59ceff0e-91fc-4807-a4ab-eac34dd02e62.png)

after:
![image](https://user-images.githubusercontent.com/20262815/218014487-075aee55-757a-48e4-ba79-aee4c846dcda.png)

多 item label 节点
![image](https://user-images.githubusercontent.com/20262815/218023025-8a091758-02c9-49dd-a9f4-ed923e2b17ed.png)

带 icon 图标时
![image](https://user-images.githubusercontent.com/20262815/218023130-e73e25e6-e20b-4318-a856-5ded30282c97.png)

带 icon 图标且搜索结果在 description 时
![image](https://user-images.githubusercontent.com/20262815/218023298-70d661d2-4388-4fe1-a052-38bf6c413e67.png)

搜索 detail 内容时
![image](https://user-images.githubusercontent.com/20262815/218023644-ceb0b46c-478c-43ce-b1e9-837927cdf7cd.png)


### Changelog
修复 quick open 搜索高亮时的空格消失问题