### PR TITLE
fix: improve style and fix breakpoints view init

### DIFF
--- a/packages/components/src/recycle-tree/basic/tree-node.tsx
+++ b/packages/components/src/recycle-tree/basic/tree-node.tsx
@@ -1,12 +1,15 @@
 import cls from 'classnames';
 import React, { useCallback } from 'react';
 
+import { isDefined } from '@opensumi/ide-utils';
+
 import { Button } from '../../button';
 import { Icon } from '../../icon';
 import { Loading } from '../../loading';
 
 import { BasicCompositeTreeNode, BasicTreeNode } from './tree-node.define';
 import { IBasicInlineMenuPosition, IBasicNodeRendererProps, DECORATIONS } from './types';
+
 import './styles.less';
 
 export const BasicTreeNodeRenderer: React.FC<
@@ -67,19 +70,23 @@ export const BasicTreeNodeRenderer: React.FC<
     },
     [onClick, onTwistierClick],
   );
-  const paddingLeft = `${(item.depth || 0) * (indent || 0)}px`;
+  // 14 * 2 = Toggle Icon Size + Icon Size
+  const paddingLeft = BasicCompositeTreeNode.is(item)
+    ? `${(item.depth || 0) * (indent || 0)}px`
+    : `${(item.depth || 0) * (indent || 0) + 14 * 2}px`;
 
