### PR TITLE
fix: update the active editor when the editor cursor changes

### DIFF
--- a/packages/extension/__tests__/browser/main.thread.editor.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.editor.test.ts
@@ -351,6 +351,16 @@ describe('MainThreadEditor Test Suites', () => {
         editorUri: resource.uri,
       }),
     );
+
+    eventBus.fire(
+      new EditorGroupChangeEvent({
+        group: workbenchEditorService.currentEditorGroup,
+        newOpenType: workbenchEditorService.currentEditorGroup.currentOpenType,
+        newResource: resource,
+        oldOpenType: null,
+        oldResource: null,
+      }),
+    );
   });
 
   it('should receive onDidChangeTextEditorVisibleRanges event when editor visible range has changed', (done) => {

--- a/packages/extension/src/browser/vscode/api/main.thread.editor.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor.ts
@@ -373,6 +373,10 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
           source: e.payload.source,
         },
       });
+
+      this.proxy.$acceptChange({
+        actived: getTextEditorId(e.payload.group, e.payload.editorUri),
+      });
     };
 
     const debouncedSelectionChange = debounce((e) => selectionChange(e), 50, {


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution

在分栏且编辑器光标变化时，插件中获取到的 activeTextEditor  没有正确更新，会导致这种情况下 `Accept Change` 错误的修改了非当前编辑器的内容

https://user-images.githubusercontent.com/17701805/227469569-f180af37-1f79-4a13-bbec-63b75e201e5f.mp4



### Changelog
- Update the active editor when the editor cursor changes.