### PR TITLE
fix: call stack stop at incorrect line because call frame with sameid

### DIFF
--- a/packages/debug/src/browser/model/debug-thread.ts
+++ b/packages/debug/src/browser/model/debug-thread.ts
@@ -158,10 +158,12 @@ export class DebugThread extends DebugThreadData {
     const result = new Map<number, DebugStackFrame>(this._frames);
     for (const raw of frames) {
       const id = raw.id;
-      const frame = this._frames.get(id) || new DebugStackFrame(this, this.session);
-      this._frames.set(id, frame);
-      frame.update({ raw });
-      result.set(id, frame);
+      if (!this._frames.get(id)) {
+        const frame = new DebugStackFrame(this, this.session);
+        this._frames.set(id, frame);
+        frame.update({ raw });
+        result.set(id, frame);
+      }
     }
     const values = [...result.values()];
     frontEndTime('doUpdateFrames');

--- a/packages/debug/src/browser/model/debug-thread.ts
+++ b/packages/debug/src/browser/model/debug-thread.ts
@@ -158,7 +158,7 @@ export class DebugThread extends DebugThreadData {
     const result = new Map<number, DebugStackFrame>(this._frames);
     for (const raw of frames) {
       const id = raw.id;
-      if (!this._frames.get(id)) {
+      if (!this._frames.has(id)) {
         const frame = new DebugStackFrame(this, this.session);
         this._frames.set(id, frame);
         frame.update({ raw });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

https://github.com/opensumi/core/issues/2465

### Changelog
当前 frame存在ID 相同时 为其设置一个 uuid