### PR TITLE
fix: get correctly fsPath on Windows findFiles

### DIFF
--- a/packages/addons/src/browser/file-search.contribution.ts
+++ b/packages/addons/src/browser/file-search.contribution.ts
@@ -356,15 +356,7 @@ export class FileSearchQuickCommandHandler {
 
   protected async getQueryFiles(fileQuery: string, alreadyCollected: Set<string>, token: CancellationToken) {
     const roots = await this.workspaceService.roots;
-    const rootUris: string[] = [];
-    roots.forEach((stat) => {
-      const uri = new URI(stat.uri);
-      if (uri.scheme !== Schemes.file) {
-        return;
-      }
-      this.logger.debug('file-search.contribution rootUri', uri.toString());
-      return rootUris.push(uri.toString());
-    });
+    const rootUris: string[] = roots.map((stat) => stat.uri);
     const files = await this.fileSearchService.find(
       fileQuery,
       {

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -72,8 +72,7 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
       limit: maxResult,
       includePatterns: [includePattern],
     };
-    const result = await this.fileSearchService.find('', fileSearchOptions);
-
+    const result = await this.fileSearchService.find('', fileSearchOptions, token);
     return result;
   }
 

--- a/packages/extension/src/hosted/api/vscode/ext.host.workspace.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.workspace.ts
@@ -458,6 +458,6 @@ export class ExtHostWorkspace implements IExtHostWorkspace {
         maxResults,
         token,
       )
-      .then((files) => files.map((file) => Uri.parse(file)));
+      .then((files) => files.map((file) => Uri.file(file)));
   }
 }

--- a/packages/file-search/__tests__/node/file-search.service.test.ts
+++ b/packages/file-search/__tests__/node/file-search.service.test.ts
@@ -23,7 +23,7 @@ describe('search-service', () => {
   const service = injector.get(IFileSearchService);
 
   it('shall fuzzy search this spec file', async () => {
-    const rootUri = FileUri.create(path.resolve(__dirname, './')).toString();
+    const rootUri = path.resolve(__dirname, './');
     const matches = await service.find('test', { rootUris: [rootUri] });
     const expectedFile = FileUri.create(__filename).displayName;
     const testFile = matches.find((e) => e.endsWith(expectedFile));
@@ -31,7 +31,7 @@ describe('search-service', () => {
   });
 
   it.skip('shall respect nested .gitignore', async () => {
-    const rootUri = FileUri.create(path.resolve(__dirname, '../test-resources')).toString();
+    const rootUri = path.resolve(__dirname, '../test-resources');
     const matches = await service.find('foo', { rootUris: [rootUri], fuzzyMatch: false });
 
     expect(matches.find((match) => match.endsWith('subdir1/sub-bar/foo.txt'))).toBeUndefined();
@@ -40,7 +40,7 @@ describe('search-service', () => {
   });
 
   it('shall cancel searches', async () => {
-    const rootUri = FileUri.create(path.resolve(__dirname, '../../../../..')).toString();
+    const rootUri = path.resolve(__dirname, '../../../../..');
     const cancelTokenSource = new CancellationTokenSource();
     cancelTokenSource.cancel();
     const matches = await service.find('foo', { rootUris: [rootUri], fuzzyMatch: false }, cancelTokenSource.token);
@@ -49,8 +49,8 @@ describe('search-service', () => {
   });
 
   it('should perform file search across all folders in the workspace', async () => {
-    const dirA = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1/sub-bar')).toString();
-    const dirB = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1/sub2')).toString();
+    const dirA = path.resolve(__dirname, '../test-resources/subdir1/sub-bar');
+    const dirB = path.resolve(__dirname, '../test-resources/subdir1/sub2');
 
     const matches = await service.find('foo', { rootUris: [dirA, dirB] });
     expect(matches).toBeDefined();
@@ -58,7 +58,7 @@ describe('search-service', () => {
   });
 
   it('search hidden file in the workspace', async () => {
-    const dir = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1')).toString();
+    const dir = path.resolve(__dirname, '../test-resources/subdir1');
 
     const matches = await service.find('.sumi', { rootUris: [dir] });
     expect(matches).toBeDefined();
@@ -67,7 +67,7 @@ describe('search-service', () => {
 
   describe('search with glob', () => {
     it('should support file searches with globs', async () => {
-      const rootUri = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1/sub2')).toString();
+      const rootUri = path.resolve(__dirname, '../test-resources/subdir1/sub2');
 
       const matches = await service.find('', { rootUris: [rootUri], includePatterns: ['**/*oo.*'] });
       expect(matches).toBeDefined();
@@ -75,7 +75,7 @@ describe('search-service', () => {
     });
 
     it('should NOT support file searches with globs without the prefixed or trailing star (*)', async () => {
-      const rootUri = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1/sub2')).toString();
+      const rootUri = path.resolve(__dirname, '../test-resources/subdir1/sub2');
 
       const trailingMatches = await service.find('', { rootUris: [rootUri], includePatterns: ['*oo'] });
       expect(trailingMatches).toBeDefined();
@@ -89,7 +89,7 @@ describe('search-service', () => {
 
   describe('search with ignored patterns', () => {
     it('should NOT ignore strings passed through the search options', async () => {
-      const rootUri = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1/sub2')).toString();
+      const rootUri = path.resolve(__dirname, '../test-resources/subdir1/sub2');
 
       const matches = await service.find('', {
         rootUris: [rootUri],
@@ -154,7 +154,7 @@ describe('search-service', () => {
   });
 
   describe('irrelevant absolute results', () => {
-    const rootUri = FileUri.create(path.resolve(__dirname, '../test-resources/subdir1/'));
+    const rootUri = path.resolve(__dirname, '../test-resources/subdir1/');
     const searchPattern = 'oox';
 
     it('not fuzzy', async () => {
@@ -175,7 +175,7 @@ describe('search-service', () => {
         limit: 200,
       });
       for (const match of matches) {
-        const relativeUri = rootUri.relative(new URI(match));
+        const relativeUri = path.relative(rootUri, match);
         expect(relativeUri !== undefined).toBe(true);
         const relativeMatch = relativeUri!.toString();
         let position = 0;

--- a/packages/file-search/src/node/file-search.service.ts
+++ b/packages/file-search/src/node/file-search.service.ts
@@ -76,7 +76,7 @@ export class FileSearchService implements IFileSearchService {
             rootUri,
             rootOptions,
             (candidate) => {
-              const fileUri = FileUri.create(path.join(rootUri.codeUri.fsPath, candidate)).toString();
+              const fileUri = path.join(rootUri.codeUri.fsPath, candidate);
               if (exactMatches.has(fileUri) || fuzzyMatches.has(fileUri)) {
                 return;
               }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fixed #2331 

### Changelog

get correctly fsPath on Windows findFiles
