### PR TITLE
Fix/windows open and localization failed

### DIFF
--- a/packages/addons/src/browser/file-search.contribution.ts
+++ b/packages/addons/src/browser/file-search.contribution.ts
@@ -343,7 +343,7 @@ export class FileSearchQuickCommandHandler {
       results = await this.getQueryFiles(lookFor, alreadyCollected, token);
       // 排序后设置第一个元素的样式
       if (results[0]) {
-        const newItems = await this.getItems([results[0].getUri()!.toString()], {
+        const newItems = await this.getItems([results[0].getUri()!.codeUri.fsPath], {
           groupLabel: localize('search.fileResults'),
           showBorder: true,
         });
@@ -413,8 +413,8 @@ export class FileSearchQuickCommandHandler {
     const items: QuickOpenItem[] = [];
 
     for (const [index, strUri] of uriList.entries()) {
-      const uri = new URI(strUri);
-      const icon = `file-icon ${await this.labelService.getIcon(uri.withoutFragment())}`;
+      const uri = URI.isUriString(strUri) ? new URI(strUri) : URI.file(strUri);
+      const icon = `file-icon ${this.labelService.getIcon(uri.withoutFragment())}`;
       let description = '';
       const relative = await this.workspaceService.asRelativePath(uri.parent);
       if (relative) {
@@ -449,11 +449,11 @@ export class FileSearchQuickCommandHandler {
   }
 
   private openFile(uri: URI) {
-    const filePath = uri.path.toString();
+    const filePath = uri.codeUri.fsPath;
     // 优先从输入上获取 line 和 column
     let range = getRangeByInput(this.currentLookFor);
     if (!range || (!range.startLineNumber && !range.startColumn)) {
-      range = getRangeByInput(uri.fragment ? filePath + '#' + uri.fragment : filePath);
+      range = getRangeByInput(uri.fragment ? '#' + uri.fragment : filePath);
     }
     this.currentLookFor = '';
     this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, uri.withoutFragment(), {

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -227,7 +227,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   private async setupExtensionNLSConfig() {
     const storagePath = (await this.extensionStoragePathServer.getLastStoragePath()) || '';
     const currentLanguage: string = this.preferenceService.get(GeneralSettingsId.Language) || getLanguageId();
-    this.extensionNodeClient.setupNLSConfig(currentLanguage, storagePath);
+    await this.extensionNodeClient.setupNLSConfig(currentLanguage, storagePath);
   }
 
   /**

--- a/packages/storage/src/browser/storage.ts
+++ b/packages/storage/src/browser/storage.ts
@@ -86,6 +86,7 @@ export class Storage implements IStorage {
     if (this.browserLocalStorage) {
       cache = await this.browserLocalStorage.getData(storageName);
     }
+    // 此处如果增加isEmptyObject判断，会导致Localization本地化插件加载失败，暂未找到原因，先去除
     if (!cache) {
       await this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace);
       cache = await this.database.getItems(storageName);

--- a/packages/storage/src/browser/storage.ts
+++ b/packages/storage/src/browser/storage.ts
@@ -86,12 +86,10 @@ export class Storage implements IStorage {
     if (this.browserLocalStorage) {
       cache = await this.browserLocalStorage.getData(storageName);
     }
-    if (!cache || isEmptyObject(cache)) {
+    if (!cache) {
       await this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace);
       cache = await this.database.getItems(storageName);
-      if (this.browserLocalStorage) {
-        this.browserLocalStorage.setData(storageName, cache);
-      }
+      this.browserLocalStorage?.setData(storageName, cache);
       this.whenReadyToWriteDeferred.resolve();
     } else {
       // 初始化服务端缓存
@@ -99,7 +97,7 @@ export class Storage implements IStorage {
         this.database.getItems(storageName).then(async (data) => {
           // 后续以服务端数据为准更新前端缓存数据，防止后续数据存取异常
           this.cache = this.jsonToMap(data);
-          await this.browserLocalStorage?.setData(storageName, data);
+          this.browserLocalStorage?.setData(storageName, data);
           this.whenReadyToWriteDeferred.resolve();
         });
       });

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -789,10 +789,10 @@ export class WorkspaceService implements IWorkspaceService {
         if (path === rootPath) {
           path = '';
         }
-        if (rootPath.slice(-1) === '/') {
+        if (rootPath.slice(-1) === Path.nativeSeparator) {
           path = path.replace(rootPath, '');
         } else {
-          path = path.replace(rootPath + '/', '');
+          path = path.replace(rootPath + Path.nativeSeparator, '');
         }
         break;
       }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3cf6cde</samp>

*  Fix a bug in the file search quick command handler, where the URI of the first result was not converted to a file system path, causing an error when opening the file. Use the `codeUri` property of the result, which is a URI with the `file` scheme, and call the `fsPath` getter to obtain the file system path. ([link](https://github.com/opensumi/core/pull/2624/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L346-R346))
* Simplify the logic of the file search quick command handler, where the URI of the file to open was constructed from the path and the fragment. Use the `codeUri` property of the result, which already contains the path and the fragment, and call the `fsPath` getter to obtain the file system path. Remove the unnecessary concatenation of the path and the fragment, since the fragment is already prefixed with a `#` character in the URI object. ([link](https://github.com/opensumi/core/pull/2624/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L452-R456))
* Improve the compatibility of the file search quick command handler, where the URI of the results could be either a string or a URI object. Use the `URI.isUriString` static method to check the type of the input, and create a new URI object only if it is a string. Otherwise, use the `URI.file` static method to create a URI object from a file system path. Remove the unnecessary `await` keyword from the `this.labelService.getIcon` call, since it is a synchronous method that returns a string. ([link](https://github.com/opensumi/core/pull/2624/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L416-R417))
* Add the missing `await` keyword to the `this.extensionNodeClient.setupNLSConfig` call, which is an asynchronous method that returns a promise. Ensure that the promise is resolved before proceeding to the next statement, which could depend on the result of the setup. This change affects the file `packages/extension/src/browser/extension.service.ts`. ([link](https://github.com/opensumi/core/pull/2624/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L230-R230))
* Remove the redundant `isEmptyObject` check from the `Storage` class, where the cache data was retrieved from the browser local storage or the database. Fix a bug that caused the localization extension to fail to load, because the cache data was an empty object, which was not considered as a valid value. Simplify the condition to check only for the existence of the cache data, regardless of its content. ([link](https://github.com/opensumi/core/pull/2624/files?diff=unified&w=0#diff-2622409dbf188178ea951b0d54e80ea4d7dc478b9a6089d60cd1c0f798d0d36cL89-R93))
* Remove the unnecessary `await` keyword from the `this.browserLocalStorage.setData` call, which is a synchronous method that does not return a promise. Make the code more consistent and avoid confusion about the execution order. These changes affect the file `packages/storage/src/browser/storage.ts`. ([link](https://github.com/opensumi/core/pull/2624/files?diff=unified&w=0#diff-2622409dbf188178ea951b0d54e80ea4d7dc478b9a6089d60cd1c0f798d0d36cL102-R101))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3cf6cde</samp>

This pull request fixes some bugs, improves compatibility and code quality, and adds a missing `await` keyword in various files. It affects the file search, localization, extension, and workspace features of the core package.
