### PR TITLE
feat: support debug configuration and toolbar view component

### DIFF
--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -75,7 +75,7 @@ import { DebugRunToCursorService } from './editor/debug-run-to-cursor.service';
 import { DebugBreakpointsService } from './view/breakpoints/debug-breakpoints.service';
 import { DebugBreakpointView } from './view/breakpoints/debug-breakpoints.view';
 import { DebugConfigurationService } from './view/configuration/debug-configuration.service';
-import { DebugConfigurationView } from './view/configuration/debug-configuration.view';
+import { DebugConfigurationContainerView } from './view/configuration/debug-configuration.view';
 import { DebugToolbarService } from './view/configuration/debug-toolbar.service';
 import { DebugConsoleService } from './view/console/debug-console.service';
 import { DebugViewModel } from './view/debug-view-model';
@@ -254,7 +254,7 @@ export class DebugContribution
         priority: 7,
         title: localize('debug.container.title'),
         containerId: DEBUG_CONTAINER_ID,
-        titleComponent: DebugConfigurationView,
+        titleComponent: DebugConfigurationContainerView,
         activateKeyBinding: 'ctrlcmd+shift+d',
       },
     );
@@ -349,7 +349,7 @@ export class DebugContribution
   onDidRender() {
     const handler = this.mainlayoutService.getTabbarHandler(DEBUG_CONTAINER_ID);
     if (handler) {
-      handler!.setTitleComponent(DebugConfigurationView);
+      handler!.setTitleComponent(DebugConfigurationContainerView);
     }
   }
 

--- a/packages/debug/src/browser/view/configuration/debug-configuration.module.less
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.module.less
@@ -1,11 +1,14 @@
 @import '~@opensumi/ide-components/lib/style/mixins.less';
 
+.debug_action_bar_internal {
+  padding: 0px 8px;
+  margin-bottom: 8px;
+}
+
 .debug_action_bar {
   height: 28px;
   display: flex;
   align-items: center;
-  padding: 0px 8px;
-  margin-bottom: 8px;
   justify-content: flex-start;
   pointer-events: all;
   overflow: hidden;
@@ -36,11 +39,14 @@
   }
 }
 
