### PR TITLE
chore: add key for HighlightLabel

### DIFF
--- a/packages/quick-open/src/browser/components/highlight-label/index.tsx
+++ b/packages/quick-open/src/browser/components/highlight-label/index.tsx
@@ -37,7 +37,7 @@ export const HighlightLabel: React.FC<HighlightLabelProp> = ({
       if (pos < highlight.start) {
         const substring = text.substring(pos, highlight.start);
         children.push(
-          <span className={labelClassName}>
+          <span className={labelClassName} key={`${children.length}-${substring}`}>
             {transformLabelWithCodicon(substring, labelIconClassName, iconService.fromString.bind(iconService))}
           </span>,
         );
@@ -45,7 +45,7 @@ export const HighlightLabel: React.FC<HighlightLabelProp> = ({
       }
       const substring = text.substring(highlight.start, highlight.end);
       children.push(
-        <span className={hightLightClassName}>
+        <span className={hightLightClassName} key={`${children.length}-${substring}`}>
           {transformLabelWithCodicon(substring, labelIconClassName, iconService.fromString.bind(iconService))}
         </span>,
       );
@@ -55,7 +55,7 @@ export const HighlightLabel: React.FC<HighlightLabelProp> = ({
     if (pos < text.length) {
       const substring = text.substring(pos);
       children.push(
-        <span className={labelClassName}>
+        <span className={labelClassName} key={`${children.length}-${substring}`}>
           {transformLabelWithCodicon(substring, labelIconClassName, iconService.fromString.bind(iconService))}
         </span>,
       );


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 725b38c</samp>

*  Add unique key props to span elements that render label text parts in `HighlightLabel` component ([link](https://github.com/opensumi/core/pull/2588/files?diff=unified&w=0#diff-63be267f38314a73b5427038fb54eb1db946086235a2cc18bc0d8a639ae04438L40-R40), [link](https://github.com/opensumi/core/pull/2588/files?diff=unified&w=0#diff-63be267f38314a73b5427038fb54eb1db946086235a2cc18bc0d8a639ae04438L48-R48), [link](https://github.com/opensumi/core/pull/2588/files?diff=unified&w=0#diff-63be267f38314a73b5427038fb54eb1db946086235a2cc18bc0d8a639ae04438L58-R58))

<!-- Additional content -->
<!-- 补充额外内容 -->

<img width="794" alt="image" src="https://user-images.githubusercontent.com/19860190/231972804-8f1a76e5-f8d5-40c0-9359-8041cac998e6.png">


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 725b38c</samp>

Fixed React key warnings and improved performance in `HighlightLabel` component. Added key props to span elements in `packages/quick-open/src/browser/components/highlight-label/index.tsx`.

add key for HighlightLabel Component