### PR TITLE
fix: 修复 download.js 脚本在 Windows 创建文件时出`?`非法字符

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -58,7 +58,7 @@ const parallelRunPromise = (lazyPromises, n) => {
 
 async function downloadExtension(url, namespace, extensionName) {
   const tmpPath = path.join(os.tmpdir(), 'extension');
-  const tmpZipFile = path.join(tmpPath, path.basename(url));
+  const tmpZipFile = path.join(tmpPath, path.basename(url.replace(/\?.+=/, '-')));
   await fs.mkdirp(tmpPath);
 
   const tmpStream = fs.createWriteStream(tmpZipFile);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
解决在 Windows 执行 `node scripts/download.js` 出现的报错：

```shell
node scripts/download.js
node:events:491
      throw er; // Unhandled 'error' event
      ^
```
### Changelog

- 修复 download.js 脚本在 Windows 创建文件时出`?`非法字符