### PR TITLE
style: add hover color token to editor tabs

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -230,6 +230,7 @@
         transform: scale(0.8);
       }
       &:hover {
+        color: var(--tab-hoverForeground);
         background-color: var(--tab-hoverBackground);
       }
       div:first-child {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes
### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04d7010</samp>

* Add a CSS variable for the tab hover foreground color (`[link](https://github.com/opensumi/core/pull/2577/files?diff=unified&w=0#diff-a92d3c79f3be1ec7533bcb9d276d6cacbd8a6a9df61391c4cfd7fcf805025ce1R233)`)

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04d7010</samp>

Improve theme support and consistency of editor tabs. Add a variable for the tab hover foreground color in `editor.module.less`.
