### PR TITLE
chore: copilot PR test

### DIFF
--- a/packages/extension/src/browser/extension-management.service.ts
+++ b/packages/extension/src/browser/extension-management.service.ts
@@ -1,5 +1,5 @@
 import { Autowired, Injectable } from '@opensumi/di';
-import { CommandService, getLanguageId, ILogger, WithEventBus } from '@opensumi/ide-core-common';
+import { CommandService, getLanguageId, ILogger, URI, WithEventBus } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { IIconService, IThemeService } from '@opensumi/ide-theme';
 import { ICON_THEME_TOGGLE_COMMAND, THEME_TOGGLE_COMMAND } from '@opensumi/ide-theme/lib/browser/theme.contribution';
@@ -208,7 +208,7 @@ export class ExtensionManagementService extends WithEventBus implements Abstract
    */
   private async removeExtension(extensionPath: string) {
     try {
-      await this.fileService.delete(extensionPath);
+      await this.fileService.delete(URI.file(extensionPath).toString());
       return true;
     } catch (err) {
       this.logger.error(err);


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5764718</samp>

Fixed a bug in `extension-management.service.ts` that prevented deleting extensions. Used `URI` class to handle file paths consistently.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5764718</samp>

> _Oh we're the coders of the sea, and we fix the bugs with glee_
> _We import the `URI` class and make the paths agree_
> _We heave away and haul away and delete the extensions fast_
> _We heave away and haul away and make the code more robust_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5764718</samp>

* Imported `URI` class to convert file paths to URIs in `removeExtension` method ([link](https://github.com/opensumi/core/pull/2549/files?diff=unified&w=0#diff-ee02fb088a19a9a0c87b1501c7a1ce3a1a6a70ce687546360ae17f0197611417L2-R2))
* Wrapped `extensionPath` parameter with `URI.file` and `toString` in `removeExtension` method to match the expected argument type of `fileService.delete` method ([link](https://github.com/opensumi/core/pull/2549/files?diff=unified&w=0#diff-ee02fb088a19a9a0c87b1501c7a1ce3a1a6a70ce687546360ae17f0197611417L211-R211))