### PR TITLE
feat: support maxResize props on the panel

### DIFF
--- a/packages/components/src/recycle-tree/basic/index.tsx
+++ b/packages/components/src/recycle-tree/basic/index.tsx
@@ -52,6 +52,7 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
   }>({ show: false });
   const [menubarItems, setMenubarItems] = useState<IBasicTreeMenu[]>([]);
   const [model, setModel] = useState<BasicTreeModel | undefined>();
+  const isDisposed = useRef<boolean>(false);
   const treeService = useRef<BasicTreeService>();
   const treeHandle = useRef<IRecycleTreeHandle>();
   const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -99,6 +100,7 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
     wrapperRef.current?.addEventListener('blur', handleBlur, true);
 
     return () => {
+      isDisposed.current = true;
       wrapperRef.current?.removeEventListener('blur', handleBlur, true);
       disposable.dispose();
       treeService.current?.dispose();
@@ -113,7 +115,9 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
     if (model) {
       await model.ensureReady;
     }
-    setModel(model);
+    if (!isDisposed.current) {
+      setModel(model);
+    }
   };
 
   const selectItem = async (item: BasicCompositeTreeNode | BasicTreeNode) => {

--- a/packages/core-browser/src/components/layout/default-layout.tsx
+++ b/packages/core-browser/src/components/layout/default-layout.tsx
@@ -32,7 +32,8 @@ export function ToolbarActionBasedLayout() {
           slot='left'
           isTabbar={true}
           defaultSize={layout.left?.currentId ? layout.left?.size || 310 : 49}
-          minResize={204}
+          minResize={280}
+          maxResize={480}
           minSize={49}
         />
         <SplitPanel id='main-vertical' minResize={300} flexGrow={1} direction='top-to-bottom'>
@@ -51,7 +52,8 @@ export function ToolbarActionBasedLayout() {
           slot='right'
           isTabbar={true}
           defaultSize={layout.right?.currentId ? layout.right?.size || 310 : 0}
-          minResize={200}
+          minResize={280}
+          maxResize={480}
           minSize={0}
         />
       </SplitPanel>

--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -243,6 +243,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
       >
         <div
           data-min-resize={getProp(element, 'minResize')}
+          data-max-resize={getProp(element, 'maxResize')}
           ref={(ele) => {
             if (ele && splitPanelService.panels.indexOf(ele) === -1) {
               splitPanelService.panels.push(ele);

--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -228,6 +228,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
         );
       }
     }
+
     elements.push(
       <PanelContext.Provider
         key={index}
@@ -251,7 +252,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
           }}
           id={getProp(element, 'id') /* @deprecated: query by data-view-id */}
           style={{
-            // 手风琴场景，固定尺寸和flex尺寸混合布局；需要在resize flex模式下禁用
+            // 手风琴场景，固定尺寸和 flex 尺寸混合布局；需要在 Resize Flex 模式下禁用
             ...(getProp(element, 'flex') &&
             !getProp(element, 'savedSize') &&
             !childList.find((item) => getProp(item, 'flexGrow'))
@@ -263,7 +264,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
               : '-1px',
             [Layout.getMaxSizeProperty(direction)]:
               maxLocks[index] && getProp(element, 'maxSize') ? getProp(element, 'maxSize') + 'px' : 'unset',
-            // resize flex模式下应用flexGrow
+            // Resize Flex 模式下应用 flexGrow
             ...(getProp(element, 'flexGrow') !== undefined ? { flexGrow: getProp(element, 'flexGrow') } : {}),
             display: hides[index] ? 'none' : 'block',
             backgroundColor: getProp(element, 'backgroundColor'),

--- a/packages/startup/entry/web/layout.tsx
+++ b/packages/startup/entry/web/layout.tsx
@@ -14,7 +14,8 @@ export function DefaultLayout() {
           slot='left'
           isTabbar={true}
           defaultSize={layout.left?.currentId ? layout.left?.size || 310 : 49}
-          minResize={204}
+          minResize={280}
+          maxResize={480}
           minSize={49}
         />
         <SplitPanel id='main-vertical' minResize={300} flexGrow={1} direction='top-to-bottom'>
@@ -32,7 +33,8 @@ export function DefaultLayout() {
           slot='right'
           isTabbar={true}
           defaultSize={layout.right?.currentId ? layout.right?.size || 310 : 0}
-          minResize={200}
+          maxResize={480}
+          minResize={280}
           minSize={0}
         />
       </SplitPanel>

--- a/packages/status-bar/src/browser/status-bar.view.tsx
+++ b/packages/status-bar/src/browser/status-bar.view.tsx
@@ -30,7 +30,6 @@ export const StatusBarView = memo(
         menuNodes: result[1],
       });
     }, []);
-
     return (
       <div
         id={VIEW_CONTAINERS.STATUSBAR}
@@ -39,16 +38,18 @@ export const StatusBarView = memo(
         onContextMenu={handleCtxMenu}
       >
         <div className={cls(styles.area, styles.left)}>
-          {statusBar.leftEntries.length &&
-            statusBar.leftEntries.map((entry: StatusBarEntry, index: number) => (
-              <StatusBarItem key={`${entry.entryId}-${index}`} {...{ ...entry, color: color ?? entry.color }} />
-            ))}
+          {statusBar.leftEntries.length
+            ? statusBar.leftEntries.map((entry: StatusBarEntry, index: number) => (
+                <StatusBarItem key={`${entry.entryId}-${index}`} {...{ ...entry, color: color ?? entry.color }} />
+              ))
+            : null}
         </div>
         <div className={cls(styles.area, styles.right)}>
-          {statusBar.rightEntries.length &&
-            statusBar.rightEntries.map((entry: StatusBarEntry, index: number) => (
-              <StatusBarItem key={`${entry.entryId}-${index}`} {...{ ...entry, color: color ?? entry.color }} />
-            ))}
+          {statusBar.rightEntries.length
+            ? statusBar.rightEntries.map((entry: StatusBarEntry, index: number) => (
+                <StatusBarItem key={`${entry.entryId}-${index}`} {...{ ...entry, color: color ?? entry.color }} />
+              ))
+            : null}
         </div>
       </div>
     );


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d27eae1</samp>

*  Add a ref variable `isDisposed` to check if the `RecycleTreeBasic` component is unmounted before updating the state ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-f395d2cb7e258e73ab294dfc90242f98dd590f5544c9b95163a4938799806892R55),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-f395d2cb7e258e73ab294dfc90242f98dd590f5544c9b95163a4938799806892R103),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-f395d2cb7e258e73ab294dfc90242f98dd590f5544c9b95163a4938799806892L116-R120))
*  Modify the `minResize` and `maxResize` props of the `SplitPanel` component in the `DefaultLayout` and `ToolbarActionBasedLayout` components, which control the layout of the left and right panels, to allow resizing between 280px and 480px ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-5d3bf88e1ef746c955715d46cc00e01275fdca827373a88ee047eaa99a5c2aefL35-R36),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-5d3bf88e1ef746c955715d46cc00e01275fdca827373a88ee047eaa99a5c2aefL54-R56),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-99adc2e00320096646c31fff7237f5ca837446dd1d09f33a3bd7f57fd3a64384L17-R18),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-99adc2e00320096646c31fff7237f5ca837446dd1d09f33a3bd7f57fd3a64384L35-R37))
*  Add a data attribute `data-max-resize` to the `SplitPanel` component, which stores the maximum resize value of each panel element ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-0ba57727cf1cb6b9943e69eb29748565c7838180ba86afdab95c6f9476e9c13bR247))
*  Add optional chaining operators and a condition to check the maximum resize values in the `ResizeHandleHorizontal` component, which handles the horizontal resizing of the panels, to avoid errors and limit resizing ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-359d629a53667bd1036319870b515e01ded7a6063467e4991d2e53bb5c4ab8f1L91-R99),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-359d629a53667bd1036319870b515e01ded7a6063467e4991d2e53bb5c4ab8f1R105-R109))
*  Refactor the `flexModeSetSize` function in the `ResizeHandleHorizontal` component, which sets the size of the fixed and flex elements in the flex mode, to simplify the logic and use constants ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-359d629a53667bd1036319870b515e01ded7a6063467e4991d2e53bb5c4ab8f1L112-R163))
*  Add spaces between the Chinese and English words in the comments of the `SplitPanel` component, for readability and consistency ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-0ba57727cf1cb6b9943e69eb29748565c7838180ba86afdab95c6f9476e9c13bL253-R255),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-0ba57727cf1cb6b9943e69eb29748565c7838180ba86afdab95c6f9476e9c13bL265-R267))
*  Add a ternary operator to check the length of the status bar item arrays in the `StatusBarView` component, which renders the status bar items, to avoid rendering an empty array as a child element ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-e630c554045730fe4df9c7786f0d2563b129a6d413e39f147923f2383f61d16fL42-R52))
*  Add and remove empty lines in the `SplitPanel` and `StatusBarView` component files, for code style consistency ([link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-0ba57727cf1cb6b9943e69eb29748565c7838180ba86afdab95c6f9476e9c13bR231),[link](https://github.com/opensumi/core/pull/2569/files?diff=unified&w=0#diff-e630c554045730fe4df9c7786f0d2563b129a6d413e39f147923f2383f61d16fL33))

close #2537 

在侧边栏默认大小控制方面，还可以通过 `AppConfig#panelSize` 的方式去控制。相关逻辑见：

https://github.com/opensumi/core/blob/19ad0bf2e18b49680965daff3bd77ff7ff5a1630/packages/main-layout/src/browser/tabbar/panel.view.tsx#L48

同时修复骨架图下面的 `0     0` 奇怪样式

![image](https://user-images.githubusercontent.com/9823838/230884189-812ed313-7c87-4bcc-b645-5cb9b2e68b1e.png)

### Changelog

support maxResize props on the panel and fix some warnings
