### PR TITLE
style: improve toolbar button style

### DIFF
--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -102,7 +102,8 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       style={{
         color: styles.iconForeground,
         backgroundColor: styles.iconBackground,
-        // 如果指定了按钮宽度，需要将padding清空，防止按钮比预期大16px
+        marginRight: styles.showTitle ? 5 : 0,
+        // 如果指定了按钮宽度，需要将padding清空，防止按钮比预期大 16px
         ...(styles.width ? { width: styles.width } : null),
         ...(styles.height ? { height: styles.height } : null),
         ...(styles.iconSize ? { fontSize: styles.iconSize, WebkitMaskSize: styles.iconSize } : null),

--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -255,7 +255,7 @@ export interface IToolbarActionBtnStyle {
   height?: number;
 
   // 是否显示 Title
-  // 20200629改动 - 默认为 true
+  // 默认为 false
   showTitle?: boolean;
 
   // icon 前景色
@@ -280,10 +280,9 @@ export interface IToolbarActionBtnStyle {
   background?: string;
 
   // 样式类型，
-  // inline则不会有外边框
-  // button则为按钮样式
-  // 20200629改动 - 默认为 button
-  // inline 模式showTitle会失效, 只显示icon
+  // inline 不会有外边框
+  // button 为按钮样式
+  // inline 模式 showTitle 会失效, 只显示icon
   btnStyle?: 'inline' | 'button';
 
   // button 的文本位置样式


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42290e8</samp>

* Change the default style of the toolbar action button to only show the icon and not the text ([link](https://github.com/opensumi/core/pull/2699/files?diff=unified&w=0#diff-b9ffff8b7eca64c21c4f21e664738b65432b4ea0fe2025ed29899dbaa872e24aL258-R258))
* Add a right margin to the icon of the toolbar action button if the text is shown, to improve the alignment and readability ([link](https://github.com/opensumi/core/pull/2699/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998L105-R106))
* Update and format the comment for the toolbar action button style interface in `packages/core-browser/src/toolbar/types.ts` ([link](https://github.com/opensumi/core/pull/2699/files?diff=unified&w=0#diff-b9ffff8b7eca64c21c4f21e664738b65432b4ea0fe2025ed29899dbaa872e24aL283-R285))

<!-- Additional content -->
<!-- 补充额外内容 -->

订正错误的默认值注释

Before：
<img width="300" alt="image" src="https://github.com/opensumi/core/assets/9823838/1b61f190-fea8-44b4-a81f-c98b5068787d">

After：
<img width="358" alt="image" src="https://github.com/opensumi/core/assets/9823838/0ff3efea-d876-43d6-b715-db623f0f9c97">

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42290e8</samp>

This pull request improves the toolbar action button style and code comment in `packages/core-browser`. It makes the button more compact and readable, and the comment more informative.
