### PR TITLE
fix: markdownDescription i18n in launch.json

### DIFF
--- a/packages/core-common/src/json-schema.ts
+++ b/packages/core-common/src/json-schema.ts
@@ -65,6 +65,7 @@ export interface IJSONSchemaMap {
 export interface IJSONSchemaSnippet {
   label?: string;
   description?: string;
+  markdownDescription?: string;
   body?: any; // a object that will be JSON stringified
   bodyText?: string; // an already stringified JSON object that can contain new lines (\n) and tabs (\t)
 }

--- a/packages/extension/src/browser/vscode/contributes/debuggers.ts
+++ b/packages/extension/src/browser/vscode/contributes/debuggers.ts
@@ -243,6 +243,9 @@ export class DebuggersContributionPoint extends VSCodeContributePoint<DebuggersC
           if (config.description) {
             config.description = replaceLocalizePlaceholder(config.description, extension.id);
           }
+          if (config.markdownDescription) {
+            config.markdownDescription = replaceLocalizePlaceholder(config.markdownDescription, extension.id);
+          }
           return config;
         },
       ),
@@ -280,6 +283,7 @@ export class DebuggersContributionPoint extends VSCodeContributePoint<DebuggersC
           recursionPropertiesDescription(prop[name].properties!);
         }
         prop[name].description = replaceLocalizePlaceholder(prop[name].description, extension.id);
+        prop[name].markdownDescription = replaceLocalizePlaceholder(prop[name].markdownDescription, extension.id);
       });
     };
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before
![image](https://user-images.githubusercontent.com/20262815/229479528-54b7b341-0bb3-4484-8b32-de50ff0fedc9.png)

after
![image](https://user-images.githubusercontent.com/20262815/229480053-d50bafdb-3eb2-44eb-bb9a-730186baa8b8.png)


### Changelog
修复 launch.json 配置代码补全的部分国际化显示异常问题