### PR TITLE
fix: open file by vscode.open command

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1319,8 +1319,13 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       const previewMode =
         this.preferenceService.get('editor.previewMode') &&
         (isUndefinedOrNull(options.preview) ? true : options.preview);
-      if (this.currentResource && this.currentResource.uri.isEqual(uri)) {
-        // 就是当前打开的resource
+      if (
+        this.currentResource &&
+        this.currentResource.uri.isEqual(uri) &&
+        // 当不存在 forceOpenType 或打开类型与当前打开类型符合时，才能说明是当前打开的 Reource 资源
+        (!options.forceOpenType || options.forceOpenType.type === this.currentOpenType?.type)
+      ) {
+        // 就是当前打开的 Resource
         if (options.focus && this.currentEditor) {
           this._domNode?.focus();
           this.currentEditor.monacoEditor.focus();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d11e91</samp>

*  Fix a bug where opening a resource with a different forceOpenType would not create a new editor ([link](https://github.com/opensumi/core/pull/2593/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8L1322-R1328))

ref: #2560.

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d11e91</samp>

Fix a bug in `workbench-editor.service.ts` that prevented opening a resource with a different forceOpenType. Enhance the editor opening logic to handle various open types.