-  const editorNodeStyle = {
+  const treeNodeStyle = {
     height: itemHeight,
     lineHeight: `${itemHeight}px`,
     paddingLeft,
   } as React.CSSProperties;
 
   const renderIcon = useCallback(
-    (node: BasicCompositeTreeNode | BasicTreeNode) => (
-      // 图标的最大高度设置为 `itemHeight - 8`, 这样在视觉上看起来有一种 padding 的效果
-      <Icon icon={node.icon} className={cls('icon', node.iconClassName)} style={{ maxHeight: itemHeight - 8 }} />
-    ),
+    (node: BasicCompositeTreeNode | BasicTreeNode) =>
+      node.iconClassName ? (
+        // 图标的最大高度设置为 `itemHeight - 8`, 这样在视觉上看起来有一种 padding 的效果
+        <Icon icon={node.icon} className={cls('icon', node.iconClassName)} style={{ maxHeight: itemHeight - 8 }} />
+      ) : null,
     [],
   );
 
@@ -163,7 +170,11 @@ export const BasicTreeNodeRenderer: React.FC<
   };
 
   const renderTwice = (item: BasicCompositeTreeNode | BasicTreeNode) => {
-    if (!(item as BasicCompositeTreeNode).expandable) {
+    if (isDefined((item as BasicCompositeTreeNode).expandable)) {
+      if (!(item as BasicCompositeTreeNode).expandable) {
+        return <div className={cls('segment', 'expansion_toggle')}></div>;
+      }
+    } else {
       return null;
     }
 
@@ -179,7 +190,7 @@ export const BasicTreeNodeRenderer: React.FC<
       onDoubleClick={handleDbClick}
       onContextMenu={handleContextMenu}
       className={cls('tree_node', className, decorations ? decorations.classlist : null)}
-      style={editorNodeStyle}
+      style={treeNodeStyle}
       data-id={item.id}
     >
       <div className='content'>

--- a/packages/core-browser/src/services/storage-service.ts
+++ b/packages/core-browser/src/services/storage-service.ts
@@ -99,6 +99,9 @@ abstract class BaseBrowserStorageService implements StorageService {
     } catch (e) {
       this.logger.error(`storage getDate error: ${e}, use defaultValue as result.`);
     }
+    if (defaultValue && isObject(defaultValue)) {
+      delete defaultValue['expires'];
+    }
     return defaultValue;
   }
 

--- a/packages/debug/__tests__/browser/view/breakpoint/debug-breakpoints.service.test.ts
+++ b/packages/debug/__tests__/browser/view/breakpoint/debug-breakpoints.service.test.ts
@@ -44,6 +44,7 @@ describe('Debug Breakpoints Service', () => {
     updateBreakpoint: jest.fn(),
     updateExceptionBreakpoints: jest.fn(),
     cleanAllMarkers: jest.fn(),
+    whenReady: Promise.resolve(),
   };
 
   const mockContextKeyService = {
@@ -111,7 +112,7 @@ describe('Debug Breakpoints Service', () => {
     expect(typeof debugBreakpointsService.toggleBreakpoints).toBe('function');
   });
 
-  it('should init success', () => {
+  it('should init success', async () => {
     expect(mockBreakpointManager.onDidChangeBreakpoints).toBeCalledTimes(1);
     expect(mockBreakpointManager.onDidChangeExceptionsBreakpoints).toBeCalledTimes(1);
     expect(mockContextKeyService.onDidChangeContext).toBeCalledTimes(1);

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -40,6 +40,7 @@
   width: 19px;
   height: 19px;
   min-width: 19px;
+  margin-right: 3px;
 }
 
 .debug_breakpoints_badge {
@@ -67,5 +68,5 @@
 }
 
 .debug_breakpoints_item_tree_node {
-  padding-left: 22px !important;
+  padding-left: 27px !important;
 }

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -89,7 +89,6 @@ export class DebugBreakpointsService extends WithEventBus {
 
   async init() {
     await this.updateRoots();
-    await this.updateBreakpoints();
     this.workspaceService.onWorkspaceChanged(async () => {
       this.updateRoots();
       this.updateBreakpoints();
@@ -98,6 +97,9 @@ export class DebugBreakpointsService extends WithEventBus {
       this.updateBreakpoints();
     });
     this.breakpoints.onDidChangeExceptionsBreakpoints(() => {
+      this.updateBreakpoints();
+    });
+    this.breakpoints.whenReady.then(() => {
       this.updateBreakpoints();
     });
     this.contextKeyService.onDidChangeContext((e) => {
@@ -190,7 +192,6 @@ export class DebugBreakpointsService extends WithEventBus {
         this.treeNodeMap.set(uri.toString(), getTreeNodes);
       }
     });
-
     this._onDidChangeBreakpointsTreeNode.fire(this.treeNodeMap);
   }
 

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -73,7 +73,7 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
           const parent = roots.filter((root) => root.isEqualOrParent(toURI))[0];
 
           breakpointTreeData.push({
-            label: parent ? parent.relative(toURI)?.toString() : URI.parse(uri).displayName,
+            label: parent ? parent.relative(toURI)?.toString() || '' : URI.parse(uri).displayName,
             expandable: true,
             iconClassName: getIcon('file-text'),
             expanded: true,

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -1,14 +1,8 @@
 import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import {
-  BasicRecycleTree,
-  CheckBox,
-  IBasicTreeData,
-  ICompositeTreeNode,
-  ITreeNodeOrCompositeTreeNode,
-} from '@opensumi/ide-components';
+import { BasicRecycleTree, CheckBox, IBasicTreeData, ICompositeTreeNode } from '@opensumi/ide-components';
 import { Badge } from '@opensumi/ide-components';
 import {
   useInjectable,
@@ -19,6 +13,7 @@ import {
   Disposable,
   ViewState,
   Event,
+  isUndefined,
 } from '@opensumi/ide-core-browser';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
 
@@ -33,6 +28,7 @@ import {
 } from '../../breakpoint';
 import { DebugSessionManager } from '../../debug-session-manager';
 
+import { BreakpointsTreeNode } from './debug-breakpoints-tree.model';
 import styles from './debug-breakpoints.module.less';
 import { DebugBreakpointsService } from './debug-breakpoints.service';
 
@@ -47,66 +43,74 @@ export interface BreakpointItem {
 export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChildren<{ viewState: ViewState }>) => {
   const debugBreakpointsService: DebugBreakpointsService = useInjectable(DebugBreakpointsService);
   const { enable, toggleBreakpointEnable } = debugBreakpointsService;
+  const isDisposed = useRef<boolean>(false);
   const [treeData, setTreeData] = useState<IBasicTreeData[]>([]);
+
+  const updateTreeData = useCallback(
+    (nodes: [string, BreakpointsTreeNode[]][]) => {
+      const { roots } = debugBreakpointsService;
+      const breakpointTreeData: IBasicTreeData[] = [];
+      nodes.forEach(([uri, items]) => {
+        const isException = EXCEPTION_BREAKPOINT_URI.toString() === uri;
+        if (isException) {
+          items.forEach((item) => {
+            breakpointTreeData.push({
+              label: '',
+              expandable: false,
+              children: [],
+              description: (
+                <BreakpointItem
+                  toggle={() => toggleBreakpointEnable(item.breakpoint)}
+                  breakpointEnabled={enable}
+                  data={item.rawData}
+                  isDebugMode={debugBreakpointsService.inDebugMode}
+                ></BreakpointItem>
+              ),
+            });
+          });
+        } else {
+          const toURI = URI.parse(uri);
+          const parent = roots.filter((root) => root.isEqualOrParent(toURI))[0];
+
+          breakpointTreeData.push({
+            label: parent ? parent.relative(toURI)?.toString() : URI.parse(uri).displayName,
+            expandable: true,
+            iconClassName: getIcon('file-text'),
+            expanded: true,
+            children: items.map((item) => ({
+              ...item,
+              label: '',
+              expandable: false,
+              description: (
+                <BreakpointItem
+                  toggle={() => toggleBreakpointEnable(item.breakpoint)}
+                  breakpointEnabled={enable}
+                  data={item.rawData}
+                  isDebugMode={debugBreakpointsService.inDebugMode}
+                ></BreakpointItem>
+              ),
+            })),
+          });
+        }
+      });
+      if (!isDisposed.current) {
+        setTreeData(breakpointTreeData);
+      }
+    },
+    [treeData],
+  );
 
   useEffect(() => {
     const dispose = new Disposable();
-
+    updateTreeData(Array.from(debugBreakpointsService.treeNodeMap.entries()));
     dispose.addDispose(
-      debugBreakpointsService.onDidChangeBreakpointsTreeNode((nodes) => {
-        const { roots } = debugBreakpointsService;
-        const breakpointTreeData: IBasicTreeData[] = [];
-
-        Array.from(nodes.entries()).forEach(([uri, items]) => {
-          const isException = EXCEPTION_BREAKPOINT_URI.toString() === uri;
-
-          if (isException) {
-            items.forEach((item) => {
-              breakpointTreeData.push({
-                label: '',
-                expandable: false,
-                children: [],
-                description: (
-                  <BreakpointItem
-                    toggle={() => toggleBreakpointEnable(item.breakpoint)}
-                    breakpointEnabled={enable}
-                    data={item.rawData}
-                    isDebugMode={debugBreakpointsService.inDebugMode}
-                  ></BreakpointItem>
-                ),
-              });
-            });
-          } else {
-            const toURI = URI.parse(uri);
-            const parent = roots.filter((root) => root.isEqualOrParent(toURI))[0];
-
-            breakpointTreeData.push({
-              label: parent ? parent.relative(toURI)!.toString() : URI.parse(uri).displayName,
-              expandable: true,
-              iconClassName: getIcon('file-text'),
-              expanded: true,
-              children: items.map((item) => ({
-                ...item,
-                label: '',
-                expandable: false,
-                description: (
-                  <BreakpointItem
-                    toggle={() => toggleBreakpointEnable(item.breakpoint)}
-                    breakpointEnabled={enable}
-                    data={item.rawData}
-                    isDebugMode={debugBreakpointsService.inDebugMode}
-                  ></BreakpointItem>
-                ),
-              })),
-            });
-          }
-        });
-
-        setTreeData(breakpointTreeData);
+      debugBreakpointsService.onDidChangeBreakpointsTreeNode((nodes: Map<string, BreakpointsTreeNode[]>) => {
+        updateTreeData(Array.from(nodes.entries()));
       }),
     );
 
     return () => {
+      isDisposed.current = true;
       dispose.dispose();
     };
   }, []);
@@ -120,11 +124,10 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
   }, [treeData]);
 
   const getItemClassName = useCallback((item: ICompositeTreeNode) => {
-    if (!item.children) {
+    if (!item.children && isUndefined((item as any).expandable)) {
       return styles.debug_breakpoints_item_tree_node;
     }
   }, []);
-
   return (
     <div className={cls(styles.debug_breakpoints, !enable && styles.debug_breakpoints_disabled)}>
       <BasicRecycleTree treeData={treeData} height={viewState.height} getItemClassName={getItemClassName} />

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -513,6 +513,11 @@ export const defaultSettingGroup: ISettingGroup[] = [
     iconClass: getIcon('setting'),
   },
   {
+    id: PreferenceSettingId.Terminal,
+    title: '%settings.group.terminal%',
+    iconClass: getIcon('terminal'),
+  },
+  {
     id: PreferenceSettingId.Editor,
     title: '%settings.group.editor%',
     iconClass: getIcon('editor'),
@@ -521,11 +526,6 @@ export const defaultSettingGroup: ISettingGroup[] = [
     id: PreferenceSettingId.View,
     title: '%settings.group.view%',
     iconClass: getIcon('detail'),
-  },
-  {
-    id: PreferenceSettingId.Terminal,
-    title: '%settings.group.terminal%',
-    iconClass: getIcon('terminal'),
   },
   {
     id: PreferenceSettingId.Feature,

--- a/packages/preferences/src/browser/preferences.view.tsx
+++ b/packages/preferences/src/browser/preferences.view.tsx
@@ -233,6 +233,8 @@ const PreferenceIndexes = observer(() => {
       data.children = children;
       if (children.length > 0) {
         data.expandable = true;
+      } else {
+        data.expandable = false;
       }
       basicTreeData.push(data);
     }

--- a/packages/storage/src/browser/storage.contribution.ts
+++ b/packages/storage/src/browser/storage.contribution.ts
@@ -1,10 +1,9 @@
-import { Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
+import { Autowired } from '@opensumi/di';
 import {
   Domain,
   StorageResolverContribution,
   URI,
   IStorage,
-  ClientAppContribution,
   STORAGE_SCHEMA,
   AppConfig,
   ScopedBrowserStorageService,
@@ -17,8 +16,8 @@ import { IStorageServer, IWorkspaceStorageServer, IGlobalStorageServer } from '.
 
 import { Storage } from './storage';
 
-@Domain(StorageResolverContribution, ClientAppContribution)
-export class DatabaseStorageContribution implements StorageResolverContribution, ClientAppContribution {
+@Domain(StorageResolverContribution)
+export class DatabaseStorageContribution implements StorageResolverContribution {
   @Autowired(IWorkspaceStorageServer)
   private workspaceStorage: IStorageServer;
 

--- a/packages/storage/src/browser/storage.ts
+++ b/packages/storage/src/browser/storage.ts
@@ -8,6 +8,8 @@ import {
   Event,
   DisposableCollection,
   Deferred,
+  isEmptyObject,
+  URI,
 } from '@opensumi/ide-core-common';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
@@ -45,16 +47,19 @@ export class Storage implements IStorage {
     private readonly workspace: IWorkspaceService,
     private readonly appConfig: AppConfig,
     private readonly storageName: string,
+    private readonly isGlobal: boolean = true,
     private readonly browserLocalStorage?: StorageService,
   ) {
     this.toDisposableCollection.push(this._onDidChangeStorage);
-    this.toDisposableCollection.push(
-      this.workspace.onWorkspaceChanged(() => {
-        this.setup(storageName);
-      }),
-    );
+
     this.flushDelayer = new ThrottledDelayer(Storage.DEFAULT_FLUSH_DELAY);
-    this.setup(storageName);
+    this.init(storageName).then(() => {
+      this.toDisposableCollection.push(
+        this.workspace.onWorkspaceChanged(() => {
+          this.init(storageName);
+        }),
+      );
+    });
   }
 
   get whenReady() {
@@ -74,13 +79,15 @@ export class Storage implements IStorage {
   }
 
   async init(storageName: string) {
-    const workspace = this.workspace.workspace;
+    // 首次加载情况下，由于 Storage 不依赖 WorkspaceService 初始化逻辑
+    // 在 `workspace` 不存在时，默认采用 `AppConfig` 内的 `workspaceDir` 配置值作为工作区路径
+    const workspace = this.workspace.workspace?.uri || URI.file(this.appConfig.workspaceDir).toString();
     let cache;
     if (this.browserLocalStorage) {
       cache = await this.browserLocalStorage.getData(storageName);
     }
-    if (!cache) {
-      await this.database.init(this.appConfig.storageDirName, workspace && workspace.uri);
+    if (!cache || isEmptyObject(cache)) {
+      await this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace);
       cache = await this.database.getItems(storageName);
       if (this.browserLocalStorage) {
         this.browserLocalStorage.setData(storageName, cache);
@@ -88,13 +95,11 @@ export class Storage implements IStorage {
       this.whenReadyToWriteDeferred.resolve();
     } else {
       // 初始化服务端缓存
-      this.database.init(this.appConfig.storageDirName, workspace && workspace.uri).then(() => {
+      this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace).then(() => {
         this.database.getItems(storageName).then(async (data) => {
           // 后续以服务端数据为准更新前端缓存数据，防止后续数据存取异常
           this.cache = this.jsonToMap(data);
-          if (this.browserLocalStorage) {
-            await this.browserLocalStorage.setData(storageName, JSON.stringify(data));
-          }
+          await this.browserLocalStorage?.setData(storageName, data);
           this.whenReadyToWriteDeferred.resolve();
         });
       });
@@ -104,13 +109,9 @@ export class Storage implements IStorage {
     this.readyDeferred.resolve();
   }
 
-  setup(storageName: string) {
-    this.init(storageName);
-  }
-
   async reConnectInit() {
     this.readyDeferred = new Deferred();
-    this.setup(this.storageName);
+    this.init(this.storageName);
   }
 
   dispose() {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e89ae06</samp>

*  Fix alignment and indentation issues of tree nodes in recycle tree and debug breakpoints views ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743L70-R78), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743L182-R193), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0L70-R71))
*  Avoid unnecessary rendering of icons and segments in tree nodes ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743L79-R89), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743L166-R177))
*  Ensure breakpoints are updated when ready and avoid potential race conditions in debug breakpoints service ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70L92), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70R102-R104))
*  Improve performance and reliability of debug breakpoint view component and handle undefined expandable property ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L3-R5), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R16), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R31), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L50-R113), [link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L123-R130))
*  Fix a bug where preference groups with no children would still be expandable ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-12115396b22ebdfd945c189c78b115b65bf3fea11ac1d59fdb8bc6b08d5851d6R236-R237))
*  Import `isDefined` utility function from `@opensumi/ide-utils` in `tree-node.tsx` ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743R4-R5))
*  Add margin to icons in debug breakpoints view ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R43))
*  Remove unused import and empty line in `debug-breakpoints.service.ts` ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70L193))
*  Remove mistakenly added entry for terminal preference group ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cL526-L530))
*  Add empty line to separate imports in `tree-node.tsx` ([link](https://github.com/opensumi/core/pull/2583/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743R12))

<!-- Additional content -->
<!-- 补充额外内容 -->
修复在调试断点面板下刷新后，断点消失问题
close #2552.

优化设置面板及调试断点面板样式
<img width="775" alt="image" src="https://user-images.githubusercontent.com/9823838/231659128-51daaa9d-5f5e-4222-9fb6-7421fa407a81.png">

close #2581 
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

improve style and fix breakpoints view init