### PR TITLE
fix: copy diff uri path at editor tab

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -734,7 +734,12 @@ export class FileTreeContribution
           return;
         }
         const copyUri: URI = uri;
-        let pathStr: string = decodeURIComponent(copyUri.path.toString());
+        let uriPath = copyUri.path.toString();
+        if (uri.scheme === 'diff') {
+          const query = uri.getParsedQuery();
+          uriPath = new URI(query.modified).path.toString();
+        }
+        let pathStr: string = decodeURIComponent(uriPath);
         // windows下移除路径前的 /
         if ((await this.appService.backendOS) === OperatingSystem.Windows) {
           pathStr = pathStr.slice(1);
@@ -748,6 +753,11 @@ export class FileTreeContribution
       execute: async (uri) => {
         if (!uri) {
           return;
+        }
+        if (uri.scheme === 'diff') {
+          const query = uri.getParsedQuery();
+          // 需要file scheme才能与工作区计算相对路径
+          uri = new URI(query.modified).withScheme('file');
         }
         let rootUri: URI;
         if (this.fileTreeService.isMultipleWorkspace) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
Copy path & copy relative path from editor tab is not working with diff uri:
<img width="915" alt="image" src="https://user-images.githubusercontent.com/13199771/228183885-befe437a-e9ce-4369-aec6-29388f26c17f.png">

### Changelog
fix: copy diff uri path at editor tab
