### PR TITLE
fix: output the stdout when launching the program with debug

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -54,6 +54,7 @@ import {
   CONTEXT_DEBUG_TYPE_KEY,
   DebugState,
   IDebugModelManager,
+  DebugOutputCaptureType,
 } from '../common';
 import { IDebugProgress } from '../common/debug-progress';
 
@@ -332,6 +333,9 @@ export class DebugSessionManager implements IDebugSessionManager {
           });
         }
         this.debugProgressService.onDebugServiceStateChange(DebugState.Running);
+      }
+      if (!resolved.outputCapture) {
+        resolved.outputCapture = DebugOutputCaptureType.STD;
       }
       const sessionId = await this.debug.createDebugSession(resolved);
       timeStart(resolved.configuration.type, {

--- a/packages/debug/src/browser/view/console/debug-console.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console.service.ts
@@ -99,24 +99,6 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
 
   public static keySet = new Set([CONTEXT_IN_DEBUG_MODE_KEY]);
 
-  constructor() {
-    this.contextKeyService.onDidChangeContext((e) => {
-      if (e.payload.affectsSome(DebugConsoleService.keySet)) {
-        const inDebugMode = this.contextKeyService.match(CONTEXT_IN_DEBUG_MODE_KEY);
-        if (inDebugMode) {
-          this.updateReadOnly(false);
-          this.updateInputDecoration();
-          this.debugContextKey.contextInDdebugMode.set(true);
-        } else {
-          this.updateReadOnly(true);
-          if (this.debugContextKey) {
-            this.debugContextKey.contextInDdebugMode.set(false);
-          }
-        }
-      }
-    });
-  }
-
   // FIXME: 需要实现新增的属性及事件
   element: HTMLElement;
   onDidFocus: Event<void>;
@@ -166,6 +148,22 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
     this.debugContextKey = this.injector.get(DebugContextKey, [
       (this.inputEditor.monacoEditor as any)._contextKeyService,
     ]);
+
+    this.contextKeyService.onDidChangeContext((e) => {
+      if (e.payload.affectsSome(DebugConsoleService.keySet)) {
+        const inDebugMode = this.contextKeyService.match(CONTEXT_IN_DEBUG_MODE_KEY);
+        if (inDebugMode) {
+          this.updateReadOnly(false);
+          this.updateInputDecoration();
+          this.debugContextKey.contextInDdebugMode.set(true);
+        } else {
+          this.updateReadOnly(true);
+          if (this.debugContextKey) {
+            this.debugContextKey.contextInDdebugMode.set(false);
+          }
+        }
+      }
+    });
 
     this.registerDecorationType();
     await this.createConsoleInput();

--- a/packages/debug/src/browser/view/console/debug-console.view.tsx
+++ b/packages/debug/src/browser/view/console/debug-console.view.tsx
@@ -1,5 +1,4 @@
 import cls from 'classnames';
-import debounce from 'lodash/debounce';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -12,7 +11,6 @@ import {
   INodeRendererProps,
   CompositeTreeNode,
   TreeNode,
-  TreeNodeEvent,
 } from '@opensumi/ide-components';
 import { Loading } from '@opensumi/ide-components';
 import { useInjectable, ViewState, getIcon } from '@opensumi/ide-core-browser';
@@ -29,8 +27,6 @@ import { DebugConsoleFilterService } from './debug-console-filter.service';
 import { IDebugConsoleModel } from './debug-console-tree.model.service';
 import styles from './debug-console.module.less';
 import { DebugConsoleService } from './debug-console.service';
-
-declare const ResizeObserver: any;
 
 export const DebugConsoleView = observer(({ viewState }: { viewState: ViewState }) => {
   const debugConsoleService = useInjectable<DebugConsoleService>(DebugConsoleService);

--- a/packages/debug/src/common/debug-session.ts
+++ b/packages/debug/src/common/debug-session.ts
@@ -18,6 +18,11 @@ export enum DebugState {
   Stopped,
 }
 
+export enum DebugOutputCaptureType {
+  CONSOLE = 'console',
+  STD = 'std',
+}
+
 export type IDebugSessionReplMode = 'separate' | 'mergeWithParent';
 
 export interface IDebugSessionOptions {
@@ -26,6 +31,7 @@ export interface IDebugSessionOptions {
   lifecycleManagedByParent?: boolean;
   repl?: IDebugSessionReplMode;
   compact?: boolean;
+  outputCapture?: DebugOutputCaptureType.STD | DebugOutputCaptureType.CONSOLE;
 }
 
 export const IDebugSession = Symbol('DebugSession');


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #2385 

定位到原因为原来适配的 `vscode-js-debug` 中针对日志输出定义了一个新的配置  `outputCapture`, 需要将默认值设置为 `std` 才能输出所有日志内容，见：https://github.com/microsoft/vscode-js-debug/blob/dbb6d458650023e6c0e1df001510bfa6ef5aecc0/src/targets/node/subprocessProgramLauncher.ts#L46

After:
<img width="942" alt="image" src="https://user-images.githubusercontent.com/9823838/223999390-a80b9185-eb47-432c-b221-224b31c403f9.png">

### Changelog

output the stdout when launching the program with debug
