### PR TITLE
fix: editor tag loading state

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1408,9 +1408,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
         const delayTimer = setTimeout(() => {
           this.notifyTabLoading(resource!);
         }, 60);
+        this.notifyTabChanged();
         await this.displayResourceComponent(resource, options);
         this._currentOrPreviousFocusedEditor = this.currentEditor;
-        this.notifyTabChanged();
         this.notifyBodyChanged();
 
         clearTimeout(delayTimer);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

![image](https://user-images.githubusercontent.com/17701805/218630274-00ad4e4b-8600-48c3-a177-da86f74cca74.png)

### Changelog

- 修复首次打开大文件时编辑器 tab 没有加载状态的问题