### PR TITLE
fix: select component display type

### DIFF
--- a/packages/components/src/select/index.tsx
+++ b/packages/components/src/select/index.tsx
@@ -1,9 +1,8 @@
 import classNames from 'classnames';
-import React, { useCallback } from 'react';
-import { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import './style.less';
-import { Icon, getIcon } from '../icon';
+import { getIcon, Icon } from '../icon';
 
 export interface IDataOption<T> {
   iconClass?: string;
@@ -395,6 +394,22 @@ export function Select<T = string>({
       }
       // 防止戳出下方屏幕
       const toBottom = window.innerHeight - boxRect.bottom;
+      if (!maxHeight) {
+        // 未设置最大高度
+        if (toBottom < 150) {
+          // 下方距离小于150，设置向上弹出选择框
+          overlayRef.current.style.bottom = selectRef.current.clientHeight + 4 + 'px';
+        } else {
+          // 下方距离大于150，设置最大高度为下方距离
+          overlayRef.current.style.maxHeight = `${toBottom}px`;
+        }
+      } else {
+        // 设置了最大高度
+        if (toBottom < parseInt(maxHeight, 10)) {
+          // 下方距离小于最大高度，设置向上弹出选择框
+          overlayRef.current.style.bottom = selectRef.current.clientHeight + 4 + 'px';
+        }
+      }
       if (!maxHeight || toBottom < parseInt(maxHeight, 10)) {
         overlayRef.current.style.maxHeight = `${toBottom}px`;
       }

--- a/packages/components/src/select/index.tsx
+++ b/packages/components/src/select/index.tsx
@@ -393,24 +393,12 @@ export function Select<T = string>({
         overlayRef.current.style.width = `${boxRect.width}px`;
       }
       // 防止戳出下方屏幕
-      const toBottom = window.innerHeight - boxRect.bottom;
-      if (!maxHeight) {
-        // 未设置最大高度
-        if (toBottom < 150) {
-          // 下方距离小于150，设置向上弹出选择框
-          overlayRef.current.style.bottom = selectRef.current.clientHeight + 4 + 'px';
-        } else {
-          // 下方距离大于150，设置最大高度为下方距离
-          overlayRef.current.style.maxHeight = `${toBottom}px`;
-        }
+      const toBottom = window.innerHeight - boxRect.bottom - 50;
+      if (toBottom < overlayRef.current.clientHeight) {
+        // 下方距离小于浮层高度，设置向上弹出选择框
+        overlayRef.current.style.bottom = selectRef.current.clientHeight + 4 + 'px';
       } else {
-        // 设置了最大高度
-        if (toBottom < parseInt(maxHeight, 10)) {
-          // 下方距离小于最大高度，设置向上弹出选择框
-          overlayRef.current.style.bottom = selectRef.current.clientHeight + 4 + 'px';
-        }
-      }
-      if (!maxHeight || toBottom < parseInt(maxHeight, 10)) {
+        // 下方距离大于浮层高度，设置最大高度为下方距离
         overlayRef.current.style.maxHeight = `${toBottom}px`;
       }
       overlayRef.current.style.position = dropdownRenderType === 'fixed' ? 'fixed' : 'absolute';


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes
#2604 
解决这个显示遮挡的问题，修复后效果如下：

<img width="511" alt="image" src="https://user-images.githubusercontent.com/3340210/233841746-e6b4a0b1-9d1e-4ff9-b915-60a30c13929a.png">


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6634fd2</samp>

* Consolidate and sort React hook imports in `Select` component ([link](https://github.com/opensumi/core/pull/2641/files?diff=unified&w=0#diff-52163e4a82eb739c516cfa12382d0b482aae0bed9658f4ee783e000ab2524712L2-R5))
* Add logic for setting overlay position and height in `Select` component ([link](https://github.com/opensumi/core/pull/2641/files?diff=unified&w=0#diff-52163e4a82eb739c516cfa12382d0b482aae0bed9658f4ee783e000ab2524712R397-R412))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6634fd2</samp>

Improve code style and overlay behavior of `Select` component. Adjust overlay position and height to fit the screen and respect the `maxHeight` prop.
