### PR TITLE
fix: git scm 1.68.1 actionButton enabled

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -456,20 +456,24 @@ class ExtHostSourceControl implements vscode.SourceControl {
     } else if (typeof actionButton?.command === 'string') {
       internal = {
         command: this._commands.converter.toInternal(actionButton as any, this._actionButtonDisposables.value)!,
-        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) => commandGroup.map(
+        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) =>
+          commandGroup.map(
             (command) => this._commands.converter.toInternal(command, this._actionButtonDisposables.value!)!,
-          )),
+          ),
+        ),
         description: (actionButton as any).title,
         enabled: true,
       };
     } else {
       internal = {
         command: this._commands.converter.toInternal(actionButton.command, this._actionButtonDisposables.value)!,
-        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) => commandGroup.map(
+        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) =>
+          commandGroup.map(
             (command) => this._commands.converter.toInternal(command, this._actionButtonDisposables.value!)!,
-          )),
+          ),
+        ),
         description: actionButton.description || (actionButton as any).tooltip,
-        enabled: actionButton.enabled,
+        enabled: true,
       };
     }
     this._proxy.$updateSourceControl(this.handle, { actionButton: internal ?? null });

--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -473,7 +473,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
           ),
         ),
         description: actionButton.description || (actionButton as any).tooltip,
-        enabled: true,
+        enabled: actionButton.enabled ?? true,
       };
     }
     this._proxy.$updateSourceControl(this.handle, { actionButton: internal ?? null });


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57a9ef4</samp>

*  Fix action button bug in hosted extension API ([link](https://github.com/opensumi/core/pull/2698/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feL468-R476))
* Format long line of code for readability ([link](https://github.com/opensumi/core/pull/2698/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feL459-R463))

<!-- Additional content -->

vscode 的 scmActionButton api 其实并没有 enable 属性，导致该 button 一直处于 disabled 状态
![image](https://github.com/opensumi/core/assets/20262815/c1734d17-46fa-41e1-8c87-16a662d751ec)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57a9ef4</samp>

Fix action button bug and refactor `secondaryCommands` in hosted extension API. This pull request enhances the functionality and readability of the `packages/extension/src/hosted/api/vscode/ext.host.scm.ts` file.
