### PR TITLE
feat: support additional and anyof/oneof field

### DIFF
--- a/packages/debug/src/browser/preferences/components/checkbox-widget.tsx
+++ b/packages/debug/src/browser/preferences/components/checkbox-widget.tsx
@@ -1,0 +1,78 @@
+import {
+  ariaDescribedByIds,
+  descriptionId,
+  getTemplate,
+  labelValue,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+  GenericObjectType,
+} from '@rjsf/utils';
+import React, { FocusEvent } from 'react';
+
+import { CheckBox } from '@opensumi/ide-components';
+import { IJSONSchema } from '@opensumi/ide-core-common';
+
+import styles from './json-widget.module.less';
+
+export const CheckboxWidget = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: WidgetProps<T, S, F>,
+) => {
+  const {
+    disabled,
+    formContext,
+    id,
+    label,
+    hideLabel,
+    onBlur,
+    onChange,
+    onFocus,
+    readonly,
+    value,
+    registry,
+    options,
+    schema,
+    uiSchema,
+  } = props;
+  const { readonlyAsDisabled = true } = formContext as GenericObjectType;
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    options,
+  );
+
+  const handleChange = ({ target }: any) => onChange(target.checked);
+
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target.checked);
+
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target.checked);
+
+  const extraProps = {
+    onBlur: !readonly ? handleBlur : undefined,
+    onFocus: !readonly ? handleFocus : undefined,
+  };
+
+  const description = options.description ?? schema.description ?? (schema as IJSONSchema).markdownDescription;
+
+  return (
+    <div className={styles.checkbox_widget_control}>
+      {!hideLabel && (
+        <label title={label} className={styles.field_label}>
+          {label}
+        </label>
+      )}
+      <CheckBox
+        checked={typeof value === 'undefined' ? false : value}
+        disabled={disabled || (readonlyAsDisabled && readonly)}
+        id={id}
+        name={id}
+        onChange={!readonly ? handleChange : undefined}
+        {...extraProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
+        label={description}
+        className={styles.checkbox}
+      />
+    </div>
+  );
+};

--- a/packages/debug/src/browser/preferences/components/fields/any-of-field.tsx
+++ b/packages/debug/src/browser/preferences/components/fields/any-of-field.tsx
@@ -7,7 +7,6 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
   titleId,
-  WidgetProps,
 } from '@rjsf/utils';
 import React from 'react';
 

--- a/packages/debug/src/browser/preferences/components/fields/any-of-field.tsx
+++ b/packages/debug/src/browser/preferences/components/fields/any-of-field.tsx
@@ -1,32 +1,91 @@
+import {
+  descriptionId,
+  FieldProps,
+  FormContextType,
+  GenericObjectType,
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  titleId,
+  WidgetProps,
+} from '@rjsf/utils';
 import React from 'react';
 
 import { Input } from '@opensumi/ide-components';
+import { IJSONSchema } from '@opensumi/ide-core-common';
 
 import styles from '../json-widget.module.less';
 
-// 对于 anyof 的处理统一使用 input
-export const AnyOfField = (props) => {
-  const { disabled, formContext, id, onBlur, onChange, onFocus, options, placeholder, readonly, schema, value } = props;
-  const { readonlyAsDisabled = true } = formContext;
+// 对于 anyof/oneof 的处理统一使用 input
+export const AnyOfField = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: FieldProps<T, S, F>,
+) => {
+  const {
+    disabled,
+    formContext,
+    idSchema,
+    onBlur,
+    id,
+    onChange,
+    onFocus,
+    options,
+    placeholder,
+    readonly,
+    registry,
+    name,
+    required,
+    schema,
+    uiOptions,
+  } = props;
+  const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const handleTextChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
     onChange(target.value === '' ? options.emptyValue : target.value);
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) => onBlur(id, target.value);
+  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) => onBlur(id!, target.value);
 
-  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) => onFocus(id, target.value);
+  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) => onFocus(id!, target.value);
+
+  const description = options.description ?? schema.description ?? (schema as IJSONSchema).markdownDescription;
+
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    uiOptions,
+  );
 
   return (
-    <Input
-      disabled={disabled || (readonlyAsDisabled && readonly)}
-      id={id}
-      name={id}
-      onBlur={!readonly ? handleBlur : undefined}
-      onChange={!readonly ? handleTextChange : undefined}
-      onFocus={!readonly ? handleFocus : undefined}
-      placeholder={placeholder}
-      className={styles.any_of_widget_control}
-      autoComplete='off'
-    />
+    <div className={styles.any_of_widget_control}>
+      {name && (
+        <div className={styles.object_title}>
+          <TitleFieldTemplate
+            id={titleId<T>(idSchema)}
+            title={name}
+            required={required}
+            schema={schema}
+            registry={registry}
+          />
+        </div>
+      )}
+      {description && (
+        <div className={styles.object_description}>
+          <DescriptionFieldTemplate
+            id={descriptionId<T>(idSchema)}
+            description={description}
+            schema={schema}
+            registry={registry}
+          />
+        </div>
+      )}
+      <Input
+        disabled={disabled || (readonlyAsDisabled && readonly)}
+        onBlur={!readonly ? handleBlur : undefined}
+        onChange={!readonly ? handleTextChange : undefined}
+        onFocus={!readonly ? handleFocus : undefined}
+        placeholder={placeholder}
+        autoComplete='off'
+      />
+    </div>
   );
 };

