### PR TITLE
fix: ensure language pack loaded

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -542,8 +542,8 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   private normalExtensions: Extension[] = [];
 
   private async runEagerExtensionsContributes() {
-    this.contributesService.initialize();
-    this.sumiContributesService.initialize();
+    await Promise.all([this.contributesService.initialize(), this.sumiContributesService.initialize()]);
+
     this.commandRegistry.beforeExecuteCommand(async (command, args) => {
       await this.activationEventService.fireEvent('onCommand', command);
       return args;

--- a/packages/extension/src/common/extension.ts
+++ b/packages/extension/src/common/extension.ts
@@ -311,7 +311,7 @@ export abstract class VSCodeContributePoint<T extends JSONType = JSONType> exten
 }
 
 export abstract class ExtensionContributesService extends WithEventBus {
-  abstract ContributionPoints: typeof VSCodeContributePoint[];
+  abstract ContributionPoints: (typeof VSCodeContributePoint)[];
 
   @Autowired(ILogger)
   private logger: ILogger;
@@ -387,8 +387,8 @@ export abstract class ExtensionContributesService extends WithEventBus {
     );
   }
 
-  public initialize() {
-    const runContributes = (phase = this.lifecycleService.phase) => {
+  public async initialize() {
+    const runContributes = async (phase = this.lifecycleService.phase) => {
       if (!phase) {
         return;
       }
@@ -399,16 +399,15 @@ export abstract class ExtensionContributesService extends WithEventBus {
         this.contributedSet.clear();
       }
 
-      this.runContributesByPhase(phase);
+      await this.runContributesByPhase(phase);
     };
-
-    runContributes();
 
     this.addDispose(
       this.lifecycleService.onDidLifeCyclePhaseChange((newPhase) => {
         runContributes(newPhase);
       }),
     );
+    await runContributes();
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db5882a</samp>

* Make the contributes services initialization parallel for better performance ([link](https://github.com/opensumi/core/pull/2632/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L545-R546))
* Fix the type annotation of the `ContributionPoints` property to use an array of classes that extend `VSCodeContributePoint` ([link](https://github.com/opensumi/core/pull/2632/files?diff=unified&w=0#diff-96be7d1ed582a90bb723f1e64a8f7c8c690c5fecc8a7c628135080e3d9819d65L314-R314))
* Make the `initialize` method of the `ExtensionContributesService` class async and call `runContributes` at the end of it ([link](https://github.com/opensumi/core/pull/2632/files?diff=unified&w=0#diff-96be7d1ed582a90bb723f1e64a8f7c8c690c5fecc8a7c628135080e3d9819d65L390-R391), [link](https://github.com/opensumi/core/pull/2632/files?diff=unified&w=0#diff-96be7d1ed582a90bb723f1e64a8f7c8c690c5fecc8a7c628135080e3d9819d65R410))
* Add the `await` keyword to the call to `this.runContributesByPhase` in the `runContributes` function ([link](https://github.com/opensumi/core/pull/2632/files?diff=unified&w=0#diff-96be7d1ed582a90bb723f1e64a8f7c8c690c5fecc8a7c628135080e3d9819d65L402-R404))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db5882a</samp>

This pull request improves the extension service by fixing bugs and enhancing performance. It corrects some errors in `extension.ts` and makes the contributes services run in parallel in `extension.service.ts`.
