### PR TITLE
fix: electron header bar default height

### DIFF
--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -22,7 +22,7 @@
   }
 
   :global .menubarWrapper {
-    background-color: var(--kt-menubar-background);
+    background-color: var(--menu-background);
   }
 
   .windowActions {

--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -1,5 +1,5 @@
 .header {
-  background: var(--menu-background) !important;
+  background: var(--menu-background);
   color: var(--titlebar-activeForeground);
   display: flex;
   align-items: center;
@@ -36,7 +36,7 @@
       padding: 0 15px;
       height: 100%;
       width: 100%;
-      display: flex !important;
+      display: flex;
       align-items: center;
 
       &:hover {

--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -1,5 +1,5 @@
 .header {
-  background: var(--menu-background);
+  background: var(--menu-background) !important;
   color: var(--titlebar-activeForeground);
   display: flex;
   align-items: center;
@@ -37,7 +37,7 @@
     padding: 0 15px;
     height: 100%;
     width: 100%;
-    display: flex;
+    display: flex !important;
     align-items: center;
 
     &:hover {

--- a/packages/electron-basic/src/browser/header/header.module.less
+++ b/packages/electron-basic/src/browser/header/header.module.less
@@ -24,38 +24,40 @@
   :global .menubarWrapper {
     background-color: var(--kt-menubar-background);
   }
-}
 
-.windowActions {
-  display: flex;
-  align-items: center;
-  -webkit-app-region: no-drag;
-  user-select: none;
-
-  > div {
-    font-size: 16px;
-    padding: 0 15px;
-    height: 100%;
-    width: 100%;
-    display: flex !important;
+  .windowActions {
+    display: flex;
     align-items: center;
+    -webkit-app-region: no-drag;
+    user-select: none;
 
-    &:hover {
-      background-color: hsla(0, 0%, 100%, 0.1);
-    }
+    > .icon {
+      font-size: 16px;
+      padding: 0 15px;
+      height: 100%;
+      width: 100%;
+      display: flex !important;
+      align-items: center;
 
-    &:hover:last-child {
-      background-color: rgba(232, 17, 35, 0.9);
-      color: white;
+      &:hover {
+        background-color: hsla(0, 0%, 100%, 0.1);
+      }
+
+      &:hover:last-child {
+        background-color: rgba(232, 17, 35, 0.9);
+        color: white;
+      }
     }
   }
 }
 
 :global(.vs) {
-  .windowActions {
-    > div:not(:last-child):hover {
-      background-color: rgba(0, 0, 0, 0.1);
-      color: #696767;
+  .header {
+    .windowActions {
+      > .icon:not(:last-child):hover {
+        background-color: rgba(0, 0, 0, 0.1);
+        color: #696767;
+      }
     }
   }
 }

--- a/packages/electron-basic/src/browser/header/header.view.tsx
+++ b/packages/electron-basic/src/browser/header/header.view.tsx
@@ -67,8 +67,14 @@ const useMaximize = () => {
   };
 };
 
-// Big Sur increases title bar height
-const isNewMacHeaderBar = () => isMacintosh && parseFloat(electronEnv.osRelease) >= 20;
+const defaultHeight = () => {
+  if (isMacintosh) {
+    // Big Sur increases title bar height
+    const isNewMacHeaderBar = parseFloat(electronEnv.osRelease) >= 20;
+    return isNewMacHeaderBar ? LAYOUT_VIEW_SIZE.BIG_SUR_TITLEBAR_HEIGHT : LAYOUT_VIEW_SIZE.TITLEBAR_HEIGHT;
+  }
+  return LAYOUT_VIEW_SIZE.MENUBAR_HEIGHT;
+};
 
 export const HeaderBarLeftComponent = () => {
   const componentRegistry: ComponentRegistry = useInjectable(ComponentRegistry);
@@ -103,7 +109,7 @@ export const HeaderBarRightComponent = () => {
     <div
       className={styles.windowActions}
       style={{
-        height: isNewMacHeaderBar() ? LAYOUT_VIEW_SIZE.BIG_SUR_TITLEBAR_HEIGHT : LAYOUT_VIEW_SIZE.TITLEBAR_HEIGHT,
+        height: defaultHeight(),
       }}
     >
       <div className={getIcon('min')} onClick={() => windowService.minimize()} />
@@ -135,7 +141,7 @@ export const ElectronHeaderBar = observer(
     RightComponent,
     TitleComponent,
     autoHide = true,
-    height = isNewMacHeaderBar() ? LAYOUT_VIEW_SIZE.BIG_SUR_TITLEBAR_HEIGHT : LAYOUT_VIEW_SIZE.TITLEBAR_HEIGHT,
+    height = defaultHeight(),
   }: React.PropsWithChildren<ElectronHeaderBarPorps>) => {
     const windowService: IWindowService = useInjectable(IWindowService);
 

--- a/packages/electron-basic/src/browser/header/header.view.tsx
+++ b/packages/electron-basic/src/browser/header/header.view.tsx
@@ -1,3 +1,4 @@
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React, { useState, useEffect, useRef } from 'react';
 
@@ -112,13 +113,13 @@ export const HeaderBarRightComponent = () => {
         height: defaultHeight(),
       }}
     >
-      <div className={getIcon('min')} onClick={() => windowService.minimize()} />
+      <div className={cls(styles.icon, getIcon('min'))} onClick={() => windowService.minimize()} />
       {maximized ? (
-        <div className={getIcon('max')} onClick={() => windowService.unmaximize()} />
+        <div className={cls(styles.icon, getIcon('max'))} onClick={() => windowService.unmaximize()} />
       ) : (
-        <div className={getIcon('unmax')} onClick={() => windowService.maximize()} />
+        <div className={cls(styles.icon, getIcon('unmax'))} onClick={() => windowService.maximize()} />
       )}
-      <div className={getIcon('close1')} onClick={() => windowService.close()} />
+      <div className={cls(styles.icon, getIcon('close1'))} onClick={() => windowService.close()} />
     </div>
   );
 };


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
修复 Windows 环境 Header Bar 高度异常
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/2226423/218063823-bc0c4031-ae95-481e-95cc-481e934d7d40.png">
正常场景
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/2226423/218064186-d2a918d3-37c0-44d0-8da7-1f5f5c450edc.png">


### Changelog
修复 Windows 环境 Header Bar 高度异常