### PR TITLE
fix: change prefix when open view

### DIFF
--- a/packages/quick-open/src/browser/quick-open.contribution.ts
+++ b/packages/quick-open/src/browser/quick-open.contribution.ts
@@ -61,7 +61,7 @@ export class QuickOpenFeatureContribution
       execute: () => this.prefixQuickOpenService.open('@'),
     });
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN_VIEW, {
-      execute: () => this.prefixQuickOpenService.open('view'),
+      execute: () => this.prefixQuickOpenService.open('view '),
     });
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39894bb</samp>

* Add a space after the `view` prefix in the quick open input for the `OPEN_VIEW` command ([link](https://github.com/opensumi/core/pull/2586/files?diff=unified&w=0#diff-4f73bd6a619ebbf6d7ad5c54cfc01de6d92215b920c3857502d940bd2f26c350L64-R64)). This improves the usability and consistency of the quick open feature in `packages/quick-open/src/browser/quick-open.contribution.ts`.

<!-- Additional content -->
<!-- 补充额外内容 -->
close #2566 
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39894bb</samp>

Improved the quick open feature by adding a space after the `view` prefix in the `OPEN_VIEW` command. This makes it easier for users to open views from the quick open input.

before:
![image](https://user-images.githubusercontent.com/19860190/231932065-dedc6464-feb3-4ee1-8d8b-6fc1b20544a0.png)
after:
![image](https://user-images.githubusercontent.com/19860190/231932093-4b3b4318-bf02-456c-aa34-808ddc81457d.png)

