### PR TITLE
fix(extension): fix extension nls config bug

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -196,8 +196,6 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   }
 
   public async activate(): Promise<void> {
-    // setup the basic environment
-    // await this.setupExtensionNLSConfig();
     await this.initExtensionMetaData();
     await this.initExtensionInstanceData();
     await this.runEagerExtensionsContributes();

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -197,7 +197,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
 
   public async activate(): Promise<void> {
     // setup the basic environment
-    await this.setupExtensionNLSConfig();
+    // await this.setupExtensionNLSConfig();
     await this.initExtensionMetaData();
     await this.initExtensionInstanceData();
     await this.runEagerExtensionsContributes();

--- a/packages/extension/src/node/extension.service.client.ts
+++ b/packages/extension/src/node/extension.service.client.ts
@@ -204,6 +204,8 @@ export class ExtensionServiceClientImpl
         ...this.convertLanguagePack(packageJson, languagePack),
       };
     }
+    const languagePackJson = await this.fileService.getFileStat(languagePath);
+    await this.fileService.setContent(languagePackJson!, JSON.stringify(languagePacks));
     await this.setupNLSConfig(languageId, storagePath);
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

#2529 这个PR还是有bug，有两行写入languagePackJson的代码被误删除了，setupExtensionNLSConfig这个方法在activate的时候必须放在后面执行，否则不会生效，修改后已经验证没有问题了，帮忙Review后合并到2.24分支吧

![image](https://user-images.githubusercontent.com/3340210/232963425-40c64357-5234-482e-ba43-2394fda906e4.png)


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8f6c1e</samp>

*  Disable extension localization loading in browser process ([link](https://github.com/opensumi/core/pull/2605/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L200-R200))
*  Write extension language pack data to file system in node process ([link](https://github.com/opensumi/core/pull/2605/files?diff=unified&w=0#diff-5637d5b22e87217b5f315ce965f10b7c914d1337fe1ce29ec2503665f446c74aR207-R208))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8f6c1e</samp>

This pull request modifies the extension system to partially support localization for extensions. It disables the loading of extension localization files in the browser process, and writes the updated language pack data to the file system in the node process.
