### PR TITLE
feat: support delete or edit breakpoints when hovering on the it

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -13,9 +13,8 @@ import { Deferred } from '@opensumi/ide-core-common';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol';
 
-import { BreakpointsChangeEvent, DEBUG_REPORT_NAME, IDebugBreakpoint } from '../../common';
+import { BreakpointsChangeEvent, DEBUG_REPORT_NAME, IDebugBreakpoint, IDebugModel } from '../../common';
 import { DebugContextKey } from '../contextkeys/debug-contextkey.service';
-import { DebugModel } from '../editor';
 import { MarkerManager, Marker } from '../markers';
 
 import { DebugExceptionBreakpoint, BREAKPOINT_KIND } from './breakpoint-marker';
@@ -26,7 +25,7 @@ export interface ExceptionBreakpointsChangeEvent {
 
 export interface SelectedBreakpoint {
   breakpoint?: IDebugBreakpoint;
-  model: DebugModel;
+  model: IDebugModel;
 }
 
 @Injectable()

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -85,7 +85,6 @@ import { DebugCallStackView } from './view/frames/debug-call-stack.view';
 import { DebugVariableView } from './view/variables/debug-variables.view';
 import { DebugWatchView } from './view/watch/debug-watch.view';
 
-
 const LAUNCH_JSON_REGEX = /launch\.json$/;
 
 export namespace DebugBreakpointWidgetCommands {
@@ -453,7 +452,6 @@ export class DebugContribution
         }
       },
       isVisible: () => !!this.selectedBreakpoint && !!this.selectedBreakpoint.breakpoint,
-      isEnabled: () => !!this.selectedBreakpoint && !!this.selectedBreakpoint.breakpoint,
     });
     commands.registerCommand(DEBUG_COMMANDS.DISABLE_BREAKPOINT, {
       execute: async (position: monaco.Position) => {

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -430,7 +430,23 @@ export class DebugContribution
     commands.registerCommand(DEBUG_COMMANDS.EDIT_BREAKPOINT, {
       execute: async (position: monaco.Position) => {
         this.reporterService.point(DEBUG_REPORT_NAME?.DEBUG_BREAKPOINT, 'edit');
+        const model = this.debugEditorController.model;
+        if (!model) {
+          return;
+        }
+
+        const { uri } = model;
+        const breakpoint = this.breakpointManager.getBreakpoint(uri, position!.lineNumber);
+        // 更新当前选中的断点
+        if (breakpoint) {
+          this.breakpointManager.selectedBreakpoint = {
+            breakpoint,
+            model,
+          };
+        }
+
         const { selectedBreakpoint } = this;
+
         if (selectedBreakpoint) {
           const { openBreakpointView } = selectedBreakpoint.model;
           let defaultContext: TSourceBrekpointProperties = 'condition';

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -15,16 +15,19 @@
   align-items: center;
   cursor: pointer;
   flex-direction: row;
-  .debug_remove_breakpoints_icon {
-    color: #c5c5c5;
+
+  .debug_breakpoints_item_control {
     display: none;
-    pointer-events: none;
   }
+
+  .debug_remove_breakpoints_icon,
+  .debug_edit_breakpoints_icon {
+    margin-right: 6px;
+  }
+
   &:hover {
-    .debug_remove_breakpoints_icon {
-      display: inline-block;
-      pointer-events: all;
-      margin-right: 6px;
+    .debug_breakpoints_item_control {
+      display: flex;
     }
     .debug_breakpoints_badge {
       display: none;
@@ -81,11 +84,18 @@
 .debug_breakpoints_file_item {
   display: flex;
   align-items: center;
+  justify-content: space-between;
 
   .file_item_control {
     display: flex;
     align-items: center;
     min-width: 18px;
+  }
+
+  .file_item_control_right {
+    .close_icon {
+      display: none;
+    }
   }
 
   .file_item_checkbox {
@@ -95,6 +105,7 @@
   .file_item_icon {
     display: block;
     margin-left: -2px;
+    margin-right: 4px;
   }
 
   &:hover {
@@ -103,6 +114,11 @@
     }
     .file_item_icon {
       display: none;
+    }
+    .close_icon {
+      display: inherit;
+      pointer-events: all;
+      margin-right: 6px;
     }
   }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0d60ad</samp>

*  Simplify the logic of the `removeAllBreakpoints` command and remove the `isEnabled` property ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-3c78853637bd4f37b7541026444e751a0505bbb992a41a7a3c102c078a5b52daL456))
*  Add internationalization, external icons, and editor-related functions to the `debug-breakpoints.view.tsx` file ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L17-R23))
*  Use the `BreakpointManager` service for managing and editing breakpoints in the `debug-breakpoints.view.tsx` file ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R31), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R214))
*  Add the `title` prop and use it as the title attribute for the breakpoint file item label in the `BreakpointFileItem` component ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L82-R87), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L148-R156), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L180-R196))
*  Add the `removeBreakpoint` function and the close icon to the `BreakpointFileItem` component and handle the click event to remove all breakpoints associated with the file ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R176-R182), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L180-R196))
*  Add the `editBreakpoint` function and the edit icon to the `BreakpointItem` component and handle the click event to open the editor and execute the `DEBUG_COMMANDS.EDIT_BREAKPOINT` command ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L284-R324), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L301-R348))
*  Add a new class `.debug_breakpoints_item_control` to control the display of the edit and remove icons for each breakpoint item in the `debug-breakpoints.module.less` file ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0L18-R30), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R95-R100), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R118-R122))
*  Align the breakpoint file item content to the left and right edges of the container and add some margin to the badge and the close icon in the `debug-breakpoints.module.less` file ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R87), [link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R108))
*  Remove an empty line from the `debug-contribution.ts` file for code readability and style consistency ([link](https://github.com/opensumi/core/pull/2655/files?diff=unified&w=0#diff-3c78853637bd4f37b7541026444e751a0505bbb992a41a7a3c102c078a5b52daL88))

<!-- Additional content -->
![Kapture 2023-04-28 at 11 25 53](https://user-images.githubusercontent.com/20262815/235047304-173e07bb-33a5-4ad3-9760-9e61ac375892.gif)

- [x] 文件节点支持 hover 删除该文件下的所有断点
- [x] 断点列表面板新增 editor breakpoint 按钮，hover 出现，点击后可以直接编辑该断点表达式


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0d60ad</samp>

This pull request improves the debug feature of the opensumi core by enhancing the code quality, style, and functionality of the `DebugContribution` class and the breakpoint view components. It also adds internationalization, external icons, and editor integration for breakpoints.
