### PR TITLE
chore: update extension engine version to 1.68.0

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
@@ -219,7 +219,7 @@ export function createApiFactory(
     ),
     env: createEnvApiFactory(rpcProtocol, extension, extHostEnv, extHostTerminal),
     debug: createDebugApiFactory(extHostDebug),
-    version: appConfig.customVSCodeEngineVersion || '1.63.2',
+    version: appConfig.customVSCodeEngineVersion || '1.68.0',
     comments: createCommentsApiFactory(extension, extHostComments),
     extensions: createExtensionsApiFactory(extensionService),
     tasks: createTaskApiFactory(extHostTasks, extension),


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

依赖对 Notebook 的空实现，目前已经可以最近支持 ESLint 插件使用（依赖内核 1.68.0）版本，同时 `Tab API` 及 `ProductIconTheme` 能力在 1.75.0 之后版本才完全完成，建议后续直接向最终版本去做实现。

参考：

- https://github.com/microsoft/vscode/commit/60d21965c76373a784fe8042f8e6108708bbac62
- https://github.com/microsoft/vscode/commit/aa69f3d7623c464aba726d12ea0d83428f43e8b9

### Changelog

update extension engine version to 1.68.0