### PR TITLE
chore: fix selection warning

### DIFF
--- a/packages/components/src/select/index.tsx
+++ b/packages/components/src/select/index.tsx
@@ -468,9 +468,9 @@ export function Select<T = string>({
 
   return (
     <div className={classNames('kt-select-container', className)} ref={selectRef}>
-      <p className={selectClasses} onClick={toggleOpen} style={style}>
+      <div className={selectClasses} onClick={toggleOpen} style={style}>
         {showSearch && open ? renderSearch() : renderSelected()}
-      </p>
+      </div>
       {showWarning && <div className='kt-select-warning-text'>{notMatchWarning}</div>}
 
       {open &&


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c619e4</samp>

* Changed the `p` element to a `div` element in the select component to fix a semantic issue ([link](https://github.com/opensumi/core/pull/2693/files?diff=unified&w=0#diff-52163e4a82eb739c516cfa12382d0b482aae0bed9658f4ee783e000ab2524712L471-R473))

<!-- Additional content -->
<!-- 补充额外内容 -->
<img width="627" alt="image" src="https://github.com/opensumi/core/assets/9823838/fd69fc74-0f82-4edb-a09e-77780a977acf">

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c619e4</samp>

Fixed a semantic issue in the `select` component by changing the wrapper element from `p` to `div`. This improves the HTML validity and does not affect the appearance or behavior of the component.
