### PR TITLE
fix: transformLabelWithCodicon white space

### DIFF
--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -20,7 +20,10 @@ export function transformLabelWithCodicon(
   const generateIconStyle = (icon?: string, styleProps?: CSSProperties | string) =>
     typeof styleProps === 'string' ? { className: clx(icon, styleProps) } : { className: icon, style: styleProps };
 
-  return label.split(SEPERATOR).map((e, index) => {
+  const splitLabel = label.split(SEPERATOR);
+  const length = splitLabel.length;
+
+  return splitLabel.map((e, index) => {
     if (!transformer) {
       return e;
     }
@@ -45,7 +48,12 @@ export function transformLabelWithCodicon(
     } else if (ICON_ERROR_REGX.test(e)) {
       return transformLabelWithCodicon(e.replaceAll(ICON_ERROR_REGX, ''), iconStyleProps, transformer, renderText);
     } else {
-      return isFunction(renderText) ? renderText(e, index) : <span key={`${index}-${e}`}>{e}</span>;
+      const withSeperator = e + (index === length - 1 ? '' : SEPERATOR);
+      return isFunction(renderText) ? (
+        renderText(withSeperator, index)
+      ) : (
+        <span key={`${index}-${e}`}>{withSeperator}</span>
+      );
     }
   });
 }

--- a/packages/status-bar/src/browser/status-bar.module.less
+++ b/packages/status-bar/src/browser/status-bar.module.less
@@ -71,6 +71,7 @@
 .popover_item {
   display: flex;
   align-items: center;
+  white-space: pre;
 }
 
 .popover_content,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4e4b05</samp>

* Split the label by the separator and store the result in `splitLabel` and `length` variables to avoid repeated calls and improve readability ([link](https://github.com/opensumi/core/pull/2600/files?diff=unified&w=0#diff-8e3a04b720a5161d44246b6c57ca6b3b5852e8314759cffb212cb08ac3a11f44L23-R26))
* Render the label text with the separator added back except for the last element and wrap each text in a span with a key prop to preserve the format and avoid React warnings ([link](https://github.com/opensumi/core/pull/2600/files?diff=unified&w=0#diff-8e3a04b720a5161d44246b6c57ca6b3b5852e8314759cffb212cb08ac3a11f44L48-R56))
* Prevent the status bar item text from wrapping to a new line by adding a CSS rule to the `.status-bar-item` class to ensure the label with codicons is displayed as a single line ([link](https://github.com/opensumi/core/pull/2600/files?diff=unified&w=0#diff-49c295b8f44f71b2395b2632fffe98ff064b6c25a080e00d2e696cdb0e7082a8R74))

<!-- Additional content -->
fix https://github.com/opensumi/core/issues/2590

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4e4b05</samp>

Refactor and improve label rendering in `core-browser` and fix status bar layout in `status-bar`.
