### PR TITLE
fix: ensure preference ready before render editor

### DIFF
--- a/packages/file-scheme/__tests__/browser/contribution.test.ts
+++ b/packages/file-scheme/__tests__/browser/contribution.test.ts
@@ -24,6 +24,12 @@ const mockFileService = {
   getFileType: jest.fn(),
 };
 
+const mockPreferenceService = {
+  onPreferenceChanged: jest.fn(),
+  get: jest.fn(() => undefined),
+  ready: Promise.resolve(),
+};
+
 describe('contribution test', () => {
   let injector: MockInjector;
   let contribution: BrowserEditorContribution;
@@ -39,14 +45,17 @@ describe('contribution test', () => {
       },
       {
         token: PreferenceService,
-        useValue: jest.fn(),
+        useValue: mockPreferenceService,
       },
       {
         token: EditorComponentRegistry,
         useClass: EditorComponentRegistryImpl,
       },
     );
-
+    injector.overrideProviders({
+      token: PreferenceService,
+      useValue: mockPreferenceService,
+    });
     const langService: ILanguageService = StandaloneServices.get(ILanguageService);
     langService.registerLanguage({
       id: 'javascript',

--- a/packages/file-scheme/src/browser/file-scheme.contribution.ts
+++ b/packages/file-scheme/src/browser/file-scheme.contribution.ts
@@ -115,7 +115,6 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
       },
     );
 
-    // 图片文件
     editorComponentRegistry.registerEditorComponentResolver(
       (scheme: string) => (scheme === Schemes.file || this.fileServiceClient.handlesScheme(scheme) ? 10 : -1),
       async (resource: IResource<any>, results: IEditorOpenType[]) => {
@@ -138,6 +137,7 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
         if (type === 'text') {
           const { metadata, uri } = resource as { uri: URI; metadata: any };
           const stat = await this.fileServiceClient.getFileStat(uri.toString());
+          await this.preference.ready;
           const maxSize = this.preference.get<number>('editor.largeFile') || 4 * 1024 * 1024 * 1024;
 
           if (stat && (stat.size || 0) > maxSize && !(metadata || {}).noPrevent) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

在 web 场景下，我们加载一个 500m 的文件会导致页面崩溃，设置 largeFile 后，刷新页面偶现这个配置项不生效。

### Changelog

ensure preference ready before render editor
