### PR TITLE
fix: auto select the latest debug configuration

### DIFF
--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -306,19 +306,21 @@ export class DebugContribution
         this.openDebugView();
       }
     });
-    this.sessionManager.onDidDestroyDebugSession((session) => {
+    this.sessionManager.onDidDestroyDebugSession(() => {
       if (this.sessionManager.sessions.length === 0) {
         this.commandService.tryExecuteCommand('statusbar.changeBackgroundColor', 'var(--statusBar-background)');
         this.commandService.tryExecuteCommand('statusbar.changeColor');
       }
     });
-    this.configurations.load();
-    this.breakpointManager.load();
-    this.configurations.onDidChange(() => this.configurations.save());
-    this.breakpointManager.onDidChangeBreakpoints(() => this.breakpointManager.save());
-    this.breakpointManager.onDidChangeExceptionsBreakpoints(() => this.breakpointManager.save());
-    this.breakpointManager.onDidChangeMarkers(() => this.breakpointManager.save());
-
+    this.configurations.whenReady.then(() => {
+      this.configurations.load();
+      this.configurations.onDidChange(() => this.configurations.save());
+    });
+    this.breakpointManager.load().then(() => {
+      this.breakpointManager.onDidChangeBreakpoints(() => this.breakpointManager.save());
+      this.breakpointManager.onDidChangeExceptionsBreakpoints(() => this.breakpointManager.save());
+      this.breakpointManager.onDidChangeMarkers(() => this.breakpointManager.save());
+    });
     this.extensionsPointService.appendExtensionPoint(['browserViews', 'properties'], {
       extensionPoint: DEBUG_CONTAINER_ID,
       frameworkKind: ['opensumi'],


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原有自动选择上次选中调试配置功能由于时序问题失效

修复后：

https://user-images.githubusercontent.com/9823838/227414349-453a5d12-8545-4d63-96d3-193aa8a919cd.mp4


### Changelog

fix auto select the latest debug configuration