### PR TITLE
feat: support setting: editor.unicodeHighlight.ambiguousCharacters

### DIFF
--- a/packages/editor/src/browser/preference/converter.ts
+++ b/packages/editor/src/browser/preference/converter.ts
@@ -723,6 +723,11 @@ export const editorOptionsConverters: Map<KaitianPreferenceKey, NoConverter | IM
       },
     },
   ],
+
+  /**
+   * Controls whether characters are highlighted that can be confused with basic ASCII characters
+   */
+  ['editor.unicodeHighlight', { monaco: 'unicodeHighlight' }],
 ]);
 
 export const textModelUpdateOptionsConverters: Map<KaitianPreferenceKey, NoConverter | IMonacoOptionsConverter> =

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1398,6 +1398,11 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     type: 'string',
     description: '%editor.configuration.defaultFormatter%',
   },
+  'editor.unicodeHighlight.ambiguousCharacters': {
+    type: 'boolean',
+    default: true,
+    description: '%editor.configuration.unicodeHighlight.ambiguousCharacters%',
+  },
 };
 
 const customEditorSchema: PreferenceSchemaProperties = {

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -917,6 +917,8 @@ export const localizationBundle = {
       "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'.",
     'editor.configuration.suggest.insertMode.insert': 'Insert suggestion without overwriting text right of the cursor.',
     'editor.configuration.suggest.insertMode.replace': 'Insert suggestion and overwrite text right of the cursor.',
+    'editor.configuration.unicodeHighlight.ambiguousCharacters':
+      'Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale.',
 
     'diffEditor.configuration.renderSideBySide':
       'Controls whether the diff editor shows the diff side by side or inline.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1026,6 +1026,8 @@ export const localizationBundle = {
     'editor.configuration.guides.indentation': '控制编辑器是否显示缩进参考线。',
     'editor.configuration.guides.highlightActiveIndentation': '控制是否突出显示编辑器中活动的缩进参考线。',
     'editor.configuration.trimAutoWhitespace': '删除自动插入的尾随空白符号。',
+    'editor.configuration.unicodeHighlight.ambiguousCharacters':
+      '控制是否突出显示可能与基本 ASCII 字符混淆的字符，但当前用户区域设置中常见的字符除外。',
 
     'diffEditor.configuration.renderSideBySide': '控制差异编辑器的显示方式。',
     'diffEditor.configuration.ignoreTrimWhitespace': '启用后，差异编辑器的前导和尾随空白字符将会忽略',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -657,6 +657,7 @@ export const defaultSettingSections: {
           localized: 'preference.editor.bracketPairColorization.enabled',
         },
         { id: 'workbench.editorAssociations' },
+        { id: 'editor.unicodeHighlight.ambiguousCharacters' },
       ],
     },
     {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
close: #2303 

### Changelog
支持 editor.unicodeHighlight.ambiguousCharacters 配置，默认开启
<img width="279" alt="截屏2023-03-30 15 55 39" src="https://user-images.githubusercontent.com/19860190/228769773-83907f7d-49cc-4442-868e-cb3693ec4ea6.png">
