### PR TITLE
chore: ignore scripts of building cli engine

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           yarn install --immutable
           yarn run init
-          yarn run build:cli-engine || true
+          yarn run build:cli-engine || echo "Skip build:cli-engine"
 
       - name: Setup .yarnrc.yml
         run: |

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           yarn install --immutable
           yarn run init
-          yarn run build:cli-engine
+          yarn run build:cli-engine || true
 
       - name: Setup .yarnrc.yml
         run: |


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 722bad1</samp>

* Ignore cli-engine build errors on Windows to enable release-rc workflow (`yarn run build:cli-engine || true` in [link](https://github.com/opensumi/core/pull/2608/files?diff=unified&w=0#diff-a023d86bb9353b6f0abc01e07d82830bff7d5599db32c54b3796ad60fd3db789L56-R56))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 722bad1</samp>

Fixed release-rc workflow on Windows by ignoring cli-engine build errors. This is a temporary workaround for a known issue with `.github/workflows/release-rc.yml`.
