### PR TITLE
fix:  add margins to the QuickOpen input

### DIFF
--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -166,7 +166,7 @@
 
   .input {
     display: flex;
-    margin: 4px 10px;
+    padding: 4px 10px;
   }
 
   .title_bar {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->
- [x] 🐛 Bug Fixes


### Background or solution
![image](https://user-images.githubusercontent.com/1762334/219533181-5214ea6d-2624-463a-8eb9-f0f4095b5af4.png)

fixed #1742

### Changelog
修复 QuickPick 面板 Input上下无间距的问题
