### PR TITLE
fix: title bar delete flag not update

### DIFF
--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -60,10 +60,6 @@ export class ElectronHeaderService extends WithEventBus implements IElectronHead
     this._templateVariables[key] = value;
   }
 
-  constructor() {
-    super();
-  }
-
   @OnEvent(ResourceDidUpdateEvent)
   onResourceDidUpdateEvent(e: ResourceDidUpdateEvent) {
     this.updateAppTitle();

--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -6,8 +6,10 @@ import {
   Emitter,
   DisposableCollection,
   isMacintosh,
+  WithEventBus,
+  OnEvent,
 } from '@opensumi/ide-core-browser';
-import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/browser';
+import { ResourceDidUpdateEvent, WorkbenchEditorService } from '@opensumi/ide-editor/lib/browser';
 import { basename, dirname, relative } from '@opensumi/ide-utils/lib/path';
 import { template } from '@opensumi/ide-utils/lib/strings';
 
@@ -24,7 +26,7 @@ if (isMacintosh) {
 }
 
 @Injectable()
-export class ElectronHeaderService implements IElectronHeaderService {
+export class ElectronHeaderService extends WithEventBus implements IElectronHeaderService {
   disposableCollection = new DisposableCollection();
 
   @Autowired(WorkbenchEditorService)
@@ -59,11 +61,12 @@ export class ElectronHeaderService implements IElectronHeaderService {
   }
 
   constructor() {
-    this.disposableCollection.push(
-      this.editorService.onActiveResourceChange(() => {
-        this.updateAppTitle();
-      }),
-    );
+    super();
+  }
+
+  @OnEvent(ResourceDidUpdateEvent)
+  onResourceDidUpdateEvent(e: ResourceDidUpdateEvent) {
+    this.updateAppTitle();
   }
 
   updateAppTitle() {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
close #2225

标题栏的名称在文件删除后，新建同名文件删除标记不会更新。

### Changelog
修复标题栏的文件删除标记不会更新