### PR TITLE
fix: remove the marked.js warning about sanitize and add sanitizer

### DIFF
--- a/packages/comments/src/browser/comments-body.tsx
+++ b/packages/comments/src/browser/comments-body.tsx
@@ -43,7 +43,6 @@ export const CommentsBody: React.FC<{
                 gfm: true,
                 breaks: false,
                 pedantic: false,
-                sanitize: true,
                 smartLists: true,
                 smartypants: false,
                 renderer,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.4",
     "@opensumi/ide-utils": "workspace:*",
+    "dompurify": "^3.0.2",
     "fuzzy": "^0.1.3",
     "lodash": "^4.17.15",
     "marked": "4.0.10",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@opensumi/ide-dev-tool": "workspace:*",
+    "@types/dompurify": "^3.0.1",
     "@types/marked": "^4.0.7",
     "@types/react-window": "^1.8.5",
     "prop-types": "^15.8.1"

--- a/packages/components/src/markdown/index.tsx
+++ b/packages/components/src/markdown/index.tsx
@@ -1,3 +1,4 @@
+import { sanitize } from 'dompurify';
 import { marked, Renderer } from 'marked';
 import React from 'react';
 
@@ -19,7 +20,7 @@ export class DefaultMarkedRenderer extends Renderer {
 }
 
 export function Markdown(props: IMarkdownProps) {
-  const parseMarkdown = (text: string, renderer: any) => marked.parse(text, { renderer });
+  const parseMarkdown = (text: string, renderer: any) => sanitize(marked.parse(text, { renderer }));
 
   const [htmlContent, setHtmlContent] = React.useState(parseMarkdown(props.value, props.renderer));
 

--- a/packages/components/src/utils/marked.ts
+++ b/packages/components/src/utils/marked.ts
@@ -1,3 +1,4 @@
+import { sanitize } from 'dompurify';
 import { marked, Renderer } from 'marked';
 
 export type IMarkedOptions = marked.MarkedOptions;
@@ -10,13 +11,16 @@ export const parseMarkdown = (
   callback?: (error: any, parseResult: string) => void,
 ) => {
   if (!callback) {
-    return marked.parse(value, options);
+    return sanitize(marked.parse(value, options));
   }
+  const wrappedCallback = (error: any, parseResult: string) => {
+    callback(error, sanitize(parseResult));
+  };
   if (options) {
-    marked.parse(value, options, callback);
+    marked.parse(value, options, wrappedCallback);
   } else {
-    marked.parse(value, callback);
+    marked.parse(value, wrappedCallback);
   }
 };
 
-export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => marked(value, options);
+export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => sanitize(marked(value, options));

--- a/packages/core-browser/src/markdown/index.tsx
+++ b/packages/core-browser/src/markdown/index.tsx
@@ -22,7 +22,6 @@ export const toMarkdownHtml = (message: string): string => {
     gfm: true,
     breaks: false,
     pedantic: false,
-    sanitize: true,
     smartLists: true,
     smartypants: false,
     renderer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,8 +2696,10 @@ __metadata:
     "@ant-design/icons": ^4.6.4
     "@opensumi/ide-dev-tool": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
+    "@types/dompurify": ^3.0.1
     "@types/marked": ^4.0.7
     "@types/react-window": ^1.8.5
+    dompurify: ^3.0.2
     fuzzy: ^0.1.3
     lodash: ^4.17.15
     marked: 4.0.10
@@ -4037,6 +4039,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dompurify@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@types/dompurify@npm:3.0.1"
+  dependencies:
+    "@types/jsdom": "*"
+    "@types/trusted-types": "*"
+  checksum: d4bf881845ac1f4619622b62945f0fda876e6c09d4c958bc7f3a84c4307f7258b9a15e334ae08c7ac5ecfcd0656415328df29d3fb737e9bce2849feaf180c6ab
+  languageName: node
+  linkType: hard
+
 "@types/ejs@npm:^3.0.2":
   version: 3.1.1
   resolution: "@types/ejs@npm:3.1.1"
@@ -4164,6 +4176,17 @@ __metadata:
     expect: ^29.0.0
     pretty-format: ^29.0.0
   checksum: 23760282362a252e6690314584d83a47512d4cd61663e957ed3398ecf98195fe931c45606ee2f9def12f8ed7d8aa102d492ec42d26facdaf8b78094a31e6568e
+  languageName: node
+  linkType: hard
+
+"@types/jsdom@npm:*":
+  version: 21.1.1
+  resolution: "@types/jsdom@npm:21.1.1"
+  dependencies:
+    "@types/node": "*"
+    "@types/tough-cookie": "*"
+    parse5: ^7.0.0
+  checksum: 7450d6e23aa31b837a1682f0e59b06838aacca85c9d030035f40e21d559169c773aee5cee9244f23c3004b78f7064f0c540ceb808d2f187deb3140f2b0449dee
   languageName: node
   linkType: hard
 
@@ -4525,6 +4548,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:*":
+  version: 2.0.3
+  resolution: "@types/trusted-types@npm:2.0.3"
+  checksum: 4794804bc4a4a173d589841b6d26cf455ff5dc4f3e704e847de7d65d215f2e7043d8757e4741ce3a823af3f08260a8d04a1a6e9c5ec9b20b7b04586956a6b005
   languageName: node
   linkType: hard
 
@@ -8759,6 +8789,13 @@ __metadata:
   dependencies:
     domelementtype: ^2.2.0
   checksum: 4c665ceed016e1911bf7d1dadc09dc888090b64dee7851cccd2fcf5442747ec39c647bb1cb8c8919f8bbdd0f0c625a6bafeeed4b2d656bbecdbae893f43ffaaa
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "dompurify@npm:3.0.2"
+  checksum: 768c3bb2f139ce1e1a53faf81aae6abe03e24d0b043e2fda0b70e91ef15bb1df854a35e82d8c519adfe5b81c24bfdad3e0b1085534bfbf427137cb742406c47f
   languageName: node
   linkType: hard
 
@@ -17056,7 +17093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.1.1":
+"parse5@npm:^7.0.0, parse5@npm:^7.1.1":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
   dependencies:


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80ad54f</samp>

*  Sanitize markdown content using dompurify library instead of deprecated and insecure sanitize option from marked library ([link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-be2671724b2a909d882a65ad7147728d8a72a34a6780b67f0fb9363e7a6f02e5L46), [link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-d3d8e9095ee47462a7c5c2babc1243f856d07d3b66f173982891bc41ef0e3a38L22-R23), [link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-e5650bf072c2b1c0b9197af89121a1100e2fae59216dd21ad036e069d6c3a267L13-R26), [link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-ce0d9a4a7ba728021e210495eac9480b2fdb5e75421447837307b4f65c281b0bL25))
* Import sanitize function from dompurify library in `comments-body.tsx`, `markdown/index.tsx`, and `utils/marked.ts` ( [link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-d3d8e9095ee47462a7c5c2babc1243f856d07d3b66f173982891bc41ef0e3a38R1), [link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-e5650bf072c2b1c0b9197af89121a1100e2fae59216dd21ad036e069d6c3a267R1))
* Add dompurify library and its type definitions as dependencies to `components/package.json` ([link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cR20), [link](https://github.com/opensumi/core/pull/2591/files?diff=unified&w=0#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cR39))

<!-- Additional content -->
<!-- 补充额外内容 -->
Close https://github.com/opensumi/core/issues/2256
Following the offical suggestion, import dom purify for sanitizer. https://marked.js.org/#usage
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80ad54f</samp>

This pull request adds `dompurify` as a dependency to sanitize HTML output from markdown content in various packages. It also removes the insecure `sanitize` option from the `marked` library and replaces it with `dompurify` in the `comments` and `core-browser` packages.
