### PR TITLE
fix: support delete files by keybinding

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -463,12 +463,12 @@ export class FileTreeContribution
       execute: (_, uris) => {
         exitFilterMode();
         if (!uris) {
-          if (this.fileTreeModelService.focusedFile) {
-            this.willDeleteUris.push(this.fileTreeModelService.focusedFile.uri);
-          } else if (this.fileTreeModelService.selectedFiles && this.fileTreeModelService.selectedFiles.length > 0) {
+          if (this.fileTreeModelService.selectedFiles?.length > 0) {
             this.willDeleteUris = this.willDeleteUris.concat(
               this.fileTreeModelService.selectedFiles.map((file) => file.uri),
             );
+          } else if (this.fileTreeModelService.focusedFile) {
+            this.willDeleteUris.push(this.fileTreeModelService.focusedFile.uri);
           } else {
             return;
           }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d052aaa</samp>

* Fix a bug where deleting a file with the keyboard shortcut would delete the wrong file if the selection and the focus were different ([link](https://github.com/opensumi/core/pull/2679/files?diff=unified&w=0#diff-bdf4535ed45e87a7f0e14a93bcdfa4cb8e15897afab8509f9a4cdf7f433f2645L466-R472))

close #2675 

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d052aaa</samp>

Fixed a file deletion bug in the file tree by changing the deletion logic. The change is part of a pull request to improve the file tree usability and keyboard navigation.
