### PR TITLE
fix: delegate closeUnmodifiedEditors command

### DIFF
--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -409,6 +409,10 @@ export class EditorContribution
       keybinding: 'ctrlcmd+k ctrlcmd+w',
     });
     keybindings.registerKeybinding({
+      command: EDITOR_COMMANDS.CLOSE_SAVED.id,
+      keybinding: 'ctrlcmd+k u',
+    });
+    keybindings.registerKeybinding({
       command: EDITOR_COMMANDS.PIN_CURRENT.id,
       keybinding: 'ctrlcmd+k enter',
     });

--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -422,7 +422,7 @@ export class ExtensionCommandContribution implements CommandContribution {
       VSCodeBuiltinCommands.NEXT_EDITOR_IN_GROUP,
       VSCodeBuiltinCommands.EVEN_EDITOR_WIDTH,
       VSCodeBuiltinCommands.CLOSE_OTHER_GROUPS,
-      VSCodeBuiltinCommands.CLOSE_SAVED,
+      VSCodeBuiltinCommands.CLOSE_UNMODIFIED_EDITORS,
       VSCodeBuiltinCommands.LAST_EDITOR_IN_GROUP,
       VSCodeBuiltinCommands.OPEN_EDITOR_AT_INDEX,
       VSCodeBuiltinCommands.CLOSE_OTHER_EDITORS,

--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -422,6 +422,7 @@ export class ExtensionCommandContribution implements CommandContribution {
       VSCodeBuiltinCommands.NEXT_EDITOR_IN_GROUP,
       VSCodeBuiltinCommands.EVEN_EDITOR_WIDTH,
       VSCodeBuiltinCommands.CLOSE_OTHER_GROUPS,
+      VSCodeBuiltinCommands.CLOSE_SAVED,
       VSCodeBuiltinCommands.LAST_EDITOR_IN_GROUP,
       VSCodeBuiltinCommands.OPEN_EDITOR_AT_INDEX,
       VSCodeBuiltinCommands.CLOSE_OTHER_EDITORS,

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -128,7 +128,7 @@ export const EVEN_EDITOR_WIDTH: Command = {
 
 export const CLOSE_OTHER_GROUPS: Command = {
   id: 'workbench.action.closeEditorsInOtherGroups',
-  delegate: EDITOR_COMMANDS.EVEN_EDITOR_GROUPS.id,
+  delegate: EDITOR_COMMANDS.CLOSE_OTHER_GROUPS.id,
 };
 
 export const OPEN_EDITOR_AT_INDEX: Command = {

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -131,6 +131,11 @@ export const CLOSE_OTHER_GROUPS: Command = {
   delegate: EDITOR_COMMANDS.CLOSE_OTHER_GROUPS.id,
 };
 
+export const CLOSE_SAVED: Command = {
+  id: 'workbench.action.closeUnmodifiedEditors',
+  delegate: EDITOR_COMMANDS.CLOSE_SAVED.id,
+};
+
 export const OPEN_EDITOR_AT_INDEX: Command = {
   id: 'workbench.action.openEditorAtIndex',
   delegate: EDITOR_COMMANDS.OPEN_EDITOR_AT_INDEX.id,

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -131,7 +131,7 @@ export const CLOSE_OTHER_GROUPS: Command = {
   delegate: EDITOR_COMMANDS.CLOSE_OTHER_GROUPS.id,
 };
 
-export const CLOSE_SAVED: Command = {
+export const CLOSE_UNMODIFIED_EDITORS: Command = {
   id: 'workbench.action.closeUnmodifiedEditors',
   delegate: EDITOR_COMMANDS.CLOSE_SAVED.id,
 };


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5b0b3a</samp>

*  Add a new command to close all unmodified editors and a keybinding for it ([link](https://github.com/opensumi/core/pull/2619/files?diff=unified&w=0#diff-60c8ffba5d20bbdd47538937244790320be906aa61ff9c7acb732dc640ab5bb5R412-R415), [link](https://github.com/opensumi/core/pull/2619/files?diff=unified&w=0#diff-b09f275754e0faf70db5040b3193f1d05e50016f89bcf82907b98bd52f01b85eR425), [link](https://github.com/opensumi/core/pull/2619/files?diff=unified&w=0#diff-fbec75cee32aef05f3342200b8b06c8551e26572d3d648883f351b670ae9549aL131-R138))
*  Fix the command id and behavior of the `CLOSE_OTHER_GROUPS` command ([link](https://github.com/opensumi/core/pull/2619/files?diff=unified&w=0#diff-fbec75cee32aef05f3342200b8b06c8551e26572d3d648883f351b670ae9549aL131-R138))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5b0b3a</samp>

This pull request adds a new command to close all unmodified editors, and updates the command ids and behaviors of some existing commands to match VS Code. The new command is available as a keybinding, an extension API, and a VS Code built-in command. The affected files are `editor.contribution.ts`, `extension.contribution.ts`, and `builtin-commands.ts`.

add keyboard shortcut for `Close Saved`
