### PR TITLE
feat: support displaying debug breakpoints in a tree view

### DIFF
--- a/packages/components/src/recycle-tree/basic/tree-node.tsx
+++ b/packages/components/src/recycle-tree/basic/tree-node.tsx
@@ -89,9 +89,8 @@ export const BasicTreeNodeRenderer: React.FC<
   );
 
   const renderDisplayName = useCallback(
-    (node: BasicCompositeTreeNode | BasicTreeNode) => (
-      node.displayName && <div className={cls('segment', 'display_name')}>{getName(node)}</div>
-    ),
+    (node: BasicCompositeTreeNode | BasicTreeNode) =>
+      node.displayName && <div className={cls('segment', 'display_name')}>{getName(node)}</div>,
     [],
   );
 
@@ -102,7 +101,7 @@ export const BasicTreeNodeRenderer: React.FC<
 
     if (typeof node.description === 'string') {
       return <div className={cls('segment_grow', 'description')}>{node.description}</div>;
-    };
+    }
 
     return node.description;
   }, []);
@@ -165,7 +164,7 @@ export const BasicTreeNodeRenderer: React.FC<
 
   const renderTwice = (item: BasicCompositeTreeNode | BasicTreeNode) => {
     if (!(item as BasicCompositeTreeNode).expandable) {
-      return <div className={cls('segment', 'expansion_toggle')}></div>;
+      return null;
     }
 
     if (BasicCompositeTreeNode.is(item)) {

--- a/packages/components/src/recycle-tree/basic/tree-node.tsx
+++ b/packages/components/src/recycle-tree/basic/tree-node.tsx
@@ -90,7 +90,7 @@ export const BasicTreeNodeRenderer: React.FC<
 
   const renderDisplayName = useCallback(
     (node: BasicCompositeTreeNode | BasicTreeNode) => (
-      <div className={cls('segment', 'display_name')}>{getName(node)}</div>
+      node.displayName && <div className={cls('segment', 'display_name')}>{getName(node)}</div>
     ),
     [],
   );
@@ -99,7 +99,12 @@ export const BasicTreeNodeRenderer: React.FC<
     if (!node.description) {
       return null;
     }
-    return <div className={cls('segment_grow', 'description')}>{node.description}</div>;
+
+    if (typeof node.description === 'string') {
+      return <div className={cls('segment_grow', 'description')}>{node.description}</div>;
+    };
+
+    return node.description;
   }, []);
 
   const inlineMenuActions = useCallback(

--- a/packages/components/src/recycle-tree/basic/types.ts
+++ b/packages/components/src/recycle-tree/basic/types.ts
@@ -67,7 +67,7 @@ export interface IBasicTreeData {
   /**
    * 描述
    */
-  description?: string;
+  description?: string | React.ReactNode;
   /**
    * 子节点
    *

--- a/packages/debug/__tests__/browser/view/breakpoint/debug-breakpoints.service.test.ts
+++ b/packages/debug/__tests__/browser/view/breakpoint/debug-breakpoints.service.test.ts
@@ -1,7 +1,11 @@
 import { IContextKeyService } from '@opensumi/ide-core-browser';
 import { Disposable, URI, IFileServiceClient, IEventBus, EventBusImpl } from '@opensumi/ide-core-common';
 import { IDebugSessionManager } from '@opensumi/ide-debug';
-import { BreakpointManager, DebugBreakpoint } from '@opensumi/ide-debug/lib/browser/breakpoint';
+import {
+  BreakpointManager,
+  DebugBreakpoint,
+  DebugExceptionBreakpoint,
+} from '@opensumi/ide-debug/lib/browser/breakpoint';
 import { DebugBreakpointsService } from '@opensumi/ide-debug/lib/browser/view/breakpoints/debug-breakpoints.service';
 import { DebugViewModel } from '@opensumi/ide-debug/lib/browser/view/debug-view-model';
 import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
@@ -132,10 +136,11 @@ describe('Debug Breakpoints Service', () => {
 
   it('extractNodes method should be work', () => {
     const breakpoint = DebugBreakpoint.create(URI.file('test.js'), { line: 1 });
-    const exceptionBreakpoint = { filter: 'test' };
-    const items = [breakpoint, exceptionBreakpoint];
-    const nodes = debugBreakpointsService.extractNodes(items as any);
-    expect(nodes.length).toBe(2);
+    const exceptionBreakpoint: DebugExceptionBreakpoint = { filter: 'test', label: '' };
+    const breakpointNode = debugBreakpointsService.extractNodes(breakpoint);
+    expect(breakpointNode?.id).toBe(breakpoint.id);
+    const exceptionNodes = debugBreakpointsService.extractNodes(exceptionBreakpoint);
+    expect(exceptionNodes?.id).toBe(exceptionBreakpoint.filter);
   });
 
   it('removeAllBreakpoints method should be work', () => {

--- a/packages/debug/src/browser/breakpoint/breakpoint-marker.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-marker.ts
@@ -1,12 +1,14 @@
 import btoa from 'btoa';
 
-import { URI } from '@opensumi/ide-core-common';
+import { Schemes, URI } from '@opensumi/ide-core-common';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
 
 import { IRuntimeBreakpoint, IDebugBreakpoint } from '../../common';
 import { Marker } from '../markers';
 
 export const BREAKPOINT_KIND = 'breakpoint';
+export const EXCEPTION_BREAKPOINT_KIND = 'exception_breakpoint';
+export const EXCEPTION_BREAKPOINT_URI = URI.parse(EXCEPTION_BREAKPOINT_KIND).withScheme(Schemes.inMemory);
 
 function generateId(uri: string, line: number, column = 1) {
   return btoa(`${uri}:${line}:${column}`);

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints-tree.model.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints-tree.model.ts
@@ -1,0 +1,18 @@
+import { IBasicTreeData } from "@opensumi/ide-components";
+import { BreakpointItem } from './debug-breakpoints.view';
+
+export interface IBreakpointsBasicTreeData extends IBasicTreeData {
+
+}
+
+export class BreakpointsTreeNode implements IBreakpointsBasicTreeData {
+  public label: string = '';
+  public rawData: BreakpointItem
+
+  constructor(label: string, rawData: BreakpointItem) {
+    this.label = label;
+    this.rawData = rawData;
+  }
+
+
+}

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints-tree.model.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints-tree.model.ts
@@ -1,5 +1,5 @@
 import { IBasicTreeData } from '@opensumi/ide-components';
-import { URI } from '@opensumi/ide-core-common';
+import { Emitter, URI } from '@opensumi/ide-core-common';
 
 import { isDebugBreakpoint } from '../../breakpoint';
 
@@ -8,15 +8,28 @@ import { BreakpointItem } from './debug-breakpoints.view';
 export class BreakpointsTreeNode implements IBasicTreeData {
   public label = '';
   public rawData: BreakpointItem;
+  private _uri: URI;
+  private _onDescriptionChange = new Emitter<string>();
 
   constructor(uri: URI, rawData: BreakpointItem) {
     const { breakpoint } = rawData;
 
+    this._uri = uri;
     this.label = isDebugBreakpoint(breakpoint) ? uri.displayName : '';
     this.rawData = rawData;
+    this.rawData.onDescriptionChange = this._onDescriptionChange.event;
   }
 
   get breakpoint() {
     return this.rawData.breakpoint;
+  }
+
+  get uri() {
+    return this._uri;
+  }
+
+  fireDescriptionChange(value: string): void {
+    this.rawData.description = value;
+    this._onDescriptionChange.fire(value);
   }
 }

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints-tree.model.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints-tree.model.ts
@@ -1,18 +1,22 @@
-import { IBasicTreeData } from "@opensumi/ide-components";
+import { IBasicTreeData } from '@opensumi/ide-components';
+import { URI } from '@opensumi/ide-core-common';
+
+import { isDebugBreakpoint } from '../../breakpoint';
+
 import { BreakpointItem } from './debug-breakpoints.view';
 
-export interface IBreakpointsBasicTreeData extends IBasicTreeData {
+export class BreakpointsTreeNode implements IBasicTreeData {
+  public label = '';
+  public rawData: BreakpointItem;
 
-}
+  constructor(uri: URI, rawData: BreakpointItem) {
+    const { breakpoint } = rawData;
 
-export class BreakpointsTreeNode implements IBreakpointsBasicTreeData {
-  public label: string = '';
-  public rawData: BreakpointItem
-
-  constructor(label: string, rawData: BreakpointItem) {
-    this.label = label;
+    this.label = isDebugBreakpoint(breakpoint) ? uri.displayName : '';
     this.rawData = rawData;
   }
 
-
+  get breakpoint() {
+    return this.rawData.breakpoint;
+  }
 }

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -21,8 +21,6 @@
     pointer-events: none;
   }
   &:hover {
-    background: var(--list-hoverBackground);
-    color: var(--list-hoverForeground);
     .debug_remove_breakpoints_icon {
       display: inline-block;
       pointer-events: all;
@@ -51,9 +49,7 @@
 
 .debug_breakpoints_description {
   display: block;
-  transform: scale(0.95);
-  opacity: 0.7;
-  margin-left: 5px;
+  opacity: 0.85;
   display: inline;
 }
 

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -65,3 +65,7 @@
   margin-right: 5px;
   flex: 1;
 }
+
+.debug_breakpoints_item_tree_node {
+  padding-left: 22px !important;
+}

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -21,6 +21,7 @@ import { DebugSessionManager } from '../../debug-session-manager';
 import { DebugViewModel } from '../debug-view-model';
 
 import { BreakpointItem } from './debug-breakpoints.view';
+import { BreakpointsTreeNode } from './debug-breakpoints-tree.model';
 
 @Injectable()
 export class DebugBreakpointsService extends WithEventBus {
@@ -59,6 +60,8 @@ export class DebugBreakpointsService extends WithEventBus {
 
   @observable
   public nodes: BreakpointItem[] = [];
+  // @observable.shallow
+  // public nodes: Map<URI, BreakpointsTreeNode[]> = new Map();
 
   @observable
   public enable: boolean;
@@ -139,38 +142,44 @@ export class DebugBreakpointsService extends WithEventBus {
     }
   }
 
-  extractNodes(items: (DebugExceptionBreakpoint | IDebugBreakpoint)[]) {
-    const nodes: BreakpointItem[] = [];
-    items.forEach((item) => {
-      if (isDebugBreakpoint(item)) {
-        const uri = URI.parse(item.uri);
-        const parent = this.roots.filter((root) => root.isEqualOrParent(uri))[0];
-        nodes.push({
-          id: item.id,
-          name: uri.displayName,
-          description: parent && parent.relative(uri)!.toString(),
-          breakpoint: item,
-        });
+  extractNodes(item: (DebugExceptionBreakpoint | IDebugBreakpoint)): BreakpointItem | undefined {
+    if (isDebugBreakpoint(item)) {
+      const uri = URI.parse(item.uri);
+      const parent = this.roots.filter((root) => root.isEqualOrParent(uri))[0];
+      return {
+        id: item.id,
+        name: uri.displayName,
+        description: parent && parent.relative(uri)!.toString(),
+        breakpoint: item,
+      };
+    }
+    if (isDebugExceptionBreakpoint(item)) {
+      return {
+        id: item.filter,
+        name: item.label,
+        description: '',
+        breakpoint: item,
       }
-      if (isDebugExceptionBreakpoint(item)) {
-        nodes.push({
-          id: item.filter,
-          name: item.label,
-          description: '',
-          breakpoint: item,
-        });
-      }
-    });
-    return nodes;
+    };
   }
 
   @action
   private async updateBreakpoints() {
     await this.breakpoints.whenReady;
-    this.nodes = this.extractNodes([
+
+    const allBreakpoints = [
       ...this.breakpoints.getExceptionBreakpoints(),
       ...this.breakpoints.getBreakpoints(),
-    ]);
+    ];
+
+    allBreakpoints.forEach((item, index) => {
+
+    });
+
+    // this.nodes = this.extractNodes([
+    //   ...this.breakpoints.getExceptionBreakpoints(),
+    //   ...this.breakpoints.getBreakpoints(),
+    // ]);
   }
 
   removeAllBreakpoints() {

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -1,7 +1,6 @@
 import { observable, action, runInAction } from 'mobx';
 
 import { Injectable, Autowired } from '@opensumi/di';
-import { IBasicRecycleTreeHandle } from '@opensumi/ide-components';
 import {
   URI,
   WithEventBus,
@@ -14,7 +13,7 @@ import {
 } from '@opensumi/ide-core-browser';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { ICodeEditor, EditorCollectionService, getSimpleEditorOptions } from '@opensumi/ide-editor';
-import { IEditorDocumentModelService, WorkbenchEditorService } from '@opensumi/ide-editor/lib/browser';
+import { IEditorDocumentModelService } from '@opensumi/ide-editor/lib/browser';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { WorkspaceEditDidRenameFileEvent, WorkspaceEditDidDeleteFileEvent } from '@opensumi/ide-workspace-edit';
 

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -155,7 +155,6 @@ export class DebugBreakpointsService extends WithEventBus {
 
   extractNodes(item: DebugExceptionBreakpoint | IDebugBreakpoint): BreakpointItem | undefined {
     if (isDebugBreakpoint(item)) {
-      const uri = URI.parse(item.uri);
       return {
         id: item.id,
         name: '',

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -1,8 +1,14 @@
 import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { BasicRecycleTree, CheckBox, IBasicTreeData } from '@opensumi/ide-components';
+import {
+  BasicRecycleTree,
+  CheckBox,
+  IBasicTreeData,
+  ICompositeTreeNode,
+  ITreeNodeOrCompositeTreeNode,
+} from '@opensumi/ide-components';
 import { Badge } from '@opensumi/ide-components';
 import {
   useInjectable,
@@ -113,9 +119,15 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
     }
   }, [treeData]);
 
+  const getItemClassName = useCallback((item: ICompositeTreeNode) => {
+    if (!item.children) {
+      return styles.debug_breakpoints_item_tree_node;
+    }
+  }, []);
+
   return (
     <div className={cls(styles.debug_breakpoints, !enable && styles.debug_breakpoints_disabled)}>
-      <BasicRecycleTree treeData={treeData} height={viewState.height} />
+      <BasicRecycleTree treeData={treeData} height={viewState.height} getItemClassName={getItemClassName} />
     </div>
   );
 });

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -4,11 +4,27 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BasicRecycleTree, CheckBox, IBasicTreeData } from '@opensumi/ide-components';
 import { Badge } from '@opensumi/ide-components';
-import { useInjectable, CommandService, EDITOR_COMMANDS, URI, getIcon, Disposable, ViewState } from '@opensumi/ide-core-browser';
+import {
+  useInjectable,
+  CommandService,
+  EDITOR_COMMANDS,
+  URI,
+  getIcon,
+  Disposable,
+  ViewState,
+} from '@opensumi/ide-core-browser';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
 
 import { IDebugBreakpoint, IDebugSessionManager, ISourceBreakpoint } from '../../../common';
-import { DebugExceptionBreakpoint, isDebugBreakpoint, isRuntimeBreakpoint, getStatus, BreakpointManager, isDebugExceptionBreakpoint } from '../../breakpoint';
+import {
+  DebugExceptionBreakpoint,
+  isDebugBreakpoint,
+  isRuntimeBreakpoint,
+  getStatus,
+  BreakpointManager,
+  isDebugExceptionBreakpoint,
+  EXCEPTION_BREAKPOINT_URI,
+} from '../../breakpoint';
 import { DebugSessionManager } from '../../debug-session-manager';
 
 import styles from './debug-breakpoints.module.less';
@@ -22,64 +38,46 @@ export interface BreakpointItem {
 }
 
 export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChildren<{ viewState: ViewState }>) => {
-  const { nodes, enable, inDebugMode, toggleBreakpointEnable }: DebugBreakpointsService =
+  const { enable, inDebugMode, toggleBreakpointEnable, onDidChangeBreakpointsTreeNode }: DebugBreakpointsService =
     useInjectable(DebugBreakpointsService);
+  const [treeData, setTreeData] = useState<IBasicTreeData[]>([]);
 
-  const treeData = React.useMemo(() => {
-    const breakpointTreeData: IBasicTreeData[] = [];
-    const exceptionBreakpoints = nodes.filter(node => isDebugExceptionBreakpoint(node.breakpoint));
-    const excludeExceptionBreakpoints = nodes.filter(node => isDebugBreakpoint(node.breakpoint));
+  useEffect(() => {
+    const dispose = new Disposable();
 
-    if (exceptionBreakpoints.length > 0) {
-      exceptionBreakpoints.forEach(item => {
-        breakpointTreeData.push({
-          id: item.id,
-          label: '',
-          description: <BreakpointItem
-            toggle={() => toggleBreakpointEnable(item.breakpoint)}
-            breakpointEnabled={enable}
-            data={item}
-            isDebugMode={inDebugMode}
-          ></BreakpointItem>,
-          expandable: false,
-          children: [],
+    dispose.addDispose(
+      onDidChangeBreakpointsTreeNode((nodes) => {
+        const breakpointTreeData: IBasicTreeData[] = [];
+
+        Array.from(nodes.entries()).forEach(([uri, items]) => {
+          const isException = EXCEPTION_BREAKPOINT_URI.toString() === uri;
+
+          breakpointTreeData.push({
+            label: isException ? '' : URI.parse(uri).displayName,
+            expandable: !isException,
+            children: items.map((item) => ({
+                ...item,
+                label: '',
+                description: (
+                  <BreakpointItem
+                    toggle={() => toggleBreakpointEnable(item.breakpoint)}
+                    breakpointEnabled={enable}
+                    data={item.rawData}
+                    isDebugMode={inDebugMode}
+                  ></BreakpointItem>
+                ),
+              })),
+          });
         });
-      })
-    }
 
-    const groupByUri: Record<string, BreakpointItem[]> = excludeExceptionBreakpoints.reduce((acc, cur) => {
-      const uri = (cur.breakpoint as ISourceBreakpoint).uri;
-      if (!acc[uri]) {
-        acc[uri] = [];
-      }
-      acc[uri].push(cur);
-      return acc;
-    }, {} as Record<string, BreakpointItem[]>);
+        setTreeData(breakpointTreeData);
+      }),
+    );
 
-    for (const uri in groupByUri) {
-      const toURI = new URI(uri);
-
-      breakpointTreeData.push({
-        id: toURI.toString(),
-        name: toURI.displayName,
-        label: toURI.displayName,
-        expandable: true,
-        children: groupByUri[uri].map(item => ({
-          label: '',
-          id: item.id,
-          name: '',
-          description: <BreakpointItem
-            toggle={() => toggleBreakpointEnable(item.breakpoint)}
-            breakpointEnabled={enable}
-            data={item}
-            isDebugMode={inDebugMode}
-          ></BreakpointItem>,
-          rawData: item,
-        })),
-      });
+    return () => {
+      dispose.dispose();
     };
-    return breakpointTreeData;
-  }, [nodes]);
+  }, []);
 
   const resolveTestChildren = React.useCallback((node?: any) => {
     if (!node) {
@@ -195,13 +193,11 @@ export const BreakpointItem = ({
     debugBreakpointsService.delBreakpoint(data.breakpoint as IDebugBreakpoint);
   };
 
-  const isExceptionBreakpoint = useMemo(() => {
-    return isDebugExceptionBreakpoint(data.breakpoint)
-  }, [data])
+  const isExceptionBreakpoint = useMemo(() => isDebugExceptionBreakpoint(data.breakpoint), [data]);
 
   return (
     <div className={cls(styles.debug_breakpoints_item)}>
-      { !isExceptionBreakpoint && <div className={cls(converBreakpointClsState(), styles.debug_breakpoints_icon)}></div> }
+      {!isExceptionBreakpoint && <div className={cls(converBreakpointClsState(), styles.debug_breakpoints_icon)}></div>}
       <CheckBox id={data.id} onChange={handleBreakpointChange} checked={enabled}></CheckBox>
       <div className={styles.debug_breakpoints_wrapper} onClick={handleBreakpointClick}>
         <span className={styles.debug_breakpoints_name}>{data.name}</span>

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -49,6 +49,7 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
 
     dispose.addDispose(
       debugBreakpointsService.onDidChangeBreakpointsTreeNode((nodes) => {
+        const { roots } = debugBreakpointsService;
         const breakpointTreeData: IBasicTreeData[] = [];
 
         Array.from(nodes.entries()).forEach(([uri, items]) => {
@@ -71,8 +72,11 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
               });
             });
           } else {
+            const toURI = URI.parse(uri);
+            const parent = roots.filter((root) => root.isEqualOrParent(toURI))[0];
+
             breakpointTreeData.push({
-              label: URI.parse(uri).displayName,
+              label: parent ? parent.relative(toURI)!.toString() : URI.parse(uri).displayName,
               expandable: true,
               iconClassName: getIcon('file-text'),
               expanded: true,

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -1,8 +1,8 @@
 import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
-import { BasicRecycleTree, CheckBox, IBasicRecycleTreeHandle, IBasicTreeData } from '@opensumi/ide-components';
+import { BasicRecycleTree, CheckBox, IBasicTreeData } from '@opensumi/ide-components';
 import { Badge } from '@opensumi/ide-components';
 import {
   useInjectable,
@@ -22,7 +22,6 @@ import {
   isDebugBreakpoint,
   isRuntimeBreakpoint,
   getStatus,
-  BreakpointManager,
   isDebugExceptionBreakpoint,
   EXCEPTION_BREAKPOINT_URI,
 } from '../../breakpoint';


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

改进调试面板的断点视图列表，支持以树视图展示
根节点是文件，子节点是该文件下的所有断点列表

before:
![image](https://user-images.githubusercontent.com/20262815/228172457-f324c775-7e86-45f7-81b3-f4e1e6763d03.png)

after:
![image](https://user-images.githubusercontent.com/20262815/228172572-bf1b1a33-b54b-484d-92b6-d95a1c5246a6.png)

同时由于需要展示断点所在行的内容，就需要获取文档引用，在展示列表时，获取文档的引用操作改为异步获取，不影响断点列表的渲染
![Kapture 2023-03-28 at 16 17 13](https://user-images.githubusercontent.com/20262815/228173828-159f13f2-0d53-4c51-a751-9a7655e4c5b0.gif)


### Changelog
support displaying debug breakpoints in a tree view