### PR TITLE
fix(styles): fix kticon wrong display value

### DIFF
--- a/packages/components/src/icon/iconfont/iconfont.css
+++ b/packages/components/src/icon/iconfont/iconfont.css
@@ -10,7 +10,7 @@
 
 .kaitian-icon[class*='kticon-'] {
   font: normal normal normal 16px/1 "kaitian-icon";
-  display: block;
+  display: inline-block;
   text-decoration: none;
   text-rendering: auto;
   text-align: center;

--- a/packages/core-browser/src/style/icon/index.less
+++ b/packages/core-browser/src/style/icon/index.less
@@ -31,7 +31,7 @@
 
 .kaitian-icon[class*='kticon-'] {
   font: normal normal normal 16px/1 'kaitian-icon';
-  display: block;
+  display: inline-block;
   text-decoration: none;
   text-rendering: auto;
   text-align: center;


### PR DESCRIPTION
### Types
- [x] 💄 Style Changes

### Background or solution

![image](https://user-images.githubusercontent.com/13938334/221466498-003a4cd9-c592-4e5a-9c85-96d266580c1c.png)


之前所有 kticon 加上块级元素，导致上游集成样式乱了
应该是为了底部 status icon 的展示效果改的：statusbar 上的 kticon 它不会自己根据高度垂直居中

当时参考的 codicon 的 style:
![image](https://user-images.githubusercontent.com/13938334/221466586-830b8fbd-3422-4e97-881a-711d83800bc9.png)

### Changelog

fix styles: `.kticon` wrong display value
