### PR TITLE
style: optimize sidebar icon size

### DIFF
--- a/packages/main-layout/src/browser/tabbar/styles.module.less
+++ b/packages/main-layout/src/browser/tabbar/styles.module.less
@@ -118,13 +118,6 @@
       height: 40px;
       margin: 0;
     }
-    :global {
-      .activity-icon {
-        font-size: 20px;
-        width: 20px;
-        height: 20px;
-      }
-    }
   }
 }
 .tab_container {


### PR DESCRIPTION
### Types
- [x] 💄 Style Changes

### Background or solution
Before:
![image](https://user-images.githubusercontent.com/12130901/236386587-ef69304d-28e4-4824-9669-13619fab2f8d.png)

After:
![image](https://user-images.githubusercontent.com/12130901/236386626-9ab0cb1e-833e-4564-b04a-99117471d5ac.png)


<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3c2e11</samp>

*  Removed redundant code that caused inconsistent icon sizes in the activity bar ([link](https://github.com/opensumi/core/pull/2672/files?diff=unified&w=0#diff-e59766e69dfac4526a3503bfee4971527d9b3e248d87caf2a8b858509fd8a5afL121-L127))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3c2e11</samp>

Removed redundant code that affected activity bar icon size. Simplified icon size styling with a CSS variable.
