### PR TITLE
feat: implement launch json editor

### DIFF
--- a/packages/core-browser/src/utils/schema.ts
+++ b/packages/core-browser/src/utils/schema.ts
@@ -1,0 +1,11 @@
+import type { Ajv } from 'ajv';
+
+let _ajv;
+export const acquireAjv = (): Ajv | undefined => {
+  if (!_ajv) {
+    const Ajv = require('ajv');
+    _ajv = new Ajv();
+    return _ajv;
+  }
+  return _ajv;
+};

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -23,6 +23,9 @@
     "@opensumi/ide-file-service": "workspace:*",
     "@opensumi/ide-task": "workspace:*",
     "@opensumi/ide-terminal-next": "workspace:*",
+    "@rjsf/core": "^5.5.2",
+    "@rjsf/utils": "^5.5.2",
+    "@rjsf/validator-ajv8": "^5.5.2",
     "anser": "^1.4.9",
     "btoa": "^1.2.1"
   },

--- a/packages/debug/src/browser/preferences/components/select-widget.tsx
+++ b/packages/debug/src/browser/preferences/components/select-widget.tsx
@@ -1,0 +1,23 @@
+import { WidgetProps } from '@rjsf/utils';
+import React, { useMemo } from 'react';
+
+import { Option, Select } from '@opensumi/ide-components';
+
+export const SelectWidget = (props: WidgetProps) => {
+  const { schema, value } = props;
+
+  const enumValue = useMemo(() => {
+    if (schema && schema.enum) {
+      return schema.enum;
+    }
+    return [];
+  }, [schema, schema.enum]);
+
+  return (
+    <Select value={value}>
+      {enumValue.forEach((data: string) => {
+        <Option value={data}>{data}</Option>;
+      })}
+    </Select>
+  );
+};

--- a/packages/debug/src/browser/preferences/components/text-widget.tsx
+++ b/packages/debug/src/browser/preferences/components/text-widget.tsx
@@ -1,0 +1,36 @@
+import { WidgetProps } from '@rjsf/utils';
+import React from 'react';
+
+import { Input } from '@opensumi/ide-components';
+
+const INPUT_STYLE = {
+  width: '100%',
+};
+
+export const TextWidget = (props: WidgetProps) => {
+  const { disabled, formContext, id, onBlur, onChange, onFocus, options, placeholder, readonly, schema, value } = props;
+  const { readonlyAsDisabled = true } = formContext;
+
+  const handleTextChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
+    onChange(target.value === '' ? options.emptyValue : target.value);
+
+  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) => onBlur(id, target.value);
+
+  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) => onFocus(id, target.value);
+
+  return schema.type === 'string' ? (
+    <Input
+      disabled={disabled || (readonlyAsDisabled && readonly)}
+      id={id}
+      name={id}
+      onBlur={!readonly ? handleBlur : undefined}
+      onChange={!readonly ? handleTextChange : undefined}
+      onFocus={!readonly ? handleFocus : undefined}
+      placeholder={placeholder}
+      style={INPUT_STYLE}
+      type={(options.inputType || 'text') as string}
+      value={value}
+      autoComplete='off'
+    />
+  ) : null;
+};

--- a/packages/debug/src/browser/preferences/launch-preferences-contribution.ts
+++ b/packages/debug/src/browser/preferences/launch-preferences-contribution.ts
@@ -29,7 +29,6 @@ export class LaunchResourceProvider implements IResourceProvider {
   readonly scheme: string = LAUNCH_VIEW_SCHEME;
 
   provideResource(uri: URI): MaybePromise<IResource<any>> {
-    // 获取文件类型 getFileType: (path: string) => string
     return {
       supportsRevive: true,
       name: localize('menu-bar.title.debug'),
@@ -38,11 +37,11 @@ export class LaunchResourceProvider implements IResourceProvider {
     };
   }
 
-  provideResourceSubname(resource: IResource, groupResources: IResource[]): string | null {
+  provideResourceSubname(): string | null {
     return null;
   }
 
-  async shouldCloseResource(resource: IResource, openedResources: IResource[][]): Promise<boolean> {
+  async shouldCloseResource(): Promise<boolean> {
     return true;
   }
 }

--- a/packages/debug/src/browser/preferences/launch.module.less
+++ b/packages/debug/src/browser/preferences/launch.module.less
@@ -63,6 +63,7 @@
     .launch_schema_body_container {
       overflow: auto;
       height: 100%;
+      padding: 0 16px 12px 16px;
     }
   }
 }

--- a/packages/debug/src/browser/preferences/launch.module.less
+++ b/packages/debug/src/browser/preferences/launch.module.less
@@ -59,6 +59,11 @@
         }
       }
     }
