### PR TITLE
fix: Add support for buffer type conversion in ObjectTransfer module

### DIFF
--- a/packages/connection/src/common/rpcProtocol.ts
+++ b/packages/connection/src/common/rpcProtocol.ts
@@ -110,6 +110,12 @@ export namespace ObjectTransfer {
           $type: 'Buffer',
           data: Array.from(new Uint8Array(value)),
         };
+      } else if (value.type === 'Buffer') {
+        // https://nodejs.org/api/buffer.html#buftojson
+        return {
+          $type: 'Buffer',
+          data: value.data,
+        };
       }
     }
 


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution
fix: #2516 

这个问题是 `writeFile` 的第二个参数支持的是 `Uint8Array` ，传入 `Buffer` 的时候类型校验不会报错。`rpc` 传递消息时通过 `JSON.stringify()` 进行转换后会变成 `{ type: 'Buffer', data: [] }`，`provider` 内处理时会报错。所以在类型转换时增加对 `Buffer` 的兼容

### Changelog
fix: rpcTransfer add buffer support