### PR TITLE
fix: conditional breakpoint centering

### DIFF
--- a/packages/debug/__tests__/browser/editor/debug-breakpoint-widget.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-breakpoint-widget.test.ts
@@ -28,6 +28,7 @@ describe('Debug Breakpoint Widget', () => {
         has: () => true,
       };
     },
+    getModel: jest.fn(() => Disposable.create(() => {})),
   };
 
   beforeAll(() => {

--- a/packages/debug/src/browser/editor/debug-breakpoint-zone-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-zone-widget.tsx
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom';
 
 import { Injectable, Autowired } from '@opensumi/di';
 import { Select, Option } from '@opensumi/ide-components';
+import { PreferenceService } from '@opensumi/ide-core-browser';
 import { localize, Emitter, Event } from '@opensumi/ide-core-common';
 import { ICodeEditor } from '@opensumi/ide-editor';
 import { ZoneWidget } from '@opensumi/ide-monaco-enhance';
 import { ICSSStyleService } from '@opensumi/ide-theme';
-import * as monacoLanguages from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages';
+import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
 import {
@@ -28,6 +29,9 @@ export class DebugBreakpointZoneWidget extends ZoneWidget {
 
   @Autowired(DebugBreakpointsService)
   protected debugBreakpointsService: DebugBreakpointsService;
+
+  @Autowired(PreferenceService)
+  protected preferenceService: PreferenceService;
 
   @Autowired(ICSSStyleService)
   protected readonly cssManager: ICSSStyleService;
@@ -219,6 +223,17 @@ export class DebugBreakpointZoneWidget extends ZoneWidget {
     this._wrapper.className = styles.debug_breakpoint_wrapper;
     this._selection.className = styles.debug_breakpoint_selected;
     this._input.className = styles.debug_breakpoint_input;
+
+    const model = this.editor.getModel();
+
+    if (!model) {
+      return;
+    }
+
+    const lineHeight = this.editor.getOption(EditorOption.lineHeight);
+    const fontSize = this.editor.getOption(EditorOption.fontSize);
+    const newTopMargin = lineHeight - fontSize;
+    this._input.style.marginTop = newTopMargin + 'px';
   }
 
   applyStyle() {

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -153,8 +153,8 @@ export abstract class ZoneWidget extends Disposable implements IHorizontalSashLa
   private _overlay: OverlayWidgetDelegate | null;
   private _viewZone: ViewZoneDelegate | null;
   private _current: monaco.IRange;
+  private _linesCount: number;
   private _resizeSash: Sash | null = null;
-  public _linesCount: number;
 
   private _onDomNodeTop = new Emitter<number>();
   protected onDomNodeTop = this._onDomNodeTop.event;

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -153,8 +153,8 @@ export abstract class ZoneWidget extends Disposable implements IHorizontalSashLa
   private _overlay: OverlayWidgetDelegate | null;
   private _viewZone: ViewZoneDelegate | null;
   private _current: monaco.IRange;
-  private _linesCount: number;
   private _resizeSash: Sash | null = null;
+  public _linesCount: number;
 
   private _onDomNodeTop = new Emitter<number>();
   protected onDomNodeTop = this._onDomNodeTop.event;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5e1257</samp>

*  Inject `PreferenceService` as a dependency of `DebugBreakpointZoneWidget` class to access editor preferences ([link](https://github.com/opensumi/core/pull/2666/files?diff=unified&w=0#diff-deafe17ac50477699d3feeffc7e457b872ee5572169d8bfecadd46318b39875dL6-R11), [link](https://github.com/opensumi/core/pull/2666/files?diff=unified&w=0#diff-deafe17ac50477699d3feeffc7e457b872ee5572169d8bfecadd46318b39875dR33-R35))
*  Adjust margin-top of input element in `show` method of `DebugBreakpointZoneWidget` class based on editor line height and font size to align with breakpoint line ([link](https://github.com/opensumi/core/pull/2666/files?diff=unified&w=0#diff-deafe17ac50477699d3feeffc7e457b872ee5572169d8bfecadd46318b39875dR226-R236))

<!-- Additional content -->
修复当设置了 lineheight 之后，表达式断点的 placeholder 不会居中的问题

before:
![image](https://user-images.githubusercontent.com/20262815/236167501-d76577f2-b14c-4c18-a517-af8153644508.png)

after:
![image](https://user-images.githubusercontent.com/20262815/236167552-a27a791d-bc37-4238-a22a-919adaf78051.png)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5e1257</samp>

Improved the UI of the debug breakpoint zone widget by using editor preferences and options.
