### PR TITLE
fix: customEditor display problem

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1409,9 +1409,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
           this.notifyTabLoading(resource!);
         }, 60);
         this.notifyTabChanged();
+        this.notifyBodyChanged();
         await this.displayResourceComponent(resource, options);
         this._currentOrPreviousFocusedEditor = this.currentEditor;
-        this.notifyBodyChanged();
 
         clearTimeout(delayTimer);
         resourceReady.resolve();

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -25,6 +25,7 @@ import {
   localize,
   MessageType,
   debounce,
+  CUSTOM_EDITOR_SCHEME,
 } from '@opensumi/ide-core-common';
 import {
   CommandService,
@@ -2279,8 +2280,8 @@ function findSuitableOpenType(
       if (!viewType) {
         return false;
       }
-
-      return p.componentId === viewType;
+      const componentId = `${CUSTOM_EDITOR_SCHEME}-${viewType}`;
+      return p.componentId === componentId;
     });
 
     if (matchAvailableType) {


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution
- notifyBodyChanged 提前  后面触发会导致 iframe webview 组件刷新在切换同名的customEditor时会有以下问题 

https://user-images.githubusercontent.com/31676999/220272635-e8d8b6f8-41a9-4821-8597-fd98bd1bda2a.mov


-  fix #2297
### Changelog
修复同名 customEditor 切换问题
修复 workbench.editorAssociations 贡献点失效