### PR TITLE
fix:extension setup nls config

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -227,7 +227,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   private async setupExtensionNLSConfig() {
     const storagePath = (await this.extensionStoragePathServer.getLastStoragePath()) || '';
     const currentLanguage: string = this.preferenceService.get(GeneralSettingsId.Language) || getLanguageId();
-    this.extensionNodeClient.setupNLSConfig(currentLanguage, storagePath);
+    await this.extensionNodeClient.setupNLSConfig(currentLanguage, storagePath);
   }
 
   /**


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

之前的代码遗漏了一个await，部分情况下本地化插件加载不出来，修复一下。


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66d927c</samp>

* Fix a bug where the extension host process would not start properly due to a race condition between setting up the NLS configuration and launching the process ([link](https://github.com/opensumi/core/pull/2648/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L230-R230))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66d927c</samp>

Added `await` to fix extension host startup bug. This ensures that the NLS configuration is set up before launching the extension host process in `extension.service.ts`.
