### PR TITLE
fix: should set renderMarginRevertIcon=false when diffEditor is readOnly

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -706,10 +706,12 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
       ? this.modifiedEditor.currentDocumentModel.languageId
       : undefined;
     const options = getConvertedMonacoOptions(this.configurationService, uriStr, languageId);
+    const readOnly = this.isReadonly();
     this.monacoDiffEditor.updateOptions({
       ...options.diffOptions,
       ...this.specialOptions,
-      readOnly: this.isReadonly(),
+      readOnly,
+      renderMarginRevertIcon: !readOnly,
     });
 
     if (this.currentUri) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

resolve #2489 

### Background or solution

### Changelog
