### PR TITLE
fix: foreground color of the match highlights on actively focused items

### DIFF
--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -258,7 +258,6 @@
           display: flex;
           flex-direction: row;
           justify-content: space-between;
-          color: inherit;
           &:hover .select_default_option_tips {
             color: var(--kt-selectDropdown-foreground);
           }

--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -470,13 +470,13 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
     let vscodeCssVariables = '#workbench-editor .monaco-editor{';
     for (const colorKey of Object.keys(colors)) {
       const targetColor = colors[colorKey] || theme.getColor(colorKey);
-      if (targetColor && !colorKey.startsWith('vscode')) {
+      if (targetColor) {
         const hexRule = `--${colorKey.replace(/\./g, '-')}: ${targetColor.toString()};\n`;
-        cssVariables += hexRule;
-      }
-      if (targetColor && colorKey.startsWith('vscode')) {
-        const hexRule = `--${colorKey.replace(/\./g, '-')}: ${targetColor.toString()};\n`;
-        vscodeCssVariables += hexRule;
+        if (colorKey.startsWith('vscode')) {
+          vscodeCssVariables += hexRule;
+        } else {
+          cssVariables += hexRule;
+        }
       }
     }
     let styleNode = document.getElementById('theme-style');

--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -467,20 +467,25 @@ export class WorkbenchThemeService extends WithEventBus implements IThemeService
     }
 
     let cssVariables = ':root{';
+    let vscodeCssVariables = '#workbench-editor .monaco-editor{';
     for (const colorKey of Object.keys(colors)) {
       const targetColor = colors[colorKey] || theme.getColor(colorKey);
-      if (targetColor) {
+      if (targetColor && !colorKey.startsWith('vscode')) {
         const hexRule = `--${colorKey.replace(/\./g, '-')}: ${targetColor.toString()};\n`;
         cssVariables += hexRule;
+      }
+      if (targetColor && colorKey.startsWith('vscode')) {
+        const hexRule = `--${colorKey.replace(/\./g, '-')}: ${targetColor.toString()};\n`;
+        vscodeCssVariables += hexRule;
       }
     }
     let styleNode = document.getElementById('theme-style');
     if (styleNode) {
-      styleNode.innerHTML = cssVariables + '}';
+      styleNode.innerHTML = vscodeCssVariables + '}' + cssVariables + '}';
     } else {
       styleNode = document.createElement('style');
       styleNode.id = 'theme-style';
-      styleNode.innerHTML = cssVariables + '}';
+      styleNode.innerHTML = vscodeCssVariables + '}' + cssVariables + '}';
       document.getElementsByTagName('head')[0].appendChild(styleNode);
     }
     if (this.currentTheme) {

--- a/packages/theme/src/common/color-tokens/custom/index.ts
+++ b/packages/theme/src/common/color-tokens/custom/index.ts
@@ -12,6 +12,7 @@ export * from './icon';
 export * from './input';
 export * from './menu';
 export * from './modal';
+export * from './monaco';
 export * from './notification';
 export * from './panel';
 export * from './select';

--- a/packages/theme/src/common/color-tokens/custom/monaco.ts
+++ b/packages/theme/src/common/color-tokens/custom/monaco.ts
@@ -1,0 +1,12 @@
+import { localize } from '@opensumi/ide-core-common';
+
+import { registerColor } from '../../utils';
+
+export const editorSuggesFocusHighlightForeground = registerColor(
+  'vscode.editorSuggestWidget.focusHighlightForeground',
+  { light: '#1a85ff', dark: '#58a6ff', hcDark: null, hcLight: null },
+  localize(
+    'editorSuggesFocusHighlightForeground',
+    'List/Tree foreground color of the match highlights on actively focused items when searching inside the list/tree.',
+  ),
+);

--- a/packages/theme/src/common/color-tokens/custom/monaco.ts
+++ b/packages/theme/src/common/color-tokens/custom/monaco.ts
@@ -1,5 +1,5 @@
 /**
- * 编译器 monaco 主题颜色使用的是 --vscode 开头的前缀
+ * monaco 编辑器内使用了 --vscode 前缀的 CSS Token，这里对其进行定义
  */
 import { localize } from '@opensumi/ide-core-common';
 

--- a/packages/theme/src/common/color-tokens/custom/monaco.ts
+++ b/packages/theme/src/common/color-tokens/custom/monaco.ts
@@ -1,3 +1,6 @@
+/**
+ * 编译器 monaco 主题颜色使用的是 --vscode 开头的前缀
+ */
 import { localize } from '@opensumi/ide-core-common';
 
 import { registerColor } from '../../utils';


### PR DESCRIPTION
### Types

- [X] 🐛 Bug Fixes

### Background or solution
fixed https://github.com/opensumi/core/issues/2520
![image](https://user-images.githubusercontent.com/1762334/230570547-1401853c-0a5e-43f5-8af1-4a0355f73fbc.png)
![image](https://user-images.githubusercontent.com/1762334/230570606-0932772d-5524-4522-9048-41bffd38939c.png)
![image](https://user-images.githubusercontent.com/1762334/230570666-257dff48-e58f-46e6-9c03-7a54df48fc89.png)


### Changelog
修复浅色主题下highlights文字颜色问题
