### PR TITLE
style: improve button disable style

### DIFF
--- a/packages/components/src/button/style.less
+++ b/packages/components/src/button/style.less
@@ -175,19 +175,23 @@
 .secondary-button:disabled,
 .primary-button:disabled,
 .ghost-danger-button:disabled,
+.default-button:disabled,
 .@{prefix}-danger-button-loading,
 .@{prefix}-primary-button-loading,
 .@{prefix}-secondary-button-loading {
   color: var(--kt-button-disableForeground) !important;
-  border-color: var(--kt-button-disableBorder) !important;
   background-color: var(--kt-button-disableBackground) !important;
-  border-style: solid;
-  border-width: 1px;
-  cursor: default;
+  // 这里是用 box-shadow 来实现边框的，因为 border 会破坏盒模型
+  box-shadow: var(--kt-button-disableBorder) 0px 0px 0px 1px;
+  cursor: not-allowed;
 
   & > .@{prefix}-button-secondary-more {
     color: var(--kt-button-disableForeground);
   }
+}
+
+.link-button:disabled {
+  cursor: not-allowed;
 }
 
 .ghost-primary-button {

--- a/packages/components/src/button/style.less
+++ b/packages/components/src/button/style.less
@@ -190,6 +190,10 @@
   }
 }
 
+.secondary-button:disabled {
+  border: none;
+}
+
 .link-button:disabled {
   cursor: not-allowed;
 }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 003346e</samp>

*  Refactor the style of disabled buttons to use box-shadow instead of border and set the cursor to not-allowed ([link](https://github.com/opensumi/core/pull/2594/files?diff=unified&w=0#diff-289029a8f22ac5e20df0607aadb456c2344316dc5c1d986880649002f79ba2c2L178-R186), [link](https://github.com/opensumi/core/pull/2594/files?diff=unified&w=0#diff-289029a8f22ac5e20df0607aadb456c2344316dc5c1d986880649002f79ba2c2R193-R196))

<!-- Additional content -->
<!-- 补充额外内容 -->

给 button 组件传递 disabled 时

before:
![image](https://user-images.githubusercontent.com/20262815/232441806-33d0953a-f33a-4d08-a21c-48cec6969d9e.png)
且鼠标 hover 上去没有显示禁用光标

after: 
![image](https://user-images.githubusercontent.com/20262815/232446771-8099bd73-f7cc-4d84-886e-a2b47bd437ef.png)
现在鼠标 hover 上去后会显示禁用光标

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 003346e</samp>

Refactor button component styles for disabled and link buttons. Use `box-shadow` and `cursor` properties to enhance the appearance and usability of the `button` component in `packages/components/src/button/style.less`.
