### PR TITLE
style: remove useless z-index

### DIFF
--- a/packages/core-browser/src/components/layout/default-layout.tsx
+++ b/packages/core-browser/src/components/layout/default-layout.tsx
@@ -25,7 +25,7 @@ export function ToolbarActionBasedLayout() {
   const { colors, layout } = getStorageValue();
   return (
     <BoxPanel direction='top-to-bottom'>
-      <SlotRenderer backgroundColor={colors.menuBarBackground} defaultSize={0} slot='top' z-index={2} />
+      <SlotRenderer backgroundColor={colors.menuBarBackground} defaultSize={0} slot='top' />
       <SplitPanel id='main-horizontal' flex={1}>
         <SlotRenderer
           backgroundColor={colors.sideBarBackground}

--- a/packages/core-browser/src/components/layout/styles.module.less
+++ b/packages/core-browser/src/components/layout/styles.module.less
@@ -17,5 +17,4 @@
 
 .wrapper {
   position: relative;
-  z-index: 2;
 }

--- a/tools/electron/README.md
+++ b/tools/electron/README.md
@@ -1,4 +1,4 @@
-# Kaitian IDE Electron 实践层
+# Electron 实践层
 
 ## Electron 版本运行步骤
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

移除了框架内多余的 `z-index` 声明，这里的声明会导致层级问题复杂性提升，将全局 Base 层级重新设置回 0，让内部组件自由控制层级关系。

测试效果：
<img width="516" alt="image" src="https://user-images.githubusercontent.com/9823838/236373994-32ddc5c5-b25c-4eeb-8e24-350c2ace9582.png">
<img width="946" alt="image" src="https://user-images.githubusercontent.com/9823838/236374020-024feaa6-5b0f-4a00-af6a-fb760f34fae6.png">

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fffc08b</samp>

*  Remove `z-index` property from `top` slot to fix modal dialog bug ([link](https://github.com/opensumi/core/pull/2670/files?diff=unified&w=0#diff-5d3bf88e1ef746c955715d46cc00e01275fdca827373a88ee047eaa99a5c2aefL28-R28), [link](https://github.com/opensumi/core/pull/2670/files?diff=unified&w=0#diff-048421f5f42f8244df05a7e1b5265b107e9137d730d3f3790b81642bbbac53e5L20))
*  Update title and subtitle of `README.md` in `tools/electron` folder to remove Kaitian IDE reference ([link](https://github.com/opensumi/core/pull/2670/files?diff=unified&w=0#diff-c9f40d96eb1fbee3106917206afdc72bc6266754d5db7249a46e76d25630dc2dL1-R1))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fffc08b</samp>

This pull request fixes a layout bug that caused menu bar to overlap modal dialogs, and updates the documentation for the `tools/electron` folder to remove product-specific references.
