### PR TITLE
fix: terminal rename fix

### DIFF
--- a/packages/terminal-next/src/browser/terminal.view.ts
+++ b/packages/terminal-next/src/browser/terminal.view.ts
@@ -162,7 +162,7 @@ export class WidgetGroup extends Disposable implements IWidgetGroup {
 
   @computed
   get snapshot() {
-    return this.current?.name || this.processName || this.name;
+    return this.name || this.current?.name || this.processName || '';
   }
 
   @computed


### PR DESCRIPTION
### Types

修复终端无法重命名的问题

- [x] 🐛 Bug Fixes

<img width="371" alt="image" src="https://user-images.githubusercontent.com/12879047/219015292-05953901-9f02-4322-8982-9a06e04bc553.png">


### Background or solution
- #1707 

### Changelog
- Fix terminal rename bug #1707 
