### PR TITLE
fix: collapsed tree node on compact mode

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -631,10 +631,11 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     const paths: string[] = [];
     let start = 0;
     if (!CompositeTreeNode.isRoot(this)) {
-      start = (this.root as CompositeTreeNode)?.getIndexAtTreeNodeId(this.id);
+      // 找到节点位置下标，向下进一步查找展开目录
+      start = (this.root as CompositeTreeNode)?.getIndexAtTreeNodeId(this.id) + 1;
     }
     const end = start + this.branchSize;
-    for (let i = start + 1; i < end; i++) {
+    for (let i = start; i < end; i++) {
       const node = (this.root as CompositeTreeNode)?.getTreeNodeAtIndex(i);
       if (CompositeTreeNode.is(node) && (node as CompositeTreeNode).expanded) {
         paths.push(node.path);

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -626,30 +626,19 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     }
   }
 
-  private isCompactNode(node: ICompositeTreeNode) {
-    return CompositeTreeNode.is(node) && node.name.includes(Path.separator);
-  }
-
-  // 获取当前节点下所有展开的节点路径
+  // 获取当前节点下所有展开的节点路径, 仅支持 Root 节点
   private getAllExpandedNodePath() {
-    let paths: string[] = [];
-    if (this.children) {
-      for (let i = 0; i < this.children.length; i++) {
-        const child = this.children[i];
-        if (CompositeTreeNode.is(child) && (child as CompositeTreeNode).expanded) {
-          if (this.isCompactNode(child) && child.parent?.path) {
-            // 当获取到的节点为压缩节点时，仅需要存储其根路径，便于后续展开更新节点状态
-            paths.push(new Path(child.parent.path).join(child.name.split(Path.separator)[0]).toString());
-          } else {
-            paths.push(child.path);
-          }
-          paths = paths.concat((child as CompositeTreeNode).getAllExpandedNodePath());
-        }
-      }
-      return paths;
-    } else {
+    const paths: string[] = [];
+    if (!CompositeTreeNode.isRoot(this)) {
       return paths;
     }
+    for (let i = 0; i < this.branchSize; i++) {
+      const node = this.getTreeNodeAtIndex(i);
+      if (CompositeTreeNode.is(node) && (node as CompositeTreeNode).expanded) {
+        paths.push(node.path);
+      }
+    }
+    return paths;
   }
 
   // 获取当前节点下所有折叠的节点路径
@@ -1627,7 +1616,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
    * 根据路径展开节点树
    * @memberof CompositeTreeNode
    */
-  public async loadTreeNodeByPath(path: string): Promise<ITreeNodeOrCompositeTreeNode | undefined> {
+  public async loadTreeNodeByPath(path: string, quiet = false): Promise<ITreeNodeOrCompositeTreeNode | undefined> {
     if (!CompositeTreeNode.isRoot(this)) {
       return;
     }
@@ -1663,7 +1652,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       return;
     }
     let next = this._children;
-    let preItem: CompositeTreeNode;
+    let preItem: CompositeTreeNode | undefined;
     let preItemPath = '';
     let name;
     while (next && (name = pathFlag.shift())) {
@@ -1685,22 +1674,12 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
           (item as CompositeTreeNode)._watcher.notifyDidChangeExpansionState(item, true);
         }
         if (pathFlag.length === 0) {
-          let child;
-          while ((child = flattenedBranchChilds.pop())) {
-            (child as CompositeTreeNode).expandBranch(child, true);
-            if (flattenedBranchChilds.length === 0) {
-              this.updateTreeNodeCache(child as CompositeTreeNode);
-            }
-          }
-          this.watcher.notifyDidUpdateBranch();
-          TreeNode.setGlobalTreeState(this.path, {
-            isLoadingPath: false,
-          });
-          return item;
+          preItem = item as CompositeTreeNode;
+          break;
         }
       }
       // 可能展开后路径发生了变化, 需要重新处理一下当前加载路径
-      if (!item && preItem!) {
+      if (!item && preItem) {
         const compactPath = splitPath(preItem.name).slice(1);
         if (compactPath[0] === name) {
           compactPath.shift();
@@ -1718,18 +1697,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       }
       // 最终加载到的路径节点
       if (!item || (!CompositeTreeNode.is(item) && pathFlag.length > 0)) {
-        let child;
-        while ((child = flattenedBranchChilds.pop())) {
-          (child as CompositeTreeNode).expandBranch(child, true);
-          if (flattenedBranchChilds.length === 0) {
-            this.updateTreeNodeCache(child as CompositeTreeNode);
-          }
-        }
-        this.watcher.notifyDidUpdateBranch();
-        TreeNode.setGlobalTreeState(this.path, {
-          isLoadingPath: false,
-        });
-        return preItem!;
+        break;
       }
       if (CompositeTreeNode.is(item)) {
         const isCompactName = item.name.indexOf(Path.separator) > 0;
@@ -1761,24 +1729,14 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
           }
         }
         if (item && pathFlag.length === 0) {
-          let child;
-          while ((child = flattenedBranchChilds.pop())) {
-            (child as CompositeTreeNode).expandBranch(child, true);
-            if (flattenedBranchChilds.length === 0) {
-              this.updateTreeNodeCache(child as CompositeTreeNode);
-            }
-          }
-          this.watcher.notifyDidUpdateBranch();
-          TreeNode.setGlobalTreeState(this.path, {
-            isLoadingPath: false,
-          });
-          return item;
+          preItem = item as CompositeTreeNode;
+          break;
         } else {
           if (!!preItemPath && preItemPath !== item.path) {
             // 说明此时已发生了路径压缩，如从 a -> a/b/c
             // 需要根据路径变化移除对应的展开路径, 这里只需考虑短变长场景
-            const prePaths = Path.splitPath(preItemPath);
-            const nextPaths = Path.splitPath(item.path);
+            const prePaths = splitPath(preItemPath);
+            const nextPaths = splitPath(item.path);
             if (nextPaths.length > prePaths.length) {
               pathFlag.splice(0, nextPaths.length - prePaths.length);
             }
@@ -1789,15 +1747,23 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
       }
     }
 
-    if (preItem!) {
+    if (preItem) {
       let child;
+      if (preItem.disposed) {
+        TreeNode.setGlobalTreeState(this.path, {
+          isLoadingPath: false,
+        });
+        return;
+      }
       while ((child = flattenedBranchChilds.pop())) {
         (child as CompositeTreeNode).expandBranch(child, true);
         if (flattenedBranchChilds.length === 0) {
           this.updateTreeNodeCache(child as CompositeTreeNode);
         }
       }
-      this.watcher.notifyDidUpdateBranch();
+      if (!quiet) {
+        this.watcher.notifyDidUpdateBranch();
+      }
       TreeNode.setGlobalTreeState(this.path, {
         isLoadingPath: false,
       });

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -626,14 +626,16 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
     }
   }
 
-  // 获取当前节点下所有展开的节点路径, 仅支持 Root 节点
+  // 获取当前节点下所有展开的节点路径
   private getAllExpandedNodePath() {
     const paths: string[] = [];
+    let start = 0;
     if (!CompositeTreeNode.isRoot(this)) {
-      return paths;
+      start = (this.root as CompositeTreeNode)?.getIndexAtTreeNodeId(this.id);
     }
-    for (let i = 0; i < this.branchSize; i++) {
-      const node = this.getTreeNodeAtIndex(i);
+    const end = start + this.branchSize;
+    for (let i = start + 1; i < end; i++) {
+      const node = (this.root as CompositeTreeNode)?.getTreeNodeAtIndex(i);
       if (CompositeTreeNode.is(node) && (node as CompositeTreeNode).expanded) {
         paths.push(node.path);
       }

--- a/packages/components/src/recycle-tree/tree/model/treeState/TreeStateManager.ts
+++ b/packages/components/src/recycle-tree/tree/model/treeState/TreeStateManager.ts
@@ -89,7 +89,7 @@ export class TreeStateManager {
       }
       for (const relPath of state.expandedDirectories.atSurface) {
         try {
-          const node = await this.root.loadTreeNodeByPath(relPath);
+          const node = await this.root.loadTreeNodeByPath(relPath, true);
           if (!node) {
             break;
           }
@@ -99,6 +99,7 @@ export class TreeStateManager {
         typeof state.scrollPosition === 'number' && state.scrollPosition > -1
           ? state.scrollPosition
           : this._scrollOffset;
+      this.root.watcher.notifyDidUpdateBranch();
       this.onDidLoadStateEmitter.fire();
     }
   }

--- a/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
@@ -1,4 +1,4 @@
-import { ICompositeTreeNode, TreeNodeType } from '@opensumi/ide-components';
+import { TreeNodeType } from '@opensumi/ide-components';
 import {
   URI,
   Disposable,
@@ -7,7 +7,6 @@ import {
   IApplicationService,
   Emitter,
   OS,
-  EDITOR_COMMANDS,
 } from '@opensumi/ide-core-browser';
 import { ICtxMenuRenderer } from '@opensumi/ide-core-browser/lib/menu/next';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
@@ -76,6 +75,7 @@ describe('FileTreeModelService should be work', () => {
     watcher: {
       on: jest.fn(() => Disposable.create(() => {})),
       notifyDidChangeMetadata: jest.fn(),
+      notifyDidUpdateBranch: jest.fn(),
     },
     watchEvents: {
       get: jest.fn(() => mockWatcher),

--- a/packages/outline/__tests__/browser/services/outline-model.service.test.ts
+++ b/packages/outline/__tests__/browser/services/outline-model.service.test.ts
@@ -245,14 +245,14 @@ describe('OutlineTreeModelService', () => {
 
   it('collapseAll method should be work', async () => {
     await outlineTreeModelService.collapseAll();
-    const node = outlineTreeModelService.treeModel!.root!.children![0] as OutlineTreeNode;
+    const node = outlineTreeModelService.treeModel?.root?.getTreeNodeAtIndex(0) as OutlineTreeNode;
     expect((node as OutlineCompositeTreeNode).expanded).toBeFalsy();
   });
 
   it('location method should be work', async () => {
     const treeHandle = { ensureVisible: jest.fn() } as any;
     outlineTreeModelService.handleTreeHandler(treeHandle);
-    const node = outlineTreeModelService.treeModel!.root!.children![0] as OutlineTreeNode;
+    const node = outlineTreeModelService.treeModel?.root?.getTreeNodeAtIndex(0) as OutlineTreeNode;
     await outlineTreeModelService.location(node);
     expect(treeHandle.ensureVisible).toBeCalledTimes(1);
   });

--- a/tools/playwright/src/tests/explorer-view.test.ts
+++ b/tools/playwright/src/tests/explorer-view.test.ts
@@ -329,4 +329,59 @@ console.log(a);`,
     await app.page.waitForTimeout(2000);
     expect(await outlineView.isVisible()).toBeFalsy();
   });
+
+  test('when a new file is created in the folder, the rest of the expanded folders are still expanded', async () => {
+    let action = await fileTreeView.getTitleActionByName('New File');
+    await action?.click();
+    // type `new_folder3` as the folder name
+    const newFileName_1 = 'new_folder3/index.js';
+    let input = await (await fileTreeView.getViewElement())?.waitForSelector('.kt-input-box');
+    if (input != null) {
+      await input.focus();
+      await input.type(newFileName_1, { delay: 200 });
+      await app.page.keyboard.press('Enter');
+    }
+    await app.page.waitForTimeout(200);
+    let node = await explorer.getFileStatTreeNodeByPath('new_folder3');
+    await node?.open();
+
+    action = await fileTreeView.getTitleActionByName('New Folder');
+    await action?.click();
+    // type `new_folder4` as the folder name
+    const newFileName_2 = 'new_folder4';
+    input = await (await fileTreeView.getViewElement())?.waitForSelector('.kt-input-box');
+    if (input != null) {
+      await input.focus();
+      await input.type(newFileName_2, { delay: 200 });
+      await app.page.keyboard.press('Enter');
+    }
+    await app.page.waitForTimeout(200);
+    // expanded `new_folder4`
+    node = await explorer.getFileStatTreeNodeByPath(newFileName_2);
+    await node?.open();
+    expect(await node?.isExpanded()).toBeTruthy();
+
+    // select the `new_folder3` folder and expanded it
+    node = await explorer.getFileStatTreeNodeByPath(newFileName_1);
+    await node?.open();
+    await node?.open();
+
+    action = await fileTreeView.getTitleActionByName('New File');
+    await action?.click();
+    // type `new_file` as the file name
+    const newFileName_3 = 'new_file';
+    input = await (await fileTreeView.getViewElement())?.waitForSelector('.kt-input-box');
+    if (input != null) {
+      await input.focus();
+      await input.type(newFileName_3, { delay: 200 });
+      await app.page.keyboard.press('Enter');
+    }
+    await app.page.waitForTimeout(200);
+
+    node = await explorer.getFileStatTreeNodeByPath(newFileName_3);
+    expect(node).toBeDefined();
+    // The `new_folder3` folder should be expaned also
+    node = await explorer.getFileStatTreeNodeByPath(newFileName_1);
+    expect(await node?.isExpanded()).toBeTruthy();
+  });
 });

--- a/tools/playwright/src/tests/explorer-view.test.ts
+++ b/tools/playwright/src/tests/explorer-view.test.ts
@@ -271,7 +271,7 @@ console.log(a);`,
     await app.page.waitForTimeout(1000);
     // |- test
     // |----a/b
-    const nodeA = await explorer.getFileStatTreeNodeByPath('test/a');
+    let nodeA = await explorer.getFileStatTreeNodeByPath('test/a');
     await nodeA?.expand();
     await app.page.waitForTimeout(2000);
     expect(await nodeA?.isCollapsed()).toBeFalsy();
@@ -282,7 +282,7 @@ console.log(a);`,
     newFileMenu = await menu?.menuItemByName('New File');
     await newFileMenu?.click();
     // type `a/d/c.js` as the file name
-    newFileName = 'a/d/c.js';
+    newFileName = 'b/c/.js';
     input = await (await fileTreeView.getViewElement())?.waitForSelector('.kt-input-box');
     if (input != null) {
       await input.focus();
@@ -294,6 +294,9 @@ console.log(a);`,
     // |----a
     // |------b
     // |------d
+    // The `a` directory becomes collapsed again due to the compressed path being reset
+    nodeA = await explorer.getFileStatTreeNodeByPath('test/a');
+    await nodeA?.expand();
     const uncompressNode = await explorer.getFileStatTreeNodeByPath('test/a/b');
     expect(uncompressNode).toBeDefined();
     expect(await uncompressNode?.label()).toBe('b');

--- a/tools/playwright/src/tests/explorer-view.test.ts
+++ b/tools/playwright/src/tests/explorer-view.test.ts
@@ -282,7 +282,7 @@ console.log(a);`,
     newFileMenu = await menu?.menuItemByName('New File');
     await newFileMenu?.click();
     // type `a/d/c.js` as the file name
-    newFileName = 'b/c/.js';
+    newFileName = 'a/d/c.js';
     input = await (await fileTreeView.getViewElement())?.waitForSelector('.kt-input-box');
     if (input != null) {
       await input.focus();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

修复文件树上折叠全部功能在压缩目录下功能不符预期问题，同时修复极端场景下，文件树文件定位可能出现的异常问题

### Changelog

fix collapsed tree node on compact mode