+.debug_configuration_container {
+  padding-right: 8px;
+  margin-bottom: 8px;
+}
+
 .debug_configuration_toolbar {
   display: flex;
   height: 28px;
-  padding-right: 8px;
-  margin-bottom: 8px;
   align-items: center;
 
   .debug_actions {

--- a/packages/debug/src/browser/view/configuration/debug-configuration.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.view.tsx
@@ -2,15 +2,15 @@ import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
-import { Select, Option } from '@opensumi/ide-components';
-import { useInjectable, localize, URI, AppConfig } from '@opensumi/ide-core-browser';
+import { Option, Select } from '@opensumi/ide-components';
+import { AppConfig, URI, localize, useInjectable } from '@opensumi/ide-core-browser';
 import { Select as NativeSelect } from '@opensumi/ide-core-browser/lib/components/select';
 
 import {
   DEFAULT_ADD_CONFIGURATION_KEY,
-  DEFAULT_NO_CONFIGURATION_KEY,
   DEFAULT_CONFIGURATION_INDEX_SEPARATOR,
   DEFAULT_CONFIGURATION_NAME_SEPARATOR,
+  DEFAULT_NO_CONFIGURATION_KEY,
   DebugSessionOptions,
 } from '../../../common';
 import { DebugAction } from '../../components';
@@ -209,10 +209,15 @@ export const DebugConfigurationContainerView = observer(() => {
   );
 });
 
+export interface DebugControllerViewProps {
+  className?: string;
+}
+
 /**
- * @API 调试配置组件: 展示 debug 启动配置项
+ * 该组件支持用户导入
+ * 后续如果有一些改动需要考虑是否有 breakchange
  */
-export const DebugControllerView = observer((props: { className?: string }) => {
+export const DebugControllerView = observer((props: DebugControllerViewProps) => {
   const {
     configurationOptions,
     toValue,

--- a/packages/debug/src/browser/view/configuration/debug-configuration.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.view.tsx
@@ -198,7 +198,21 @@ export const DebugActionBar = React.memo(({ runDebug, openConfiguration, openDeb
   </div>
 ));
 
-export const DebugConfigurationView = observer((props) => {
+export const DebugConfigurationContainerView = observer(() => {
+  const { float } = useInjectable<DebugConfigurationService>(DebugConfigurationService);
+
+  return (
+    <>
+      <DebugControllerView className={styles.debug_configuration_container} />
+      {!float && <DebugToolbarView float={false} className={styles.debug_action_bar_internal} />}
+    </>
+  );
+});
+
+/**
+ * @API 调试配置组件: 展示 debug 启动配置项
+ */
+export const DebugControllerView = observer((props: { className?: string }) => {
   const {
     configurationOptions,
     toValue,
@@ -208,12 +222,12 @@ export const DebugConfigurationView = observer((props) => {
     openDebugConsole,
     updateConfiguration,
     start,
-    float,
     isMultiRootWorkspace,
     workspaceRoots,
   } = useInjectable<DebugConfigurationService>(DebugConfigurationService);
   const appConfig = useInjectable<AppConfig>(AppConfig);
   const addConfigurationLabel = localize('debug.action.add.configuration');
+
   const setCurrentConfiguration = React.useCallback((event: React.ChangeEvent<HTMLSelectElement> | string) => {
     let value: React.ChangeEvent<HTMLSelectElement> | string;
     if (typeof event === 'object') {
@@ -236,21 +250,18 @@ export const DebugConfigurationView = observer((props) => {
   }, []);
 
   return (
-    <div>
-      <div className={styles.debug_configuration_toolbar}>
-        <ConfigurationSelector
-          currentValue={currentValue}
-          options={configurationOptions}
-          onChangeConfiguration={setCurrentConfiguration}
-          isMultiRootWorkspace={isMultiRootWorkspace}
-          addConfigurationLabel={addConfigurationLabel}
-          toValue={toValue}
-          isElectronRenderer={appConfig.isElectronRenderer}
-          workspaceRoots={workspaceRoots}
-        />
-        <DebugActionBar runDebug={start} openConfiguration={openConfiguration} openDebugConsole={openDebugConsole} />
-      </div>
-      {!float && <DebugToolbarView float={false} />}
+    <div className={cls(styles.debug_configuration_toolbar, props.className || '')}>
+      <ConfigurationSelector
+        currentValue={currentValue}
+        options={configurationOptions}
+        onChangeConfiguration={setCurrentConfiguration}
+        isMultiRootWorkspace={isMultiRootWorkspace}
+        addConfigurationLabel={addConfigurationLabel}
+        toValue={toValue}
+        isElectronRenderer={appConfig.isElectronRenderer}
+        workspaceRoots={workspaceRoots}
+      />
+      <DebugActionBar runDebug={start} openConfiguration={openConfiguration} openDebugConsole={openDebugConsole} />
     </div>
   );
 });

--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -7,13 +7,13 @@ import { Injectable } from '@opensumi/di';
 import { Option, Select } from '@opensumi/ide-components';
 import {
   AppConfig,
-  getIcon,
-  localize,
-  PreferenceService,
-  useInjectable,
   DisposableCollection,
+  PreferenceService,
   electronEnv,
+  getIcon,
   isMacintosh,
+  localize,
+  useInjectable,
 } from '@opensumi/ide-core-browser';
 import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { Select as NativeSelect } from '@opensumi/ide-core-browser/lib/components/select';
@@ -83,7 +83,8 @@ export interface DebugToolbarViewProps {
 }
 
 /**
- * @API 调试工具栏组件
+ * 该组件支持用户导入
+ * 后续如果有一些改动需要考虑是否有 breakchange
  */
 export const DebugToolbarView = observer((props: DebugToolbarViewProps) => {
   const {

--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -79,8 +79,12 @@ class FloatController {
 
 export interface DebugToolbarViewProps {
   float: boolean;
+  className?: string;
 }
 
+/**
+ * @API 调试工具栏组件
+ */
 export const DebugToolbarView = observer((props: DebugToolbarViewProps) => {
   const {
     state,
@@ -221,7 +225,7 @@ export const DebugToolbarView = observer((props: DebugToolbarViewProps) => {
   );
 
   return (
-    <div className={styles.debug_action_bar}>
+    <div className={cls(styles.debug_action_bar, props.className || '')}>
       {renderSelections(sessions.filter((s: DebugSession) => !s.parentSession))}
       <div className={styles.debug_actions}>
         {renderContinue(state)}


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

借助 menubar 的高度自定义能力，我们将 debug configuration 和 debug toolbar 实现了组件化，集成方可以将其作为单独的 react 组件导入到自定义的 menubar contribution 中，类似这样

```typescript
export const MenuBarView = () => (
  <div className={styles.menu_bar_debug}>
    <DebugControllerView />
    <DebugToolbarView float={false} />
  </div>
);
```

效果如下
![image](https://user-images.githubusercontent.com/20262815/230561030-4c676950-d0b6-4b43-b9b8-a4d19f982c29.png)

-----
1. 这两个组件后续如果有一些改动需要考虑是否有 breakchange，我在注释里通过 @API 来标识该组件是支持用户作为 API 组件导入的
2. 代码示例和最佳实践文档需要更新

### Changelog
支持 debug configuration 和 debug toolbar 的组件化