### PR TITLE
fix: search tree height not change reactively

### DIFF
--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -102,7 +102,7 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
 
   useEffect(() => {
     setOffsetTop((searchOptionRef.current && searchOptionRef.current.clientHeight) || 0);
-  }, [offsetTop, searchOptionRef.current, searchContent, searchBrowserService]);
+  }, [offsetTop, searchOptionRef.current, searchContent, searchBrowserService, UIState.isDetailOpen]);
 
   const collapsePanelContainerStyle = {
     width: viewState.width || '100%',


### PR DESCRIPTION
### Types

修复了在展开「显示搜索条件」后搜索，然后关闭展示搜索条件之后，展示搜索结果的RecycleTree高度不会自适应变化的BUG。

- [x] 🐛 Bug Fixes

### Background or solution
- search tree height not change reactively

### Changelog
- fix: search tree height not change reactively
