### PR TITLE
chore: use `SIGKILL` signal kill extension process

### DIFF
--- a/packages/extension/src/node/extension.host.manager.ts
+++ b/packages/extension/src/node/extension.host.manager.ts
@@ -45,7 +45,7 @@ export class ExtensionHostManager implements IExtensionHostManager {
   }
   treeKill(pid: number) {
     return new Promise<void>((resolve, reject) => {
-      treeKill(pid, (err) => {
+      treeKill(pid, 'SIGKILL', (err) => {
         if (err) {
           reject(err);
         } else {

--- a/packages/extension/src/node/extension.service.client.ts
+++ b/packages/extension/src/node/extension.service.client.ts
@@ -194,15 +194,16 @@ export class ExtensionServiceClientImpl
     }
 
     const languagePackJson = await this.fileService.getFileStat(languagePath);
-    await this.fileService.setContent(languagePackJson!, JSON.stringify(languagePacks));
+    if (languagePackJson) {
+      await this.fileService.setContent(languagePackJson, JSON.stringify(languagePacks));
 
-    const nlsConfig = await lp.getNLSConfiguration(
-      'f06011ac164ae4dc8e753a3fe7f9549844d15e35',
-      storagePath,
-      languageId.toLowerCase(),
-    );
-    // tslint:disable-next-line: no-string-literal
-    nlsConfig['_languagePackSupport'] = true;
-    process.env.VSCODE_NLS_CONFIG = JSON.stringify(nlsConfig);
+      const nlsConfig = await lp.getNLSConfiguration(
+        'f06011ac164ae4dc8e753a3fe7f9549844d15e35',
+        storagePath,
+        languageId.toLowerCase(),
+      );
+      nlsConfig['_languagePackSupport'] = true;
+      process.env.VSCODE_NLS_CONFIG = JSON.stringify(nlsConfig);
+    }
   }
 }


### PR DESCRIPTION
### Types

- [x] 🧹 Chores


### Background or solution

之前在处理这个 docker 中会产生僵尸进程的时候写的代码 https://github.com/opensumi/core/issues/2166

treeKill 默认发的是 SIGTERM，有些进程是不会立刻退出的。

### Changelog

use `SIGKILL` signal kill extension process