### PR TITLE
Revert "fix: use bash resolve shellpath"

### DIFF
--- a/packages/core-node/src/bootstrap/shell-path.ts
+++ b/packages/core-node/src/bootstrap/shell-path.ts
@@ -49,7 +49,7 @@ async function createUpdateShellPathPromise(): Promise<void> {
     shellPath = await new Promise((resolve, reject) => {
       const buf: Buffer[] = [];
       const proc = spawn(
-        '/bin/bash',
+        process.env.SHELL || '/bin/bash',
         ['-ilc', 'echo -n "_SHELL_ENV_DELIMITER_"; env; echo -n "_SHELL_ENV_DELIMITER_"; exit;'],
         {
           stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
Reverts opensumi/core#2021

如果用戶使用的是 zsh 比如 .zshrc 配置的內容，使用 /bin/bash 将会丢失相关的 PATH 信息。