### PR TITLE
fix: debug breakpoint in empty line

### DIFF
--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -354,7 +354,7 @@ export class DebugModel implements IDebugModel {
    */
   protected createBreakpointDecoration(breakpoint: IDebugBreakpoint): monaco.editor.IModelDeltaDecoration {
     const lineNumber = breakpoint.raw.line;
-    const column = breakpoint.raw.column || 1;
+    const column = breakpoint.raw.column || 0;
     const range = new monaco.Range(lineNumber, column, lineNumber, column + 1);
     return {
       range,

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -500,7 +500,7 @@ export class DebugModel implements IDebugModel {
     const session = this.debugSessionManager.currentSession;
     const status = breakpoint.status.get((session && session.id) || '');
     const lineNumber = status && status.line ? status.line : breakpoint.raw.line;
-    const column = breakpoint.raw.column || 1;
+    const column = breakpoint.raw.column || 0;
     const model = this.editor.getModel()!;
     const renderInline = column > model.getLineFirstNonWhitespaceColumn(lineNumber);
     const range = new monaco.Range(lineNumber, column, lineNumber, column + 1);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

修复#2669这个问题
空白行的时候model.getLineFirstNonWhitespaceColumn(lineNumber)返回0，column默认为1会导致渲染一个行内断点，调整column默认值为0

### Background or solution

close #2669 

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1681462</samp>

* Change the default column value from 1 to 0 in the breakpoint constructor ([link](https://github.com/opensumi/core/pull/2682/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL503-R503)). This fixes a bug with breakpoint rendering and aligns with the monaco editor and the debug adapter protocol.

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1681462</samp>

Fixed a breakpoint rendering bug in the editor by using zero-based column indexing in `debug-model.ts`. This makes it consistent with the monaco editor and the debug adapter protocol.
