### PR TITLE
style: improve outline treenode style

### DIFF
--- a/packages/editor/src/browser/preference/contribution.ts
+++ b/packages/editor/src/browser/preference/contribution.ts
@@ -1,8 +1,8 @@
-import { PreferenceContribution, Domain, ClientAppContribution } from '@opensumi/ide-core-browser';
+import { PreferenceContribution, Domain } from '@opensumi/ide-core-browser';
 
 import { editorPreferenceSchema } from './schema';
 
-@Domain(PreferenceContribution, ClientAppContribution)
+@Domain(PreferenceContribution)
 export class EditorPreferenceContribution implements PreferenceContribution {
   schema = editorPreferenceSchema;
 }

--- a/packages/outline/src/browser/outline-node.tsx
+++ b/packages/outline/src/browser/outline-node.tsx
@@ -63,7 +63,7 @@ export const OutlineNode: React.FC<OutlineNodeRenderedProps> = ({
   };
 
   const paddingLeft = `${
-    defaultLeftPadding + (item.depth || 0) * (leftPadding || 0) + (!OutlineCompositeTreeNode.is(item) ? 16 : 0)
+    defaultLeftPadding + (item.depth || 0) * (leftPadding || 0) + (!OutlineCompositeTreeNode.is(item) ? 12 : 0)
   }px`;
 
   const editorNodeStyle = {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

close #2315.

After:
<img width="318" alt="image" src="https://user-images.githubusercontent.com/9823838/220654694-7062d2d6-ece4-4541-a69b-7bb818e9ffdb.png">

### Changelog

 improve outline treenode style
