### PR TITLE
WIP: fix: registerMenuItem support ComponentMenuItem

### DIFF
--- a/packages/core-browser/src/menu/next/base.ts
+++ b/packages/core-browser/src/menu/next/base.ts
@@ -18,7 +18,6 @@ import {
 } from '@opensumi/ide-core-common';
 import { ContextKeyExpr } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 
-
 import { MenuId } from './menu-id';
 
 export const MenuContribution = Symbol('MenuContribution');
@@ -311,21 +310,23 @@ export class CoreMenuRegistryImpl implements IMenuRegistry {
       return [];
     }
 
-    const result = (this._menuItems.get(id) || []).slice(0).reduce((prev, cur) => {
-      if (isIComponentMenuItem(cur)) {
-        // 目前只支持 `EditorTitle` 开放 `ComponentMenuItem`
-        if (CoreMenuRegistryImpl.EnableComponentMenuIds.includes(id)) {
-          prev.push({
-            ...cur,
-            group: 'navigation',
-          });
-        }
-      } else {
-        prev.push(cur);
-      }
+    // const result = (this._menuItems.get(id) || []).slice(0).reduce((prev, cur) => {
+    //   if (isIComponentMenuItem(cur)) {
+    //     // 目前只支持 `EditorTitle` 开放 `ComponentMenuItem`
+    //     if (CoreMenuRegistryImpl.EnableComponentMenuIds.includes(id)) {
+    //       prev.push({
+    //         ...cur,
+    //         group: 'navigation',
+    //       });
+    //     }
+    //   } else {
+    //     prev.push(cur);
+    //   }
 
-      return prev;
-    }, [] as Array<IMenuItem | ISubmenuItem | IComponentMenuItem>);
+    //   return prev;
+    // }, [] as Array<IMenuItem | ISubmenuItem | IComponentMenuItem>);
+
+    const result = (this._menuItems.get(id) || []).slice(0);
 
     if (id === MenuId.CommandPalette) {
       // CommandPalette 特殊处理, 默认展示所有的 command

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -7,6 +7,7 @@ import {
   TabBarToolbarContribution,
   ToolbarRegistry,
 } from '@opensumi/ide-core-browser/lib/layout';
+import { MenuContribution } from '@opensumi/ide-core-browser/lib/menu/next';
 import {
   Disposable,
   CommandContribution,
@@ -22,7 +23,7 @@ import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import { OutputLinkProvider } from './output-link.provider';
 import { outputPreferenceSchema } from './output-preference';
 import { OutputService } from './output.service';
-import { Output, ChannelSelector } from './output.view';
+import { Output, ChannelSelector, CustomMenuItem } from './output.view';
 
 const OUTPUT_CLEAR: Command = {
   id: 'output.channel.clear',
@@ -30,6 +31,7 @@ const OUTPUT_CLEAR: Command = {
 };
 
 @Domain(
+  MenuContribution,
   CommandContribution,
   ComponentContribution,
   TabBarToolbarContribution,
@@ -39,6 +41,7 @@ const OUTPUT_CLEAR: Command = {
 export class OutputContribution
   extends Disposable
   implements
+    MenuContribution,
     CommandContribution,
     ComponentContribution,
     TabBarToolbarContribution,
@@ -69,6 +72,22 @@ export class OutputContribution
   registerCommands(commands: CommandRegistry): void {
     commands.registerCommand(OUTPUT_CLEAR, {
       execute: () => this.outputService.selectedChannel?.clear(),
+    });
+  }
+  registerMenus(menuRegistry): void {
+    menuRegistry.registerMenuItem('tabbar/bottom/common', {
+      // command: 'custom_group_0011',
+      component: CustomMenuItem,
+      order: -1,
+      group: 'navigation',
+      when: '!bottomFullExpanded',
+    });
+    menuRegistry.registerMenuItem('tabbar/bottom/common', {
+      // command: 'custom_group_0011',
+      component: CustomMenuItem,
+      order: -2,
+      group: 'custom_group_001',
+      when: '!bottomFullExpanded',
     });
   }
 

--- a/packages/output/src/browser/output.view.tsx
+++ b/packages/output/src/browser/output.view.tsx
@@ -2,10 +2,11 @@ import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { useEffect, createRef } from 'react';
 
-import { Select, Option } from '@opensumi/ide-components';
+import { Select, Option, Icon } from '@opensumi/ide-components';
 import { useInjectable, ViewState, AppConfig } from '@opensumi/ide-core-browser';
 import { OUTPUT_CONTAINER_ID } from '@opensumi/ide-core-browser/lib/common/container-id';
 import { Select as NativeSelect } from '@opensumi/ide-core-browser/lib/components/select';
+import { IComponentMenuItemProps } from '@opensumi/ide-core-browser/lib/menu/next/base';
 import { IMainLayoutService } from '@opensumi/ide-main-layout/lib/common/main-layout.definition';
 
 import styles from './output.module.less';
@@ -106,3 +107,5 @@ export const ChannelSelector = observer(() => {
     </Select>
   );
 });
+
+export const CustomMenuItem: React.FC<IComponentMenuItemProps> = () => <Icon icon='explorer' />;


### PR DESCRIPTION
registerMenuItem 放开对自定义组件的限制后，默认分组(navigation)可以正常展示，但有 2 个问题

1. 设置了自定义分组的菜单项未展示
![image](https://user-images.githubusercontent.com/127910654/232447825-e8ca12b4-d3ba-4e24-b71e-12e16cd488b6.png)

2. 注册时增加 command 配置会导致菜单项注册失败