### PR TITLE
refactor: auto update decoration targets

### DIFF
--- a/packages/debug/__tests__/browser/editor/debug-hover-model.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-hover-model.test.ts
@@ -18,7 +18,6 @@ describe('Debug Hover Model', () => {
 
   it('should have enough API', () => {
     expect(typeof debugHoverModel.init).toBe('function');
-    expect(typeof debugHoverModel.onWillUpdate).toBe('function');
     expect(mockRoot.watcher.on).toBeCalledTimes(3);
   });
 

--- a/packages/debug/__tests__/browser/editor/debug-hover-tree.model.service.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-hover-tree.model.service.test.ts
@@ -81,7 +81,7 @@ describe('Debug Hover Model', () => {
 
   it('initTreeModel method should be work', () => {
     debugHoverTreeModelService.initTreeModel(mockRoot);
-    expect(mockRoot.watcher.on).toBeCalledTimes(7);
+    expect(mockRoot.watcher.on).toBeCalledTimes(8);
   });
 
   it('activeNodeDecoration method should be work', () => {

--- a/packages/debug/src/browser/editor/debug-hover-model.ts
+++ b/packages/debug/src/browser/editor/debug-hover-model.ts
@@ -9,15 +9,10 @@ export class DebugHoverModel extends TreeModel {
   static DEFAULT_FLUSH_DELAY = 100;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(DebugHoverModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: ExpressionContainer) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {
@@ -30,7 +25,6 @@ export class DebugHoverModel extends TreeModel {
         this.flushDispatchChangeDelayer.cancel();
       }
       this.flushDispatchChangeDelayer.trigger(async () => {
-        await this.onWillUpdateEmitter.fireAndAwait();
         this.dispatchChange();
       });
     });

--- a/packages/debug/src/browser/editor/debug-hover-tree.model.service.ts
+++ b/packages/debug/src/browser/editor/debug-hover-tree.model.service.ts
@@ -134,16 +134,6 @@ export class DebugHoverTreeModelService {
         this.loadingDecoration.removeTarget(target);
       }),
     );
-    this.disposableCollection.push(
-      this.treeModel!.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.selectedNodes.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedNodes[0].path);
-          this.selectedDecoration.addTarget(node as ExpressionNode);
-        }
-      }),
-    );
   }
 
   async initTreeModel(root: ExpressionVariable) {

--- a/packages/debug/src/browser/view/console/debug-console-model.ts
+++ b/packages/debug/src/browser/view/console/debug-console-model.ts
@@ -9,16 +9,11 @@ export class DebugConsoleTreeModel extends TreeModel {
   static DEFAULT_FLUSH_DELAY = 100;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(DebugConsoleTreeModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
   private _tempScrollOffset = 0;
 
   constructor(@Optional() root: ExpressionContainer) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   /**
@@ -40,7 +35,6 @@ export class DebugConsoleTreeModel extends TreeModel {
         this.flushDispatchChangeDelayer.cancel();
       }
       this.flushDispatchChangeDelayer.trigger(async () => {
-        await this.onWillUpdateEmitter.fireAndAwait();
         this.dispatchChange();
       });
     });

--- a/packages/debug/src/browser/view/console/debug-console-tree.model.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console-tree.model.service.ts
@@ -251,16 +251,6 @@ export class DebugConsoleModelService implements IDebugConsoleModelService {
         this.loadingDecoration.removeTarget(target);
       }),
     );
-    this.treeModelDisposableCollection.push(
-      this.treeModel.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.selectedNodes.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedNodes[0].path);
-          this.selectedDecoration.addTarget(node as ExpressionNode);
-        }
-      }),
-    );
   }
 
   async initTreeModel(session?: DebugSession, force?: boolean) {

--- a/packages/debug/src/browser/view/variables/debug-variables-model.ts
+++ b/packages/debug/src/browser/view/variables/debug-variables-model.ts
@@ -9,15 +9,10 @@ export class DebugVariablesModel extends TreeModel {
   static DEFAULT_FLUSH_DELAY = 100;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(DebugVariablesModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: ExpressionContainer) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {
@@ -30,7 +25,6 @@ export class DebugVariablesModel extends TreeModel {
         this.flushDispatchChangeDelayer.cancel();
       }
       this.flushDispatchChangeDelayer.trigger(async () => {
-        await this.onWillUpdateEmitter.fireAndAwait();
         this.dispatchChange();
       });
     });

--- a/packages/debug/src/browser/view/variables/debug-variables-tree.model.service.ts
+++ b/packages/debug/src/browser/view/variables/debug-variables-tree.model.service.ts
@@ -252,16 +252,6 @@ export class DebugVariablesModelService {
         this.loadingDecoration.removeTarget(target);
       }),
     );
-    this.disposableCollection.push(
-      this.treeModel.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.selectedNodes.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedNodes[0].path);
-          this.selectedDecoration.addTarget(node as ExpressionNode);
-        }
-      }),
-    );
   }
 
   async initTreeModel(session?: DebugSession) {

--- a/packages/debug/src/browser/view/watch/debug-watch-model.ts
+++ b/packages/debug/src/browser/view/watch/debug-watch-model.ts
@@ -9,15 +9,10 @@ export class DebugWatchModel extends TreeModel {
   static DEFAULT_FLUSH_DELAY = 100;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(DebugWatchModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: ExpressionContainer) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {
@@ -30,7 +25,6 @@ export class DebugWatchModel extends TreeModel {
         this.flushDispatchChangeDelayer.cancel();
       }
       this.flushDispatchChangeDelayer.trigger(async () => {
-        await this.onWillUpdateEmitter.fireAndAwait();
         this.dispatchChange();
       });
     });

--- a/packages/debug/src/browser/view/watch/debug-watch-tree.model.service.ts
+++ b/packages/debug/src/browser/view/watch/debug-watch-tree.model.service.ts
@@ -225,16 +225,6 @@ export class DebugWatchModelService {
         this.loadingDecoration.removeTarget(target);
       }),
     );
-    this.disposableCollection.push(
-      this.treeModel.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.selectedNodes.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedNodes[0].path);
-          this.selectedDecoration.addTarget(node as ExpressionNode);
-        }
-      }),
-    );
   }
 
   async initTreeModel() {

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
@@ -339,16 +339,6 @@ export class ExtensionTreeViewModel {
         this.reveal(treeItemId);
       }),
     );
-    this.disposableCollection.push(
-      this.treeModel!.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.selectedNodes.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedNodes[0].path);
-          this.selectedDecoration.addTarget(node as ExtensionTreeNode);
-        }
-      }),
-    );
   }
 
   async updateTreeModel() {

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.ts
@@ -9,15 +9,10 @@ export class ExtensionTreeModel extends TreeModel {
   static DEFAULT_FLUSH_DELAY = 100;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(ExtensionTreeModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: ExtensionTreeRoot) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {
@@ -30,7 +25,6 @@ export class ExtensionTreeModel extends TreeModel {
         this.flushDispatchChangeDelayer.cancel();
       }
       this.flushDispatchChangeDelayer.trigger(async () => {
-        await this.onWillUpdateEmitter.fireAndAwait();
         this.dispatchChange();
       });
     });

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.node.defined.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.node.defined.ts
@@ -62,7 +62,7 @@ export class ExtensionCompositeTreeNode extends CompositeTreeNode {
     expanded?: boolean,
     sourceUri?: UriComponents,
   ) {
-    super(tree, parent, undefined);
+    super(tree, parent, undefined, { name: treeItemId });
     this.isExpanded = expanded || false;
     this.sourceUri = sourceUri;
     this._command = command;
@@ -150,7 +150,7 @@ export class ExtensionTreeNode extends TreeNode {
     private _accessibilityInformation?: IAccessibilityInformation,
     private sourceUri?: UriComponents,
   ) {
-    super(tree as ITree, parent, undefined);
+    super(tree as ITree, parent, undefined, { name: treeItemId });
     if (isString(label)) {
       this._displayName = label;
     } else if (isObject(label)) {

--- a/packages/file-tree-next/src/browser/dialog/file-dialog-model.service.ts
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog-model.service.ts
@@ -154,23 +154,6 @@ export class FileTreeDialogModel implements IFileDialogModel {
         this.loadingDecoration.removeTarget(target);
       }),
     );
-    this.disposableCollection.push(
-      this.treeModel!.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.focusedFile) {
-          const node = this.treeModel?.root.getTreeNodeByPath(this.focusedFile.path);
-          if (node) {
-            this.activeFileDecoration(node as File, false);
-          }
-        } else if (this.selectedFiles.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedFiles[0].path);
-          if (node) {
-            this.selectFileDecoration(node as File, false);
-          }
-        }
-      }),
-    );
   }
 
   async updateTreeModel(path: string) {

--- a/packages/file-tree-next/src/browser/file-tree-model.ts
+++ b/packages/file-tree-next/src/browser/file-tree-model.ts
@@ -20,15 +20,10 @@ export class FileTreeModel extends TreeModel {
   public readonly decorationService: FileTreeDecorationService;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(FileTreeModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: Directory) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: Directory) {
@@ -46,7 +41,6 @@ export class FileTreeModel extends TreeModel {
       this.flushDispatchChangeDelayer.cancel();
     }
     this.flushDispatchChangeDelayer.trigger(async () => {
-      await this.onWillUpdateEmitter.fireAndAwait();
       this.dispatchChange();
     });
   }

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -335,54 +335,6 @@ export class FileTreeModelService {
         this.initTreeModel();
       }),
     );
-    this.disposableCollection.push(
-      this.treeModel?.onWillUpdate(() => {
-        if (!this.initTreeModelReady) {
-          return;
-        }
-        // 更新树前更新下选中节点
-        if (this.willSelectedNodePath) {
-          const node = this.treeModel.root.getTreeNodeByPath(this.willSelectedNodePath) as File;
-          if (node) {
-            this.selectFileDecoration(node, false);
-            this.willSelectedNodePath = null;
-          }
-        }
-
-        if (this.contextMenuFile) {
-          const node = this.treeModel?.root.getTreeNodeByPath(this.contextMenuFile.path);
-          if (node) {
-            this.contextMenuDecoration.removeTarget(this.contextMenuFile);
-            this.contextMenuFile = node as File;
-            this.contextMenuDecoration.addTarget(node);
-          }
-        }
-
-        if (this.focusedFile) {
-          const node = this.treeModel?.root.getTreeNodeByPath(this.focusedFile.path);
-          if (node) {
-            this.focusedDecoration.removeTarget(this.focusedFile);
-            this.focusedFile = node as File;
-            this.focusedDecoration.addTarget(node);
-          }
-        }
-
-        if (this.selectedFiles.length !== 0) {
-          const nodes: (File | Directory)[] = [];
-          this.selectedFiles.forEach((file) => {
-            this.selectedDecoration.removeTarget(file);
-          });
-          for (const file of this.selectedFiles) {
-            const node = this.treeModel?.root.getTreeNodeByPath(file.path);
-            if (node) {
-              this.selectedDecoration.addTarget(node);
-              nodes.push(node as File);
-            }
-          }
-          this._selectedFiles = nodes;
-        }
-      }),
-    );
     // 当labelService注册的对应节点图标变化时，通知视图更新
     this.disposableCollection.push(
       this.labelService.onDidChange(async () => {

--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -219,29 +219,6 @@ export class OpenedEditorModelService {
       }),
     );
 
-    this.disposableCollection.push(
-      this.treeModel!.onWillUpdate(() => {
-        // 更新树前更新下选中节点
-        if (this.contextMenuFile) {
-          const node = this.treeModel?.root.getTreeNodeByPath(this.contextMenuFile.path);
-          if (node) {
-            this.activeFileDecoration(node as EditorFile, false);
-          }
-        } else if (this.focusedFile) {
-          const node = this.treeModel?.root.getTreeNodeByPath(this.focusedFile.path);
-          if (node) {
-            this.activeFileDecoration(node as EditorFile, false);
-          }
-        } else if (this.selectedFiles.length !== 0) {
-          // 仅处理一下单选情况
-          const node = this.treeModel?.root.getTreeNodeByPath(this.selectedFiles[0].path);
-          if (node) {
-            this.selectFileDecoration(node as EditorFile, false);
-          }
-        }
-      }),
-    );
-
     this.onTreeModelChangeEmitter.fire(this._treeModel);
   }
 

--- a/packages/opened-editor/src/browser/services/opened-editor-model.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.ts
@@ -14,15 +14,10 @@ export class OpenedEditorModel extends TreeModel {
   public readonly decorationService: OpenedEditorDecorationService;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(OpenedEditorModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: EditorFileGroup) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {
@@ -38,7 +33,6 @@ export class OpenedEditorModel extends TreeModel {
       this.flushDispatchChangeDelayer.cancel();
     }
     this.flushDispatchChangeDelayer.trigger(async () => {
-      await this.onWillUpdateEmitter.fireAndAwait();
       this.dispatchChange();
     });
   }

--- a/packages/outline/src/browser/services/outline-model.service.ts
+++ b/packages/outline/src/browser/services/outline-model.service.ts
@@ -195,20 +195,6 @@ export class OutlineModelService {
           this._treeModelDisposeMap.disposeKey(key);
         }),
       );
-      this._treeModelDisposeMap.set(
-        uri.toString(),
-        treeModel.onWillUpdate(() => {
-          if (this.focusedNode) {
-            // 更新树前更新下选中节点
-            const node = treeModel!.root.getTreeNodeById(this.focusedNode.id);
-            this.activeNodeDecoration(node as OutlineTreeNode, false);
-          } else if (this.selectedNodes.length !== 0) {
-            // 仅处理一下单选情况
-            const node = treeModel!.root.getTreeNodeById(this.selectedNodes[0].id);
-            this.selectNodeDecoration(node as OutlineTreeNode, false);
-          }
-        }),
-      );
     }
     this.setTreeModel(treeModel);
     return treeModel;

--- a/packages/outline/src/browser/services/outline-model.service.ts
+++ b/packages/outline/src/browser/services/outline-model.service.ts
@@ -82,7 +82,6 @@ export class OutlineModelService {
     100,
     80,
   );
-  private _treeModelDisposeMap = new DisposableMap();
   private _whenInitTreeModelReady: Promise<void>;
 
   private _whenReady: Promise<void>;
@@ -190,11 +189,6 @@ export class OutlineModelService {
         treeModel,
         decoration,
       });
-      this.disposableCollection.push(
-        this._allTreeModels.onKeyDidDelete(uri.toString(), ({ key }) => {
-          this._treeModelDisposeMap.disposeKey(key);
-        }),
-      );
     }
     this.setTreeModel(treeModel);
     return treeModel;
@@ -602,6 +596,5 @@ export class OutlineModelService {
 
   dispose() {
     this.disposableCollection.dispose();
-    this._treeModelDisposeMap.dispose();
   }
 }

--- a/packages/outline/src/browser/services/outline-model.ts
+++ b/packages/outline/src/browser/services/outline-model.ts
@@ -9,15 +9,10 @@ export class OutlineTreeModel extends TreeModel {
   static DEFAULT_FLUSH_DELAY = 100;
 
   private flushDispatchChangeDelayer = new ThrottledDelayer<void>(OutlineTreeModel.DEFAULT_FLUSH_DELAY);
-  private onWillUpdateEmitter: Emitter<void> = new Emitter();
 
   constructor(@Optional() root: OutlineCompositeTreeNode) {
     super();
     this.init(root);
-  }
-
-  get onWillUpdate(): Event<void> {
-    return this.onWillUpdateEmitter.event;
   }
 
   init(root: CompositeTreeNode) {
@@ -30,7 +25,6 @@ export class OutlineTreeModel extends TreeModel {
         this.flushDispatchChangeDelayer.cancel();
       }
       this.flushDispatchChangeDelayer.trigger(async () => {
-        await this.onWillUpdateEmitter.fireAndAwait();
         this.dispatchChange();
       });
     });


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 79b8bf5</samp>

*  Removed the `onWillUpdate` event and its related fields, getters, calls, and listeners from various tree model classes and services, as it was no longer needed ([link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-cc7aaa95dfbea65cae99d0df33ffac6fcfce93efe17bcb62a19e57b625432512L21), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-3a580d7172e75ebc841794b48b82445aa9f74576704e6d96a2bfc618c48fbb25L12), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-3a580d7172e75ebc841794b48b82445aa9f74576704e6d96a2bfc618c48fbb25L19-L22), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-3a580d7172e75ebc841794b48b82445aa9f74576704e6d96a2bfc618c48fbb25L33), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-11c1c631dc83237aefb636f2bfb959aa5affd8fd993d84eafb8dd41ee72ef11bL12), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-11c1c631dc83237aefb636f2bfb959aa5affd8fd993d84eafb8dd41ee72ef11bL20-L23), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-11c1c631dc83237aefb636f2bfb959aa5affd8fd993d84eafb8dd41ee72ef11bL43), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-189e9ff133d51f9c3e4b244f8fe30819f1697b6597235f0a5d90b6ede72189f9L12), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-189e9ff133d51f9c3e4b244f8fe30819f1697b6597235f0a5d90b6ede72189f9L19-L22), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-189e9ff133d51f9c3e4b244f8fe30819f1697b6597235f0a5d90b6ede72189f9L33), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-2507e96f32ee807171a62ed24e4755c6215b9b082d9ec8ac0628f305b41914c2L12), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-2507e96f32ee807171a62ed24e4755c6215b9b082d9ec8ac0628f305b41914c2L19-L22), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-2507e96f32ee807171a62ed24e4755c6215b9b082d9ec8ac0628f305b41914c2L33), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-9cd30794224d0d8b23407be098b62725fdf4917c70a8c1c470e3a6e781106354L12), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-9cd30794224d0d8b23407be098b62725fdf4917c70a8c1c470e3a6e781106354L19-L22), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-9cd30794224d0d8b23407be098b62725fdf4917c70a8c1c470e3a6e781106354L33), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-571b3925515f450aa3a09270864b5e62e73e62aab67c83432082729102537c1eL23), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-571b3925515f450aa3a09270864b5e62e73e62aab67c83432082729102537c1eL30-L33), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-571b3925515f450aa3a09270864b5e62e73e62aab67c83432082729102537c1eL49), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-b005f5edaf2c7583efb5540b8f48793ea34632ff07e300d0a6381c66c81466cfL17), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-b005f5edaf2c7583efb5540b8f48793ea34632ff07e300d0a6381c66c81466cfL24-L27), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-b005f5edaf2c7583efb5540b8f48793ea34632ff07e300d0a6381c66c81466cfL41), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-971b93e6f5100658a996311c2472156ab29079b921b4a97ab6a1b25260650723L12), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-971b93e6f5100658a996311c2472156ab29079b921b4a97ab6a1b25260650723L19-L22), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-971b93e6f5100658a996311c2472156ab29079b921b4a97ab6a1b25260650723L33), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-6d8efdefdfd58013b77edd9fcec06424b2aaff1cb67b314c18cd935a8c4fdc56L137-L146), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-4f5a3ea42c0a3fb4e6d982d3d50988501d5c9eed3e147f499c69a1116ba078fbL254-L263), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-555fa197b7857042423c6eb0d136e74b2eb3735611e468f56f3618de72424a90L255-L264), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-717a3ee2a54ae2286c83effd4ce5b10b81fdffdc09b8f025047d75320fa79b38L228-L237), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-62eec07281380ab87c175917b8d526f5c597af6167e94b7b8cb08fd411dd433aL342-L351), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-f38e6a6a8d811143189b52c97f3afac5a7ede6bc1b72f43cb8a14d16d87095c4L157-L173), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L338-L385), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L222-L244), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-a7febf52fcfcdc33bac886a49be524309ad21edfa8db3419cbb20969f7060577L85), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-a7febf52fcfcdc33bac886a49be524309ad21edfa8db3419cbb20969f7060577L193-L211), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-a7febf52fcfcdc33bac886a49be524309ad21edfa8db3419cbb20969f7060577L619))
*  Added a new `DecorationsManager` class in `packages/components/src/recycle-tree/tree/decoration/DecorationManager.ts` to handle the decoration updates for the tree nodes, and used it in the constructors of various tree model classes and services ([link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-7f30aaf0a8c851010a8750837f8330ba24bcd4cf8190bbfc0bb92294010d9a71L27-R27), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-7f30aaf0a8c851010a8750837f8330ba24bcd4cf8190bbfc0bb92294010d9a71R34), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-7f30aaf0a8c851010a8750837f8330ba24bcd4cf8190bbfc0bb92294010d9a71R156-R167))
*  Modified the constructors of the `ExtensionCompositeTreeNode` and `ExtensionTreeNode` classes in `packages/extension/src/browser/vscode/api/tree-view/tree-view.node.defined.ts` to pass the `treeItemId` parameter as the name option to the super constructor, to ensure the node has a unique identifier that matches the extension tree item ([link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-d19f7e3d2b999d0b3b78462d468d43b26c77c01b18add2d17b04ef54dcb8f369L65-R65), [link](https://github.com/opensumi/core/pull/2690/files?diff=unified&w=0#diff-d19f7e3d2b999d0b3b78462d468d43b26c77c01b18add2d17b04ef54dcb8f369L153-R153))

<!-- Additional content -->
<!-- 补充额外内容 -->

精简代码结构

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79b8bf5</samp>

This pull request removes the redundant `onWillUpdate` events from various tree model classes and simplifies their code. It also enhances the `DecorationsManager` class to handle the decoration updates automatically when the tree nodes change. Additionally, it assigns names to the extension tree nodes based on their IDs to avoid conflicts. It also updates the related tests and services to reflect these changes.
