### PR TITLE
fix: improve context menu content fontsize

### DIFF
--- a/packages/core-browser/src/components/actions/styles.module.less
+++ b/packages/core-browser/src/components/actions/styles.module.less
@@ -1,3 +1,4 @@
+@import '~@opensumi/ide-core-browser/lib/style/variable.less';
 .icon,
 .submenuIcon {
   width: 12px;
@@ -52,6 +53,9 @@
     .shortcut {
       color: var(--menu-selectionForeground);
     }
+  }
+  .label {
+    font-size: @base-font-size;
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
文件树的文字大小是13px，右键菜单默认是14px，修改成跟菜单一样的变量
![image](https://user-images.githubusercontent.com/1762334/222080349-5d2f9f93-7b7d-4bb8-af3a-1b3c4b1bf234.png)

### Changelog
右键文件树菜单的字体太大
