### PR TITLE
fix(search): auto select search content when expanding search panel (#2522)

### DIFF
--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -180,8 +180,9 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
 
   const focusSearchInput = useCallback(
     (value: string) => {
-      searchInputRef.current?.focus();
       setSearch(value);
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
     },
     [searchInputRef.current, search],
   );


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a18b7ee</samp>

*  Swap the order of `setSearch` and `focus` calls, and add a `select` call, to select the search input value when using the keyboard shortcut ([link](https://github.com/opensumi/core/pull/2662/files?diff=unified&w=0#diff-21c2d67af30c506b54dfa3451a605ec037134cf89487aa3468c0ac56f3851773L183-R185))

close: #2522

### Changelog

fix: 展开搜索面板自动选中搜索内容
