### PR TITLE
feat: quick-open support busy option

### DIFF
--- a/packages/core-browser/src/layout/view-id.ts
+++ b/packages/core-browser/src/layout/view-id.ts
@@ -15,4 +15,5 @@ export namespace VIEW_CONTAINERS {
   export const QUICKPICK_INPUT = `${VIEW_CONTAINERS_PREFIX}-quickpick-input`;
   export const QUICKPICK_TABS = `${VIEW_CONTAINERS_PREFIX}-quickpick-tabs`;
   export const QUICKPICK_ITEM = `${VIEW_CONTAINERS_PREFIX}-quickpick-item`;
+  export const QUICKPICK_PROGRESS = `${VIEW_CONTAINERS_PREFIX}-quickpick-progress`;
 }

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -247,6 +247,7 @@ export interface QuickOpenService {
   showDecoration(type: VALIDATE_TYPE): void;
   hideDecoration(): void;
   refresh(): void;
+  updateOptions(options: QuickOpenOptions): void;
 }
 
 export type QuickOpenOptions = Partial<QuickOpenOptions.Resolved>;
@@ -355,6 +356,10 @@ export namespace QuickOpenOptions {
      * 内容更新后保持滚动区域不变
      */
     keepScrollPosition?: boolean;
+    /**
+     * 是否显示 progress
+     */
+    busy?: boolean;
   }
   export const defaultOptions: Resolved = Object.freeze({
     enabled: true,

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -482,6 +482,7 @@ abstract class ExtQuickInput implements vscode.InputBox {
     this._placeholder = '';
     this._password = false;
     this._ignoreFocusOut = false;
+    this._busy = false;
 
     this.disposableCollection = new DisposableCollection();
     this.disposableCollection.push((this._onDidAcceptEmitter = new Emitter()));

--- a/packages/quick-open/src/browser/quick-open.type.ts
+++ b/packages/quick-open/src/browser/quick-open.type.ts
@@ -88,6 +88,7 @@ export interface QuickOpenInputOptions extends QuickOpenTabOptions {
   valueSelection?: [number, number];
   canSelectMany?: boolean;
   keepScrollPosition?: boolean;
+  busy?: boolean;
 }
 
 export interface IQuickOpenWidget extends QuickOpenTabOptions {
@@ -95,6 +96,7 @@ export interface IQuickOpenWidget extends QuickOpenTabOptions {
   selectIndex: number;
   validateType?: VALIDATE_TYPE;
   keepScrollPosition?: boolean;
+  busy?: boolean;
   readonly MAX_HEIGHT: number;
   readonly isShow: boolean;
   readonly items: QuickOpenItem[];
@@ -111,4 +113,5 @@ export interface IQuickOpenWidget extends QuickOpenTabOptions {
   show(prefix: string, options: QuickOpenInputOptions): void;
   hide(reason?: HideReason): void;
   blur(): void;
+  updateProgressStatus(visible: boolean): void;
 }

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -13,6 +13,8 @@ import {
 } from '@opensumi/ide-components';
 import { Key, KeyCode, useInjectable, localize, isUndefined } from '@opensumi/ide-core-browser';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
+import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
+import { ProgressBar } from '@opensumi/ide-core-browser/lib/progress/progress-bar';
 import {
   HideReason,
   QuickInputButton,
@@ -339,6 +341,8 @@ export const QuickOpenList: React.FC<{
 export const QuickOpenView = observer(() => {
   const { widget } = React.useContext(QuickOpenContext);
   const listApi = React.useRef<IRecycleListHandler>();
+  const progressService: IProgressService = useInjectable(IProgressService);
+  const indicator = progressService.getIndicator(VIEW_CONTAINERS.QUICKPICK_PROGRESS);
 
   const scrollOffsetBefore = React.useRef(0);
 
@@ -466,6 +470,10 @@ export const QuickOpenView = observer(() => {
     widget.callbacks.onSelect(item, widget.selectIndex);
   }, [widget.items, widget.selectIndex, widget.keepScrollPosition]);
 
+  React.useEffect(() => {
+    widget.updateProgressStatus(!!widget.busy);
+  }, [widget.busy]);
+
   const onKeydown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     // 处于 composition 的输入，不做处理，否则在按 enter 后会直接打开选择的第一个文件，并且快捷键完全失效
     if (KEY_CODE_MAP[event.nativeEvent.keyCode] === KeyCodeEnum.KEY_IN_COMPOSITION) {
@@ -525,6 +533,9 @@ export const QuickOpenView = observer(() => {
     <div id={VIEW_CONTAINERS.QUICKPICK} tabIndex={0} className={styles.container} onKeyDown={onKeydown} onBlur={onBlur}>
       <QuickOpenHeader />
       <QuickOpenInput />
+      <div id={VIEW_CONTAINERS.QUICKPICK_PROGRESS} className={styles.progress_bar} >
+        <ProgressBar progressModel={indicator!.progressModel} />
+      </div>
       {widget.renderTab?.()}
       <QuickOpenList onReady={onListReady} onScroll={onListScroll} />
     </div>

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -338,11 +338,25 @@ export const QuickOpenList: React.FC<{
   ) : null;
 });
 
+export const QuickOpenProgress = observer(() => {
+  const { widget } = React.useContext(QuickOpenContext);
+  const progressService: IProgressService = useInjectable(IProgressService);
+  const indicator = progressService.getIndicator(VIEW_CONTAINERS.QUICKPICK_PROGRESS);
+
+  React.useEffect(() => {
+    widget.updateProgressStatus(!!widget.busy);
+  }, [widget.busy]);
+
+  return (
+    <div id={VIEW_CONTAINERS.QUICKPICK_PROGRESS} className={styles.progress_bar} >
+      <ProgressBar progressModel={indicator!.progressModel} />
+    </div>
+  );
+});
+
 export const QuickOpenView = observer(() => {
   const { widget } = React.useContext(QuickOpenContext);
   const listApi = React.useRef<IRecycleListHandler>();
-  const progressService: IProgressService = useInjectable(IProgressService);
-  const indicator = progressService.getIndicator(VIEW_CONTAINERS.QUICKPICK_PROGRESS);
 
   const scrollOffsetBefore = React.useRef(0);
 
@@ -470,10 +484,6 @@ export const QuickOpenView = observer(() => {
     widget.callbacks.onSelect(item, widget.selectIndex);
   }, [widget.items, widget.selectIndex, widget.keepScrollPosition]);
 
-  React.useEffect(() => {
-    widget.updateProgressStatus(!!widget.busy);
-  }, [widget.busy]);
-
   const onKeydown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     // 处于 composition 的输入，不做处理，否则在按 enter 后会直接打开选择的第一个文件，并且快捷键完全失效
     if (KEY_CODE_MAP[event.nativeEvent.keyCode] === KeyCodeEnum.KEY_IN_COMPOSITION) {
@@ -533,9 +543,7 @@ export const QuickOpenView = observer(() => {
     <div id={VIEW_CONTAINERS.QUICKPICK} tabIndex={0} className={styles.container} onKeyDown={onKeydown} onBlur={onBlur}>
       <QuickOpenHeader />
       <QuickOpenInput />
-      <div id={VIEW_CONTAINERS.QUICKPICK_PROGRESS} className={styles.progress_bar} >
-        <ProgressBar progressModel={indicator!.progressModel} />
-      </div>
+      <QuickOpenProgress />
       {widget.renderTab?.()}
       <QuickOpenList onReady={onListReady} onScroll={onListScroll} />
     </div>

--- a/packages/quick-open/src/browser/quickInput.inputBox.ts
+++ b/packages/quick-open/src/browser/quickInput.inputBox.ts
@@ -35,7 +35,8 @@ export class InputBoxImpl {
       oldOptions.totalSteps !== newOptions.totalSteps ||
       oldOptions.buttons !== newOptions.buttons ||
       oldOptions.validationMessage !== newOptions.validationMessage ||
-      oldOptions.validationType !== newOptions.validationType
+      oldOptions.validationType !== newOptions.validationType ||
+      oldOptions.busy !== newOptions.busy
     );
   }
 
@@ -60,6 +61,7 @@ export class InputBoxImpl {
      * 每次刷新会触发 onType，从而使页面的展示更新
      */
     if (this.shouldUpdate(newOptions, oldOptions)) {
+      this.quickOpenService.updateOptions(newOptions);
       this.refresh();
     }
   }
@@ -159,6 +161,7 @@ export class InputBoxImpl {
         ignoreFocusOut: this.options.ignoreFocusOut,
         enabled: this.options.enabled,
         valueSelection: this.options.valueSelection,
+        busy: this.options.busy,
         onClose: (canceled) => {
           // VSCode 对于这里的表现是，如果不是用户主动取消（说明调用成功），则不会调用 onDidHide
           if (canceled) {

--- a/packages/quick-open/src/browser/styles.module.less
+++ b/packages/quick-open/src/browser/styles.module.less
@@ -188,4 +188,8 @@
     flex-shrink: 0;
     margin-left: 5px;
   }
+
+  .progress_bar {
+    position: relative;
+  }
 }

--- a/packages/quick-open/src/common/mocks/quick-open.service.ts
+++ b/packages/quick-open/src/common/mocks/quick-open.service.ts
@@ -22,4 +22,7 @@ export class MockQuickOpenService implements QuickOpenService {
   hideDecoration(): void {
     throw new Error('Method not implemented.');
   }
+  updateOptions(options: QuickOpenOptions): void {
+    throw new Error('Method not implemented.');
+  };
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
vscode:
![vscode-busy](https://user-images.githubusercontent.com/9477255/231635835-fdcbab02-658b-4552-bf01-45c4f10269a4.gif)
opensumi:
![opensumi-busy](https://user-images.githubusercontent.com/9477255/231636215-d6a77c32-869e-4747-b2eb-be395a5cd021.gif)


### <samp>🤖 Generated by Copilot at ba50fad</samp>

*  Add a new `busy` property to various interfaces and classes related to the quick pick widget, such as `QuickOpenInputOptions`, `IQuickOpenWidget`, `IKaitianQuickOpenControllerOpts`, and `Resolved` ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-27adcfe43b78217fabf448b56fdd299f340097f3331147ef3307426ddcf3fa1fR250), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-27adcfe43b78217fabf448b56fdd299f340097f3331147ef3307426ddcf3fa1fR359-R362), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86R50), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-586f0727f06ff3bbb7a0f6580b8b7118f4b49998d4cbc8cbda26a113e87e6029R91), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-586f0727f06ff3bbb7a0f6580b8b7118f4b49998d4cbc8cbda26a113e87e6029R99), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-6cef777676951622df1128d6b97965529c202ddb93a316c71f600449c3c9ce22R164))
*  Add a new method `updateOptions` to the `QuickOpenService` and `MonacoQuickOpenService` classes, and implement it in the `QuickOpenWidget` and `InputBoxImpl` classes, to allow updating the options of the quick pick widget, such as the busy state, without closing and reopening it ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-27adcfe43b78217fabf448b56fdd299f340097f3331147ef3307426ddcf3fa1fR250), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86R136-R140), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4R203-R227), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-6cef777676951622df1128d6b97965529c202ddb93a316c71f600449c3c9ce22R64))
*  Inject the `IProgressService` to the `MonacoQuickOpenService` and `QuickOpenWidget` classes, and use it to register and dispose a progress indicator for the quick pick widget, using the `QUICKPICK_PROGRESS` ID from the `VIEW_CONTAINERS` enum ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86L14-R18), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86L71-R81), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86R107), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86R114),  [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4L3-R3), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4R14-R15), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4R58-R60), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4R203-R227))
*  Add a new `div` element with the `QUICKPICK_PROGRESS` ID and the `progress_bar` class to the `QuickOpenView` function, and render a `ProgressBar` component inside it, to show the progress bar element in the quick pick widget ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-20e4dc46b94cf72b6e1623d2b69b8567c06aaa6e5ca4d7ef7a56845bde03dff5R16-R17), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-20e4dc46b94cf72b6e1623d2b69b8567c06aaa6e5ca4d7ef7a56845bde03dff5R536-R538))
*  Add a new effect to the `QuickOpenView` function, and a new method `updateProgressStatus` to the `IQuickOpenWidget` and `QuickOpenWidget` interfaces and classes, to update the visibility of the progress bar element based on the busy state of the quick pick widget ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-586f0727f06ff3bbb7a0f6580b8b7118f4b49998d4cbc8cbda26a113e87e6029R116), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-20e4dc46b94cf72b6e1623d2b69b8567c06aaa6e5ca4d7ef7a56845bde03dff5R473-R476), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4R203-R227))
*  Add a new style rule to the `progress_bar` class, to position the progress bar element in the quick pick widget ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-83d1f18a11c4628e30d8e972f2e652d489166a789ef9b562b4c73367e93173c7R191-R194))
*  Initialize the `_busy` property of the `ExtQuickInput` class to `false`, and pass the `busy` property of the `opts` object to the `widget` object in the `MonacoQuickOpenService` class, to set the initial and updated busy state of the quick pick widget ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-535cb53d1888c004f19b7369d5b1da90462def0d39ad8d6d9d2b382ea571e80aR485), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-ff6860d3b51c6750266e7e6434a7fd6f60f9f925ffa9601468a056d9bf050d86R128), [link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-f96acf4c25fadaa5c3e1117c089f6d262a7f783d3922e1087e867c11e22773c4R153))
*  Add a new condition to the `shouldUpdate` method of the `InputBoxImpl` class, to determine whether the input box should update its options based on the busy state of the quick pick widget ([link](https://github.com/opensumi/core/pull/2579/files?diff=unified&w=0#diff-6cef777676951622df1128d6b97965529c202ddb93a316c71f600449c3c9ce22L38-R39))

<!-- Additional content -->
<!-- 补充额外内容 -->

#2576 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba50fad</samp>

This pull request adds a new feature to the quick pick widget, which is a progress bar that indicates when the widget is busy. It modifies several files in the `quick-open` and `core-browser` packages to support updating the widget options and the progress status dynamically. It also updates the `extension` package to initialize the busy state of the widget.


* feat: quickpick support busy option
* feat: quickpick instance property change will update widget