### PR TITLE
fix: restart debug session on node-debug

### DIFF
--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -182,7 +182,7 @@ export class DebugSessionConnection implements IDisposable {
     };
 
     let cancelationListener: IDisposable;
-    if (args && Object.keys(args).length > 0) {
+    if (args) {
       request.arguments = args;
     }
 

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -485,11 +485,11 @@ export class DebugSessionManager implements IDebugSessionManager {
     return session && this.doRestart(session);
   }
   protected async doRestart(session: DebugSession, restart?: any): Promise<DebugSession | undefined> {
-    if (await session.restart()) {
+    const { options, configuration } = session;
+    if (await session.restart({ arguments: configuration })) {
       return session;
     }
     await session.terminate(true);
-    const { options, configuration } = session;
     configuration.__restart = restart;
     return this.start(options);
   }

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -948,14 +948,14 @@ export class DebugSession implements IDebugSession {
     ]);
   }
 
-  async restart(): Promise<boolean> {
+  async restart(args: DebugProtocol.RestartArguments): Promise<boolean> {
     this.cancelAllRequests();
     if (this.capabilities.supportsRestartRequest) {
       this.terminated = false;
       if (this.lifecycleManagedByParent && this.parentSession) {
-        await this.parentSession.restart();
+        await this.parentSession.restart(args);
       } else {
-        await this.sendRequest('restart', {});
+        await this.sendRequest('restart', args);
       }
       return true;
     }

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -953,7 +953,7 @@ export class DebugSession implements IDebugSession {
     if (this.capabilities.supportsRestartRequest) {
       this.terminated = false;
       if (this.lifecycleManagedByParent && this.parentSession) {
-        await this.parentSession.restart(args);
+        await this.parentSession.restart({ arguments: (this.parentSession as DebugSession).configuration });
       } else {
         await this.sendRequest('restart', args);
       }

--- a/packages/debug/src/common/debug-session.ts
+++ b/packages/debug/src/common/debug-session.ts
@@ -74,7 +74,7 @@ export interface IDebugSession extends IDisposable {
     args: DebugRequestTypes[K][0],
     token?: CancellationToken | undefined,
   ): Promise<DebugRequestTypes[K][1]>;
-  restart(): Promise<boolean>;
+  restart(args: DebugProtocol.RestartArguments): Promise<boolean>;
   disconnect(restart?: boolean | undefined): Promise<void>;
   terminate(restart?: boolean | undefined): Promise<void>;
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a42d8a</samp>

*  Simplify the condition for sending arguments to the debug adapter ([link](https://github.com/opensumi/core/pull/2570/files?diff=unified&w=0#diff-36e86b04135416c26aa8182cabc565cf187381200d50da31d0db921e3872d76bL185-R185)). Remove the redundant check for `Object.keys(args).length > 0` and use only `if (args)` instead. This improves the readability and performance of the `sendRequest` method in `debug-session-connection.ts`.

<!-- Additional content -->
<!-- 补充额外内容 -->
定位到原因是在 JS Debugger 插件中针对 restart 参数有序列化逻辑，传入 undefined 会导致报错，见：

![image](https://user-images.githubusercontent.com/9823838/231041123-019c6d9c-34a1-43a0-abbb-587b34b2d2fa.png)

修复后：

https://user-images.githubusercontent.com/9823838/231041280-7a2b200b-d7d4-4a7e-80ad-24245ea0a9ac.mp4

close #2565 
### Changelog

fix restart debug session on node-debug