--- a/packages/debug/src/browser/preferences/components/fields/object-filed.tsx
+++ b/packages/debug/src/browser/preferences/components/fields/object-filed.tsx
@@ -1,0 +1,10 @@
+import { getDefaultRegistry } from '@rjsf/core';
+import { FieldProps } from '@rjsf/utils';
+import { FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import React from 'react';
+
+const DefaultObjectField: any = getDefaultRegistry().fields.ObjectField;
+
+export const ObjectField = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: FieldProps<T, S, F>,
+) => <DefaultObjectField {...props} />;

--- a/packages/debug/src/browser/preferences/components/fields/title-field.tsx
+++ b/packages/debug/src/browser/preferences/components/fields/title-field.tsx
@@ -1,0 +1,35 @@
+import { FormContextType, TitleFieldProps, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import classNames from 'classnames';
+import React from 'react';
+
+import styles from '../json-widget.module.less';
+
+export const TitleField = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: TitleFieldProps<T, S, F>,
+) => {
+  const { id, required, registry, title } = props;
+  const { formContext } = registry;
+  const { colon = true } = formContext;
+
+  let labelChildren = title;
+  if (colon && typeof title === 'string' && title.trim() !== '') {
+    labelChildren = title.replace(/[：:]\s*$/, '');
+  }
+
+  const handleLabelClick = () => {
+    if (!id) {
+      return;
+    }
+
+    const control: HTMLLabelElement | null = document.querySelector(`[id="${id}"]`);
+    if (control && control.focus) {
+      control.focus();
+    }
+  };
+
+  return title ? (
+    <label title={title} className={styles.field_label}>
+      {title}
+    </label>
+  ) : null;
+};

--- a/packages/debug/src/browser/preferences/components/fields/title-field.tsx
+++ b/packages/debug/src/browser/preferences/components/fields/title-field.tsx
@@ -1,5 +1,4 @@
 import { FormContextType, TitleFieldProps, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
-import classNames from 'classnames';
 import React from 'react';
 
 import styles from '../json-widget.module.less';
@@ -7,25 +6,7 @@ import styles from '../json-widget.module.less';
 export const TitleField = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: TitleFieldProps<T, S, F>,
 ) => {
-  const { id, required, registry, title } = props;
-  const { formContext } = registry;
-  const { colon = true } = formContext;
-
-  let labelChildren = title;
-  if (colon && typeof title === 'string' && title.trim() !== '') {
-    labelChildren = title.replace(/[：:]\s*$/, '');
-  }
-
-  const handleLabelClick = () => {
-    if (!id) {
-      return;
-    }
-
-    const control: HTMLLabelElement | null = document.querySelector(`[id="${id}"]`);
-    if (control && control.focus) {
-      control.focus();
-    }
-  };
+  const { title } = props;
 
   return title ? (
     <label title={title} className={styles.field_label}>

--- a/packages/debug/src/browser/preferences/components/json-widget.module.less
+++ b/packages/debug/src/browser/preferences/components/json-widget.module.less
@@ -16,3 +16,21 @@
     margin: 0;
   }
 }
+
+.checkbox_widget_control {
+  display: flex;
+  flex-direction: column;
+
+  .checkbox {
+    font-size: 14px;
+    opacity: 0.75;
+    white-space: pre-wrap;
+    color: var(--descriptionForeground);
+  }
+}
+
+.field_label {
+  margin-bottom: 10px;
+  font-size: 1.5em;
+  display: inline-block;
+}

--- a/packages/debug/src/browser/preferences/components/select-widget.tsx
+++ b/packages/debug/src/browser/preferences/components/select-widget.tsx
@@ -1,12 +1,30 @@
-import { WidgetProps } from '@rjsf/utils';
+import {
+  descriptionId,
+  FormContextType,
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  titleId,
+  WidgetProps,
+} from '@rjsf/utils';
 import React, { useMemo } from 'react';
 
 import { Option, Select } from '@opensumi/ide-components';
 
 import styles from './json-widget.module.less';
 
