### PR TITLE
feat: read-only resource render lock icon

### DIFF
--- a/packages/editor/__tests__/browser/resource.test.ts
+++ b/packages/editor/__tests__/browser/resource.test.ts
@@ -122,6 +122,7 @@ describe('resource service tests', () => {
         uri: resUri,
         decoration: {
           dirty: true,
+          readOnly: true,
         },
       }),
     );
@@ -137,6 +138,7 @@ describe('resource service tests', () => {
         uri: resUri,
         decoration: {
           dirty: false,
+          readOnly: false,
         },
       }),
     );
@@ -284,6 +286,7 @@ describe('resource service tests', () => {
         uri: new URI('fileOnDisk://path/to/a.ts'),
         decoration: {
           dirty: true,
+          readOnly: false,
         },
       }),
     );

--- a/packages/editor/__tests__/browser/resource.test.ts
+++ b/packages/editor/__tests__/browser/resource.test.ts
@@ -122,7 +122,6 @@ describe('resource service tests', () => {
         uri: resUri,
         decoration: {
           dirty: true,
-          readOnly: true,
         },
       }),
     );
@@ -138,7 +137,6 @@ describe('resource service tests', () => {
         uri: resUri,
         decoration: {
           dirty: false,
-          readOnly: false,
         },
       }),
     );

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -630,6 +630,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
       new EditorDocumentModelContentChangedEvent({
         uri: this.uri,
         dirty: this.dirty,
+        readonly: this.readonly,
         changes,
         eol: this.eol,
         isRedoing,

--- a/packages/editor/src/browser/doc-model/types.ts
+++ b/packages/editor/src/browser/doc-model/types.ts
@@ -270,6 +270,7 @@ export class EditorDocumentModelContentChangedEvent extends BasicEvent<IEditorDo
 export interface IEditorDocumentModelContentChangedEventPayload {
   uri: URI;
   dirty: boolean;
+  readonly: boolean;
   changes: IEditorDocumentModelContentChange[];
   eol: string;
   versionId: number;

--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -517,6 +517,14 @@ export class BrowserCodeEditor extends BaseMonacoEditorWrapper implements ICodeE
       position: this.monacoEditor.getPosition(),
       selectionLength: 0,
     });
+
+    /**
+     * 由于通过 monaco model 并不能得到该文档是否 readonly
+     * 所以这里需要对 readonly 单独设置一下
+     */
+    this.monacoEditor.updateOptions({
+      readOnly: documentModelRef.instance.readonly,
+    });
   }
 }
 

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -241,6 +241,9 @@
           background-position: 2px;
         }
       }
+      .editor_readonly_icon {
+        margin-left: 8px;
+      }
       .kt_editor_close_icon {
         margin-right: 0 !important;
         display: flex;

--- a/packages/editor/src/browser/resource.service.ts
+++ b/packages/editor/src/browser/resource.service.ts
@@ -255,6 +255,7 @@ export class ResourceServiceImpl extends WithEventBus implements ResourceService
 
 const DefaultResourceDecoration: IResourceDecoration = {
   dirty: false,
+  readOnly: false,
 };
 
 const GhostResourceProvider: IResourceProvider = {

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -27,6 +27,7 @@ import {
   PreferenceService,
   DisposableCollection,
   Event,
+  getExternalIcon,
 } from '@opensumi/ide-core-browser';
 import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { LAYOUT_VIEW_SIZE } from '@opensumi/ide-core-browser/lib/layout/constants';
@@ -385,6 +386,9 @@ export const Tabs = ({ group }: ITabsProps) => {
             </div>
             <div>{resource.name}</div>
             {subname ? <div className={styles.subname}>{subname}</div> : null}
+            {decoration.readOnly ? (
+              <span className={classnames(getExternalIcon('lock'), styles.editor_readonly_icon)}></span>
+            ) : null}
             <div className={styles.tab_right}>
               <div
                 className={classnames({

--- a/packages/editor/src/common/resource.ts
+++ b/packages/editor/src/common/resource.ts
@@ -93,7 +93,8 @@ export class ResourceDecorationNeedChangeEvent extends BasicEvent<IResourceDecor
 export type IResourceUpdateType = 'change' | 'remove';
 
 export interface IResourceDecoration {
-  dirty: boolean;
+  dirty?: boolean;
+  readOnly?: boolean;
 }
 
 export interface IResourceDecorationChangeEventPayload {

--- a/packages/opened-editor/__tests__/browser/opened-editor.service.test.ts
+++ b/packages/opened-editor/__tests__/browser/opened-editor.service.test.ts
@@ -193,6 +193,7 @@ describe('OpenedEditorModelService should be work', () => {
           uri: testFileUri,
           decoration: {
             dirty: true,
+            readOnly: false,
           },
         }),
       );


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

code editor
![image](https://user-images.githubusercontent.com/20262815/220020249-c920a485-b2fc-4000-8d31-94f24c404c67.png)

diff editor
![image](https://user-images.githubusercontent.com/20262815/220020458-c696270b-f172-43b4-b288-44adc4dc486f.png)

### Changelog
只读文件的 tab 增加 lock 图标
