### PR TITLE
fix: clear old listen and initView when extension restart

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -364,7 +364,6 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
     if (!init) {
       // 重启场景下需要将申明过 browserView 的 sumi 插件的 contributes 重新跑一遍
       await this.rerunSumiViewExtensionContributes();
-
       // 重启场景下把 ActivationEvent 再发一次
       if (this.activationEventService.activatedEventSet.size) {
         const activatedEventArr = Array.from(this.activationEventService.activatedEventSet);
@@ -630,8 +629,18 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
     const extensionPaths = Array.from(activatedViewExtensionMap.keys());
 
     await Promise.all(
-      extensionPaths.map((path) => this.extensionInstanceManageService.getExtensionInstanceByPath(path)?.initialize()),
+      extensionPaths.map((path) => {
+        const extension = this.extensionInstanceManageService.getExtensionInstanceByPath(path);
+        if (extension) {
+          extension.initialize();
+          this.contributesService.register(extension.id, extension.contributes);
+          this.sumiContributesService.register(extension.id, extension.packageJSON.kaitianContributes || {});
+        }
+      }),
     );
+
+    this.contributesService.initialize();
+    this.sumiContributesService.initialize();
 
     activatedViewExtensionMap.clear();
   }

--- a/packages/extension/src/node/extension.service.ts
+++ b/packages/extension/src/node/extension.service.ts
@@ -256,6 +256,10 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
     extServer.listen(extServerListenOptions, () => {
       this.logger.log(`${clientId} ext server listen on ${JSON.stringify(extServerListenOptions)}`);
     });
+    // 重启时，旧的 path 已经不再使用，但是系统未清理，导致 listen 会失败，所以在连接关闭时，主动清理
+    extServer.on('close', () => {
+      this.extServerListenOptions.delete(clientId);
+    });
   }
 
   private async _createExtHostProcess(clientId: string, options?: ICreateProcessOptions) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fix: #2311 

### Changelog

* clear old listen option when extServer closed
* rerun view extension contributes
