### PR TITLE
fix: webview csp source

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.api.webview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.webview.ts
@@ -99,7 +99,7 @@ export class ExtHostWebview implements Webview {
   public get cspSource() {
     let cspSource = this.cspResourceRoots.join(' ');
     if (this.extensionLocation) {
-      cspSource += `'self' vscode-resource:/${this.extensionLocation.path}/`.toLowerCase();
+      cspSource += ` 'self' vscode-resource:/${this.extensionLocation.path}/`.toLowerCase();
     }
     return cspSource;
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

之前 OpenSumi 对于 WebView CSPSource 做了一个处理，但是存在一个空格的问题会导致设置错误，这个 PR 修复了空格的问题。

<img width="716" alt="image" src="https://user-images.githubusercontent.com/12879047/232658803-3d37a701-b5ac-4e65-9faa-6948efe33a16.png">


<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9433d5</samp>

* Fix webview resource loading bug by adding a space before `'self'` in cspSource ([link](https://github.com/opensumi/core/pull/2597/files?diff=unified&w=0#diff-2ca456daee43c1e3bbc7c34f0f86f92cd29c8b28abdc9335997b9559ee0f1a62L102-R102))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9433d5</samp>

Fix a webview resource loading bug by adding a space in the cspSource string. The bug affected extensions that use webviews and was caused by a typo in `ext.host.api.webview.ts`.
