### PR TITLE
fix: namespace conflicts between extHost and extBrowser

### DIFF
--- a/packages/core-common/src/log.ts
+++ b/packages/core-common/src/log.ts
@@ -22,6 +22,8 @@ export enum SupportLogNamespace {
   Browser = 'browser',
   // 插件进程
   ExtensionHost = 'extHost',
+  // 插件浏览器层
+  ExtensionBrowser = 'extBrowser',
   // 应用层
   App = 'app',
   // 其他未分类

--- a/packages/core-common/src/log.ts
+++ b/packages/core-common/src/log.ts
@@ -22,8 +22,6 @@ export enum SupportLogNamespace {
   Browser = 'browser',
   // 插件进程
   ExtensionHost = 'extHost',
-  // 插件浏览器层
-  ExtensionBrowser = 'extBrowser',
   // 应用层
   App = 'app',
   // 其他未分类

--- a/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
+++ b/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
@@ -6,11 +6,11 @@ import {
   IJSONSchema,
   IJSONSchemaSnippet,
   WaitUntilEvent,
+  ILogger,
 } from '@opensumi/ide-core-browser';
 import { DebugServer, DebuggerDescription, IDebugSessionManager, IDebugSessionDTO } from '@opensumi/ide-debug';
 import { DebugConfigurationManager } from '@opensumi/ide-debug/lib/browser/debug-configuration-manager';
 import { DebugConfiguration } from '@opensumi/ide-debug/lib/common/debug-configuration';
-import { ILoggerManagerClient, SupportLogNamespace, ILogServiceClient } from '@opensumi/ide-logs/lib/browser';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
 import { DebugActivationEvent } from '../../../../common/vscode';
@@ -43,9 +43,8 @@ export class ExtensionDebugService implements DebugServer, ExtensionDebugAdapter
   @Autowired(IWorkspaceService)
   protected readonly workspaceService: IWorkspaceService;
 
-  @Autowired(ILoggerManagerClient)
-  protected readonly loggerManager: ILoggerManagerClient;
-  protected logger: ILogServiceClient;
+  @Autowired(ILogger)
+  protected readonly logger: ILogger;
 
   @Autowired(IDebugSessionManager)
   protected readonly debugSessionManager: IDebugSessionManager;
@@ -63,7 +62,6 @@ export class ExtensionDebugService implements DebugServer, ExtensionDebugAdapter
   }
 
   protected init(): void {
-    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
     this.debugSessionManager.onWillStartDebugSession((event) => this.ensureDebugActivation(event));
     this.debugSessionManager.onWillResolveDebugConfiguration((event) =>
       this.ensureDebugActivation(event, 'onDebugResolve', event.debugType),

--- a/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
+++ b/packages/extension/src/browser/vscode/api/debug/extension-debug-service.ts
@@ -63,7 +63,7 @@ export class ExtensionDebugService implements DebugServer, ExtensionDebugAdapter
   }
 
   protected init(): void {
-    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionHost);
+    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
     this.debugSessionManager.onWillStartDebugSession((event) => this.ensureDebugActivation(event));
     this.debugSessionManager.onWillResolveDebugConfiguration((event) =>
       this.ensureDebugActivation(event, 'onDebugResolve', event.debugType),

--- a/packages/extension/src/browser/vscode/api/main.thread.connection.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.connection.ts
@@ -25,7 +25,7 @@ export class MainThreadConnection implements IMainThreadConnectionService {
 
   constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostConnection);
-    this.logger = this.LoggerManager.getLogger(SupportLogNamespace.ExtensionHost);
+    this.logger = this.LoggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
   }
 
   dispose() {

--- a/packages/extension/src/browser/vscode/api/main.thread.connection.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.connection.ts
@@ -1,7 +1,7 @@
 import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { ILoggerManagerClient, ILogServiceClient, SupportLogNamespace, Deferred } from '@opensumi/ide-core-browser';
-import { Disposable, DisposableCollection } from '@opensumi/ide-core-common';
+import { Deferred } from '@opensumi/ide-core-browser';
+import { Disposable, DisposableCollection, ILogger } from '@opensumi/ide-core-common';
 
 import {
   IMainThreadConnectionService,
@@ -19,13 +19,11 @@ export class MainThreadConnection implements IMainThreadConnectionService {
   private connectionsReady = new Map<string, Deferred<void>>();
   private readonly toDispose = new DisposableCollection();
 
-  @Autowired(ILoggerManagerClient)
-  protected readonly LoggerManager: ILoggerManagerClient;
-  protected readonly logger: ILogServiceClient;
+  @Autowired(ILogger)
+  protected readonly logger: ILogger;
 
   constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostConnection);
-    this.logger = this.LoggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
   }
 
   dispose() {

--- a/packages/extension/src/browser/vscode/api/main.thread.debug.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.debug.ts
@@ -114,7 +114,7 @@ export class MainThreadDebug implements IMainThreadDebug {
     @Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol,
     @Optional(IMainThreadConnectionService) private mainThreadConnection: IMainThreadConnectionService,
   ) {
-    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionHost);
+    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostDebug);
     this.listen();
     this.registerDebugContributions();

--- a/packages/extension/src/browser/vscode/api/main.thread.debug.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.debug.ts
@@ -1,13 +1,6 @@
 import { Injectable, Optional, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import {
-  DisposableCollection,
-  Uri,
-  ILoggerManagerClient,
-  ILogServiceClient,
-  SupportLogNamespace,
-  URI,
-} from '@opensumi/ide-core-browser';
+import { DisposableCollection, Uri, URI, ILogger } from '@opensumi/ide-core-browser';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import {
   DebuggerDescription,
@@ -91,9 +84,8 @@ export class MainThreadDebug implements IMainThreadDebug {
   @Autowired(DebugSessionContributionRegistry)
   protected readonly sessionContributionRegistry: ExtensionDebugSessionContributionRegistry;
 
-  @Autowired(ILoggerManagerClient)
-  protected readonly loggerManager: ILoggerManagerClient;
-  protected readonly logger: ILogServiceClient;
+  @Autowired(ILogger)
+  protected readonly logger: ILogger;
 
   @Autowired(ITerminalApiService)
   protected readonly terminalService: ITerminalApiService;
@@ -114,7 +106,6 @@ export class MainThreadDebug implements IMainThreadDebug {
     @Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol,
     @Optional(IMainThreadConnectionService) private mainThreadConnection: IMainThreadConnectionService,
   ) {
-    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostDebug);
     this.listen();
     this.registerDebugContributions();

--- a/packages/extension/src/browser/vscode/api/main.thread.log.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.log.ts
@@ -5,14 +5,13 @@ import { ILoggerManagerClient, SupportLogNamespace, ILogServiceClient } from '@o
 
 import { IMainThreadExtensionLog, MainThreadExtensionLogIdentifier } from '../../../common/extension-log';
 
-
 @Injectable()
 export class MainThreadExtensionLog implements IMainThreadExtensionLog {
   @Autowired(ILoggerManagerClient)
   private readonly loggerManager: ILoggerManagerClient;
 
   private get logger(): ILogServiceClient {
-    return this.loggerManager.getLogger(SupportLogNamespace.ExtensionHost);
+    return this.loggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
   }
 
   $getLevel() {

--- a/packages/extension/src/browser/vscode/api/main.thread.log.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.log.ts
@@ -1,18 +1,13 @@
 import { Injectable, Injector, Autowired } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { LogLevel } from '@opensumi/ide-core-common';
-import { ILoggerManagerClient, SupportLogNamespace, ILogServiceClient } from '@opensumi/ide-logs/lib/browser';
+import { ILogger, LogLevel } from '@opensumi/ide-core-common';
 
 import { IMainThreadExtensionLog, MainThreadExtensionLogIdentifier } from '../../../common/extension-log';
 
 @Injectable()
 export class MainThreadExtensionLog implements IMainThreadExtensionLog {
-  @Autowired(ILoggerManagerClient)
-  private readonly loggerManager: ILoggerManagerClient;
-
-  private get logger(): ILogServiceClient {
-    return this.loggerManager.getLogger(SupportLogNamespace.ExtensionBrowser);
-  }
+  @Autowired(ILogger)
+  protected readonly logger: ILogger;
 
   $getLevel() {
     return this.logger.getLevel();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
一般情况下，插件进程的日志会写入到 logDir/20230315/extHost.log 文件中，但由于 OpenSumi 在插件实现上有自己的 browser 层，会导致情况特殊，browser 写入的日志是通过 Node 进程写入的。

插件中 browser 层的日志是通过 Node 进程也同时写入到 extHost.log 中，在两个进程同时打开文件句柄，会导致 Windows 环境下的写锁保护机制报错，导致日志写入失败。

解决方法：插件的 Browser 使用另外一个命名空间，和插件进程区分开，保证不同的集成不会写入同一个文件，同时也能保证逻辑清晰。

closed #2383 

### Changelog
修复插件浏览器层的日志和插件进程的命名空间冲突