+
+    .launch_schema_body_container {
+      overflow: auto;
+      height: 100%;
+    }
   }
 }
 

--- a/packages/debug/src/browser/preferences/launch.view.tsx
+++ b/packages/debug/src/browser/preferences/launch.view.tsx
@@ -219,13 +219,13 @@ const LaunchBody = ({
       lodashGet(schemaContributions, ['properties', 'configurations', 'items', 'oneOf'] as (keyof IJSONSchema)[]) || [];
 
     // 2. 再从 snippetItem body 中找出符合条件的 oneOf（可能存在多个，如果有多个就只取第一个）
-    const findOneOf = oneOfPool.filter((oneOf) => {
+    const findOneOf = oneOfPool.find((oneOf) => {
       const { body } = snippetItem;
       return ajv!.validate(oneOf, body);
     });
 
-    if (findOneOf.length > 0) {
-      setSchemaProperties(findOneOf[0]);
+    if (findOneOf) {
+      setSchemaProperties(findOneOf);
     }
   }, [snippetItem, schemaContributions]);
 

--- a/packages/debug/src/browser/preferences/templates/array-field-item-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/array-field-item-template.tsx
@@ -1,0 +1,96 @@
+import {
+  ArrayFieldTemplateItemType,
+  FieldTemplateProps,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from '@rjsf/utils';
+import cls from 'classnames';
+import React, { Fragment } from 'react';
+
+import styles from './json-templates.module.less';
+
+const BTN_GRP_STYLE = {
+  width: '100%',
+};
+
+const BTN_STYLE = {
+  width: 'calc(100% / 4)',
+};
+
+export const ArrayFieldItemTemplate = <
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(
+  props: ArrayFieldTemplateItemType<T, S, F>,
+) => {
+  const {
+    className,
+    children,
+    disabled,
+    hasCopy,
+    hasMoveDown,
+    hasMoveUp,
+    hasRemove,
+    hasToolbar,
+    index,
+    onCopyIndexClick,
+    onDropIndexClick,
+    onReorderClick,
+    readonly,
+    registry,
+    uiSchema,
+    schema,
+  } = props;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+
+  return (
+    <div key={`array-item-${index}`} className={cls(className, styles.array_field_item_template)}>
+      <div className={styles.control_field}>{React.cloneElement(children, { name: '' })}</div>
+
+      {hasToolbar && (
+        <div className={styles.toolbar}>
+          <div style={BTN_GRP_STYLE}>
+            {(hasMoveUp || hasMoveDown) && (
+              <MoveUpButton
+                disabled={disabled || readonly || !hasMoveUp}
+                onClick={onReorderClick(index, index - 1)}
+                style={BTN_STYLE}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {(hasMoveUp || hasMoveDown) && (
+              <MoveDownButton
+                disabled={disabled || readonly || !hasMoveDown}
+                onClick={onReorderClick(index, index + 1)}
+                style={BTN_STYLE}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {hasCopy && (
+              <CopyButton
+                disabled={disabled || readonly}
+                onClick={onCopyIndexClick(index)}
+                style={BTN_STYLE}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {hasRemove && (
+              <RemoveButton
+                disabled={disabled || readonly}
+                onClick={onDropIndexClick(index)}
+                style={BTN_STYLE}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/debug/src/browser/preferences/templates/array-field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/array-field-template.tsx
@@ -1,0 +1,96 @@
+import {
+  getTemplate,
+  getUiOptions,
+  ArrayFieldTemplateProps,
+  ArrayFieldTemplateItemType,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from '@rjsf/utils';
+import cls from 'classnames';
+import React from 'react';
+
+import styles from './json-templates.module.less';
+
+const DESCRIPTION_COL_STYLE = {
+  paddingBottom: '8px',
+};
+
+export const ArrayFieldTemplate = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: ArrayFieldTemplateProps<T, S, F>,
+) => {
+  const {
+    canAdd,
+    className,
+    disabled,
+    formContext,
+    idSchema,
+    items,
+    onAddClick,
+    readonly,
+    registry,
+    required,
+    schema,
+    title,
+    uiSchema,
+  } = props;
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const ArrayFieldDescriptionTemplate = getTemplate<'ArrayFieldDescriptionTemplate', T, S, F>(
+    'ArrayFieldDescriptionTemplate',
+    registry,
+    uiOptions,
+  );
+  const ArrayFieldItemTemplate = getTemplate<'ArrayFieldItemTemplate', T, S, F>(
+    'ArrayFieldItemTemplate',
+    registry,
+    uiOptions,
+  );
+  const ArrayFieldTitleTemplate = getTemplate<'ArrayFieldTitleTemplate', T, S, F>(
+    'ArrayFieldTitleTemplate',
+    registry,
+    uiOptions,
+  );
+  const {
+    ButtonTemplates: { AddButton },
+  } = registry.templates;
+
+  return (
+    <fieldset className={cls(className)} id={idSchema.$id}>
+      <div className={styles.array_field_template}>
+        {(uiOptions.title || title) && (
+          <div className={styles.array_item_label}>
+            <ArrayFieldTitleTemplate
+              idSchema={idSchema}
+              required={required}
+              title={uiOptions.title || title}
+              schema={schema}
+              uiSchema={uiSchema}
+              registry={registry}
+            />
+          </div>
+        )}
+        {(uiOptions.description || schema.description) && (
+          <div className={styles.array_item_description}>
+            <ArrayFieldDescriptionTemplate
+              description={uiOptions.description || schema.description}
+              idSchema={idSchema}
+              schema={schema}
+              uiSchema={uiSchema}
+              registry={registry}
+            />
+          </div>
+        )}
+        {items &&
+          items.map(({ key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>) => (
+            <ArrayFieldItemTemplate key={key} {...itemProps} />
+          ))}
+
+        {canAdd && (
+          <div className={styles.array_item_add}>
+            <AddButton disabled={disabled || readonly} onClick={onAddClick} uiSchema={uiSchema} registry={registry} />
+          </div>
+        )}
+      </div>
+    </fieldset>
+  );
+};

--- a/packages/debug/src/browser/preferences/templates/button-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/button-template.tsx
@@ -1,0 +1,38 @@
+import { IconButtonProps } from '@rjsf/utils';
+import React from 'react';
+
+import { Button, getIcon } from '@opensumi/ide-components';
+import { defaultIconfont } from '@opensumi/ide-components/lib/icon/iconfont/iconMap';
+import { localize } from '@opensumi/ide-core-common';
+
+export const MoveUpButton = (props: IconButtonProps) => (
+  <Button {...props} type='primary' icon={defaultIconfont.arrowup}>
+    <span className={getIcon(defaultIconfont.arrowup)}></span>
+  </Button>
+);
+
+export const MoveDownButton = (props: IconButtonProps) => (
+  <Button {...props} type='primary' icon={defaultIconfont.arrowdown}>
+    <span className={getIcon(defaultIconfont.arrowdown)}></span>
+  </Button>
+);
+
+export const RemoveButton = (props: IconButtonProps) => (
+  <Button {...props} type='danger' icon={defaultIconfont.delete}>
+    <span className={getIcon(defaultIconfont.delete)}></span>
+  </Button>
+);
+
+export const AddButton = (props: IconButtonProps) => (
+  <Button {...props} type='primary' icon={defaultIconfont.plus}>
+    <span className={getIcon(defaultIconfont.plus)}></span> {localize('debug.launch.view.template.button.addItem')}
+  </Button>
+);
+
+export const CopyButton = (props: IconButtonProps) => (
+  <Button {...props} type='primary' icon={defaultIconfont['file-copy']}>
+    <span className={getIcon(defaultIconfont['file-copy'])}></span>
+  </Button>
+);
+
+export const SubmitButton = (props: IconButtonProps) => <Button>{localize('ButtonOK')}</Button>;

--- a/packages/debug/src/browser/preferences/templates/description-field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/description-field-template.tsx
@@ -1,0 +1,22 @@
+import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import React from 'react';
+
+import styles from './json-templates.module.less';
+
+export const DescriptionFieldTemplate = <
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(
+  props: DescriptionFieldProps<T, S, F>,
+) => {
+  const { id, description } = props;
+  if (!description) {
+    return null;
+  }
+  return (
+    <span id={id} className={styles.description_field_template}>
+      {description}
+    </span>
+  );
+};

--- a/packages/debug/src/browser/preferences/templates/field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/field-template.tsx
@@ -1,0 +1,40 @@
+import { FieldTemplateProps } from '@rjsf/utils';
+import cls from 'classnames';
+import React, { useMemo } from 'react';
+
+import styles from './json-templates.module.less';
+
+export const FieldTemplate = (props: FieldTemplateProps) => {
+  const { classNames, style, help, description, errors, children, id, schema, label, displayLabel } = props;
+  const renderDescription = useMemo(() => {
+    if (id === 'root' || schema.type === 'array') {
+      return null;
+    }
+
+    return description;
+  }, [id, schema, schema.type, description]);
+
+  const renderLabel = useMemo(() => {
+    if (id === 'root' || schema.type === 'array' || displayLabel === false) {
+      return null;
+    }
+
+    return (
+      label && (
+        <label title={label} className={styles.field_label}>
+          {label}
+        </label>
+      )
+    );
+  }, [id, schema, schema.type, label, displayLabel]);
+
+  return (
+    <div className={cls(classNames, styles.field_template)} style={style}>
+      {renderLabel}
+      {renderDescription}
+      {children}
+      {errors}
+      {help}
+    </div>
+  );
+};

--- a/packages/debug/src/browser/preferences/templates/json-templates.module.less
+++ b/packages/debug/src/browser/preferences/templates/json-templates.module.less
@@ -30,15 +30,8 @@
 .array_field_template {
   display: flex;
   flex-direction: column;
-
-  .array_item_label {
-  }
-
   .array_item_description {
     margin-bottom: 8px;
-  }
-
-  .array_item_add {
   }
 }
 

--- a/packages/debug/src/browser/preferences/templates/json-templates.module.less
+++ b/packages/debug/src/browser/preferences/templates/json-templates.module.less
@@ -1,0 +1,65 @@
+.array_field_item_template {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+
+  .control_field {
+    margin-right: 8px;
+    min-width: 180px;
+  }
+
+  .toolbar {
+    button {
+      border-radius: 0;
+    }
+  }
+}
+
+.field_template {
+  display: flex;
+  flex-direction: column;
+
+  .field_label {
+    margin-bottom: 10px;
+    font-weight: 600;
+    font-size: 14px;
+    display: inline-block;
+  }
+}
+
+.array_field_template {
+  display: flex;
+  flex-direction: column;
+
+  .array_item_label {
+  }
+
+  .array_item_description {
+    margin-bottom: 8px;
+  }
+
+  .array_item_add {
+  }
+}
+
+.object_field_template {
+  .object_title {
+    margin-bottom: 16px;
+  }
+
+  .object_description {
+    margin-bottom: 8px;
+  }
+
+  .property_wrapper {
+    margin-bottom: 16px;
+  }
+}
+
+.description_field_template {
+  display: inline-block;
+  margin-bottom: 10px;
+  font-size: 14px;
+  opacity: 0.75;
+  color: var(--descriptionForeground);
+}

--- a/packages/debug/src/browser/preferences/templates/object-field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/object-field-template.tsx
@@ -1,0 +1,70 @@
+import {
+  ObjectFieldTemplateProps,
+  canExpand,
+  StrictRJSFSchema,
+  RJSFSchema,
+  FormContextType,
+  getTemplate,
+  getUiOptions,
+  descriptionId,
+  titleId,
+} from '@rjsf/utils';
+import React from 'react';
+
+import styles from './json-templates.module.less';
+
+export const ObjectFieldTemplate = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: ObjectFieldTemplateProps<T, S, F>,
+) => {
+  const {
+    schema,
+    uiSchema,
+    formData,
+    onAddClick,
+    disabled,
+    required,
+    readonly,
+    registry,
+    idSchema,
+    title,
+    description,
+  } = props;
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    uiOptions,
+  );
+
+  return (
+    <fieldset className={styles.object_field_template}>
+      {title && (
+        <div className={styles.object_title}>
+          <TitleFieldTemplate
+            id={titleId<T>(idSchema)}
+            title={title}
+            required={required}
+            schema={schema}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        </div>
+      )}
+      {description && (
+        <div className={styles.object_description}>
+          <DescriptionFieldTemplate
+            id={descriptionId<T>(idSchema)}
+            description={description}
+            schema={schema}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        </div>
+      )}
+      {props.properties.map((element) => (
+        <div className={styles.property_wrapper}>{React.cloneElement(element.content, { displayLabel: true })}</div>
+      ))}
+    </fieldset>
+  );
+};

--- a/packages/editor/src/browser/types.ts
+++ b/packages/editor/src/browser/types.ts
@@ -418,7 +418,7 @@ export interface IBreadCrumbPart {
 
   uri?: URI;
 
-  isSymbol?: Boolean;
+  isSymbol?: boolean;
 
   getSiblings?(): MaybePromise<{ parts: IBreadCrumbPart[]; currentIndex: number }>;
 

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -377,6 +377,8 @@ export const localizationBundle = {
     'debug.launch.configurations.debugLinuxConfiguration': 'Linux specific launch configuration attributes.',
     'debug.launch.typeNotSupported': 'The debug session type "{0}" is not supported.',
     'debug.launch.catchError': 'There was an error starting the debug session, check the logs for more details.',
+    'debug.launch.view.template.button.addItem': 'Add items',
+
     'debug.widget.exception.thrownWithId': 'Exception has occurred: {0}',
     'debug.widget.exception.thrown': 'Exception has occurred.',
 

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -354,6 +354,8 @@ export const localizationBundle = {
     'debug.launch.configurations.debugLinuxConfiguration': '特定于 Linux 的启动配置属性。',
     'debug.launch.typeNotSupported': '调试类型 "{0}" 不支持',
     'debug.launch.catchError': '启动调试进程时遇到了错误, 请检查调试控制台',
+    'debug.launch.view.template.button.addItem': '添加一项',
+
     'debug.widget.exception.thrownWithId': '发生异常: {0}',
     'debug.widget.exception.thrown': '出现异常。',
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a8ce32</samp>

*  Add and use React JSON Schema Form library to render and validate JSON schemas in the debug launch view ([link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-4ab5bf726d0813cd862123b2515e4201cc0c9b67031365c01107c10a0daf6b4bR26-R28), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-f86d1cd15965214231cce3fa2b44d0fa407e9832d41b5ba1afb1847ddabe6ebbR1-R23), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-22e325d5312d9c44550fad5f1619256919014d486f96e39dcb76c98c1ac799f3R1-R36), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bR1-R3), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL15-R48), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL40-R80), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL53-R97), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL73-R113), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL155-R288), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-bae5761df273439b8c38dedcf4a6d84682f842eb74cc140b900b7be95694a716R1-R96), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-2cab35c675650588fe515cc4a0a677a3d682c5ab97db765762ac68b23c75ad60R1-R96), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967R1-R38), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-6e7f7e9f5e5e44e10732f9da7583ce43aa515c3a938f4b7fdd379e2dc7601c9bR1-R22), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-483d2e76d3cdfee74cfb9ce43e708f0814fd6e27ab8b431fbd6414944c69105dR1-R40), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-0b47ea19c9728a74dab1d95d912bbfb2059e790bb2eeb5d49963010a73ee4b2dR1-R65), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deR1-R70), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R380-R381), [link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R357-R358))
* Add a new utility function `acquireAjv` to lazily import and return an instance of the `Ajv` validator library ([link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-9fd2241c22e0044e8474facd1ea57dcf10d55f0e7aeceb921f14b733fdf4a77dR1-R11))
* Simplify the signature of two methods in the `LaunchResourceProvider` class by removing unused parameters ([link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-469d2164fd977fac513d47f5fdae2bc3ec04d5896e3f576b075504a9c0e981afL41-R44))
* Remove a comment that is no longer relevant to the `LaunchResourceProvider` class ([link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-469d2164fd977fac513d47f5fdae2bc3ec04d5896e3f576b075504a9c0e981afL32))
* Add a new CSS class `.launch_schema_body_container` to style the container element of the launch schema body ([link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-1c9f4efbfc56bf5e861ebb6f10ddd4b5e01574289aceee3140b103097513ca47R62-R67))
* Fix a typo in the interface `IBreadCrumbPart` in the `editor` package ([link](https://github.com/opensumi/core/pull/2598/files?diff=unified&w=0#diff-4094653eb8c5e5971274e17d7a7d8a8837b1c4e2acd4804c1ef92a2b0b8178c6L421-R421))

<!-- Additional content -->

dark 主题
![image](https://user-images.githubusercontent.com/20262815/232665937-1b2504c7-37db-4e2d-9fdf-55bca2774c21.png)


light 主题
![image](https://user-images.githubusercontent.com/20262815/232665880-536aa9e8-5826-47dc-a7d6-2d927a866d91.png)

- [x] 支持 input 输入框来编辑 type 是 string 的 json schema
- [x] 支持以多项列表选择器来编辑 type 为 array 的 json schema
- [x] 支持以 select 选择器来编辑 type 为 object 的 json schema
- [x] 样式优化
- [x] 支持通过 debug 的 snippet items 来默认填充数据

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a8ce32</samp>

This pull request introduces a new UI for the debug launch view using the React JSON Schema Form library and custom components. It also refactors and fixes some code in the `debug` and `editor` packages, and adds some localization and styling.
