### PR TITLE
fix: call stack stop at incorrect line because call frame with sameid

### DIFF
--- a/packages/debug/src/browser/model/debug-thread.ts
+++ b/packages/debug/src/browser/model/debug-thread.ts
@@ -1,4 +1,5 @@
 import { Event, Emitter } from '@opensumi/ide-core-browser';
+import { uuid } from '@opensumi/ide-core-common';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
 
 import { DEBUG_REPORT_NAME, IDebugExceptionInfo } from '../../common';
@@ -83,7 +84,7 @@ export class DebugThread extends DebugThreadData {
     return this.session.sendRequest('terminateThreads', { threadIds: [this.raw.id] });
   }
 
-  protected readonly _frames = new Map<number, DebugStackFrame>();
+  protected readonly _frames = new Map<number | string, DebugStackFrame>();
   get frames(): DebugStackFrame[] {
     return Array.from(this._frames.values());
   }
@@ -155,10 +156,13 @@ export class DebugThread extends DebugThreadData {
       threadId: this.raw.id,
       threadAmount: this.session.threadCount,
     });
-    const result = new Map<number, DebugStackFrame>(this._frames);
+    const result = new Map<string | number, DebugStackFrame>(this._frames);
     for (const raw of frames) {
-      const id = raw.id;
-      const frame = this._frames.get(id) || new DebugStackFrame(this, this.session);
+      let id: string | number = raw.id;
+      if (this._frames.get(id)) {
+        id = uuid();
+      }
+      const frame = new DebugStackFrame(this, this.session);
       this._frames.set(id, frame);
       frame.update({ raw });
       result.set(id, frame);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

https://github.com/opensumi/core/issues/2465

### Changelog
当前 frame存在ID 相同时 为其设置一个 uuid