### PR TITLE
fix: SCM tree view can not be collapsed

### DIFF
--- a/packages/components/src/recycle-tree/RecycleTree.tsx
+++ b/packages/components/src/recycle-tree/RecycleTree.tsx
@@ -658,7 +658,7 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
   private getItemAtIndex = (index: number): INodeRendererProps => {
     const { filter } = this.props;
     if (!!filter && this.filterFlattenBranch.length > 0) {
-      return this.idToFilterRendererPropsCache.get(this.filterFlattenBranch[index])! as INodeRendererProps;
+      return this.idToFilterRendererPropsCache.get(this.filterFlattenBranch[index]) as INodeRendererProps;
     }
     let cached = this.idxToRendererPropsCache.get(index);
     if (!cached) {

--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.ts
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.ts
@@ -44,7 +44,7 @@ export class SCMResourceGroup extends CompositeTreeNode {
     public raw: ISCMTreeNodeDescription<ISCMResourceGroup>,
     public readonly resource: ISCMResourceGroup,
   ) {
-    super(tree as ITree, parent, undefined, { name: resource.label });
+    super(tree as ITree, parent);
     // 目录节点默认全部展开
     this.isExpanded = true;
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac591e6</samp>

*  Simplified the logic for returning the default and valid values of preference properties in the `PreferenceSchemaProvider` and `PreferenceServiceImpl` classes ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-db044c1814db170c0520eb19111ecf674b4388cdb406cb3c987791257131bc6fL198-R198), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-f5345a60a02a556a6c25622679659982402f3ce1df5acb6c0409d9ca57117ea8L314-R321))
* Removed the unused `onWillUpdate` event and emitter from the `DebugHoverModel`, `DebugConsoleTreeModel`, `DebugVariablesModel`, `DebugWatchModel` classes and their corresponding services and tests ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-cc7aaa95dfbea65cae99d0df33ffac6fcfce93efe17bcb62a19e57b625432512L21), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-3a580d7172e75ebc841794b48b82445aa9f74576704e6d96a2bfc618c48fbb25L12), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-3a580d7172e75ebc841794b48b82445aa9f74576704e6d96a2bfc618c48fbb25L19-L22), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-3a580d7172e75ebc841794b48b82445aa9f74576704e6d96a2bfc618c48fbb25L33), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-6d8efdefdfd58013b77edd9fcec06424b2aaff1cb67b314c18cd935a8c4fdc56L137-L146), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-11c1c631dc83237aefb636f2bfb959aa5affd8fd993d84eafb8dd41ee72ef11bL12), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-11c1c631dc83237aefb636f2bfb959aa5affd8fd993d84eafb8dd41ee72ef11bL20-L23), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-11c1c631dc83237aefb636f2bfb959aa5affd8fd993d84eafb8dd41ee72ef11bL43), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-4f5a3ea42c0a3fb4e6d982d3d50988501d5c9eed3e147f499c69a1116ba078fbL254-L263), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-189e9ff133d51f9c3e4b244f8fe30819f1697b6597235f0a5d90b6ede72189f9L12), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-189e9ff133d51f9c3e4b244f8fe30819f1697b6597235f0a5d90b6ede72189f9L19-L22), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-189e9ff133d51f9c3e4b244f8fe30819f1697b6597235f0a5d90b6ede72189f9L33), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-555fa197b7857042423c6eb0d136e74b2eb3735611e468f56f3618de72424a90L255-L264), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-2507e96f32ee807171a62ed24e4755c6215b9b082d9ec8ac0628f305b41914c2L12), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-2507e96f32ee807171a62ed24e4755c6215b9b082d9ec8ac0628f305b41914c2L19-L22), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-2507e96f32ee807171a62ed24e4755c6215b9b082d9ec8ac0628f305b41914c2L33), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-717a3ee2a54ae2286c83effd4ce5b10b81fdffdc09b8f025047d75320fa79b38L228-L237))
* Changed the default values for the `column` variable in the `DebugModel` class to align with the monaco editor column index starting from 0 ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL357-R357), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL503-R503))
* Added the `updateTarget` method and listener to the `DecorationsManager` class to update the decoration targets when the tree branch changes ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-7f30aaf0a8c851010a8750837f8330ba24bcd4cf8190bbfc0bb92294010d9a71R34), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-7f30aaf0a8c851010a8750837f8330ba24bcd4cf8190bbfc0bb92294010d9a71R156-R167))
* Changed the button text for closing the dialog from "知道了" to "OK" in the `dialog` component ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-f15451e06ceb5ff32391799374a90767bb2fa1a63c6028328fb0019183eb7428L103-R103))
* Changed the `span` element for the select option icon to a `div` element in the `select` component ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-52163e4a82eb739c516cfa12382d0b482aae0bed9658f4ee783e000ab2524712L447-R447))
* Changed the `root` parameter of the `DecorationsManager` constructor to a private readonly property ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-7f30aaf0a8c851010a8750837f8330ba24bcd4cf8190bbfc0bb92294010d9a71L27-R27))
* Removed the non-null assertion operator from the return statement of the `getRendererProps` method in the `RecycleTree` component ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L661-R661))
* Removed the `z-index` prop and style from the `SlotRenderer` component and the `slot` class in the `layout` component ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-5d3bf88e1ef746c955715d46cc00e01275fdca827373a88ee047eaa99a5c2aefL28-R28), [link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-048421f5f42f8244df05a7e1b5265b107e9137d730d3f3790b81642bbbac53e5L20))
* Removed the duplicated styles for the dialog icon and close button from the `dialog` component ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-30f54684fc99cf7f876dfd25384a0cabf61f6625dfcfac35fdcba77c44440b62L49-L80))
* Removed the unused `PREFERENCE_PROPERTY_TYPE` enum from the import statement in the `preference-contribution` file ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-db044c1814db170c0520eb19111ecf674b4388cdb406cb3c987791257131bc6fL18))
* Added an empty line to the `toolbar` styles file for readability and formatting ([link](https://github.com/opensumi/core/pull/2689/files?diff=unified&w=0#diff-78716d418280bb462c90bbb02a3055c27022ce72c628a02dcefd70d03f7bbc58R161))

<!-- Additional content -->
<!-- 补充额外内容 -->

close #2683.

核心修改在第一个 Commit，第二个 Commit 移除了框架内多余的选中态更新逻辑，将逻辑内置到了 `DecorationManager` 中处理，移除多余代码。

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac591e6</samp>

This pull request refactors and simplifies various classes and methods related to the dialog, recycle tree, select, layout, preference, and debug components. It removes unused or redundant code, fixes potential bugs, and improves readability and consistency. It also updates some tests and styles accordingly.
