### PR TITLE
fix: treeview node duplicated when switching tree mode

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -331,8 +331,8 @@ export class TreeNode implements ITreeNode {
     if (this._disposed) {
       return;
     }
-    this._watcher.notifyDidDispose(this);
     this._disposed = true;
+    this._watcher.notifyDidDispose(this);
   }
 }
 

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.node.defined.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.node.defined.ts
@@ -62,7 +62,7 @@ export class ExtensionCompositeTreeNode extends CompositeTreeNode {
     expanded?: boolean,
     sourceUri?: UriComponents,
   ) {
-    super(tree, parent, undefined, { name: treeItemId });
+    super(tree, parent, undefined);
     this.isExpanded = expanded || false;
     this.sourceUri = sourceUri;
     this._command = command;
@@ -150,7 +150,7 @@ export class ExtensionTreeNode extends TreeNode {
     private _accessibilityInformation?: IAccessibilityInformation,
     private sourceUri?: UriComponents,
   ) {
-    super(tree as ITree, parent, undefined, { name: treeItemId });
+    super(tree as ITree, parent, undefined);
     if (isString(label)) {
       this._displayName = label;
     } else if (isObject(label)) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

在使用 Gitlens 12+ 版本情况下，List 及 Tree 模式下，使用的 TreeItem.id 会出现重复的路径问题，最终导致 TreeView 刷新获取到的路径存在异常问题。

这里的修复去掉了对于 TreeViewItem.id 的依赖，转而使用不等的内置 ID 进行节点创建。

### Changelog

fix treeview node duplicated when switching tree mode
