### PR TITLE
fix: scm badge is too large to display the problem

### DIFF
--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -188,7 +188,11 @@ export const IconTabView: React.FC<{ component: ComponentRegistryInfo }> = obser
           </span>
         </Badge>
       ) : (
-        component.options?.badge && <Badge className={styles.tab_badge}>{component.options?.badge}</Badge>
+        component.options?.badge && (
+          <Badge className={styles.tab_badge}>
+            {parseInt(component.options.badge, 10) > 99 ? '99+' : component.options.badge}
+          </Badge>
+        )
       )}
     </div>
   );
@@ -197,7 +201,11 @@ export const IconTabView: React.FC<{ component: ComponentRegistryInfo }> = obser
 export const TextTabView: React.FC<{ component: ComponentRegistryInfo }> = observer(({ component }) => (
   <div className={styles.text_tab}>
     <div className={styles.bottom_tab_title}>{component.options?.title?.toUpperCase()}</div>
-    {component.options?.badge && <Badge className={styles.tab_badge}>{component.options?.badge}</Badge>}
+    {component.options?.badge && (
+      <Badge className={styles.tab_badge}>
+        {parseInt(component.options.badge, 10) > 99 ? '99+' : component.options.badge}
+      </Badge>
+    )}
   </div>
 ));
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution
![image](https://user-images.githubusercontent.com/1762334/218430608-ac3bd87c-5ff9-4361-a1d5-5c13e5531540.png)
![image](https://user-images.githubusercontent.com/1762334/218430676-b5270705-fa21-443d-a409-fcb3127ebd8a.png)

### Changelog
修复scm的badge太长导致的展示问题
