### PR TITLE
feat: quickInput support hideOnDidAccept

### DIFF
--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -542,6 +542,11 @@ export interface QuickInputOptions {
    * otherwise the defined range will be selected.
    */
   valueSelection?: [number, number];
+  /**
+   * Set to `false` to keep the input box open when onDidAccept trigger
+   * default is true
+   */
+  hideOnDidAccept?: boolean;
 
   /**
    * An optional function that will be called to validate input and to give a hint

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -454,6 +454,7 @@ abstract class ExtQuickInput implements vscode.InputBox {
   private _enabled: boolean;
   private _busy: boolean;
   private _ignoreFocusOut: boolean;
+  private _hideOnDidAccept: boolean;
 
   private disposableCollection: DisposableCollection;
 
@@ -483,6 +484,7 @@ abstract class ExtQuickInput implements vscode.InputBox {
     this._password = false;
     this._ignoreFocusOut = false;
     this._busy = false;
+    this._hideOnDidAccept = true;
 
     this.disposableCollection = new DisposableCollection();
     this.disposableCollection.push((this._onDidAcceptEmitter = new Emitter()));
@@ -614,6 +616,15 @@ abstract class ExtQuickInput implements vscode.InputBox {
     }
   }
 
+  get hideOnDidAccept(): boolean {
+    return this._hideOnDidAccept;
+  }
+
+  set hideOnDidAccept(hideOnDidAccept: boolean) {
+    this._hideOnDidAccept = hideOnDidAccept;
+    this.update({ hideOnDidAccept });
+  }
+
   getOptions(): QuickInputOptions {
     return {
       value: this.value,
@@ -629,6 +640,7 @@ abstract class ExtQuickInput implements vscode.InputBox {
       buttons: this.buttons as unknown as QuickTitleButton[],
       busy: this.busy,
       enabled: this.enabled,
+      hideOnDidAccept: this.hideOnDidAccept,
     };
   }
 

--- a/packages/quick-open/src/browser/quickInput.inputBox.ts
+++ b/packages/quick-open/src/browser/quickInput.inputBox.ts
@@ -136,8 +136,10 @@ export class InputBoxImpl {
               }
               if (!error && mode === Mode.OPEN) {
                 this.onDidAcceptEmitter.fire(lookFor);
-                this.quickTitleBar.hide();
-                return true;
+                if (this.options.hideOnDidAccept) {
+                  this.quickTitleBar.hide();
+                  return true;
+                }
               }
               return false;
             },


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eba182c</samp>

*  Add `hideOnDidAccept` option to `QuickInputOptions` interface to let extensions control input box visibility on accept ([link](https://github.com/opensumi/core/pull/2631/files?diff=unified&w=0#diff-27adcfe43b78217fabf448b56fdd299f340097f3331147ef3307426ddcf3fa1fR545-R549))
*  Store `hideOnDidDidAccept` value in `ExtQuickInput` class and provide getter and setter for it ([link](https://github.com/opensumi/core/pull/2631/files?diff=unified&w=0#diff-535cb53d1888c004f19b7369d5b1da90462def0d39ad8d6d9d2b382ea571e80aR457), [link](https://github.com/opensumi/core/pull/2631/files?diff=unified&w=0#diff-535cb53d1888c004f19b7369d5b1da90462def0d39ad8d6d9d2b382ea571e80aR619-R627))
*  Initialize `hideOnDidAccept` to `true` by default in `ExtQuickInput` constructor ([link](https://github.com/opensumi/core/pull/2631/files?diff=unified&w=0#diff-535cb53d1888c004f19b7369d5b1da90462def0d39ad8d6d9d2b382ea571e80aR487))
*  Pass `hideOnDidAccept` value from `ExtQuickInput` to `InputBoxImpl` through `showInputBox` method ([link](https://github.com/opensumi/core/pull/2631/files?diff=unified&w=0#diff-535cb53d1888c004f19b7369d5b1da90462def0d39ad8d6d9d2b382ea571e80aR643))
*  Modify `onType` method of `InputBoxImpl` to check `hideOnDidAccept` before hiding input box on accept ([link](https://github.com/opensumi/core/pull/2631/files?diff=unified&w=0#diff-6cef777676951622df1128d6b97965529c202ddb93a316c71f600449c3c9ce22L139-R142))

<!-- Additional content -->
<!-- 补充额外内容 -->

feat: #2585  采用了第二种方式，防止影响已有的插件实现。

增加这个参数是为了配合 `busy` 属性，可以实现输入内容并按下回车后，可以与远端交互，根据返回结果，主动控制输入框的显示与隐藏

效果如下：
![Kapture 2023-04-21 at 15 29 37](https://user-images.githubusercontent.com/9477255/233571694-b17b94cf-c7bf-4ed8-b29f-84c32cabb282.gif)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eba182c</samp>

This pull request adds a new option `hideOnDidAccept` to the quick input API, which lets extensions decide whether to hide the input box when the user accepts the input. This option is implemented in the `ExtQuickInput`, `QuickInputOptions`, and `InputBoxImpl` classes.