-export const SelectWidget = (props: WidgetProps) => {
-  const { schema, value, id } = props;
+export const SelectWidget = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: WidgetProps<T, S, F>,
+) => {
+  const { schema, value, id, registry, uiOptions, name, required } = props;
+  const description = schema.description;
+
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    uiOptions,
+  );
 
   const enumValue = useMemo(() => {
     if (schema && schema.enum) {
@@ -16,12 +34,35 @@ export const SelectWidget = (props: WidgetProps) => {
   }, [schema, schema.enum]);
 
   return (
-    <Select key={id} value={value} className={styles.select_widget_control} dropdownRenderType='absolute'>
-      {enumValue.map((data: string) => (
-        <Option value={data} label={data} key={data}>
-          {data}
-        </Option>
-      ))}
-    </Select>
+    <div className={styles.select_widget_control}>
+      {name && (
+        <div className={styles.object_title}>
+          <TitleFieldTemplate
+            id={titleId<T>(id)}
+            title={name}
+            required={required}
+            schema={schema}
+            registry={registry}
+          />
+        </div>
+      )}
+      {description && (
+        <div className={styles.object_description}>
+          <DescriptionFieldTemplate
+            id={descriptionId<T>(id)}
+            description={description}
+            schema={schema}
+            registry={registry}
+          />
+        </div>
+      )}
+      <Select key={id} value={value} dropdownRenderType='absolute'>
+        {enumValue.map((data: string) => (
+          <Option value={data} label={data} key={data}>
+            {data}
+          </Option>
+        ))}
+      </Select>
+    </div>
   );
 };

--- a/packages/debug/src/browser/preferences/components/text-widget.tsx
+++ b/packages/debug/src/browser/preferences/components/text-widget.tsx
@@ -1,4 +1,13 @@
-import { WidgetProps } from '@rjsf/utils';
+import {
+  descriptionId,
+  FormContextType,
+  GenericObjectType,
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  titleId,
+  WidgetProps,
+} from '@rjsf/utils';
 import React, { useMemo } from 'react';
 
 import { Input } from '@opensumi/ide-components';
@@ -20,9 +29,36 @@ const doubleQuotesRegex = new RegExp(/^\^\"(.*)\"/gm);
  */
 const snippet = new SnippetParser();
 
-export const TextWidget = (props: WidgetProps) => {
-  const { disabled, formContext, id, onBlur, onChange, onFocus, options, placeholder, readonly, schema, value } = props;
-  const { readonlyAsDisabled = true } = formContext;
+export const TextWidget = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: WidgetProps<T, S, F>,
+) => {
+  const {
+    disabled,
+    formContext,
+    id,
+    onBlur,
+    onChange,
+    onFocus,
+    options,
+    placeholder,
+    readonly,
+    schema,
+    value,
+    registry,
+    label,
+    hideLabel,
+    required,
+    uiSchema,
+    uiOptions,
+  } = props;
+  const { readonlyAsDisabled = true } = formContext as GenericObjectType;
+
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    uiOptions,
+  );
 
   const parseValue = useMemo(() => {
     if (typeof value !== 'string') {
@@ -52,19 +88,46 @@ export const TextWidget = (props: WidgetProps) => {
     return schema.type;
   }, [schema, schema.type]);
 
+  const description = useMemo(() => schema.description || '', [schema, schema.description]);
+
   return (
-    <Input
-      disabled={disabled || (readonlyAsDisabled && readonly)}
-      id={id}
-      name={id}
-      onBlur={!readonly ? handleBlur : undefined}
-      onChange={!readonly ? handleTextChange : undefined}
-      onFocus={!readonly ? handleFocus : undefined}
-      placeholder={placeholder}
-      type={type}
-      value={parseValue}
-      className={styles.text_widget_control}
-      autoComplete='off'
-    />
+    <div>
+      {!hideLabel && label && (
+        <div className={styles.object_title}>
+          <TitleFieldTemplate
+            id={titleId<T>(id)}
+            title={label}
+            required={required}
+            schema={schema}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        </div>
+      )}
+      {description && (
+        <div className={styles.object_description}>
+          <DescriptionFieldTemplate
+            id={descriptionId<T>(id)}
+            description={description}
+            schema={schema}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        </div>
+      )}
+      <Input
+        disabled={disabled || (readonlyAsDisabled && readonly)}
+        id={id}
+        name={id}
+        onBlur={!readonly ? handleBlur : undefined}
+        onChange={!readonly ? handleTextChange : undefined}
+        onFocus={!readonly ? handleFocus : undefined}
+        placeholder={placeholder}
+        type={type}
+        value={parseValue}
+        className={styles.text_widget_control}
+        autoComplete='off'
+      />
+    </div>
   );
 };

--- a/packages/debug/src/browser/preferences/launch.view.tsx
+++ b/packages/debug/src/browser/preferences/launch.view.tsx
@@ -27,6 +27,7 @@ import { launchExtensionSchemaUri } from '../../common/debug-schema';
 
 import { CheckboxWidget } from './components/checkbox-widget';
 import { AnyOfField } from './components/fields/any-of-field';
+import { ObjectField } from './components/fields/object-filed';
 import { TitleField } from './components/fields/title-field';
 import { SelectWidget } from './components/select-widget';
 import { TextWidget } from './components/text-widget';
@@ -203,6 +204,9 @@ const Form = withTheme({
     SelectWidget,
     CheckboxWidget,
   },
+  fields: {
+    ObjectField,
+  },
 });
 
 const LaunchBody = ({
@@ -243,7 +247,7 @@ const LaunchBody = ({
     const { label, body, description } = snippetItem;
     const { properties } = schemaProperties;
 
-    const snippetProperties = Object.keys(body).reduce((pre: IJSONSchemaMap, cur: string) => {
+    const snippetProperties = Object.keys(properties).reduce((pre: IJSONSchemaMap, cur: string) => {
       const curProp = properties![cur];
 
       if (curProp?.type === 'array' && isUndefined(curProp?.items)) {

--- a/packages/debug/src/browser/preferences/launch.view.tsx
+++ b/packages/debug/src/browser/preferences/launch.view.tsx
@@ -247,7 +247,7 @@ const LaunchBody = ({
     const { label, body, description } = snippetItem;
     const { properties } = schemaProperties;
 
-    const snippetProperties = Object.keys(properties).reduce((pre: IJSONSchemaMap, cur: string) => {
+    const snippetProperties = Object.keys(body).reduce((pre: IJSONSchemaMap, cur: string) => {
       const curProp = properties![cur];
 
       if (curProp?.type === 'array' && isUndefined(curProp?.items)) {

--- a/packages/debug/src/browser/preferences/templates/additional-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/additional-template.tsx
@@ -13,7 +13,7 @@ import {
 import React, { FocusEvent, useMemo } from 'react';
 
 import { Input } from '@opensumi/ide-components';
-import { IJSONSchema } from '@opensumi/ide-core-common';
+import { formatLocalize, IJSONSchema, localize } from '@opensumi/ide-core-common';
 
 import styles from './json-templates.module.less';
 
@@ -114,7 +114,7 @@ export const WrapIfAdditionalTemplate = <
                       <Input
                         className={styles.form_control}
                         defaultValue={label}
-                        placeholder={'请输入 Key'}
+                        placeholder={formatLocalize('debug.launch.view.template.input.placeholder', 'Key')}
                         disabled={disabled || (readonlyAsDisabled && readonly)}
                         id={`${id}-key`}
                         name={`${id}-key`}
@@ -124,7 +124,7 @@ export const WrapIfAdditionalTemplate = <
                       <Input
                         className={styles.form_control}
                         defaultValue={label}
-                        placeholder={'请输入 Value'}
+                        placeholder={formatLocalize('debug.launch.view.template.input.placeholder', 'Value')}
                         disabled={disabled || (readonlyAsDisabled && readonly)}
                         id={`${id}-key`}
                         name={`${id}-key`}

--- a/packages/debug/src/browser/preferences/templates/additional-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/additional-template.tsx
@@ -1,0 +1,136 @@
+import {
+  ADDITIONAL_PROPERTY_FLAG,
+  UI_OPTIONS_KEY,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WrapIfAdditionalTemplateProps,
+  ADDITIONAL_PROPERTIES_KEY,
+  getUiOptions,
+  getTemplate,
+  PROPERTIES_KEY,
+  titleId,
+  descriptionId,
+} from '@rjsf/utils';
+import React, { FocusEvent, ReactElement, useMemo } from 'react';
+
+import { Input } from '@opensumi/ide-components';
+import { IJSONSchema } from '@opensumi/ide-core-common';
+
+import styles from './json-templates.module.less';
+
+export const WrapIfAdditionalTemplate = <
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(
+  props: WrapIfAdditionalTemplateProps<T, S, F>,
+) => {
+  const {
+    children,
+    classNames,
+    style,
+    disabled,
+    id,
+    label,
+    onKeyChange,
+    onDropPropertyClick,
+    readonly,
+    registry,
+    required,
+    schema,
+    uiSchema,
+  } = props;
+  const { type, properties } = schema;
+  const { readonlyAsDisabled = true } = registry.formContext;
+  const { templates, translateString } = registry;
+  const { RemoveButton, AddButton } = templates.ButtonTemplates;
+  const isAdditional = ADDITIONAL_PROPERTY_FLAG in schema || ADDITIONAL_PROPERTIES_KEY in schema;
+  const description = schema.description ?? (schema as IJSONSchema).markdownDescription;
+
+  /**
+   * 不存在 additionalProperties 的话直接返回 children
+   * 为了防止一些属性的 properties 过多，造成页面过长（比如 node 的 linux 配置项），对于 id 非 root 的配置项让其去 launch 文件处理
+   * 二期再将这部分能力加上
+   */
+  // const isDisplayNode = useMemo(() => type !== 'object' , [type, isAdditional])
+  if (!isAdditional) {
+    return (
+      <div className={classNames} style={style}>
+        {id === 'root' || type !== 'object' ? children : null}
+      </div>
+    );
+  }
+
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    uiOptions,
+  );
+
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => onKeyChange(target.value);
+  const isHasProperties = useMemo(() => properties && Object.keys(properties).length > 0, [schema, properties]);
+
+  return (
+    <div className={classNames} style={style}>
+      <div className={styles.additional_field_template}>
+        {label && (
+          <TitleFieldTemplate
+            id={titleId<T>(id)}
+            title={label}
+            required={required}
+            schema={schema}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        )}
+        {description && (
+          <DescriptionFieldTemplate
+            id={descriptionId<T>(id)}
+            description={description}
+            schema={schema}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        )}
+        {
+          // 如果不存在 properties 则说明是可以添加任意的 key:value 对象
+          isHasProperties ? (
+            <div className={styles.children_field}>
+              <div className={styles.dividing}></div>
+              <div className={styles.children_container}>{children}</div>
+            </div>
+          ) : (
+            <div className={styles.form_additional}>
+              <div className={styles.form_group}>
+                <Input
+                  className={styles.form_control}
+                  defaultValue={label}
+                  placeholder={'请输入 Key'}
+                  disabled={disabled || (readonlyAsDisabled && readonly)}
+                  id={`${id}-key`}
+                  name={`${id}-key`}
+                  onBlur={!readonly ? handleBlur : undefined}
+                  type='text'
+                />
+                <Input
+                  className={styles.form_control}
+                  defaultValue={label}
+                  placeholder={'请输入 Value'}
+                  disabled={disabled || (readonlyAsDisabled && readonly)}
+                  id={`${id}-key`}
+                  name={`${id}-key`}
+                  onBlur={!readonly ? handleBlur : undefined}
+                  type='text'
+                />
+                <RemoveButton className='array-item-remove' disabled={disabled || readonly} registry={registry} />
+              </div>
+            </div>
+          )
+        }
+      </div>
+    </div>
+  );
+};

--- a/packages/debug/src/browser/preferences/templates/base-input-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/base-input-template.tsx
@@ -1,0 +1,79 @@
+import {
+  ariaDescribedByIds,
+  BaseInputTemplateProps,
+  examplesId,
+  getInputProps,
+  FormContextType,
+  GenericObjectType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from '@rjsf/utils';
+import React, { ChangeEvent, FocusEvent } from 'react';
+
+import { Input } from '@opensumi/ide-components';
+
+const INPUT_STYLE = {
+  width: '100%',
+};
+
+export const BaseInputTemplate = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: BaseInputTemplateProps<T, S, F>,
+) => {
+  const {
+    disabled,
+    formContext,
+    id,
+    onBlur,
+    onChange,
+    onChangeOverride,
+    onFocus,
+    options,
+    placeholder,
+    readonly,
+    schema,
+    value,
+    type,
+  } = props;
+  const inputProps = getInputProps<T, S, F>(schema, type, options, false);
+  const { readonlyAsDisabled = true } = formContext as GenericObjectType;
+
+  const handleNumberChange = (nextValue: number | null) => onChange(nextValue);
+
+  const handleTextChange = onChangeOverride
+    ? onChangeOverride
+    : ({ target }: ChangeEvent<HTMLInputElement>) => onChange(target.value === '' ? options.emptyValue : target.value);
+
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => onBlur(id, target.value);
+
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) => onFocus(id, target.value);
+
+  const input = (
+    <Input
+      disabled={disabled || (readonlyAsDisabled && readonly)}
+      id={id}
+      name={id}
+      onBlur={!readonly ? handleBlur : undefined}
+      onChange={!readonly ? handleTextChange : undefined}
+      onFocus={!readonly ? handleFocus : undefined}
+      placeholder={placeholder}
+      style={INPUT_STYLE}
+      list={schema.examples ? examplesId<T>(id) : undefined}
+      {...inputProps}
+      value={value}
+      aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
+    />
+  );
+
+  return (
+    <>
+      {input}
+      {Array.isArray(schema.examples) && (
+        <datalist id={examplesId<T>(id)}>
+          {(schema.examples as string[])
+            .concat(schema.default && !schema.examples.includes(schema.default) ? ([schema.default] as string[]) : [])
+            .map((example) => <option key={example} value={example} />)}
+        </datalist>
+      )}
+    </>
+  );
+};

--- a/packages/debug/src/browser/preferences/templates/button-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/button-template.tsx
@@ -5,6 +5,8 @@ import { Button, getIcon } from '@opensumi/ide-components';
 import { defaultIconfont } from '@opensumi/ide-components/lib/icon/iconfont/iconMap';
 import { localize } from '@opensumi/ide-core-common';
 
+import styles from './json-templates.module.less';
+
 export const MoveUpButton = (props: IconButtonProps) => (
   <Button {...props} type='primary' icon={defaultIconfont.arrowup}>
     <span className={getIcon(defaultIconfont.arrowup)}></span>
@@ -35,4 +37,8 @@ export const CopyButton = (props: IconButtonProps) => (
   </Button>
 );
 
-export const SubmitButton = (props: IconButtonProps) => <Button>{localize('ButtonOK')}</Button>;
+export const SubmitButton = (props: IconButtonProps) => (
+  <Button {...props} type='secondary' icon={defaultIconfont.plus} className={styles.add_new_field}>
+    <span className={getIcon(defaultIconfont.plus)}></span> 新增配置项
+  </Button>
+);

--- a/packages/debug/src/browser/preferences/templates/button-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/button-template.tsx
@@ -39,6 +39,6 @@ export const CopyButton = (props: IconButtonProps) => (
 
 export const SubmitButton = (props: IconButtonProps) => (
   <Button {...props} type='secondary' icon={defaultIconfont.plus} className={styles.add_new_field}>
-    <span className={getIcon(defaultIconfont.plus)}></span> 新增配置项
+    <span className={getIcon(defaultIconfont.plus)}></span> {localize('debug.launch.view.template.button.submit')}
   </Button>
 );

--- a/packages/debug/src/browser/preferences/templates/description-field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/description-field-template.tsx
@@ -1,5 +1,7 @@
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
-import React from 'react';
+import React, { useMemo } from 'react';
+
+import { IJSONSchema } from '@opensumi/ide-core-common';
 
 import styles from './json-templates.module.less';
 
@@ -10,7 +12,12 @@ export const DescriptionFieldTemplate = <
 >(
   props: DescriptionFieldProps<T, S, F>,
 ) => {
-  const { id, description } = props;
+  const { id, schema } = props;
+  const description = useMemo(
+    () => schema.description ?? (schema as IJSONSchema).markdownDescription,
+    [schema, schema.description, (schema as IJSONSchema).markdownDescription],
+  );
+
   if (!description) {
     return null;
   }

--- a/packages/debug/src/browser/preferences/templates/field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/field-template.tsx
@@ -10,8 +10,6 @@ import {
 import cls from 'classnames';
 import React from 'react';
 
-import styles from './json-templates.module.less';
-
 export const FieldTemplate = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: FieldTemplateProps<T, S, F>,
 ) => {

--- a/packages/debug/src/browser/preferences/templates/field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/field-template.tsx
@@ -1,40 +1,73 @@
-import { FieldTemplateProps } from '@rjsf/utils';
+import {
+  FieldTemplateProps,
+  FormContextType,
+  GenericObjectType,
+  getTemplate,
+  getUiOptions,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from '@rjsf/utils';
 import cls from 'classnames';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import styles from './json-templates.module.less';
 
-export const FieldTemplate = (props: FieldTemplateProps) => {
-  const { classNames, style, help, description, errors, children, id, schema, label, displayLabel } = props;
-  const renderDescription = useMemo(() => {
-    if (id === 'root' || schema.type === 'array') {
-      return null;
-    }
+export const FieldTemplate = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: FieldTemplateProps<T, S, F>,
+) => {
+  const {
+    classNames,
+    style,
+    children,
+    id,
+    schema,
+    label,
+    hidden,
+    formContext,
+    uiSchema,
+    registry,
+    disabled,
+    onDropPropertyClick,
+    onKeyChange,
+    required,
+    readonly,
+  } = props;
 
-    return description;
-  }, [id, schema, schema.type, description]);
+  const { wrapperStyle } = formContext as GenericObjectType;
 
-  const renderLabel = useMemo(() => {
-    if (id === 'root' || schema.type === 'array' || displayLabel === false) {
-      return null;
-    }
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const WrapIfAdditionalTemplate = getTemplate<'WrapIfAdditionalTemplate', T, S, F>(
+    'WrapIfAdditionalTemplate',
+    registry,
+    uiOptions,
+  );
 
-    return (
-      label && (
-        <label title={label} className={styles.field_label}>
-          {label}
-        </label>
-      )
-    );
-  }, [id, schema, schema.type, label, displayLabel]);
+  if (hidden) {
+    return null;
+  }
 
   return (
-    <div className={cls(classNames, styles.field_template)} style={style}>
-      {renderLabel}
-      {renderDescription}
-      {children}
-      {errors}
-      {help}
-    </div>
+    <WrapIfAdditionalTemplate
+      classNames={classNames}
+      style={style}
+      disabled={disabled}
+      id={id}
+      label={label}
+      onDropPropertyClick={onDropPropertyClick}
+      onKeyChange={onKeyChange}
+      readonly={readonly}
+      required={required}
+      schema={schema}
+      uiSchema={uiSchema}
+      registry={registry}
+    >
+      {id === 'root' ? (
+        children
+      ) : (
+        <div className={cls(classNames)} style={wrapperStyle}>
+          {children}
+        </div>
+      )}
+    </WrapIfAdditionalTemplate>
   );
 };

--- a/packages/debug/src/browser/preferences/templates/json-templates.module.less
+++ b/packages/debug/src/browser/preferences/templates/json-templates.module.less
@@ -29,7 +29,7 @@
 }
 
 .object_field_template {
-  .container_field {
+  .object_field_container {
     .object_title {
       margin-bottom: 16px;
     }
@@ -64,15 +64,23 @@
   display: flex;
   flex-direction: column;
 
-  .form_additional {
+  .form_additional_container {
     min-width: 300px;
     max-width: 500px;
     width: 100%;
 
     .form_group {
       display: flex;
+      margin-bottom: 12px;
+
       .form_control {
         margin-right: 16px;
+      }
+    }
+
+    .form_additional_children {
+      .object_field_container {
+        display: none;
       }
     }
   }

--- a/packages/debug/src/browser/preferences/templates/json-templates.module.less
+++ b/packages/debug/src/browser/preferences/templates/json-templates.module.less
@@ -18,12 +18,6 @@
 .field_template {
   display: flex;
   flex-direction: column;
-
-  .field_label {
-    margin-bottom: 10px;
-    font-size: 1.5em;
-    display: inline-block;
-  }
 }
 
 .array_field_template {
@@ -35,16 +29,18 @@
 }
 
 .object_field_template {
-  .object_title {
-    margin-bottom: 16px;
-  }
+  .container_field {
+    .object_title {
+      margin-bottom: 16px;
+    }
 
-  .object_description {
-    margin-bottom: 8px;
-  }
+    .object_description {
+      margin-bottom: 8px;
+    }
 
-  .property_wrapper {
-    margin-bottom: 16px;
+    .property_wrapper {
+      margin-bottom: 16px;
+    }
   }
 }
 
@@ -53,5 +49,51 @@
   margin-bottom: 10px;
   font-size: 14px;
   opacity: 0.75;
+  white-space: pre-wrap;
   color: var(--descriptionForeground);
+}
+
+.add_new_field {
+  min-width: 300px;
+  max-width: 500px;
+  width: 100%;
+  border-style: dashed;
+}
+
+.additional_field_template {
+  display: flex;
+  flex-direction: column;
+
+  .form_additional {
+    min-width: 300px;
+    max-width: 500px;
+    width: 100%;
+
+    .form_group {
+      display: flex;
+      .form_control {
+        margin-right: 16px;
+      }
+    }
+  }
+
+  .children_field {
+    position: relative;
+
+    .object_title,
+    .object_description {
+      display: none;
+    }
+
+    .dividing {
+      width: 2px;
+      background-color: var(--editorGroup-border);
+      height: 100%;
+      position: absolute;
+    }
+
+    .children_container {
+      margin-left: 16px;
+    }
+  }
 }

--- a/packages/debug/src/browser/preferences/templates/object-field-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/object-field-template.tsx
@@ -7,15 +7,32 @@ import {
   getUiOptions,
   descriptionId,
   titleId,
+  canExpand,
 } from '@rjsf/utils';
 import React from 'react';
+
+import { Button, getIcon } from '@opensumi/ide-components';
+import { defaultIconfont } from '@opensumi/ide-components/lib/icon/iconfont/iconMap';
 
 import styles from './json-templates.module.less';
 
 export const ObjectFieldTemplate = <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: ObjectFieldTemplateProps<T, S, F>,
 ) => {
-  const { schema, uiSchema, required, registry, idSchema, title, description } = props;
+  const {
+    schema,
+    uiSchema,
+    required,
+    registry,
+    idSchema,
+    title,
+    description,
+    disabled,
+    readonly,
+    properties,
+    formData,
+    onAddClick,
+  } = props;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
   const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
@@ -23,37 +40,54 @@ export const ObjectFieldTemplate = <T = any, S extends StrictRJSFSchema = RJSFSc
     registry,
     uiOptions,
   );
+  const {
+    ButtonTemplates: { AddButton },
+  } = registry.templates;
 
   return (
-    <fieldset className={styles.object_field_template}>
-      {title && (
-        <div className={styles.object_title}>
-          <TitleFieldTemplate
-            id={titleId<T>(idSchema)}
-            title={title}
-            required={required}
-            schema={schema}
-            uiSchema={uiSchema}
+    <div className={styles.object_field_template}>
+      <fieldset>
+        <div className={styles.container_field}>
+          {title && (
+            <div className={styles.object_title}>
+              <TitleFieldTemplate
+                id={titleId<T>(idSchema)}
+                title={title}
+                required={required}
+                schema={schema}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            </div>
+          )}
+          {description && (
+            <div className={styles.object_description}>
+              <DescriptionFieldTemplate
+                id={descriptionId<T>(idSchema)}
+                description={description}
+                schema={schema}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            </div>
+          )}
+          {properties
+            .filter((e) => !e.hidden)
+            .map((element) => (
+              <div key={element.name} className={styles.property_wrapper}>
+                {element.content}
+              </div>
+            ))}
+        </div>
+        {canExpand<T, S, F>(schema, uiSchema, formData) && (
+          <AddButton
+            className='object-property-expand'
+            onClick={onAddClick(schema)}
+            disabled={disabled || readonly}
             registry={registry}
           />
-        </div>
-      )}
-      {description && (
-        <div className={styles.object_description}>
-          <DescriptionFieldTemplate
-            id={descriptionId<T>(idSchema)}
-            description={description}
-            schema={schema}
-            uiSchema={uiSchema}
-            registry={registry}
-          />
-        </div>
-      )}
-      {props.properties.map((element) => (
-        <div key={element.name} className={styles.property_wrapper}>
-          {React.cloneElement(element.content, { displayLabel: true })}
-        </div>
-      ))}
-    </fieldset>
+        )}
+      </fieldset>
+    </div>
   );
 };

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -380,6 +380,8 @@ export const localizationBundle = {
     'debug.launch.typeNotSupported': 'The debug session type "{0}" is not supported.',
     'debug.launch.catchError': 'There was an error starting the debug session, check the logs for more details.',
     'debug.launch.view.template.button.addItem': 'Add items',
+    'debug.launch.view.template.input.placeholder': 'Please enter {0}',
+    'debug.launch.view.template.button.submit': 'Add new configuration item',
 
     'debug.widget.exception.thrownWithId': 'Exception has occurred: {0}',
     'debug.widget.exception.thrown': 'Exception has occurred.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -357,6 +357,8 @@ export const localizationBundle = {
     'debug.launch.typeNotSupported': '调试类型 "{0}" 不支持',
     'debug.launch.catchError': '启动调试进程时遇到了错误, 请检查调试控制台',
     'debug.launch.view.template.button.addItem': '添加一项',
+    'debug.launch.view.template.input.placeholder': '请输入 {0}',
+    'debug.launch.view.template.button.submit': '新增配置项',
 
     'debug.widget.exception.thrownWithId': '发生异常: {0}',
     'debug.widget.exception.thrown': '出现异常。',


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 169772e</samp>

*  Add the CheckboxWidget component to render boolean schemas with a checkbox input and a label and description ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-21384e6a7fb0d7a1661f8d7d9f822845611f433a2c2dedaf9cc6b4d1da3724dbR1-R78), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-6771b64600fe1c461bcb549a971144b394bd7bf1ada950c86e4b2cdeb150e805R19-R36), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bR204))
*  Modify the SelectWidget and TextWidget components to render the title and description of the schema using the TitleFieldTemplate and DescriptionFieldTemplate components ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-f86d1cd15965214231cce3fa2b44d0fa407e9832d41b5ba1afb1847ddabe6ebbL1-R9), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-f86d1cd15965214231cce3fa2b44d0fa407e9832d41b5ba1afb1847ddabe6ebbL8-R28), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-f86d1cd15965214231cce3fa2b44d0fa407e9832d41b5ba1afb1847ddabe6ebbL19-R66), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-22e325d5312d9c44550fad5f1619256919014d486f96e39dcb76c98c1ac799f3L1-R10), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-22e325d5312d9c44550fad5f1619256919014d486f96e39dcb76c98c1ac799f3L23-R62), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-22e325d5312d9c44550fad5f1619256919014d486f96e39dcb76c98c1ac799f3L55-R131))
*  Add the TitleFieldTemplate and DescriptionFieldTemplate components to render the title and description of the schema with a label and a markdown component ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-f560f59e8908590c9e2a034725b8fef61e88b906398360d2773c35c0bdc27c46R1-R35), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-6e7f7e9f5e5e44e10732f9da7583ce43aa515c3a938f4b7fdd379e2dc7601c9bL2-R5), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-6e7f7e9f5e5e44e10732f9da7583ce43aa515c3a938f4b7fdd379e2dc7601c9bL13-R20))
*  Add the WrapIfAdditionalTemplate component to wrap the field with a label and description if the schema has additional properties or the additionalProperty flag ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86b8f1061b6e5516b2cd0d79f787c704e7493273a02fe0c49a82856103a26bb0R1-R136), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-483d2e76d3cdfee74cfb9ce43e708f0814fd6e27ab8b431fbd6414944c69105dL1-R71))
*  Add the BaseInputTemplate component to render a base input element for string, number, integer, or boolean schemas ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-62966662e292f6274876f75f7069345f26be1a533ade1f19bd35c5da33a5d1c4R1-R79), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bR299-R301))
*  Modify the LaunchBody component to modify the schema properties before passing them to the Form component, and to add the OneOfField, CheckboxWidget, and the new templates to the Form component props ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL28-R37), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bR263-R272), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL272-R292), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bR299-R301))
*  Modify the AnyOfField component to import the TitleField and DescriptionField components and the IJSONSchema interface ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-94e917ae3faff1c340391acb24ecf29a47c7a33498630923496345b20c575a5fL1-R89))
*  Modify the SubmitButton component to customize the appearance and text of the button ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967R8-R9), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967L38-R44))
*  Modify the FieldTemplate component to use the WrapIfAdditionalTemplate component ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-483d2e76d3cdfee74cfb9ce43e708f0814fd6e27ab8b431fbd6414944c69105dL1-R71))
*  Modify the ObjectFieldTemplate component to wrap the object title, description, and properties with a container_field div element, and to add an add button for the additional properties if the schema can be expanded ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deL10-R16), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deL18-R35), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deL26-R91))
*  Modify the styles for the object fields and the additional properties in the `json-templates.module.less` file ([link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-0b47ea19c9728a74dab1d95d912bbfb2059e790bb2eeb5d49963010a73ee4b2dL21-L26), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-0b47ea19c9728a74dab1d95d912bbfb2059e790bb2eeb5d49963010a73ee4b2dL38-R43), [link](https://github.com/opensumi/core/pull/2692/files?diff=unified&w=0#diff-0b47ea19c9728a74dab1d95d912bbfb2059e790bb2eeb5d49963010a73ee4b2dL56-R99))

<!-- Additional content -->

![image](https://github.com/opensumi/core/assets/20262815/df57f10e-3e3e-44d3-89f7-42ae5d0ac429)
![image](https://github.com/opensumi/core/assets/20262815/d82b9d10-b84a-4f60-ad32-58affcb915db)
![image](https://github.com/opensumi/core/assets/20262815/98f74652-9977-4639-80be-1b94e34c21b4)


- [x] 新增 checkbox widget 部件
- [x] 支持渲染 markdownDescription
- [x] 新增 additional template，用于处理 additionalProperties 属性
- [x] 优化代码

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 169772e</samp>

This pull request improves the debug preferences form by adding support for more schema features and widgets, such as titles, descriptions, additional properties, and checkboxes. It also updates the components and templates that render the schema form, and adds some styles and dependencies. It mainly affects the files in the `packages/debug/src/browser/preferences` folder.
