### PR TITLE
fix: cache built-in storage data

### DIFF
--- a/packages/core-browser/src/services/storage-service.ts
+++ b/packages/core-browser/src/services/storage-service.ts
@@ -91,18 +91,20 @@ abstract class BaseBrowserStorageService implements StorageService {
 
   public getData<T>(key: string, defaultValue?: T): T | undefined {
     const result = this.storage.getItem(this.prefix(key));
+    let data;
     if (isUndefinedOrNull(result)) {
       return defaultValue;
     }
     try {
-      return JSON.parse(result);
+      data = JSON.parse(result);
     } catch (e) {
       this.logger.error(`storage getDate error: ${e}, use defaultValue as result.`);
+      data = defaultValue;
     }
-    if (defaultValue && isObject(defaultValue)) {
-      delete defaultValue['expires'];
+    if (data && isObject(data)) {
+      delete data['expires'];
     }
-    return defaultValue;
+    return data;
   }
 
   public removeData<T>(key: string): void {

--- a/packages/storage/src/browser/storage.ts
+++ b/packages/storage/src/browser/storage.ts
@@ -86,7 +86,7 @@ export class Storage implements IStorage {
     if (this.browserLocalStorage) {
       cache = await this.browserLocalStorage.getData(storageName);
     }
-    if (!cache || isEmptyObject(cache)) {
+    if (!cache) {
       await this.database.init(this.appConfig.storageDirName, this.isGlobal ? undefined : workspace);
       cache = await this.database.getItems(storageName);
       if (this.browserLocalStorage) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

这里修复了 Stroage 针对空对象的缓存，确实有部分数据是空对象，如 Extension 是否被禁用的数据，这里移除了 `isEmptyObject` 的判断。

但这里的修复仅能解决二次访问的国际化语言生效问题，在目前的逻辑中，首次访问（无缓存）情况下，语言插件与其他插件接近于并发执行，而语言插件目前依赖
https://github.com/opensumi/core/blob/ec4dea43c2b37548604364d721034b57dcdf931f/packages/extension/src/browser/vscode/contributes/localization.ts#L76

这里的逻辑进行初始化，有明显的后置执行问题，故在这种情况下，大概率语言插件是不生效的，需要通过对这块的加载时序进行优化才能从根本上解决这个问题。

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

copilot:summary
