### PR TITLE
fix(extension): fix extension nls config bug

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -197,7 +197,8 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
 
   public async activate(): Promise<void> {
     // setup the basic environment
-    await this.setupExtensionNLSConfig();
+    // 不能在这里设置，因为这里的设置会被插件覆盖
+    // await this.setupExtensionNLSConfig();
     await this.initExtensionMetaData();
     await this.initExtensionInstanceData();
     await this.runEagerExtensionsContributes();

--- a/packages/extension/src/node/extension.service.client.ts
+++ b/packages/extension/src/node/extension.service.client.ts
@@ -204,6 +204,9 @@ export class ExtensionServiceClientImpl
         ...this.convertLanguagePack(packageJson, languagePack),
       };
     }
+    const languagePackJson = await this.fileService.getFileStat(languagePath);
+    await this.fileService.setContent(languagePackJson!, JSON.stringify(languagePacks));
+
     await this.setupNLSConfig(languageId, storagePath);
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

#2529 这个PR还是有bug，有两行写入languagePackJson的代码被误删除了，setupExtensionNLSConfig这个方法在activate的时候必须放在后面执行，否则不会生效，修改后已经验证没有问题了。

<img width="476" alt="image" src="https://user-images.githubusercontent.com/3340210/232813502-f7b875a2-81a0-437b-ad6f-65c6b1ea9811.png">


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b0dfef</samp>

*  Comment out the call to `setupExtensionNLSConfig` in the `activate` method of the `ExtensionServiceImpl` class to avoid overwriting the language pack settings by the plugins ([link](https://github.com/opensumi/core/pull/2601/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L200-R201))
*  Add the logic to write the language pack settings to the `languagePath` file in the `ExtensionServiceClientImpl` class by using the `fileService` methods ([link](https://github.com/opensumi/core/pull/2601/files?diff=unified&w=0#diff-5637d5b22e87217b5f315ce965f10b7c914d1337fe1ce29ec2503665f446c74aR207-R209))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b0dfef</samp>

Commented out a method call in `extension.service.ts` and added logic to write language pack settings to a file in `extension.service.client.ts`. These changes fix the issue of incorrect language pack settings when loading extensions.
