### PR TITLE
feat: support upstream control tree node render behavior

### DIFF
--- a/packages/comments/src/browser/tree/comment-node.tsx
+++ b/packages/comments/src/browser/tree/comment-node.tsx
@@ -99,7 +99,7 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
   );
 
   const renderTwice = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
-    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowExpand) {
+    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {
       return renderFolderToggle(node as CommentFileNode);
     }
   }, []);

--- a/packages/comments/src/browser/tree/comment-node.tsx
+++ b/packages/comments/src/browser/tree/comment-node.tsx
@@ -99,7 +99,7 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
   );
 
   const renderTwice = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
-    if (CommentFileNode.is(node)) {
+    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowExpand) {
       return renderFolderToggle(node as CommentFileNode);
     }
   }, []);

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -147,8 +147,8 @@ export class CommentModelService extends Disposable {
 
   handleItemClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
     this.applyFocusedDecoration(node);
-    if (CommentFileNode.is(node)) {
-      this.toggleDirectory(node);
+    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowExpand) {
+      this.toggleDirectory(node as CommentFileNode | CommentContentNode);
     }
   };
 

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -147,7 +147,7 @@ export class CommentModelService extends Disposable {
 
   handleItemClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
     this.applyFocusedDecoration(node);
-    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowExpand) {
+    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {
       this.toggleDirectory(node as CommentFileNode | CommentContentNode);
     }
   };

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -145,11 +145,10 @@ export class CommentModelService extends Disposable {
     this.removeFocusedDecoration();
   };
 
-  handleItemClick = async (ev: React.MouseEvent, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+  handleItemClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
     this.applyFocusedDecoration(node);
     if (CommentFileNode.is(node)) {
       this.toggleDirectory(node);
-    } else if (node) {
     }
   };
 

--- a/packages/comments/src/browser/tree/tree-node.defined.ts
+++ b/packages/comments/src/browser/tree/tree-node.defined.ts
@@ -76,6 +76,7 @@ export class CommentContentNode extends CompositeTreeNode {
 
   private _renderedLabel: string | React.ReactNode;
   private _renderedDescription: string | React.ReactNode;
+  private _isAllowExpand: boolean;
 
   private _onSelectHandler: (node?: CommentContentNode) => void;
 
@@ -91,10 +92,18 @@ export class CommentContentNode extends CompositeTreeNode {
   ) {
     super(tree as ITree, parent);
     this._renderedDescription = description;
+    // 评论节点默认是展开状态
+    this.isExpanded = true;
+    // 是否允许通过 toggleExpand 来展开收起，可以由上层控制，默认不允许
+    this.setIsAllowExpand(false);
   }
 
-  get expanded() {
-    return true;
+  get isAllowExpand(): boolean {
+    return this._isAllowExpand;
+  }
+
+  setIsAllowExpand(v: boolean) {
+    this._isAllowExpand = v;
   }
 
   set label(value: string | React.ReactNode) {

--- a/packages/comments/src/browser/tree/tree-node.defined.ts
+++ b/packages/comments/src/browser/tree/tree-node.defined.ts
@@ -95,7 +95,7 @@ export class CommentContentNode extends CompositeTreeNode {
     // 评论节点默认是展开状态
     this.isExpanded = true;
     // 是否允许通过 toggleExpand 来展开收起，可以由上层控制，默认不允许
-    this.setIsAllowToggle(false);
+    this._isAllowToggle = false;
   }
 
   get isAllowToggle(): boolean {

--- a/packages/comments/src/browser/tree/tree-node.defined.ts
+++ b/packages/comments/src/browser/tree/tree-node.defined.ts
@@ -76,7 +76,7 @@ export class CommentContentNode extends CompositeTreeNode {
 
   private _renderedLabel: string | React.ReactNode;
   private _renderedDescription: string | React.ReactNode;
-  private _isAllowExpand: boolean;
+  private _isAllowToggle: boolean;
 
   private _onSelectHandler: (node?: CommentContentNode) => void;
 
@@ -95,15 +95,15 @@ export class CommentContentNode extends CompositeTreeNode {
     // 评论节点默认是展开状态
     this.isExpanded = true;
     // 是否允许通过 toggleExpand 来展开收起，可以由上层控制，默认不允许
-    this.setIsAllowExpand(false);
+    this.setIsAllowToggle(false);
   }
 
-  get isAllowExpand(): boolean {
-    return this._isAllowExpand;
+  get isAllowToggle(): boolean {
+    return this._isAllowToggle;
   }
 
-  setIsAllowExpand(v: boolean) {
-    this._isAllowExpand = v;
+  setIsAllowToggle(v: boolean) {
+    this._isAllowToggle = v;
   }
 
   set label(value: string | React.ReactNode) {

--- a/packages/comments/src/common/index.ts
+++ b/packages/comments/src/common/index.ts
@@ -424,10 +424,6 @@ export interface ICommentsFeatureRegistry {
    */
   getCommentsPanelTreeNodeHandlers(): PanelTreeNodeHandler[];
   /**
-   * 获取底部面板评论树的处理函数
-   */
-  getCommentsPanelTreeNodeHandlers(): PanelTreeNodeHandler[];
-  /**
    * 获取文件上传处理函数
    */
   getFileUploadHandler(): FileUploadHandler | undefined;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

1. 将 resolveChildren 里对每个 tree 节点的处理抽离成独立函数，方便上游 override
2. CommentContentNode 增加 isAllowToggle 字段，用于判断是否允许 expand 的行为

### Changelog
支持上游集成方控制评论模块的树组件渲染行为