### PR TITLE
fix: modified readonly logic of diff editor

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -676,13 +676,21 @@ export class BrowserDiffEditor extends Disposable implements IDiffEditor {
     await this.doUpdateDiffOptions();
   }
 
+  isReadonly(): boolean {
+    return !!this.modifiedDocModel?.readonly;
+  }
+
   private async doUpdateDiffOptions() {
     const uriStr = this.modifiedEditor.currentUri ? this.modifiedEditor.currentUri.toString() : undefined;
     const languageId = this.modifiedEditor.currentDocumentModel
       ? this.modifiedEditor.currentDocumentModel.languageId
       : undefined;
     const options = getConvertedMonacoOptions(this.configurationService, uriStr, languageId);
-    this.monacoDiffEditor.updateOptions({ ...options.diffOptions, ...this.specialOptions });
+    this.monacoDiffEditor.updateOptions({
+      ...options.diffOptions,
+      ...this.specialOptions,
+      readOnly: this.isReadonly(),
+    });
   }
 
   updateDiffOptions(options: Partial<monaco.editor.IDiffEditorOptions>) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

monaco diff editor 的只读逻辑是根据 modified model 的 readonly 字段决定的，原先这里的逻辑并没有覆盖到

### Changelog
修复 diff 视图下 modified model 的只读逻辑不生效的问题