### PR TITLE
fix: quickPick trigger options.onChangeValue

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -119,6 +119,7 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
         buttons: (options as QuickPickOptions).buttons,
         step: (options as QuickPickOptions).step,
         totalSteps: (options as QuickPickOptions).totalSteps,
+        value: (options as QuickPickOptions).value,
       },
     );
 
@@ -426,6 +427,7 @@ class ExtQuickPick<T extends vscode.QuickPickItem> implements vscode.QuickPick<T
           ignoreFocusOut: this.ignoreFocusOut,
           _sessionId: this.quickPickIndex,
           keepScrollPosition: this.keepScrollPosition,
+          value: this.value,
         } as QuickPickOptions,
       )
       .then((item) => {

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -53,7 +53,7 @@ export interface IKaitianQuickOpenControllerOpts extends QuickOpenTabOptions {
 @Injectable()
 export class MonacoQuickOpenService implements QuickOpenService {
   protected _widget: QuickOpenWidget | undefined;
-  protected opts: IKaitianQuickOpenControllerOpts;
+  protected opts: KaitianQuickOpenControllerOpts;
   protected container: HTMLElement;
   protected previousActiveElement: Element | undefined;
 
@@ -114,7 +114,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
     this.progressDispose.dispose();
   }
 
-  protected internalOpen(opts: IKaitianQuickOpenControllerOpts): void {
+  protected internalOpen(opts: KaitianQuickOpenControllerOpts): void {
     this.opts = opts;
     const widget = this.widget;
 
@@ -134,7 +134,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
   }
 
   updateOptions(options: IKaitianQuickOpenControllerOpts): void {
-    this.opts = options;
+    this.opts.updateOptions(options);
     this.widget.updateOptions(options);
   }
 
@@ -217,7 +217,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
     if (this.widget && options.onType) {
       options.onType(lookFor, (model) => {
         // 触发 onchange 事件
-        if (this.preLookFor !== lookFor && this.opts.onChangeValue) {
+        if (this.preLookFor !== lookFor) {
           this.opts.onChangeValue(lookFor);
         }
         this.preLookFor = lookFor;
@@ -240,7 +240,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
 }
 
 export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControllerOpts {
-  protected readonly options: QuickOpenOptions.Resolved;
+  protected options: QuickOpenOptions.Resolved;
 
   constructor(
     protected readonly model: IKaitianQuickOpenModel,
@@ -318,6 +318,16 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
     if (this.options.onKeyMods) {
       this.options.onKeyMods(keyMods);
     }
+  }
+
+  onChangeValue(lookFor: string): void {
+    if (this.options.onChangeValue) {
+      this.options.onChangeValue(lookFor);
+    }
+  }
+
+  updateOptions(options?: QuickOpenOptions) {
+    this.options = QuickOpenOptions.resolve(options);
   }
 
   /**


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fix: #2211

这个问题是由于输入时 `onChangeValue` 回调未触发，同时默认的 value 未被更新至传入 quickInput。

虽然这个修复可以解决 issue 里面的问题，但是我们现在的 quickPick 实现有一些问题，每次输入值变动都会创建新的 item，就会有闪烁的问题，我试了下修复这个现象，发现可能得重构 quickPick 才行了。

核心问题是这里：https://github.com/opensumi/core/blob/main/packages/quick-open/src/browser/quick-pick.service.ts#L41
现在的 quickPickItem 是筛选，不是更新，要修改整个 item 的控制逻辑才能解决闪烁的问题。这个 pr 先修复 bug 了。

### Changelog

* quickPick trigger options.onChangeValue on input

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bb1f95</samp>

This pull request enhances the quick pick functionality in the hosted extension environment by allowing the extension host to control the input value. It also refactors the quick open service to use a class-based approach for the options.
