### PR TITLE
fix(core-browser): move react to peerDependencies

### DIFF
--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -34,7 +34,6 @@
     "mobx-react-lite": "^1.3.1",
     "onigasm": "2.2.2",
     "rc-menu": "^9.3.2",
-    "react": "^16.8.6",
     "react-autosize-textarea": "^7.0.0",
     "react-ctxmenu-trigger": "^1.0.0",
     "react-custom-scrollbars": "^4.2.1",
@@ -44,5 +43,11 @@
     "resize-observer-polyfill": "1.5.1",
     "strip-json-comments": "3.0.1",
     "vscode-textmate": "7.0.1"
+  },
+  "devDependencies": {
+    "react": "^16.8.6"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,6 +2762,8 @@ __metadata:
     resize-observer-polyfill: 1.5.1
     strip-json-comments: 3.0.1
     vscode-textmate: 7.0.1
+  peerDependencies:
+    react: ">=16.8.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Types

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [x] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
@opensumi/ide-core-browser depends on react@^16.8.6, which should be put in peerDependencies to avoid creating extra unnecessary react@16.x environment.

### Changelog
fix(core-browser): move react to peerDependencies.
