### PR TITLE
fix(file-tree): should prioritize delete selected files

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -463,17 +463,18 @@ export class FileTreeContribution
       execute: (_, uris) => {
         exitFilterMode();
         if (!uris) {
-          if (this.fileTreeModelService.focusedFile) {
-            this.willDeleteUris.push(this.fileTreeModelService.focusedFile.uri);
-          } else if (this.fileTreeModelService.selectedFiles && this.fileTreeModelService.selectedFiles.length > 0) {
+          if (this.fileTreeModelService.selectedFiles && this.fileTreeModelService.selectedFiles.length > 0) {
             this.willDeleteUris = this.willDeleteUris.concat(
               this.fileTreeModelService.selectedFiles.map((file) => file.uri),
             );
-          } else {
-            return;
+          } else if (this.fileTreeModelService.focusedFile) {
+            this.willDeleteUris.push(this.fileTreeModelService.focusedFile.uri);
           }
         } else {
           this.willDeleteUris = this.willDeleteUris.concat(uris);
+        }
+        if (this.willDeleteUris.length === 0) {
+          return;
         }
         return this.deleteThrottler.queue<void>(this.doDelete.bind(this));
       },


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

close: #2675 

如果你选中多个文件，按删除快捷键，它会优先删除 focus 的文件，其实用户希望的是删除所有已经选中的文件，而不是当前最后 focus 的这个文件。


### Changelog

file tree should prioritize delete selected files
