### PR TITLE
fix: capturer uncatch error

### DIFF
--- a/packages/connection/src/common/utils.ts
+++ b/packages/connection/src/common/utils.ts
@@ -1,5 +1,3 @@
-import { isDefined } from '@opensumi/ide-core-common';
-
 declare global {
   interface Window {
     __OPENSUMI_DEVTOOLS_GLOBAL_HOOK__: any;
@@ -39,7 +37,7 @@ export function parse(input: string, reviver?: (this: any, key: string, value: a
 }
 
 export function getCapturer() {
-  if (isDefined(window) && window.__OPENSUMI_DEVTOOLS_GLOBAL_HOOK__?.captureRPC) {
+  if (typeof window !== 'undefined' && window.__OPENSUMI_DEVTOOLS_GLOBAL_HOOK__?.captureRPC) {
     return window.__OPENSUMI_DEVTOOLS_GLOBAL_HOOK__.captureRPC;
   }
   return;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

此处的修改会有uncatch的error，导致electron版本无法启动，先回退到之前的版本了

<img width="713" alt="image" src="https://user-images.githubusercontent.com/3340210/233816707-e06641ec-822d-4455-95a5-50cfedc1f718.png">


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a38f3d</samp>

* Refactor the `connection` package to remove the dependency on `@opensumi/ide-core-common` ([link](https://github.com/opensumi/core/pull/2636/files?diff=unified&w=0#diff-08102d19e28c59cee7b774d4e112922a2331f476334e16da61be621ed6a82f55L1-L2), [link](https://github.com/opensumi/core/pull/2636/files?diff=unified&w=0#diff-08102d19e28c59cee7b774d4e112922a2331f476334e16da61be621ed6a82f55L42-R40))
  - Replace the `isDefined` function with a direct check of `typeof window !== 'undefined'` in `utils.ts` to detect the browser environment ([link](https://github.com/opensumi/core/pull/2636/files?diff=unified&w=0#diff-08102d19e28c59cee7b774d4e112922a2331f476334e16da61be621ed6a82f55L42-R40))
  - Remove the unused import of `isDefined` from `@opensumi/ide-core-common` in `utils.ts` ([link](https://github.com/opensumi/core/pull/2636/files?diff=unified&w=0#diff-08102d19e28c59cee7b774d4e112922a2331f476334e16da61be621ed6a82f55L1-L2))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a38f3d</samp>

Simplified the browser detection logic and reduced the coupling of the `connection` package by removing the `@opensumi/ide-core-common` dependency.
