### PR TITLE
fix: support normal prelunchTask on debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ This version we remove some useless filled icons on the framework and use outlin
 - `anymock`
 - `LinkE`
 
+#### 2. Task label format changed
+
+In order to be compatible with the use of Task commands by some extensions.
+
+The task label format change from `{0} : {1}` to `{0}: {1}`, like `npm : build` -> `npm: build`.
+
 ## v2.22.0
 
 ### What's New Features

--- a/packages/debug/src/browser/contextkeys/debug-contextkey.service.ts
+++ b/packages/debug/src/browser/contextkeys/debug-contextkey.service.ts
@@ -25,7 +25,7 @@ export class DebugContextKey {
 
   public readonly contextInDebugRepl: IContextKey<boolean>;
   public readonly contextInDebugConsole: IContextKey<boolean>;
-  public readonly contextInDdebugMode: IContextKey<boolean>;
+  public readonly contextInDebugMode: IContextKey<boolean>;
   public readonly contextDebugState: IContextKey<keyof typeof DebugState>;
   public readonly contextVariableEvaluateNamePresent: IContextKey<boolean>;
   public readonly contextSetVariableSupported: IContextKey<boolean>;
@@ -38,7 +38,7 @@ export class DebugContextKey {
     this._contextKeyService = this.globalContextKeyService.createScoped(dom);
     this.contextInDebugRepl = CONTEXT_IN_DEBUG_REPL.bind(this.contextKeyScoped);
     this.contextInDebugConsole = CONTEXT_IN_DEBUG_CONSOLE.bind(this.contextKeyScoped);
-    this.contextInDdebugMode = CONTEXT_IN_DEBUG_MODE.bind(this.contextKeyScoped);
+    this.contextInDebugMode = CONTEXT_IN_DEBUG_MODE.bind(this.contextKeyScoped);
     this.contextDebugState = CONTEXT_DEBUG_STATE.bind(this.contextKeyScoped);
     this.contextVariableEvaluateNamePresent = CONTEXT_VARIABLE_EVALUATE_NAME_PRESENT.bind(this.contextKeyScoped);
     this.contextSetVariableSupported = CONTEXT_SET_VARIABLE_SUPPORTED.bind(this.contextKeyScoped);

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -455,7 +455,7 @@ export class DebugSessionManager implements IDebugSessionManager {
       this.debugContextKey.contextSetVariableSupported.set(session.capabilities.supportsSetVariable ?? false);
       this.debugContextKey.contextRestartFrameSupported.set(session.capabilities.supportsRestartFrame ?? false);
       this.debugContextKey.contextDebugState.set(DebugState[session.state] as keyof typeof DebugState);
-      this.debugContextKey.contextInDdebugMode.set(state !== DebugState.Inactive);
+      this.debugContextKey.contextInDebugMode.set(state !== DebugState.Inactive);
     });
     session.on('terminated', (event) => {
       const restart = event.body && event.body.restart;

--- a/packages/debug/src/browser/editor/debug-editor-contribution.ts
+++ b/packages/debug/src/browser/editor/debug-editor-contribution.ts
@@ -332,7 +332,7 @@ export class DebugEditorContribution implements IEditorFeatureContribution {
     codeEditorService.registerDecorationType('inline-value-decoration', INLINE_VALUE_DECORATION_KEY, {});
   }
 
-  public setHoverEnabled(editor: IEditor, isEnabled = !this.debugContextKey.contextInDdebugMode.get()) {
+  public setHoverEnabled(editor: IEditor, isEnabled = !this.debugContextKey.contextInDebugMode.get()) {
     editor.monacoEditor.updateOptions({
       hover: {
         enabled: isEnabled,

--- a/packages/debug/src/browser/view/console/debug-console.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console.service.ts
@@ -99,24 +99,6 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
 
   public static keySet = new Set([CONTEXT_IN_DEBUG_MODE_KEY]);
 
-  constructor() {
-    this.contextKeyService.onDidChangeContext((e) => {
-      if (e.payload.affectsSome(DebugConsoleService.keySet)) {
-        const inDebugMode = this.contextKeyService.match(CONTEXT_IN_DEBUG_MODE_KEY);
-        if (inDebugMode) {
-          this.updateReadOnly(false);
-          this.updateInputDecoration();
-          this.debugContextKey.contextInDdebugMode.set(true);
-        } else {
-          this.updateReadOnly(true);
-          if (this.debugContextKey) {
-            this.debugContextKey.contextInDdebugMode.set(false);
-          }
-        }
-      }
-    });
-  }
-
   // FIXME: 需要实现新增的属性及事件
   element: HTMLElement;
   onDidFocus: Event<void>;
@@ -166,6 +148,22 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
     this.debugContextKey = this.injector.get(DebugContextKey, [
       (this.inputEditor.monacoEditor as any)._contextKeyService,
     ]);
+
+    this.contextKeyService.onDidChangeContext((e) => {
+      if (e.payload.affectsSome(DebugConsoleService.keySet)) {
+        const inDebugMode = this.contextKeyService.match(CONTEXT_IN_DEBUG_MODE_KEY);
+        if (inDebugMode) {
+          this.updateReadOnly(false);
+          this.updateInputDecoration();
+          this.debugContextKey.contextInDebugMode.set(true);
+        } else {
+          this.updateReadOnly(true);
+          if (this.debugContextKey) {
+            this.debugContextKey.contextInDebugMode.set(false);
+          }
+        }
+      }
+    });
 
     this.registerDecorationType();
     await this.createConsoleInput();

--- a/packages/debug/src/browser/view/frames/debug-call-stack-session.view.tsx
+++ b/packages/debug/src/browser/view/frames/debug-call-stack-session.view.tsx
@@ -211,7 +211,10 @@ export const DebugStackSessionView = (props: DebugStackSessionViewProps) => {
         >
           {supportsThreadIdCorrespond || threads.length > 0 ? (
             <>
-              <div className={unfold ? getIcon('down') : getIcon('right')} onClick={() => setUnfold(!unfold)}></div>
+              <div
+                className={unfold ? getIcon('arrow-down') : getIcon('arrow-right')}
+                onClick={() => setUnfold(!unfold)}
+              ></div>
               <div className={cls([getIcon('debug'), styles.debug_session_icon])}></div>
             </>
           ) : (

--- a/packages/debug/src/browser/view/frames/debug-call-stack-thread.view.tsx
+++ b/packages/debug/src/browser/view/frames/debug-call-stack-thread.view.tsx
@@ -68,7 +68,10 @@ export const DebugStackThreadView = (props: DebugStackThreadViewProps) => {
       {mutiple && (
         <div style={{ paddingLeft: `${indent}px` }} className={styles.debug_stack_item_label}>
           {thread.frames.length > 0 ? (
-            <div className={expanded ? getIcon('down') : getIcon('right')} onClick={() => setExpanded(!expanded)}></div>
+            <div
+              className={expanded ? getIcon('arrow-down') : getIcon('arrow-right')}
+              onClick={() => setExpanded(!expanded)}
+            ></div>
           ) : (
             <div style={{ width: 14 }}></div>
           )}

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1216,7 +1216,7 @@ export const localizationBundle = {
     'treeview.command.action.collapse': 'Collapse ALL',
 
     'task.outputchannel.name': 'Task',
-    'task.label': '{0} : {1}',
+    'task.label': '{0}: {1}',
     'TaskService.pickRunTask': 'Select the task to run',
     'TerminalTaskSystem.terminalName': 'Task - {0}',
     'terminal.integrated.exitedWithCode': 'The terminal process terminated with exit code: {0}',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -834,7 +834,7 @@ export const localizationBundle = {
     'treeview.command.action.collapse': '全部折叠',
 
     'task.outputchannel.name': '任务',
-    'task.label': '{0} : {1}',
+    'task.label': '{0}: {1}',
     'TaskService.pickRunTask': '选择要运行的任务',
     'TerminalTaskSystem.terminalName': '任务 - {0}',
     'terminal.integrated.exitedWithCode': '终端进程已终止，退出代码: {0}',


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #2321.

对齐 Task Label 格式，以兼容 VS Code 下可正常使用的 Task 命令声明

### Changelog

support normal prelunchTask on debug
