### PR TITLE
fix: FileTreeNode decoration color style dose not take effect

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-node.module.less
+++ b/packages/file-tree-next/src/browser/file-tree-node.module.less
@@ -7,6 +7,7 @@
   flex-direction: column;
   position: relative;
   cursor: pointer;
+  color: var(--foreground);
 
   &:hover {
     color: var(--kt-tree-hoverForeground);
@@ -150,7 +151,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: left;
-  color: var(--foreground);
+  color: inherit;
 }
 
 .file_tree_node_prompt_wrap {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

FileTreeNode css will cover decoreation style, change it priority

![image](https://user-images.githubusercontent.com/9477255/220510406-090be5e0-56ae-4b25-a1c8-c99f3355c54c.png)

### Changelog

fix: change fileTreeNode color style priority
