### PR TITLE
chore: show extension download error

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -64,6 +64,12 @@ async function downloadExtension(url, namespace, extensionName) {
   const tmpStream = fs.createWriteStream(tmpZipFile);
   const res = await nodeFetch(url, { timeout: 100000, headers });
 
+  if (res.status !== 200) {
+    throw {
+      message: `${res.status} ${res.statusText}`,
+    };
+  }
+
   res.body.pipe(tmpStream);
   await Promise.race([awaitEvent(res.body, 'end'), awaitEvent(res.body, 'error')]);
   tmpStream.close();


### PR DESCRIPTION
### Types

- [x]  🧹 Chores

### Background or solution

before：
<img width="569" alt="image" src="https://user-images.githubusercontent.com/12130901/218026674-b292e198-1ff9-46a3-a50f-44aa1ad005a5.png">
插件市场没有对应的插件，并没有正确的错误提示

after：
![image](https://user-images.githubusercontent.com/12130901/218026874-fc4b8eaa-8abc-42cb-a9d1-d98f522b8ad6.png)


### Changelog
当下载插件失败时候将错误抛出
