### PR TITLE
test: add extension E2E test case

### DIFF
--- a/tools/playwright/src/source-control-view.ts
+++ b/tools/playwright/src/source-control-view.ts
@@ -10,8 +10,12 @@ export class OpenSumiSourceControlView extends OpenSumiView {
     });
   }
 
+  async getTreeNode() {
+    return await this.page.$('[class*="scm_tree_node_content___"]');
+  }
+
   async getTreeNodeActionById(id: string) {
-    const header = await this.page.$('[class*="scm_tree_node_content___"]');
+    const header = await this.getTreeNode();
     if (!header) {
       return;
     }

--- a/tools/playwright/src/tests/extension.test.ts
+++ b/tools/playwright/src/tests/extension.test.ts
@@ -1,0 +1,53 @@
+import path from 'path';
+
+import { expect } from '@playwright/test';
+
+import { OpenSumiApp } from '../app';
+import { OpenSumiExplorerView } from '../explorer-view';
+import { OpenSumiSCMView } from '../scm-view';
+import { OpenSumiTerminalView } from '../terminal-view';
+import { OpenSumiWorkspace } from '../workspace';
+
+import test, { page } from './hooks';
+
+let app: OpenSumiApp;
+let explorer: OpenSumiExplorerView;
+let scm: OpenSumiSCMView;
+let workspace: OpenSumiWorkspace;
+
+test.describe('OpenSumi Extension', () => {
+  // 用 git 插件来验证扩展相关功能
+  test.beforeAll(async () => {
+    workspace = new OpenSumiWorkspace([path.resolve('./src/tests/workspaces/git-workspace')]);
+    app = await OpenSumiApp.load(page, workspace);
+    explorer = await app.open(OpenSumiExplorerView);
+    explorer.initFileTreeView(workspace.workspace.displayName);
+    const terminal = await app.open(OpenSumiTerminalView);
+    // There should have GIT on the PATH
+    await terminal.sendText('git init');
+  });
+
+  test.afterAll(() => {
+    app.dispose();
+  });
+
+  test('The scm TreeNode view need show', async () => {
+    scm = await app.open(OpenSumiSCMView);
+    await scm.open();
+    await app.page.waitForTimeout(2000);
+    const node = await scm.scmView.getTreeNode();
+    expect(node).toBeTruthy();
+  });
+
+  test('The scm TreeNode view need reShow', async () => {
+    scm = await app.open(OpenSumiSCMView);
+    await scm.open();
+    await app.quickCommandPalette.trigger('Restart Extension Host Process');
+    await app.page.waitForTimeout(1000);
+    const node = await scm.scmView.getTreeNode();
+    expect(node).toBeNull();
+    await app.page.waitForTimeout(4000);
+    const newNode = await scm.scmView.getTreeNode();
+    expect(newNode).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Types

- [x] ⏱ Tests

### Background or solution

Issue: #2534 

利用 git 插件，对插件视图挂载进行测试，支持两个场景
* 初始化
* 重启

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 732f075</samp>

*  Refactor `getTreeNodeActionById` method of `OpenSumiSourceControlView` class to extract tree node finding logic into `getTreeNode` method ([link](https://github.com/opensumi/core/pull/2638/files?diff=unified&w=0#diff-60615bf68ae467feb17823968e899abd6eed40c4bd3e97ffe219fa3b72f1dca1L13-R18))
* Add new test file `extension.test.ts` that tests OpenSumi extension system using git extension as an example ([link](https://github.com/opensumi/core/pull/2638/files?diff=unified&w=0#diff-5c3c7a78e0509d7ec85ffd0c6beea9a1677a768850d61a5f3a8dd2db13cc41afR1-R53))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 732f075</samp>

Refactor the `getTreeNodeActionById` method of the `OpenSumiSourceControlView` class and add a new test file `extension.test.ts` that tests the OpenSumi extension system using the git extension. These changes improve the code quality and the test coverage of the source control view.
