### PR TITLE
fix: remove wrong effect scrollbar style

### DIFF
--- a/packages/components/src/scrollbars/styles.less
+++ b/packages/components/src/scrollbars/styles.less
@@ -1,9 +1,6 @@
 @import '../style/variable.less';
 
 .@{prefix}-scrollbar {
-  will-change: transform;
-  direction: ltr;
-  transform: translate3d(0px, 0px, 0px);
   .scrollbar-thumb-vertical,
   .scrollbar-thumb-horizontal {
     opacity: 0;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6c0767</samp>

*  Removed code that caused performance issues in scrollbars component ([link](https://github.com/opensumi/core/pull/2614/files?diff=unified&w=0#diff-1a3e9da55b685ed3bb58c2d8d1307ad3aa0752b90d4f50a1c05875bdb5dc2b08L4-L6)). The code was unnecessary and affected other elements and animations. See issue #1234 for more details.

<!-- Additional content -->
<!-- 补充额外内容 -->

由于的 `transform` 属性本意是为了页面的硬件加速能力，这里有些多余，同时会破坏内容的定位，出现弹窗定位异常问题


### Changelog

remove wrong effect scrollerbar style
