### PR TITLE
fix(extension): disable ext console override

### DIFF
--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -115,6 +115,26 @@ function patchProcess() {
   };
 }
 
+function _wrapConsoleMethod(method: 'log' | 'info' | 'warn' | 'error') {
+  // eslint-disable-next-line no-console
+  const original = console[method].bind(console);
+
+  Object.defineProperty(console, method, {
+    set: () => {},
+    get: () =>
+      function () {
+        original(arguments);
+      },
+  });
+}
+
+function patchConsole() {
+  _wrapConsoleMethod('info');
+  _wrapConsoleMethod('log');
+  _wrapConsoleMethod('warn');
+  _wrapConsoleMethod('error');
+}
+
 export async function extProcessInit(config: ExtProcessConfig = {}) {
   const extAppConfig = JSON.parse(argv[KT_APP_CONFIG_KEY] || '{}');
   const { injector, ...extConfig } = config;
@@ -134,6 +154,7 @@ export async function extProcessInit(config: ExtProcessConfig = {}) {
     setLanguageId(locale);
   }
   patchProcess();
+  patchConsole();
   const { extProtocol: protocol, logger } = await initRPCProtocol(extInjector);
   try {
     let Preload = require('./ext.host');


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dfb3af6</samp>

*  Patch console methods to prevent overwriting by other modules ([link](https://github.com/opensumi/core/pull/2620/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30R118-R137), [link](https://github.com/opensumi/core/pull/2620/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30R157))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfb3af6</samp>

Patch console methods in extension process to preserve logging output. This change affects the file `ext.process-base.ts` in the extension package.

Disallow extension processes to modify the console function