### PR TITLE
feat: support flashing prompt for focus breakpoints in the editor

### DIFF
--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -154,6 +154,11 @@ export const corePreferenceSchema: PreferenceSchema = {
       type: 'boolean',
       default: true,
     },
+    'debug.breakpoint.editorHint': {
+      type: 'boolean',
+      default: true,
+      description: '%preference.debug.breakpoint.editorHint%',
+    },
     'debug.toolbar.top': {
       type: 'number',
       default: 0,
@@ -299,6 +304,7 @@ export interface CoreConfiguration {
   'explorer.confirmMove': boolean;
   'explorer.compactFolders': boolean;
   'debug.toolbar.float': boolean;
+  'debug.breakpoint.editorHint': boolean;
   'debug.toolbar.top': number;
   'debug.toolbar.height': number;
   'files.watcherExclude': { [key: string]: boolean };

--- a/packages/debug/__tests__/browser/editor/debug-model.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-model.test.ts
@@ -127,7 +127,7 @@ describe('Debug Model', () => {
 
   it('debugModel should be init success', () => {
     expect(mockEditor.onKeyDown).toBeCalledTimes(1);
-    expect(mockEditor.getModel).toBeCalledTimes(4);
+    expect(mockEditor.getModel).toBeCalledTimes(1);
     expect(mockBreakpointManager.onDidChange).toBeCalledTimes(1);
   });
 

--- a/packages/debug/src/browser/debug-style.less
+++ b/packages/debug/src/browser/debug-style.less
@@ -1,8 +1,8 @@
-@sumi_top_stack_frame_line_color: #ffff6673;
-@dark_sumi_top_stack_frame_line_color: #ffff0033;
-@sumi_debug_focused_stack_frame_line_color: #cee7ce73;
-@dark_sumi_debug_focused_stack_frame_line_color: #7abd7a4d;
-@dark_sumi_debug_top_stack_frame_exception_line_color: #6c2022;
+@top_stack_frame_line_bg_color: #ffff6673;
+@dark_top_stack_frame_line_bg_color: #ffff0033;
+@focused_stack_frame_line_bg_color: #cee7ce73;
+@dark_focused_stack_frame_line_bg_color: #7abd7a4d;
+@dark_exception_line_bg_color: #6c2022;
 
 .sumi-breakpoint-icon-size {
   background-size: 16px 16px;

--- a/packages/debug/src/browser/debug-style.less
+++ b/packages/debug/src/browser/debug-style.less
@@ -79,11 +79,11 @@
 }
 
 .monaco-editor .view-overlays .sumi-debug-top-stack-frame-line {
-  background-color: @sumi_top_stack_frame_line_color;
+  background-color: @top_stack_frame_line_bg_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-debug-top-stack-frame-line {
-  background-color: @dark_sumi_top_stack_frame_line_color;
+  background-color: @dark_top_stack_frame_line_bg_color;
 }
 
 @keyframes slide-out {
@@ -102,11 +102,11 @@
 }
 
 .monaco-editor .view-overlays .sumi-focus-breakpoints-stack-frame-line {
-  background-color: @sumi_top_stack_frame_line_color;
+  background-color: @top_stack_frame_line_bg_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-focus-breakpoints-stack-frame-line {
-  background-color: @dark_sumi_top_stack_frame_line_color;
+  background-color: @dark_top_stack_frame_line_bg_color;
 }
 
 .monaco-editor .sumi-debug-focused-stack-frame {
@@ -120,15 +120,15 @@
 }
 
 .monaco-editor .view-overlays .sumi-debug-focused-stack-frame-line {
-  background-color: @sumi_debug_focused_stack_frame_line_color;
+  background-color: @focused_stack_frame_line_bg_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-debug-focused-stack-frame-line {
-  background-color: @dark_sumi_debug_focused_stack_frame_line_color;
+  background-color: @dark_focused_stack_frame_line_bg_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-debug-top-stack-frame-exception-line {
-  background-color: @dark_sumi_debug_top_stack_frame_exception_line_color;
+  background-color: @dark_exception_line_bg_color;
 }
 
 .inline-breakpoint-widget.codicon {

--- a/packages/debug/src/browser/debug-style.less
+++ b/packages/debug/src/browser/debug-style.less
@@ -1,3 +1,9 @@
+@sumi_top_stack_frame_line_color: #ffff6673;
+@dark_sumi_top_stack_frame_line_color: #ffff0033;
+@sumi_debug_focused_stack_frame_line_color: #cee7ce73;
+@dark_sumi_debug_focused_stack_frame_line_color: #7abd7a4d;
+@dark_sumi_debug_top_stack_frame_exception_line_color: #6c2022;
+
 .sumi-breakpoint-icon-size {
   background-size: 16px 16px;
   cursor: pointer;
@@ -73,11 +79,34 @@
 }
 
 .monaco-editor .view-overlays .sumi-debug-top-stack-frame-line {
-  background: #ffff6673;
+  background-color: @sumi_top_stack_frame_line_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-debug-top-stack-frame-line {
-  background: #ffff0033;
+  background-color: @dark_sumi_top_stack_frame_line_color;
+}
+
+@keyframes slide-out {
+  100% {
+    background-color: transparent;
+  }
+}
+
+.monaco-editor .view-overlays .sumi-focus-breakpoints-stack-frame-line,
+.monaco-editor.vs-dark .view-overlays .sumi-focus-breakpoints-stack-frame-line {
+  animation: slide-out 0.3s;
+  animation-iteration-count: 1;
+  animation-timing-function: ease-in;
+  animation-fill-mode: forwards;
+  -webkit-animation-fill-mode: forwards;
+}
+
+.monaco-editor .view-overlays .sumi-focus-breakpoints-stack-frame-line {
+  background-color: @sumi_top_stack_frame_line_color;
+}
+
+.monaco-editor.vs-dark .view-overlays .sumi-focus-breakpoints-stack-frame-line {
+  background-color: @dark_sumi_top_stack_frame_line_color;
 }
 
 .monaco-editor .sumi-debug-focused-stack-frame {
@@ -91,15 +120,15 @@
 }
 
 .monaco-editor .view-overlays .sumi-debug-focused-stack-frame-line {
-  background: #cee7ce73;
+  background-color: @sumi_debug_focused_stack_frame_line_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-debug-focused-stack-frame-line {
-  background: #7abd7a4d;
+  background-color: @dark_sumi_debug_focused_stack_frame_line_color;
 }
 
 .monaco-editor.vs-dark .view-overlays .sumi-debug-top-stack-frame-exception-line {
-  background-color: #6c2022;
+  background-color: @dark_sumi_debug_top_stack_frame_exception_line_color;
 }
 
 .inline-breakpoint-widget.codicon {

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -122,7 +122,7 @@ export class DebugModel implements IDebugModel {
 
   async init() {
     const model = this.editor.getModel()!;
-    let timmer: number | undefined;
+    let timer: number | undefined;
     this._uri = new URI(model.uri.toString());
     this.decorator = new DebugDecorator();
 
@@ -145,13 +145,13 @@ export class DebugModel implements IDebugModel {
           },
         ]);
 
-        if (timmer) {
-          clearTimeout(timmer);
+        if (timer) {
+          clearTimeout(timer);
         }
 
-        timmer = window.setTimeout(() => {
+        timer = window.setTimeout(() => {
           this.renderFrames();
-          clearTimeout(timmer);
+          clearTimeout(timer);
         }, 300);
       }),
       this.editor.getModel()!.onDidChangeContent(() => this.updateBreakpoints()),

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -119,7 +119,7 @@ export class DebugModel implements IDebugModel {
 
   async init() {
     const model = this.editor.getModel()!;
-    let timeOut: NodeJS.Timer;
+    let timmer: number | undefined;
     this._uri = new URI(model.uri.toString());
     this.decorator = new DebugDecorator();
 
@@ -136,13 +136,13 @@ export class DebugModel implements IDebugModel {
           },
         ]);
 
-        if (timeOut) {
-          clearTimeout(timeOut);
+        if (timmer) {
+          clearTimeout(timmer);
         }
 
-        timeOut = global.setTimeout(() => {
+        timmer = window.setTimeout(() => {
           this.renderFrames();
-          clearTimeout(timeOut);
+          clearTimeout(timmer);
         }, 300);
       }),
       this.editor.getModel()!.onDidChangeContent(() => this.updateBreakpoints()),

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -127,7 +127,6 @@ export class DebugModel implements IDebugModel {
       this.breakpointWidget,
       this.editor.onKeyDown(() => this.debugHoverWidget.hide({ immediate: false })),
       this.editor.onDidChangeModelContent(() => this.renderFrames()),
-      this.editor.onDidFocusEditorText(() => this.renderFrames()),
       this.debugSessionManager.onDidChange(() => this.renderFrames()),
       this.debugBreakpointsService.onDidFocusedBreakpoints(({ range }) => {
         this.renderFrames([

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -1,7 +1,7 @@
 import debounce from 'lodash/debounce';
 
 import { Injector, Injectable, Autowired } from '@opensumi/di';
-import { DomListener, IContextKeyService, IReporterService } from '@opensumi/ide-core-browser';
+import { DomListener, IContextKeyService, IReporterService, PreferenceService } from '@opensumi/ide-core-browser';
 import {
   ICtxMenuRenderer,
   generateMergedCtxMenu,
@@ -66,6 +66,9 @@ export class DebugModel implements IDebugModel {
   @Autowired(IReporterService)
   private readonly reporterService: IReporterService;
 
+  @Autowired(PreferenceService)
+  private readonly preferenceService: PreferenceService;
+
   protected frameDecorations: string[] = [];
   protected topFrameRange: monaco.Range | undefined;
 
@@ -129,6 +132,12 @@ export class DebugModel implements IDebugModel {
       this.editor.onDidChangeModelContent(() => this.renderFrames()),
       this.debugSessionManager.onDidChange(() => this.renderFrames()),
       this.debugBreakpointsService.onDidFocusedBreakpoints(({ range }) => {
+        const enableHint = this.preferenceService.getValid('debug.breakpoint.editorHint', true);
+
+        if (!enableHint) {
+          return;
+        }
+
         this.renderFrames([
           {
             options: options.FOCUS_BREAKPOINTS_STACK_FRAME_DECORATION,

--- a/packages/debug/src/browser/editor/debug-styles.ts
+++ b/packages/debug/src/browser/editor/debug-styles.ts
@@ -28,6 +28,13 @@ export const TOP_STACK_FRAME_DECORATION: monaco.editor.IModelDecorationOptions =
   stickiness: STICKINESS,
 };
 
+export const FOCUS_BREAKPOINTS_STACK_FRAME_DECORATION: monaco.editor.IModelDecorationOptions = {
+  description: 'focus-breakpoints-stack-frame-line',
+  isWholeLine: true,
+  className: 'sumi-focus-breakpoints-stack-frame-line',
+  stickiness: STICKINESS,
+};
+
 export const TOP_STACK_FRAME_EXCEPTION_DECORATION: monaco.editor.IModelDecorationOptions = {
   description: 'debug-top-stack-frame-exception-line',
   isWholeLine: true,

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -10,6 +10,7 @@ import {
   Schemes,
   Emitter,
   Event,
+  IRange,
 } from '@opensumi/ide-core-browser';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { ICodeEditor, EditorCollectionService, getSimpleEditorOptions } from '@opensumi/ide-editor';
@@ -66,6 +67,9 @@ export class DebugBreakpointsService extends WithEventBus {
   readonly onDidChangeBreakpointsTreeNode: Event<Map<string, BreakpointsTreeNode[]>> =
     this._onDidChangeBreakpointsTreeNode.event;
 
+  private readonly _onDidFocusedBreakpoints = new Emitter<{ uri: URI; range: IRange }>();
+  readonly onDidFocusedBreakpoints: Event<{ uri: URI; range: IRange }> = this._onDidFocusedBreakpoints.event;
+
   private _inputEditor: ICodeEditor;
 
   public get inputEditor(): ICodeEditor {
@@ -85,6 +89,10 @@ export class DebugBreakpointsService extends WithEventBus {
   constructor() {
     super();
     this.init();
+  }
+
+  public launchFocusedBreakpoints(data: { uri: URI; range: IRange }): void {
+    this._onDidFocusedBreakpoints.fire(data);
   }
 
   async init() {

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -518,6 +518,8 @@ export const localizationBundle = {
     'preference.debug.console.filter.mode.matcher': 'matcher',
     'preference.debug.console.wordWrap': 'Controls if the lines should wrap in the debug console.',
     'preference.debug.inline.values': 'Show variable values inline in editor while debugging.',
+    'preference.debug.breakpoint.editorHint':
+      'After enabling, there will be a background color blinking prompt when clicking on the breakpoint list to jump to the editor.',
 
     // workbench
     'preference.workbench.refactoringChanges.showPreviewStrategy':

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -402,6 +402,9 @@ export const localizationBundle = {
     'preference.explorer.fileTree.indent.title': '资源管理器：文件树子节点缩进',
     'preference.explorer.fileTree.baseIndent.title': '资源管理器：文件树基础缩进',
     'preference.debug.toolbar.float.title': '运行与调试：浮层模式',
+    'preference.debug.breakpoint.editorHint.title': '控制是否开启编辑器断点闪烁提示',
+    'preference.debug.breakpoint.editorHint': '启用后，点击断点列表跳转到编辑器时，会有背景色闪烁提示',
+
     'preference.debug.console.filter.mode': '调试控制台筛选器模式',
     'preference.debug.console.filter.mode.filter': '过滤模式',
     'preference.debug.console.filter.mode.matcher': '匹配模式',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -755,6 +755,7 @@ export const defaultSettingSections: {
         { id: 'debug.console.wordWrap', localized: 'preference.debug.console.wordWrap' },
         { id: 'debug.inline.values', localized: 'preference.debug.inline.values' },
         { id: 'debug.toolbar.float', localized: 'preference.debug.toolbar.float.title' },
+        { id: 'debug.breakpoint.editorHint', localized: 'preference.debug.breakpoint.editorHint.title' },
       ],
     },
   ],

--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -180,8 +180,9 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
 
   const focusSearchInput = useCallback(
     (value: string) => {
-      searchInputRef.current?.focus();
       setSearch(value);
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
     },
     [searchInputRef.current, search],
   );


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ccbacd</samp>

*  Add less variables for debug colors and use them for editor decorations ([link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-8478699d8b36318dea12c0dbe414766cd7abf7f534d38a9b5196b03edd358c87R1-R6), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-8478699d8b36318dea12c0dbe414766cd7abf7f534d38a9b5196b03edd358c87L76-R111), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-8478699d8b36318dea12c0dbe414766cd7abf7f534d38a9b5196b03edd358c87L94-R131))
*  Inject and use DebugBreakpointsService to provide events and methods for breakpoints and stack frames ([link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR29), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR51-R53), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70R13), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70R70-R72), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70R94-R97))
*  Implement focus breakpoints stack frame line feature to highlight the stack frame that corresponds to the breakpoint that was hit ([link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL118-R125), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR131-R147), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL159-R182), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL166-R189), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-9c4399b5585f12a56c92815dee829e9bf1ed21e94c02766795218fb952a3d707R31-R37), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L162-R171), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L176-R196))
*  Use proper types and syntax for opening resources in the editor from the breakpoints view ([link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L17-R19), [link](https://github.com/opensumi/core/pull/2652/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L176-R196))

<!-- Additional content -->
![Kapture 2023-04-26 at 15 15 14](https://user-images.githubusercontent.com/20262815/234498911-c30ef479-2e31-40b2-aac2-36065fd8c6bb.gif)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ccbacd</samp>

This pull request enhances the debug module with new features and styles for breakpoints and stack frames. It introduces less variables for debug colors, animates the focus breakpoints stack frame line in the editor, and improves the type safety and functionality of the breakpoints view. It also refactors some code and adds new events and methods to the DebugBreakpointsService class. The changes affect the files `debug-style.less`, `debug-model.ts`, `debug-breakpoints.service.ts`, `debug-breakpoints.view.tsx`, and `debug-styles.ts`.
