### PR TITLE
feat(editor): editor save code action notify configuration

### DIFF
--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1378,6 +1378,11 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     default: EDITOR_DEFAULTS.contribInfo.codeActionsOnSaveTimeout,
     description: '%editor.configuration.codeActionsOnSaveTimeout%',
   },
+  'editor.codeActionsOnSaveNotification': {
+    type: 'boolean',
+    default: true,
+    description: '%editor.configuration.codeActionsOnSaveNotification%',
+  },
   'editor.selectionClipboard': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.selectionClipboard,
@@ -1397,6 +1402,11 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.defaultFormatter': {
     type: 'string',
     description: '%editor.configuration.defaultFormatter%',
+  },
+  'editor.unicodeHighlight.ambiguousCharacters': {
+    type: 'boolean',
+    default: true,
+    description: '%editor.configuration.unicodeHighlight.ambiguousCharacters%',
   },
 };
 

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -539,6 +539,8 @@ export const localizationBundle = {
     'preference.files.trimTrailingWhitespace': 'Trim Trailing Whitespace',
     'preference.files.insertFinalNewline': 'Insert Final Newline',
     'preference.editor.lineHeight': 'Line Height',
+    'preference.editor.saveCodeActions': 'Code Actions On Save',
+    'preference.editor.saveCodeActionsNotification': 'Whether to notify when code operations run at save time',
 
     'keymaps.tab.name': 'Keyboard Shortcuts',
 
@@ -891,6 +893,7 @@ export const localizationBundle = {
     'editor.configuration.codeActionsOnSave': 'Code action kinds to be run on save.',
     'editor.configuration.codeActionsOnSaveTimeout':
       'Timeout in milliseconds after which the code actions that are run on save are cancelled.',
+    'editor.configuration.codeActionsOnSaveNotification': 'Whether to notify when code operations run at save time.',
     'editor.configuration.selectionClipboard': 'Controls whether the Linux primary clipboard should be supported.',
     'editor.configuration.largeFileOptimizations':
       'Special handling for large files to disable certain memory intensive features.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -497,6 +497,8 @@ export const localizationBundle = {
     'preference.editor.bracketPairColorization.enabled': '括号着色',
     'preference.array.additem': '添加',
     'preference.editor.lineHeight': '行高',
+    'preference.editor.saveCodeActions': '保存时运行的代码操作类型',
+    'preference.editor.saveCodeActionsNotification': '代码操作执行时是否展示通知信息',
 
     'preference.item.notValid': '{0} 不是有效选项',
 
@@ -998,6 +1000,11 @@ export const localizationBundle = {
     'editor.configuration.suggest.details.visible': '控制编辑器代码补全是否默认展开详情信息',
     'editor.configuration.experimental.stickyScroll.enabled': '在编辑器顶部的滚动过程中显示嵌套的当前作用域。',
     'editor.configuration.maxTokenizationLineLength': '由于性能原因，超过这个长度的行将不会被标识。',
+    'editor.configuration.codeActionsOnSave.organizeImports': '控制是否应在文件保存时整理导入（Import）语句。',
+    'editor.configuration.codeActionsOnSave.fixAll': '控制是否应在文件保存时运行自动修复操作。',
+    'editor.configuration.codeActionsOnSave': '在保存时运行的代码操作类型',
+    'editor.configuration.codeActionsOnSaveTimeout': '在此超时时间(毫秒)之后代码操作将被取消。',
+    'editor.configuration.codeActionsOnSaveNotification': '代码操作执行时是否展示通知信息',
     'editor.configuration.quickSuggestionsDelay': '控制显示智能提示的延迟时长 (毫秒)。',
     'editor.configuration.tabSize':
       '控制 Tab 缩进等于的空格数。若启用 `#editor.detectIndentation#`，该设置可能会被覆盖',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -644,6 +644,9 @@ export const defaultSettingSections: {
         { id: 'editor.formatOnSave', localized: 'preference.editor.formatOnSave' },
         { id: 'editor.formatOnSaveTimeout', localized: 'preference.editor.formatOnSaveTimeout' },
         { id: 'editor.formatOnPaste', localized: 'preference.editor.formatOnPaste' },
+        // 代码操作
+        { id: 'editor.codeActionsOnSave', localized: 'preference.editor.saveCodeActions' },
+        { id: 'editor.codeActionsOnSaveNotification', localized: 'preference.editor.saveCodeActionsNotification' },
         // 智能提示
         { id: 'editor.quickSuggestionsDelay', localized: 'preference.editor.quickSuggestionsDelay' },
         // 文件


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

编辑器模块执行saveCodeActions时默认会弹出Notification提示，新增配置可选是否弹窗提示。

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b9c7a2c</samp>

*  Add new preference options to control code actions on save and the notification message
  * Define the schema and default values for `editor.codeActionsOnSaveNotification` and `editor.unicodeHighlight.ambiguousCharacters` in `monacoEditorSchema` ([link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-d2e2b9fe5f9466a2457d8fa83b5be6e7196c166629732594386fad511fb01d6eR1381-R1385),[link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-d2e2b9fe5f9466a2457d8fa83b5be6e7196c166629732594386fad511fb01d6eR1406-R1410))
  * Add the preference labels and descriptions to the English and Chinese localization bundles ([link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R542-R543),[link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R896),[link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R500-R501),[link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R1003-R1007))
  * Include the new options in the preference UI under the "Code Actions" group ([link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR647-R649))
  * Extract the code from the `save` method of `SaveParticipant` into `runActions` ([link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-4d9d7151a8ae93dd4f3e1ed1b864ce98a2a6368e8c2bfcbb12bbc3ffbdfd36cbL106-R182))
  * Pass the `progress` parameter to `runActions` and check for its nullity before reporting progress ([link](https://github.com/opensumi/core/pull/2599/files?diff=unified&w=0#diff-4d9d7151a8ae93dd4f3e1ed1b864ce98a2a6368e8c2bfcbb12bbc3ffbdfd36cbL182-R201))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9c7a2c</samp>

This pull request enhances the code actions on save feature in the editor by adding new preference options, a notification toggle, and localization support. It updates the files `saveParticipants.ts`, `schema.ts`, `en-US.lang.ts`, `zh-CN.lang.ts`, and `preference-settings.service.ts` to implement these changes. It also upgrades the monaco editor dependency to the latest version.
