### PR TITLE
fix: return statement will break for..of loop

### DIFF
--- a/packages/file-service/src/node/file-service-watcher.ts
+++ b/packages/file-service/src/node/file-service-watcher.ts
@@ -326,7 +326,7 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
       if (event.action === INsfw.actions.RENAMED) {
         const deletedPath = this.resolvePath(event.directory, event.oldFile!);
         if (isIgnored(watcherId, deletedPath)) {
-          return;
+          continue;
         }
 
         this.pushDeleted(deletedPath);
@@ -334,14 +334,14 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
         if (event.newDirectory) {
           const path = this.resolvePath(event.newDirectory, event.newFile!);
           if (isIgnored(watcherId, path)) {
-            return;
+            continue;
           }
 
           this.pushAdded(path);
         } else {
           const path = this.resolvePath(event.directory, event.newFile!);
           if (isIgnored(watcherId, path)) {
-            return;
+            continue;
           }
 
           this.pushAdded(path);
@@ -349,7 +349,7 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
       } else {
         const path = this.resolvePath(event.directory, event.file!);
         if (isIgnored(watcherId, path)) {
-          return;
+          continue;
         }
 
         if (event.action === INsfw.actions.CREATED) {


### PR DESCRIPTION
### Types

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
这里存在逻辑错误，当批量事件中有某一项命中了 ignored 逻辑时，return 语句会直接退出 for of 循环，导致后续的事件项未被处理。
这个逻辑错误会导致在 linux 系统下依赖了文件变更监听的功能一定概率不能正常工作

### Changelog
