### PR TITLE
refactor: use sumiContributes and compatible with kaitianContributes 

### DIFF
--- a/packages/core-browser/src/extensions/extensions-point.service.ts
+++ b/packages/core-browser/src/extensions/extensions-point.service.ts
@@ -27,7 +27,7 @@ export class ExtensionsPointServiceImpl implements IExtensionsSchemaService {
   private appendPropertiesFactory(kind: FrameworkKind): (points: string[], desc: IExtensionPointDescriptor) => void {
     const properties =
       kind === 'opensumi'
-        ? OpensumiExtensionPackageSchema.properties!.kaitianContributes.properties
+        ? OpensumiExtensionPackageSchema.properties!.sumiContributes.properties
         : VSCodeExtensionPackageSchema.properties!.contributes.properties;
 
     return (points: string[], desc: IExtensionPointDescriptor) => {

--- a/packages/core-browser/src/extensions/extensions-point.service.ts
+++ b/packages/core-browser/src/extensions/extensions-point.service.ts
@@ -8,7 +8,7 @@ import { FrameworkKind, IExtensionPointDescriptor, IExtensionsSchemaService } fr
 
 import { IJSONSchemaRegistry } from '../monaco';
 
-import { OpensumiExtensionPackageSchema } from './schema/opensumiExtensionPackageSchema';
+import { OpenSumiExtensionPackageSchema } from './schema/opensumiExtensionPackageSchema';
 import { VSCodeExtensionPackageSchema } from './schema/vscodeExtensionPackageSchema';
 
 export const EXTENSION_JSON_URI = 'vscode://schemas/vscode-extensions';
@@ -20,14 +20,14 @@ export class ExtensionsPointServiceImpl implements IExtensionsSchemaService {
   private schemaRegistry: IJSONSchemaRegistry;
 
   private registerSchema(): void {
-    this.schemaRegistry.registerSchema(OPENSUMI_EXTENSION_JSON_URI, OpensumiExtensionPackageSchema, ['package.json']);
+    this.schemaRegistry.registerSchema(OPENSUMI_EXTENSION_JSON_URI, OpenSumiExtensionPackageSchema, ['package.json']);
     this.schemaRegistry.registerSchema(EXTENSION_JSON_URI, VSCodeExtensionPackageSchema, ['package.json']);
   }
 
   private appendPropertiesFactory(kind: FrameworkKind): (points: string[], desc: IExtensionPointDescriptor) => void {
     const properties =
       kind === 'opensumi'
-        ? OpensumiExtensionPackageSchema.properties!.sumiContributes.properties
+        ? OpenSumiExtensionPackageSchema.properties!.sumiContributes.properties
         : VSCodeExtensionPackageSchema.properties!.contributes.properties;
 
     return (points: string[], desc: IExtensionPointDescriptor) => {
@@ -42,7 +42,7 @@ export class ExtensionsPointServiceImpl implements IExtensionsSchemaService {
     };
   }
 
-  private appendOpensumiProperties(points: string[], desc: IExtensionPointDescriptor): void {
+  private appendOpenSumiProperties(points: string[], desc: IExtensionPointDescriptor): void {
     this.appendPropertiesFactory('opensumi')(points, desc);
   }
 
@@ -58,7 +58,7 @@ export class ExtensionsPointServiceImpl implements IExtensionsSchemaService {
     const { frameworkKind = ['vscode'] } = desc;
 
     if (frameworkKind.includes('opensumi')) {
-      this.appendOpensumiProperties(points, desc);
+      this.appendOpenSumiProperties(points, desc);
     }
 
     if (frameworkKind.includes('vscode')) {

--- a/packages/core-browser/src/extensions/schema/opensumiExtensionPackageSchema.ts
+++ b/packages/core-browser/src/extensions/schema/opensumiExtensionPackageSchema.ts
@@ -2,7 +2,7 @@ import { localize } from '@opensumi/ide-core-common';
 
 export const OpensumiExtensionPackageSchema = {
   properties: {
-    kaitianContributes: {
+    sumiContributes: {
       description: localize('sumiContributes.opensumiContributes'),
       type: 'object',
       properties: {} as { [key: string]: any },

--- a/packages/core-browser/src/extensions/schema/opensumiExtensionPackageSchema.ts
+++ b/packages/core-browser/src/extensions/schema/opensumiExtensionPackageSchema.ts
@@ -1,9 +1,9 @@
 import { localize } from '@opensumi/ide-core-common';
 
-export const OpensumiExtensionPackageSchema = {
+export const OpenSumiExtensionPackageSchema = {
   properties: {
     sumiContributes: {
-      description: localize('sumiContributes.opensumiContributes'),
+      description: localize('sumiContributes.contributes'),
       type: 'object',
       properties: {} as { [key: string]: any },
       default: {},

--- a/packages/extension/__mocks__/extensions.ts
+++ b/packages/extension/__mocks__/extensions.ts
@@ -52,7 +52,7 @@ export const mockExtensionProps2: IExtensionProps = {
     name: 'sumi-extension-error',
     main: './index.js',
     version: '0.0.1',
-    kaitianContributes: {
+    sumiContributes: {
       viewsProxies: ['FakeComponentId'],
       nodeMain: './index.js',
       workerMain: './worker.error.js',

--- a/packages/extension/__tests__/browser/extension-service/extension-service-mock-helper.ts
+++ b/packages/extension/__tests__/browser/extension-service/extension-service-mock-helper.ts
@@ -121,7 +121,7 @@ const mockExtensionProps: IExtensionProps = {
   packageJSON: {
     name: 'sumi-extension',
     extensionDependencies: ['uuid-for-test-extension-deps'],
-    kaitianContributes: {
+    sumiContributes: {
       viewsProxies: ['Leftview', 'TitleView'],
       browserViews: {
         left: {
@@ -307,7 +307,7 @@ const mockExtension = {
   uri: Uri.file(mockExtensionProps.path),
   contributes: Object.assign(
     mockExtensionProps.packageJSON.contributes,
-    mockExtensionProps.packageJSON.kaitianContributes,
+    mockExtensionProps.packageJSON.sumiContributes,
   ),
   activate: () => true,
   reset() {},

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.extensions.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.extensions.test.ts
@@ -27,7 +27,7 @@ const mockExtension = {
     .codeUri,
   packageJSON: {
     name: 'sumi-extension',
-    kaitianContributes: {
+    sumiContributes: {
       workerMain: 'worker.js',
     },
   },

--- a/packages/extension/src/browser/extension-management.service.ts
+++ b/packages/extension/src/browser/extension-management.service.ts
@@ -170,7 +170,7 @@ export class ExtensionManagementService extends WithEventBus implements Abstract
     await extension.initialize();
     this.eventBus.fire(new ExtensionDidEnabledEvent(extension.toJSON()));
 
-    this.sumiContributesService.register(extension.id, extension.packageJSON.kaitianContributes || {});
+    this.sumiContributesService.register(extension.id, extension.packageJSON.sumiContributes || {});
     this.contributesService.register(extension.id, extension.contributes);
     this.sumiContributesService.initialize();
     this.contributesService.initialize();

--- a/packages/extension/src/browser/extension-view.service.ts
+++ b/packages/extension/src/browser/extension-view.service.ts
@@ -179,18 +179,18 @@ export class ViewExtProcessService implements AbstractViewExtProcessService {
   public async activeExtension(extension: IExtension, protocol: IRPCProtocol) {
     const { extendConfig, packageJSON, contributes } = extension;
     // 对使用 kaitian.js 的老插件兼容
-    // 因为可能存在即用了 kaitian.js 作为入口，又注册了 kaitianContributes 贡献点的插件
+    // 因为可能存在即用了 kaitian.js 作为入口，又注册了 sumiContributes 贡献点的插件
     if (extendConfig?.browser?.main) {
       warning(
         false,
-        '[Deprecated warning]: kaitian.js is deprecated, please use `package.json#kaitianContributes` instead',
+        '[Deprecated warning]: kaitian.js is deprecated, please use `package.json#sumiContributes` instead',
       );
       await this.activateExtensionByDeprecatedExtendConfig(extension as Extension);
       return;
     }
 
     // 激活 workerMain/browserMain 相关部分
-    if (packageJSON.kaitianContributes && contributes?.browserMain) {
+    if (packageJSON.sumiContributes && contributes?.browserMain) {
       await this.activeExtensionContributes(extension);
     }
   }

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -65,11 +65,11 @@ export class WorkerExtProcessService
   public async activeExtension(extension: IExtension, isWebExtension: boolean): Promise<void> {
     const { extendConfig, packageJSON } = extension;
     // 对使用 kaitian.js 的老插件兼容
-    // 因为可能存在即用了 kaitian.js 作为入口，又注册了 kaitianContributes 贡献点的插件
+    // 因为可能存在即用了 kaitian.js 作为入口，又注册了 sumiContributes 贡献点的插件
     if (extendConfig?.worker?.main) {
       warning(
         false,
-        '[Deprecated warning]: kaitian.js is deprecated, please use `package.json#kaitianContributes` instead',
+        '[Deprecated warning]: kaitian.js is deprecated, please use `package.json#sumiContributes` instead',
       );
       await this.doActivateExtension(extension);
       return;
@@ -77,7 +77,7 @@ export class WorkerExtProcessService
 
     if (
       // 激活 workerMain 相关部分
-      (packageJSON.kaitianContributes && extension.contributes?.workerMain) ||
+      (packageJSON.sumiContributes && extension.contributes?.workerMain) ||
       // 激活 packageJSON.browser 相关部分
       (isWebExtension && packageJSON.browser)
     ) {

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -271,7 +271,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
 
       if (extension?.contributes && extension.enabled) {
         this.contributesService.register(extension.id, extension.contributes);
-        this.sumiContributesService.register(extension.id, extension.packageJSON.kaitianContributes || {});
+        this.sumiContributesService.register(extension.id, extension.packageJSON.sumiContributes || {});
       }
     }
 
@@ -651,7 +651,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
         if (extension) {
           extension.initialize();
           this.contributesService.register(extension.id, extension.contributes);
-          this.sumiContributesService.register(extension.id, extension.packageJSON.kaitianContributes || {});
+          this.sumiContributesService.register(extension.id, extension.packageJSON.sumiContributes || {});
         }
       }),
     );

--- a/packages/extension/src/hosted/ext.host.ts
+++ b/packages/extension/src/hosted/ext.host.ts
@@ -347,7 +347,7 @@ export default class ExtensionHostServiceImpl implements IExtensionHostService {
   }
 
   private containsSumiContributes(extension: IExtensionDescription): boolean {
-    if (extension.packageJSON.kaitianContributes) {
+    if (extension.packageJSON.sumiContributes) {
       return true;
     }
     return false;
@@ -433,10 +433,10 @@ export default class ExtensionHostServiceImpl implements IExtensionHostService {
       }
     }
 
-    if (extension.packageJSON.kaitianContributes && extension.packageJSON.kaitianContributes.nodeMain) {
+    if (extension.packageJSON.sumiContributes && extension.packageJSON.sumiContributes.nodeMain) {
       try {
         const reportTimer = this.reporterService.time(REPORT_NAME.ACTIVE_EXTENSION);
-        extendModule = getNodeRequire()(path.join(extension.path, extension.packageJSON.kaitianContributes.nodeMain));
+        extendModule = getNodeRequire()(path.join(extension.path, extension.packageJSON.sumiContributes.nodeMain));
         reportTimer.timeEnd(extension.id, {
           version: extension.packageJSON.version,
         });
@@ -509,16 +509,16 @@ export default class ExtensionHostServiceImpl implements IExtensionHostService {
   private getExtendModuleProxy(extension: IExtensionDescription, isSumiContributes: boolean) {
     /**
      * @example
-     * "kaitianContributes": {
+     * "sumiContributes": {
      *  "viewsProxies": ["ViewComponentID"],
      * }
      */
     if (
       isSumiContributes &&
-      extension.packageJSON.kaitianContributes &&
-      extension.packageJSON.kaitianContributes.viewsProxies
+      extension.packageJSON.sumiContributes &&
+      extension.packageJSON.sumiContributes.viewsProxies
     ) {
-      return this.getExtensionViewModuleProxy(extension, extension.packageJSON.kaitianContributes.viewsProxies);
+      return this.getExtensionViewModuleProxy(extension, extension.packageJSON.sumiContributes.viewsProxies);
     } else if (extension.extendConfig && extension.extendConfig.browser && extension.extendConfig.browser.componentId) {
       return this.getExtensionViewModuleProxy(extension, extension.extendConfig.browser.componentId);
     } else {

--- a/packages/extension/src/hosted/worker.host.ts
+++ b/packages/extension/src/hosted/worker.host.ts
@@ -209,12 +209,12 @@ export class ExtensionWorkerHost implements IExtensionWorkerHost {
   private getExtendModuleProxy(extension: IExtensionProps) {
     /**
      * @example
-     * "kaitianContributes": {
+     * "sumiContributes": {
      *  "viewsProxies": ["ViewComponentID"],
      * }
      */
-    if (extension.packageJSON.kaitianContributes && extension.packageJSON.kaitianContributes.viewsProxies) {
-      return this.getExtensionViewModuleProxy(extension, extension.packageJSON.kaitianContributes.viewsProxies);
+    if (extension.packageJSON.sumiContributes && extension.packageJSON.sumiContributes.viewsProxies) {
+      return this.getExtensionViewModuleProxy(extension, extension.packageJSON.sumiContributes.viewsProxies);
     } else if (extension.extendConfig && extension.extendConfig.browser && extension.extendConfig.browser.componentId) {
       return this.getExtensionViewModuleProxy(extension, extension.extendConfig.browser.componentId);
     } else {

--- a/packages/extension/src/node/extension.scanner.ts
+++ b/packages/extension/src/node/extension.scanner.ts
@@ -6,7 +6,6 @@ import semver from 'semver';
 
 import { getDebugLogger, getNodeRequire, Uri } from '@opensumi/ide-core-node';
 
-
 import { IExtensionMetaData, IExtraMetaData } from '../common';
 
 import { mergeContributes } from './merge-contributes';
@@ -119,8 +118,13 @@ export class ExtensionScanner {
       }
     }
 
-    // merge for `kaitianContributes` and `contributes`
-    packageJSON.contributes = mergeContributes(packageJSON.kaitianContributes, packageJSON.contributes);
+    // compatible with `kaitianContributes` declare
+    if (!packageJSON.sumiContributes && packageJSON.kaitianContributes) {
+      packageJSON.sumiContributes = packageJSON.kaitianContributes;
+    }
+
+    // merge for `sumiContributes` and `contributes`
+    packageJSON.contributes = mergeContributes(packageJSON.sumiContributes, packageJSON.contributes);
 
     const extension = {
       // vscode 规范

--- a/packages/extension/src/node/merge-contributes.ts
+++ b/packages/extension/src/node/merge-contributes.ts
@@ -1,5 +1,5 @@
 /**
- * handle `kaitianContributes` and `contributes`
+ * handle `sumiContributes` and `contributes`
  */
 import mergeWith from 'lodash/mergeWith';
 

--- a/packages/i18n/src/common/contributes/en-US.lang.ts
+++ b/packages/i18n/src/common/contributes/en-US.lang.ts
@@ -1,5 +1,5 @@
 export const browserViews = {
-  // kaitianContributes
+  // sumiContributes
   'sumiContributes.opensumiContributes': 'All contributions of the Opensumi Extension represented by this package.',
 
   // 公用 properties，如 command

--- a/packages/i18n/src/common/contributes/en-US.lang.ts
+++ b/packages/i18n/src/common/contributes/en-US.lang.ts
@@ -1,6 +1,6 @@
 export const browserViews = {
   // sumiContributes
-  'sumiContributes.opensumiContributes': 'All contributions of the Opensumi Extension represented by this package.',
+  'sumiContributes.contributes': 'Declare all contributions of the OpenSumi Extension.',
 
   // 公用 properties，如 command
   'sumiContributes.common.command':

--- a/packages/i18n/src/common/contributes/zh-CN.lang.ts
+++ b/packages/i18n/src/common/contributes/zh-CN.lang.ts
@@ -1,5 +1,5 @@
 export const browserViews = {
-  // kaitianContributes
+  // sumiContributes
   'sumiContributes.opensumiContributes': '由此包表示的 Opensumi 扩展的所有贡献',
 
   // 公用 properties，如 command

--- a/packages/i18n/src/common/contributes/zh-CN.lang.ts
+++ b/packages/i18n/src/common/contributes/zh-CN.lang.ts
@@ -1,6 +1,6 @@
 export const browserViews = {
   // sumiContributes
-  'sumiContributes.opensumiContributes': '由此包表示的 Opensumi 扩展的所有贡献',
+  'sumiContributes.contributes': '声明 OpenSumi 扩展的所有贡献点信息',
 
   // 公用 properties，如 command
   'sumiContributes.common.command': '要执行的命令。该命令必须在 "contributes.command" 中声明（内置命令除外）',

--- a/packages/startup/entry/web-lite/lite-module/extension/utils.ts
+++ b/packages/startup/entry/web-lite/lite-module/extension/utils.ts
@@ -49,8 +49,13 @@ export function mergeContributes(
 export async function getExtension(extensionId: string, version: string): Promise<IExtensionMetaData | undefined> {
   const extPath = `gw.alipayobjects.com/os/marketplace/assets/${extensionId}/v${version}/extension/`;
   const packageJSON = await fetch(`https://${extPath}package.json`).then((res) => res.json());
-  // merge for `kaitianContributes` and `contributes`
-  packageJSON.contributes = mergeContributes(packageJSON.kaitianContributes, packageJSON.contributes);
+
+  // compatible with `kaitianContributes` declare
+  if (!packageJSON.sumiContributes && packageJSON.kaitianContributes) {
+    packageJSON.sumiContributes = packageJSON.kaitianContributes;
+  }
+  // merge for `sumiContributes` and `contributes`
+  packageJSON.contributes = mergeContributes(packageJSON.sumiContributes, packageJSON.contributes);
 
   const extensionPath = 'ext://' + extPath;
   const extension = {

--- a/packages/types/sumi.d.ts
+++ b/packages/types/sumi.d.ts
@@ -577,7 +577,7 @@ declare module 'sumi' {
 
       /**
        * 设置 Button 的 State
-       * state 需要对应在 kaitianContributes 中配置
+       * state 需要对应在 sumiContributes 中配置
        * @param state
        * @param 额外改变的 title
        */
@@ -610,7 +610,7 @@ declare module 'sumi' {
       onStateChanged: Event<{ from: string; to: string }>;
 
       /**
-       * 显示 button 元素对应的 popover 元素，需要在 kaitianContributes 中配置
+       * 显示 button 元素对应的 popover 元素，需要在 sumiContributes 中配置
        */
       showPopover(): Promise<void>;
 
@@ -620,7 +620,7 @@ declare module 'sumi' {
     export interface IToolbarSelectActionHandle<T> {
       /**
        * 设置 Select 的 State
-       * state 需要对应在 kaitianContributes 中配置
+       * state 需要对应在 sumiContributes 中配置
        * @param state
        */
       setState(state: string): Promise<void>;


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74babfe</samp>

*  Rename the `kaitianContributes` property to `sumiContributes` in the extension package schema and the extension contribution points registration and activation logic ([link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-366289ffb7e39f53297fa56da7119b46f475882d9ac3e2ed10b03b9ba2f524e4L30-R30), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-7943476a12073afcaf3964223a391b3ac42a27789e21fb54c5531aa1112e7bdbL5-R5), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-ee02fb088a19a9a0c87b1501c7a1ce3a1a6a70ce687546360ae17f0197611417L173-R173), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-7e4610f55daeaaca635b72e1cba7d5548f4d5ad6d5e36466dc1b26052ca015c1L182-R186), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-7e4610f55daeaaca635b72e1cba7d5548f4d5ad6d5e36466dc1b26052ca015c1L193-R193), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-56c70608623e5329d4b53a62c8d82b065f5c5b4ddf3aab359a8c22b6bc354016L68-R72), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-56c70608623e5329d4b53a62c8d82b065f5c5b4ddf3aab359a8c22b6bc354016L80-R80), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L274-R274), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-3d705c2bf9f71760b12685e3d9e61fc6339b3886d9ace8c550014b9b2547b806L654-R654), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-62990366c95d4e68747b72694a7f1f31eeeccd44aa455911ff445b0b3375d135L436-R439), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-62990366c95d4e68747b72694a7f1f31eeeccd44aa455911ff445b0b3375d135L518-R521), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL212-R217))
*  Add compatibility checks for the legacy extensions that use the `kaitianContributes` property and merge it with the `sumiContributes` property in the `ExtensionScanner` class and the `getExtension` function ([link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-23ac5d986d011d0020b71866085025bdad642bd54c9c60588277bb3b5860b370L122-R128), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-56b6091c5dfa529ced7473f9d74917f33e8ecfb6039a7ad9217fa9f3ada7a471L52-R59))
*  Update the `containsSumiContributes` method in the `ext.host.ts` file to use the `sumiContributes` property instead of the `kaitianContributes` property ([link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-62990366c95d4e68747b72694a7f1f31eeeccd44aa455911ff445b0b3375d135L350-R350))
*  Update the comments and the localization values that refer to the `kaitianContributes` property in the `ext.host.ts`, `merge-contributes.ts`, `en-US.lang.ts`, and `zh-CN.lang.ts` files ([link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-62990366c95d4e68747b72694a7f1f31eeeccd44aa455911ff445b0b3375d135L512-R512), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-a8a97067eabc6c14292002497312bf4f68d3354885f3af9b71f1622de3949b1dL2-R2), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-c20faf7a0479fc71b0143e07913ac8eb35f22537d41bf74b12fc3aec686127d0L2-R2), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-77fd021913ae53d95584cf31e7a51658aca21ae8f865adf8d0e97b8205d04ac3L2-R2))
*  Update the mock extension values that use the `kaitianContributes` property in the test files ([link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-bdb1f85cb61f115d10f4d33e41403e8e38bdf6b43a4f1d81a33dea2417c8e460L55-R55), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-1756b2ee05d53914deb4cca2cf5d3052151039aa92dbdd410e9e7c0b4d2e9fbdL124-R124), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-1756b2ee05d53914deb4cca2cf5d3052151039aa92dbdd410e9e7c0b4d2e9fbdL310-R310), [link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-c88fe93e73be2eebb160a25a9aeea6dcfa93a0e5aed55068fb9943a20fe6ea01L30-R30))
*  Remove an empty line from the `extension.scanner.ts` file ([link](https://github.com/opensumi/core/pull/2664/files?diff=unified&w=0#diff-23ac5d986d011d0020b71866085025bdad642bd54c9c60588277bb3b5860b370L9))

<!-- Additional content -->
<!-- 补充额外内容 -->

支持 `sumiContributes` 贡献点同时兼容 `kaitianContributes` 写法，当仅有 `kaitianContributes` 存在时，使用 `kaitianContributes`, 其他情况一律采用 `sumiContributes`

重要修改见第一个提交

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74babfe</samp>

This pull request renames the `kaitianContributes` property to `sumiContributes` in various files related to the extension framework and contribution points. This is to unify the naming convention and avoid confusion with the deprecated `kaitian.js` entry point. The pull request also adds some compatibility checks and code style improvements for the extension contribution points.
