### PR TITLE
fix(theme): foucs first entry theme when then input is not empty

### DIFF
--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -288,7 +288,7 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
         const themeId = await this.showPickWithPreview(
           items,
           {
-            selectIndex: () => defaultSelected,
+            selectIndex: (lookFor) => (lookFor ? -1 : defaultSelected), // 默认展示当前主题，如果有输入，则选择第一个，否则 selectIndex 一直不变导致显示有问题
             placeholder: localize('theme.quickopen.plh'),
           },
           (value) => {
@@ -353,7 +353,7 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
         const themeId = await this.showPickWithPreview(
           items,
           {
-            selectIndex: () => defaultSelected,
+            selectIndex: (lookFor) => (lookFor ? -1 : defaultSelected),
             placeholder: localize('icon.quickopen.plh'),
           },
           (value) => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3cd7bbf</samp>

* Fix bugs in quick open menus for selecting themes and icons ([link](https://github.com/opensumi/core/pull/2589/files?diff=unified&w=0#diff-dcb5191f1bf09965dd5877505807382b585478f3c5f08a8f5f79c6f225516b1bL291-R291), [link](https://github.com/opensumi/core/pull/2589/files?diff=unified&w=0#diff-dcb5191f1bf09965dd5877505807382b585478f3c5f08a8f5f79c6f225516b1bL356-R356))

<!-- Additional content -->
<!-- 补充额外内容 -->
close #2209 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3cd7bbf</samp>

This pull request enhances the theme and icon selection features in the `theme.contribution.ts` file. It prevents the quick open menus from highlighting the current theme or icon when the user searches for a different one.
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/19860190/231991300-ceb7c3c9-cd8d-444e-af83-e5f6683c2c44.png">

