### PR TITLE
fix: uninstall extension failed in electron

### DIFF
--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -396,7 +396,7 @@ export class FileServiceClient implements IFileServiceClient {
   }
 
   async delete(uriString: string, options?: FileDeleteOptions) {
-    if (this.appConfig.isElectronRenderer && options && options.moveToTrash) {
+    if (this.appConfig.isElectronRenderer) {
       const uri = new URI(uriString);
       if (uri.scheme === Schemes.file) {
         return (this.injector.get(IElectronMainUIService) as IElectronMainUIService).moveToTrash(uri.codeUri.fsPath);

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -396,7 +396,7 @@ export class FileServiceClient implements IFileServiceClient {
   }
 
   async delete(uriString: string, options?: FileDeleteOptions) {
-    if (this.appConfig.isElectronRenderer) {
+    if (this.appConfig.isElectronRenderer && options?.moveToTrash !== false) {
       const uri = new URI(uriString);
       if (uri.scheme === Schemes.file) {
         return (this.injector.get(IElectronMainUIService) as IElectronMainUIService).moveToTrash(uri.codeUri.fsPath);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
close https://github.com/opensumi/ide-electron/issues/64

electron 环境卸载插件调用了 fileService.delete， delete 实现中判断如果是 electron 并且设置了 moveToTrash 就会使用 electron 的 api 删除文件。但如果没有设置 moveToTrash 标记，就会走原始的删除文件。原始的删除文件在 mac 下会报错， 找不到 app/node/macos-trash 可执行文件。

在 ide-electron 环境中，删除插件其实移到 Trash 可能更好，避免一些误操作导致文件无法恢复。

### Changelog
修复 ide-electron 环境卸载插件失败的问题
