### PR TITLE
fix: remove status bar warnings

### DIFF
--- a/packages/core-browser/src/react-providers/slot.tsx
+++ b/packages/core-browser/src/react-providers/slot.tsx
@@ -122,13 +122,15 @@ export class SlotRendererRegistry {
         <ErrorBoundary>
           {components.map((componentInfo, index: number) => {
             // 默认的只渲染一个
-            const Component = componentInfo.views[0].component!;
-            return (
-              <Component
-                {...(componentInfo.options && componentInfo.options.initialProps)}
-                key={`${Component.name}-${index}`}
-              />
-            );
+            const Component = componentInfo.views[0].component;
+            if (Component) {
+              return (
+                <Component
+                  {...(componentInfo.options && componentInfo.options.initialProps)}
+                  key={`${Component.name || Component.displayName}-${index}`}
+                />
+              );
+            }
           })}
         </ErrorBoundary>
       )

--- a/packages/core-browser/src/style/normalize.less
+++ b/packages/core-browser/src/style/normalize.less
@@ -9,13 +9,9 @@ body {
   // 全局默认字体颜色
   color: var(--foreground);
   background-color: var(--editor-background);
-  font-size: var(--base-font-size);
+  font-size: 13px;
   // 设置 antialiased 会导致整体清晰度降低
   // -webkit-font-smoothing: antialiased;
-}
-
-:root {
-  --base-font-size: 13px;
 }
 
 html {

--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -9,7 +9,7 @@ export function transformLabelWithCodicon(
   label: string,
   iconStyles: CSSProperties = {},
   transformer?: (str: string) => string | undefined,
-  renderText?: (str: string) => React.ReactNode,
+  renderText?: (str: string, index: number) => React.ReactNode,
 ) {
   const ICON_REGX = /\$\(([a-z.]+\/)?([a-z-]+)(~[a-z]+)?\)/gi;
   const ICON_WITH_ANIMATE_REGX = /\$\(([a-z.]+\/)?([a-z-]+)~([a-z]+)\)/gi;
@@ -32,7 +32,7 @@ export function transformLabelWithCodicon(
       const newStr = e.replaceAll(ICON_REGX, (e) => `${SEPERATOR}${e}${SEPERATOR}`);
       return transformLabelWithCodicon(newStr, iconStyles, transformer);
     } else {
-      return isFunction(renderText) ? renderText(e) : <span key={`${index}-${e}`}>{e}</span>;
+      return isFunction(renderText) ? renderText(e, index) : <span key={`${index}-${e}`}>{e}</span>;
     }
   });
 }

--- a/packages/startup/entry/sample-modules/menu-bar/menu-bar.contribution.ts
+++ b/packages/startup/entry/sample-modules/menu-bar/menu-bar.contribution.ts
@@ -7,7 +7,7 @@ import { MenuBarView } from './menu-bar.view';
 @Domain(ComponentContribution)
 export class MenuBarContribution implements ComponentContribution {
   // Component key
-  static MenuBarContainer = '@opensumi/menu-bar-example';
+  static MenuBarContainer = 'menubar';
 
   registerComponent(registry: ComponentRegistry): void {
     registry.register(MenuBarContribution.MenuBarContainer, {

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -28,7 +28,7 @@ renderApp({
     ...defaultConfig,
     ...{
       [SlotLocation.top]: {
-        modules: ['@opensumi/menu-bar-example', 'toolbar'],
+        modules: ['menubar', 'toolbar'],
       },
     },
     ...{

--- a/packages/status-bar/src/browser/status-bar.service.ts
+++ b/packages/status-bar/src/browser/status-bar.service.ts
@@ -130,7 +130,7 @@ export class StatusBarService extends Disposable implements IStatusBarService {
     // 优先读取 storage 数据
     const hidden = this.getStorageState(id)?.hidden ?? entry.hidden;
     entry.hidden = hidden;
-    // 确保相同 id 只注册一次菜单
+    // 确保相同 id 只注册一次菜单me
     // 比如源码管理会注册多个状态栏元素，但菜单只会注册一个
     if (entry.name && this.getEntriesById(id).length === 0) {
       const toggleContextKey = new RawContextKey(`${id}:toggle`, !hidden);

--- a/packages/status-bar/src/browser/status-bar.view.tsx
+++ b/packages/status-bar/src/browser/status-bar.view.tsx
@@ -1,7 +1,8 @@
 import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React from 'react';
+import React, { useCallback, memo } from 'react';
 
+import { StatusBarEntry } from '@opensumi/ide-core-browser';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
 import { generateCtxMenu, ICtxMenuRenderer } from '@opensumi/ide-core-browser/lib/menu/next';
 import { useInjectable } from '@opensumi/ide-core-browser/lib/react-hooks';
@@ -10,14 +11,14 @@ import { IStatusBarService } from '@opensumi/ide-core-browser/lib/services';
 import { StatusBarItem } from './status-bar-item.view';
 import styles from './status-bar.module.less';
 
-export const StatusBarView = React.memo(
+export const StatusBarView = memo(
   observer(() => {
     const statusBar: IStatusBarService = useInjectable(IStatusBarService);
     const ctxMenuRenderer = useInjectable<ICtxMenuRenderer>(ICtxMenuRenderer);
     const backgroundColor = statusBar.getBackgroundColor();
     const color = statusBar.getColor();
 
-    const handleCtxMenu = React.useCallback((e: React.MouseEvent<HTMLElement>) => {
+    const handleCtxMenu = useCallback((e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault();
       const result = generateCtxMenu({
         menus: statusBar.contextMenu,
@@ -38,16 +39,20 @@ export const StatusBarView = React.memo(
         onContextMenu={handleCtxMenu}
       >
         <div className={cls(styles.area, styles.left)}>
-          {statusBar.leftEntries.map((entry) => (
-            <StatusBarItem key={entry.entryId} {...{ ...entry, color: color ?? entry.color }} />
-          ))}
+          {statusBar.leftEntries.length &&
+            statusBar.leftEntries.map((entry: StatusBarEntry, index: number) => (
+              <StatusBarItem key={`${entry.entryId}-${index}`} {...{ ...entry, color: color ?? entry.color }} />
+            ))}
         </div>
         <div className={cls(styles.area, styles.right)}>
-          {statusBar.rightEntries.map((entry) => (
-            <StatusBarItem key={entry.entryId} {...{ ...entry, color: color ?? entry.color }} />
-          ))}
+          {statusBar.rightEntries.length &&
+            statusBar.rightEntries.map((entry: StatusBarEntry, index: number) => (
+              <StatusBarItem key={`${entry.entryId}-${index}`} {...{ ...entry, color: color ?? entry.color }} />
+            ))}
         </div>
       </div>
     );
   }),
 );
+
+StatusBarView.displayName = 'StatusBar';

--- a/packages/toolbar/src/browser/toolbar.view.tsx
+++ b/packages/toolbar/src/browser/toolbar.view.tsx
@@ -61,3 +61,5 @@ export const ToolBar = observer<Pick<React.HTMLProps<HTMLElement>, 'className'>>
     </div>
   );
 });
+
+ToolBar.displayName = 'ToolBar';


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

warnings from #2340 changed.

<img width="1050" alt="截屏2023-03-14 10 24 04" src="https://user-images.githubusercontent.com/9823838/224883499-848e4cd0-5247-4aa4-805a-3ae287aca717.png">

### Changelog

remove status bar warnings