### PR TITLE
style: fix default treenode overflow style

### DIFF
--- a/packages/components/src/recycle-tree/RecycleTree.tsx
+++ b/packages/components/src/recycle-tree/RecycleTree.tsx
@@ -864,7 +864,7 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
   };
 
   private renderItem = ({ index, style }): JSX.Element => {
-    const { children, overflow, supportDynamicHeights } = this.props;
+    const { children, overflow = 'ellipsis', supportDynamicHeights } = this.props;
     const node = this.getItemAtIndex(index) as IFilterNodeRendererProps;
     const wrapRef = createRef<HTMLDivElement>();
     if (!node) {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

这里代码误删导致默认值失效 https://github.com/opensumi/core/pull/2339/files#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L868

### Changelog

fix default treenode overflow style
