### PR TITLE
fix(addon): windows open search file failed

### DIFF
--- a/packages/addons/src/browser/file-search.contribution.ts
+++ b/packages/addons/src/browser/file-search.contribution.ts
@@ -343,7 +343,7 @@ export class FileSearchQuickCommandHandler {
       results = await this.getQueryFiles(lookFor, alreadyCollected, token);
       // 排序后设置第一个元素的样式
       if (results[0]) {
-        const newItems = await this.getItems([results[0].getUri()!.toString()], {
+        const newItems = await this.getItems([results[0].getUri()!.codeUri.fsPath], {
           groupLabel: localize('search.fileResults'),
           showBorder: true,
         });
@@ -413,8 +413,8 @@ export class FileSearchQuickCommandHandler {
     const items: QuickOpenItem[] = [];
 
     for (const [index, strUri] of uriList.entries()) {
-      const uri = new URI(strUri);
-      const icon = `file-icon ${await this.labelService.getIcon(uri.withoutFragment())}`;
+      const uri = URI.isUriString(strUri) ? new URI(strUri) : URI.file(strUri);
+      const icon = `file-icon ${this.labelService.getIcon(uri.withoutFragment())}`;
       let description = '';
       const relative = await this.workspaceService.asRelativePath(uri.parent);
       if (relative) {
@@ -449,11 +449,11 @@ export class FileSearchQuickCommandHandler {
   }
 
   private openFile(uri: URI) {
-    const filePath = uri.path.toString();
+    const filePath = uri.codeUri.fsPath;
     // 优先从输入上获取 line 和 column
     let range = getRangeByInput(this.currentLookFor);
     if (!range || (!range.startLineNumber && !range.startColumn)) {
-      range = getRangeByInput(uri.fragment ? filePath + '#' + uri.fragment : filePath);
+      range = getRangeByInput(uri.fragment ? '#' + uri.fragment : filePath);
     }
     this.currentLookFor = '';
     this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, uri.withoutFragment(), {

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -789,10 +789,10 @@ export class WorkspaceService implements IWorkspaceService {
         if (path === rootPath) {
           path = '';
         }
-        if (rootPath.slice(-1) === '/') {
+        if (rootPath.slice(-1) === Path.nativeSeparator) {
           path = path.replace(rootPath, '');
         } else {
-          path = path.replace(rootPath + '/', '');
+          path = path.replace(rootPath + Path.nativeSeparator, '');
         }
         break;
       }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

修复window上使用ctrl+p快速打开文件功能
1、修复点选文件后没有反应的问题（windows上new URI()有坑，生成的uri不正确）
2、修复文件相对路径显示不正确的问题（分隔符不能是/需要按照操作系统来确定）

<img width="713" alt="image" src="https://user-images.githubusercontent.com/3340210/233250660-75589098-2997-4bea-b136-5a476edfdfec.png">


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f901b5</samp>

* Fix file search icon bug for different schemes ([link](https://github.com/opensumi/core/pull/2613/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L346-R346))
* Optimize and simplify file search performance and compatibility by avoiding unnecessary URI creation and using utility function ([link](https://github.com/opensumi/core/pull/2613/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L416-R417), [link](https://github.com/opensumi/core/pull/2613/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L452-R456))
* Enhance `asRelativePath` method to handle both POSIX and Windows paths ([link](https://github.com/opensumi/core/pull/2613/files?diff=unified&w=0#diff-64279a622b3843d06985ee3625b01394b44b7f0ff7e9f2577b1656af68f7a488L792-R795))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f901b5</samp>

This pull request improves the file search and workspace features of the core package. It fixes a bug with file icons, enhances performance and compatibility, and handles different path separators. It affects the files `file-search.contribution.ts` and `workspace-service.ts`.
