### PR TITLE
fix: title bar not change with the file

### DIFF
--- a/packages/electron-basic/src/browser/header/header.service.ts
+++ b/packages/electron-basic/src/browser/header/header.service.ts
@@ -60,6 +60,15 @@ export class ElectronHeaderService extends WithEventBus implements IElectronHead
     this._templateVariables[key] = value;
   }
 
+  constructor() {
+    super();
+    this.disposableCollection.push(
+      this.editorService.onActiveResourceChange(() => {
+        this.updateAppTitle();
+      }),
+    );
+  }
+
   @OnEvent(ResourceDidUpdateEvent)
   onResourceDidUpdateEvent(e: ResourceDidUpdateEvent) {
     this.updateAppTitle();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
Electron 中的 title bar 不会随着文件的切换变更改变文件名称。

### Changelog
修复 Electron 标题栏文件名称没有自动切换的问题
