### PR TITLE
fix: activate extension without popping up theme quick open

### DIFF
--- a/packages/extension-manager/src/common/index.ts
+++ b/packages/extension-manager/src/common/index.ts
@@ -49,6 +49,7 @@ export class VSXExtension {
   readonly path?: string;
   readonly realpath?: string;
   readonly extensionId?: string;
+  readonly originId?: string;
   static KEYS: Set<keyof VSXExtension> = new Set([
     'version',
     'iconUrl',

--- a/packages/extension/src/browser/extension-management.service.ts
+++ b/packages/extension/src/browser/extension-management.service.ts
@@ -123,7 +123,23 @@ export class ExtensionManagementService extends WithEventBus implements Abstract
         this.disableExtension(oldExtensionPath!);
       }
 
-      return await this.enableExtension(extensionInstance);
+      await this.enableExtension(extensionInstance);
+
+      const colorThemes = this.themeService.getAvailableThemeInfos();
+      if (colorThemes.some((theme) => theme.extensionId === extensionInstance.id)) {
+        this.commandService.executeCommand(THEME_TOGGLE_COMMAND.id, {
+          extensionId: extensionInstance.id,
+        });
+        return;
+      }
+
+      const iconThemes = this.iconService.getAvailableThemeInfos();
+      if (iconThemes.some((theme) => theme.extensionId === extensionInstance.id)) {
+        this.commandService.executeCommand(ICON_THEME_TOGGLE_COMMAND.id, {
+          extensionId: extensionInstance.id,
+        });
+        return;
+      }
     }
   }
 
@@ -185,22 +201,6 @@ export class ExtensionManagementService extends WithEventBus implements Abstract
     this.contributesService.register(extension.id, extension.contributes);
     this.sumiContributesService.initialize();
     this.contributesService.initialize();
-
-    const colorThemes = this.themeService.getAvailableThemeInfos();
-    if (colorThemes.some((theme) => theme.extensionId === extension.id)) {
-      this.commandService.executeCommand(THEME_TOGGLE_COMMAND.id, {
-        extensionId: extension.id,
-      });
-      return;
-    }
-
-    const iconThemes = this.iconService.getAvailableThemeInfos();
-    if (iconThemes.some((theme) => theme.extensionId === extension.id)) {
-      this.commandService.executeCommand(ICON_THEME_TOGGLE_COMMAND.id, {
-        extensionId: extension.id,
-      });
-      return;
-    }
   }
 
   /**

--- a/packages/extension/src/browser/extension-management.service.ts
+++ b/packages/extension/src/browser/extension-management.service.ts
@@ -1,8 +1,6 @@
 import { Autowired, Injectable } from '@opensumi/di';
-import { CommandService, getLanguageId, ILogger, URI, WithEventBus } from '@opensumi/ide-core-common';
+import { getLanguageId, ILogger, URI, WithEventBus } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
-import { IIconService, IThemeService } from '@opensumi/ide-theme';
-import { ICON_THEME_TOGGLE_COMMAND, THEME_TOGGLE_COMMAND } from '@opensumi/ide-theme/lib/browser/theme.contribution';
 
 import {
   AbstractExtensionManagementService,
@@ -37,15 +35,6 @@ export class ExtensionManagementService extends WithEventBus implements Abstract
 
   @Autowired(IFileServiceClient)
   private fileService: IFileServiceClient;
-
-  @Autowired(IThemeService)
-  protected readonly themeService: IThemeService;
-
-  @Autowired(IIconService)
-  protected readonly iconService: IIconService;
-
-  @Autowired(CommandService)
-  protected readonly commandService: CommandService;
 
   @Autowired(ILogger)
   private readonly logger: ILogger;
@@ -123,23 +112,7 @@ export class ExtensionManagementService extends WithEventBus implements Abstract
         this.disableExtension(oldExtensionPath!);
       }
 
-      await this.enableExtension(extensionInstance);
-
-      const colorThemes = this.themeService.getAvailableThemeInfos();
-      if (colorThemes.some((theme) => theme.extensionId === extensionInstance.id)) {
-        this.commandService.executeCommand(THEME_TOGGLE_COMMAND.id, {
-          extensionId: extensionInstance.id,
-        });
-        return;
-      }
-
-      const iconThemes = this.iconService.getAvailableThemeInfos();
-      if (iconThemes.some((theme) => theme.extensionId === extensionInstance.id)) {
-        this.commandService.executeCommand(ICON_THEME_TOGGLE_COMMAND.id, {
-          extensionId: extensionInstance.id,
-        });
-        return;
-      }
+      return await this.enableExtension(extensionInstance);
     }
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 007839e</samp>

*  Move and simplify theme toggle logic for extensions ([link](https://github.com/opensumi/core/pull/2643/files?diff=unified&w=0#diff-ee02fb088a19a9a0c87b1501c7a1ce3a1a6a70ce687546360ae17f0197611417L126-R142), [link](https://github.com/opensumi/core/pull/2643/files?diff=unified&w=0#diff-ee02fb088a19a9a0c87b1501c7a1ce3a1a6a70ce687546360ae17f0197611417L188-L203))

<!-- Additional content -->
fix： https://github.com/opensumi/core/issues/2642

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 007839e</samp>

This pull request fixes a theme bug and enhances the extension installation and uninstallation process. It changes the `extension-management.service.ts` file to toggle the theme only when an extension is installed, not when it is uninstalled.
