### PR TITLE
fix: localization load failed

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -227,7 +227,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   private async setupExtensionNLSConfig() {
     const storagePath = (await this.extensionStoragePathServer.getLastStoragePath()) || '';
     const currentLanguage: string = this.preferenceService.get(GeneralSettingsId.Language) || getLanguageId();
-    this.extensionNodeClient.setupNLSConfig(currentLanguage, storagePath);
+    await this.extensionNodeClient.setupNLSConfig(currentLanguage, storagePath);
   }
 
   /**

--- a/packages/storage/src/browser/storage.ts
+++ b/packages/storage/src/browser/storage.ts
@@ -86,6 +86,7 @@ export class Storage implements IStorage {
     if (this.browserLocalStorage) {
       cache = await this.browserLocalStorage.getData(storageName);
     }
+    // 此处如果增加isEmptyObject判断，会导致Localization本地化插件加载失败，暂未找到原因，先去除
     if (!cache) {
       await this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace);
       cache = await this.database.getItems(storageName);

--- a/packages/storage/src/browser/storage.ts
+++ b/packages/storage/src/browser/storage.ts
@@ -86,12 +86,10 @@ export class Storage implements IStorage {
     if (this.browserLocalStorage) {
       cache = await this.browserLocalStorage.getData(storageName);
     }
-    if (!cache || isEmptyObject(cache)) {
+    if (!cache) {
       await this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace);
       cache = await this.database.getItems(storageName);
-      if (this.browserLocalStorage) {
-        this.browserLocalStorage.setData(storageName, cache);
-      }
+      this.browserLocalStorage?.setData(storageName, cache);
       this.whenReadyToWriteDeferred.resolve();
     } else {
       // 初始化服务端缓存
@@ -99,7 +97,7 @@ export class Storage implements IStorage {
         this.database.getItems(storageName).then(async (data) => {
           // 后续以服务端数据为准更新前端缓存数据，防止后续数据存取异常
           this.cache = this.jsonToMap(data);
-          await this.browserLocalStorage?.setData(storageName, data);
+          this.browserLocalStorage?.setData(storageName, data);
           this.whenReadyToWriteDeferred.resolve();
         });
       });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

setupNLSConfig没有await，导致多语言插件加载异常
storage中的isEmptyObject(cache)判断，导致多语言插件加载失败，去除可以正常使用


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0236a1</samp>

*  Ensure NLS configuration is set up before activating extensions by adding `await` keyword ([link](https://github.com/opensumi/core/pull/2623/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L230-R230))
*  Fix localization extension loading bug by removing `isEmptyObject` check from database initialization condition in `storage.ts` ([link](https://github.com/opensumi/core/pull/2623/files?diff=unified&w=0#diff-2622409dbf188178ea951b0d54e80ea4d7dc478b9a6089d60cd1c0f798d0d36cL89-R93))
*  Remove unnecessary `await` keyword from `setData` call in `storage.ts` to improve performance and readability ([link](https://github.com/opensumi/core/pull/2623/files?diff=unified&w=0#diff-2622409dbf188178ea951b0d54e80ea4d7dc478b9a6089d60cd1c0f798d0d36cL102-R101))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0236a1</samp>

This pull request fixes localization issues for extensions and the storage service. It changes the `Storage` class to handle NLS data correctly and adds an `await` keyword to `this.extensionNodeClient.setupNLSConfig` in `extension.service.ts` to ensure proper extension activation.
