### PR TITLE
feat: debug breakpoint file items supports enable/disable switch

### DIFF
--- a/packages/components/src/recycle-tree/basic/tree-node.define.ts
+++ b/packages/components/src/recycle-tree/basic/tree-node.define.ts
@@ -52,6 +52,10 @@ export class BasicCompositeTreeNode extends CompositeTreeNode {
     return this._displayName;
   }
 
+  get renderLabel() {
+    return this.raw.renderLabel;
+  }
+
   get icon() {
     return this.raw.icon;
   }
@@ -88,6 +92,10 @@ export class BasicTreeNode extends TreeNode {
 
   get displayName() {
     return this._displayName;
+  }
+
+  get renderLabel() {
+    return this.raw.renderLabel;
   }
 
   get description() {

--- a/packages/components/src/recycle-tree/basic/tree-node.tsx
+++ b/packages/components/src/recycle-tree/basic/tree-node.tsx
@@ -101,6 +101,8 @@ export const BasicTreeNodeRenderer: React.FC<
     [],
   );
 
+  const renderLabel = useCallback((node: BasicCompositeTreeNode | BasicTreeNode) => node.renderLabel, []);
+
   const renderDescription = useCallback((node: BasicCompositeTreeNode | BasicTreeNode) => {
     if (!node.description) {
       return null;
@@ -197,7 +199,7 @@ export const BasicTreeNodeRenderer: React.FC<
         {renderTwice(item)}
         {renderIcon(item)}
         <div className={'overflow_wrap'}>
-          {renderDisplayName(item)}
+          {renderLabel(item) || renderDisplayName(item)}
           {renderDescription(item)}
         </div>
         {renderNodeTail()}

--- a/packages/components/src/recycle-tree/basic/types.ts
+++ b/packages/components/src/recycle-tree/basic/types.ts
@@ -60,6 +60,11 @@ export interface IBasicTreeData {
    */
   label: string;
   /**
+   * 自定义渲染 label
+   * 传入该参数会覆盖 label
+   */
+  renderLabel?: React.ReactNode;
+  /**
    * 图标
    */
   icon?: string;

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -77,3 +77,32 @@
     color: var(--debugIcon-activateBreakpointsForeground);
   }
 }
+
+.debug_breakpoints_file_item {
+  display: flex;
+  align-items: center;
+
+  .file_item_control {
+    display: flex;
+    align-items: center;
+    min-width: 18px;
+  }
+
+  .file_item_checkbox {
+    display: none;
+  }
+
+  .file_item_icon {
+    display: block;
+    margin-left: -2px;
+  }
+
+  &:hover {
+    .file_item_checkbox {
+      display: inherit;
+    }
+    .file_item_icon {
+      display: none;
+    }
+  }
+}

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -158,29 +158,22 @@ export const BreakpointFileItem = ({ label, icon, breakpointItems }: BreakpointF
   const defaultEnabled = useMemo(() => breakpointItems.some((item) => item.enabled), [breakpointItems]);
   const [enabled, setEnabled] = React.useState<boolean>(defaultEnabled);
 
-  useEffect(() => {
-    if (enabled) {
-      // 找出非 enable 的 breakpoint
-      const disabledBreakpoints = breakpointItems.filter((item) => !item.enabled);
-      disabledBreakpoints.forEach((breakpoint) => {
-        debugBreakpointsService.toggleBreakpointEnable(breakpoint);
-      });
-    } else {
-      const disabledBreakpoints = breakpointItems.filter((item) => item.enabled);
-      disabledBreakpoints.forEach((breakpoint) => {
-        debugBreakpointsService.toggleBreakpointEnable(breakpoint);
-      });
-    }
-  }, [enabled]);
-
-  const handleCheckBoxChange = () => {
+  const handleCheckBoxChange = (preEnabled: boolean) => {
+    const matchBreakpoints = breakpointItems.filter((item) => item.enabled === preEnabled);
+    matchBreakpoints.forEach((breakpoint) => {
+      debugBreakpointsService.toggleBreakpointEnable(breakpoint);
+    });
     setEnabled(!enabled);
   };
 
   return (
     <div className={styles.debug_breakpoints_file_item}>
       <div className={styles.file_item_control}>
-        <CheckBox className={styles.file_item_checkbox} onChange={handleCheckBoxChange} checked={enabled}></CheckBox>
+        <CheckBox
+          className={styles.file_item_checkbox}
+          onChange={() => handleCheckBoxChange(enabled)}
+          checked={enabled}
+        ></CheckBox>
         <i className={cls(icon, styles.file_item_icon)}></i>
       </div>
       <span>{label}</span>

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -158,13 +158,16 @@ export const BreakpointFileItem = ({ label, icon, breakpointItems }: BreakpointF
   const defaultEnabled = useMemo(() => breakpointItems.some((item) => item.enabled), [breakpointItems]);
   const [enabled, setEnabled] = React.useState<boolean>(defaultEnabled);
 
-  const handleCheckBoxChange = (preEnabled: boolean) => {
-    const matchBreakpoints = breakpointItems.filter((item) => item.enabled === preEnabled);
-    matchBreakpoints.forEach((breakpoint) => {
-      debugBreakpointsService.toggleBreakpointEnable(breakpoint);
-    });
-    setEnabled(!enabled);
-  };
+  const handleCheckBoxChange = useCallback(
+    (preEnabled: boolean) => {
+      const matchBreakpoints = breakpointItems.filter((item) => item.enabled === preEnabled);
+      matchBreakpoints.forEach((breakpoint) => {
+        debugBreakpointsService.toggleBreakpointEnable(breakpoint);
+      });
+      setEnabled(!enabled);
+    },
+    [enabled],
+  );
 
   return (
     <div className={styles.debug_breakpoints_file_item}>


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a8151b</samp>

*  Add support for custom labels in basic tree nodes ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-2bef4e8bab9db8201dbe4c89fe507403742f202a4f0708900847d5842bfc1e1aR55-R58), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-2bef4e8bab9db8201dbe4c89fe507403742f202a4f0708900847d5842bfc1e1aR97-R100), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743R104-R105), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743L200-R202), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-b55cd1eb16840587609c41957ffdab5672352b31a07015ef99e920f6ac60f0d8R63-R67))
  - Add optional `renderLabel` property to `IBasicTreeData` interface ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-b55cd1eb16840587609c41957ffdab5672352b31a07015ef99e920f6ac60f0d8R63-R67))
  - Add getter methods `renderLabel` to `BasicCompositeTreeNode` and `BasicTreeNode` classes ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-2bef4e8bab9db8201dbe4c89fe507403742f202a4f0708900847d5842bfc1e1aR55-R58), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-2bef4e8bab9db8201dbe4c89fe507403742f202a4f0708900847d5842bfc1e1aR97-R100))
  - Define `renderLabel` function to return `renderLabel` property of node ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743R104-R105))
  - Modify JSX element to render custom label or default label ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-b73269d6747ffc36531cdf7af34228f676e69057dfa1a0c17870ef19a2ff4743L200-R202))
* Implement custom label component for breakpoint file tree node ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L74-R86), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R146-R183), [link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R73-R101))
  - Add `renderLabel` property to breakpoint file tree node using `BreakpointFileItem` component ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L74-R86))
  - Define `BreakpointFileItem` component to render checkbox, icon, and label text ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R146-R183))
  - Use `DebugBreakpointsService` to toggle enablement of breakpoints in file ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R146-R183))
  - Add style rule for `.debug_breakpoints_file_item` class ([link](https://github.com/opensumi/core/pull/2611/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R73-R101))

<!-- Additional content -->
![Kapture 2023-04-19 at 15 42 24](https://user-images.githubusercontent.com/20262815/233004481-1a6cee4b-0b63-4ca5-91f4-2f2a31f0fe08.gif)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a8151b</samp>

This pull request enhances the recycle tree component and the debug breakpoints view by adding support for custom labels for tree nodes. It defines a `renderLabel` property for the tree data and a `BreakpointFileItem` component for the breakpoint file nodes. It also adds some style rules for the custom label component.
