### PR TITLE
chore: export localizationRegistryMap

### DIFF
--- a/packages/core-common/src/localize.ts
+++ b/packages/core-common/src/localize.ts
@@ -6,7 +6,7 @@ export type ILocalizationKey = string; // ts不支持symbol作为key
 
 let _currentLanguageId = 'zh-CN';
 
-const localizationRegistryMap = new CaseInsensitiveMap<string, LocalizationRegistry>();
+export const localizationRegistryMap = new CaseInsensitiveMap<string, LocalizationRegistry>();
 
 export function localize(
   symbol: ILocalizationKey,


### PR DESCRIPTION
### Types
在开发时可能需要列出一下正在使用的语言包，方便查看当前系统已经在使用的 scope、key，重载文案的时候作为参考

- [x] 🧹 Chores

### Background or solution

### Changelog
