### PR TITLE
fix: active editor logic

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.editor.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.editor.ts
@@ -324,37 +324,7 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
           this.editorService.currentEditorGroup &&
           isEditor(this.editorService.currentEditorGroup.currentOpenType)
         ) {
-          let side: string | undefined;
-
-          const isDiffOriginal =
-            this.editorService.currentEditorGroup.currentOpenType?.type === EditorOpenType.diff &&
-            this.editorService.currentEditorGroup.diffEditor.originalEditor.currentUri?.isEqual(uri);
-
-          const isDiffMorified =
-            this.editorService.currentEditorGroup.currentOpenType?.type === EditorOpenType.diff &&
-            this.editorService.currentEditorGroup.diffEditor.modifiedEditor.currentUri?.isEqual(uri);
-
-          if (isDiffOriginal) {
-            side = 'original';
-          }
-
-          if (isDiffMorified) {
-            side = 'modified';
-          }
-
-          if (side) {
-            this.proxy.$acceptChange({
-              actived: getTextEditorId(this.editorService.currentEditorGroup, uri, side),
-            });
-          } else {
-            // 这里 id 还是兼容旧逻辑不做改动
-            this.proxy.$acceptChange({
-              actived: getTextEditorId(
-                this.editorService.currentEditorGroup,
-                this.editorService.currentEditorGroup.currentResource?.uri!,
-              ),
-            });
-          }
+          this.acceptCurrentEditor(uri);
         } else {
           this.proxy.$acceptChange({
             actived: '-1',
@@ -374,9 +344,7 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
         },
       });
 
-      this.proxy.$acceptChange({
-        actived: getTextEditorId(e.payload.group, e.payload.editorUri),
-      });
+      this.acceptCurrentEditor(e.payload.editorUri);
     };
 
     const debouncedSelectionChange = debounce((e) => selectionChange(e), 50, {
@@ -437,6 +405,40 @@ export class MainThreadEditorService extends WithEventBus implements IMainThread
         }
       }),
     );
+  }
+
+  private acceptCurrentEditor(uri: URI) {
+    let side: string | undefined;
+
+    const isDiffOriginal =
+      this.editorService.currentEditorGroup.currentOpenType?.type === EditorOpenType.diff &&
+      this.editorService.currentEditorGroup.diffEditor.originalEditor.currentUri?.isEqual(uri);
+
+    const isDiffMorified =
+      this.editorService.currentEditorGroup.currentOpenType?.type === EditorOpenType.diff &&
+      this.editorService.currentEditorGroup.diffEditor.modifiedEditor.currentUri?.isEqual(uri);
+
+    if (isDiffOriginal) {
+      side = 'original';
+    }
+
+    if (isDiffMorified) {
+      side = 'modified';
+    }
+
+    if (side) {
+      this.proxy.$acceptChange({
+        actived: getTextEditorId(this.editorService.currentEditorGroup, uri, side),
+      });
+    } else {
+      // 这里 id 还是兼容旧逻辑不做改动
+      this.proxy.$acceptChange({
+        actived: getTextEditorId(
+          this.editorService.currentEditorGroup,
+          this.editorService.currentEditorGroup.currentResource?.uri!,
+        ),
+      });
+    }
   }
 
   async $applyEdits(


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13ddf3e</samp>

*  Refactor the logic of sending the active text editor id to the proxy when the current editor group changes or emits an `editorChanged` event ([link](https://github.com/opensumi/core/pull/2677/files?diff=unified&w=0#diff-89cfdb7cdeba988b1f33afa38c5f78386a50f685728d58dd86638ca881bef9a2L327-R327), [link](https://github.com/opensumi/core/pull/2677/files?diff=unified&w=0#diff-89cfdb7cdeba988b1f33afa38c5f78386a50f685728d58dd86638ca881bef9a2L377-R347))
* Implement the `acceptCurrentEditor` method to support diff editor sides ([link](https://github.com/opensumi/core/pull/2677/files?diff=unified&w=0#diff-89cfdb7cdeba988b1f33afa38c5f78386a50f685728d58dd86638ca881bef9a2R410-R443))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13ddf3e</samp>

Refactor and improve the extension proxy's active text editor id handling. Add support for diff editors in `main.thread.editor.ts`.
