### PR TITLE
refactor: consolidated clientId retrieval code

### DIFF
--- a/packages/core-browser/src/application/application.service.ts
+++ b/packages/core-browser/src/application/application.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Autowired } from '@opensumi/di';
+import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
+import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser/ws-channel-handler';
 import {
   OS,
   OperatingSystem,
@@ -9,6 +10,7 @@ import {
 } from '@opensumi/ide-core-common';
 
 import { AppConfig } from '../react-providers/config-provider';
+import { electronEnv } from '../utils/electron';
 
 @Injectable()
 export class ApplicationService implements IApplicationService {
@@ -17,6 +19,9 @@ export class ApplicationService implements IApplicationService {
 
   @Autowired(AppConfig)
   private readonly appConfig: AppConfig;
+
+  @Autowired(INJECTOR_TOKEN)
+  protected readonly injector: Injector;
 
   private _backendOS: OperatingSystem;
 
@@ -47,5 +52,14 @@ export class ApplicationService implements IApplicationService {
   async getBackendOS() {
     await this._initialized.promise;
     return this.backendOS;
+  }
+
+  get clientId(): string {
+    if (this.appConfig.isElectronRenderer && !this.appConfig.isRemote) {
+      return electronEnv.metadata.windowClientId;
+    } else {
+      const wsChannel = this.injector.get(WSChannelHandler);
+      return wsChannel.clientId;
+    }
   }
 }

--- a/packages/core-common/src/types/application.ts
+++ b/packages/core-common/src/types/application.ts
@@ -3,6 +3,12 @@ import { OperatingSystem } from '@opensumi/ide-utils';
 export const IApplicationService = Symbol('IApplicationService');
 
 export interface IApplicationService {
+  /**
+   * In Electron environment, if `isRemote` is not specified, use local connection by default: `electronEnv.metadata.windowClientId`
+   * Otherwise, use WebSocket connection: `WSChannelHandler.clientId`
+   */
+  clientId: string;
+
   /** 前端 OS */
   frontendOS: OperatingSystem;
   /** 后端 OS */

--- a/packages/extension/src/browser/extension-node.service.ts
+++ b/packages/extension/src/browser/extension-node.service.ts
@@ -17,6 +17,7 @@ import {
   IDisposable,
   toDisposable,
   createElectronClientConnection,
+  IApplicationService,
 } from '@opensumi/ide-core-browser';
 
 import {
@@ -46,6 +47,9 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
 
   @Autowired(ExtensionNodeServiceServerPath)
   private readonly extensionNodeClient: IExtensionNodeClientService;
+
+  @Autowired(IApplicationService)
+  protected readonly applicationService: IApplicationService;
 
   private _apiFactoryDisposables: IDisposable[] = [];
 
@@ -136,17 +140,7 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
   }
 
   private get clientId() {
-    let clientId: string;
-
-    if (this.appConfig.isElectronRenderer && !this.appConfig.isRemote) {
-      this.logger.verbose('createExtProcess electronEnv.metadata.windowClientId', electronEnv.metadata.windowClientId);
-      clientId = electronEnv.metadata.windowClientId;
-    } else {
-      const WSChannelHandler = this.injector.get(IWSChannelHandler);
-      clientId = WSChannelHandler.clientId;
-    }
-
-    return clientId;
+    return this.applicationService.clientId;
   }
 
   private async createExtProcess() {

--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -1,7 +1,6 @@
 import type vscode from 'vscode';
 
 import { Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser';
 import {
   EDITOR_COMMANDS,
   UriComponents,
@@ -10,7 +9,6 @@ import {
   CommandRegistry,
   CommandService,
   Domain,
-  electronEnv,
   FILE_COMMANDS,
   formatLocalize,
   getIcon,
@@ -25,10 +23,10 @@ import {
   replaceLocalizePlaceholder,
   URI,
   ILogger,
-  AppConfig,
   CUSTOM_EDITOR_SCHEME,
   runWhenIdle,
   QuickPickService,
+  IApplicationService,
 } from '@opensumi/ide-core-browser';
 import {
   IStatusBarService,
@@ -64,18 +62,8 @@ import * as VSCodeBuiltinCommands from './vscode/builtin-commands';
 import { WalkthroughsService } from './walkthroughs.service';
 
 export const getClientId = (injector: Injector) => {
-  let clientId: string;
-  const appConfig: AppConfig = injector.get(AppConfig);
-
-  // Electron 环境下，未指定 isRemote 时默认使用本地连接
-  // 否则使用 WebSocket 连接
-  if (appConfig.isElectronRenderer && !appConfig.isRemote) {
-    clientId = electronEnv.metadata.windowClientId;
-  } else {
-    const channelHandler = injector.get(WSChannelHandler);
-    clientId = channelHandler.clientId;
-  }
-  return clientId;
+  const service: IApplicationService = injector.get(IApplicationService);
+  return service.clientId;
 };
 
 @Domain(ClientAppContribution)

--- a/packages/remote-opener/src/browser/remote.opener.contribution.ts
+++ b/packages/remote-opener/src/browser/remote.opener.contribution.ts
@@ -1,7 +1,6 @@
 import { Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser';
-import { AppConfig, ClientAppContribution, electronEnv } from '@opensumi/ide-core-browser';
-import { ContributionProvider, Domain, getDebugLogger } from '@opensumi/ide-core-common';
+import { ClientAppContribution } from '@opensumi/ide-core-browser';
+import { ContributionProvider, Domain, getDebugLogger, IApplicationService } from '@opensumi/ide-core-common';
 
 import { IRemoteOpenerService, RemoteOpenerServicePath } from '../common';
 import {
@@ -12,18 +11,8 @@ import {
 
 // 从extension.contribution.ts中Copy过来，因为直接引入会有一定概率触发IDE初始化问题
 const getClientId = (injector: Injector) => {
-  let clientId: string;
-  const appConfig: AppConfig = injector.get(AppConfig);
-
-  // Electron 环境下，未指定 isRemote 时默认使用本地连接
-  // 否则使用 WebSocket 连接
-  if (appConfig.isElectronRenderer && !appConfig.isRemote) {
-    clientId = electronEnv.metadata.windowClientId;
-  } else {
-    const channelHandler = injector.get(WSChannelHandler);
-    clientId = channelHandler.clientId;
-  }
-  return clientId;
+  const service: IApplicationService = injector.get(IApplicationService);
+  return service.clientId;
 };
 
 @Domain(ClientAppContribution)

--- a/packages/terminal-next/__tests__/browser/inject.ts
+++ b/packages/terminal-next/__tests__/browser/inject.ts
@@ -5,6 +5,7 @@ import {
   PreferenceService,
   EventBusImpl,
   CorePreferences,
+  ApplicationService,
 } from '@opensumi/ide-core-browser';
 import { MockContextKeyService } from '@opensumi/ide-core-browser/__mocks__/context-key';
 import { MockLogger, MockLoggerManageClient, MockLoggerService } from '@opensumi/ide-core-browser/__mocks__/logger';
@@ -19,6 +20,7 @@ import {
   ILoggerManagerClient,
   ILogServiceManager,
   ILogger,
+  IApplicationService,
 } from '@opensumi/ide-core-common';
 import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
@@ -87,6 +89,10 @@ export const injector = new MockInjector([
   {
     token: ITerminalService,
     useClass: MockSocketService,
+  },
+  {
+    token: IApplicationService,
+    useClass: ApplicationService,
   },
   {
     token: IContextKeyService,

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -21,6 +21,7 @@ import {
   withNullAsUndefined,
   isThemeColor,
   Uri,
+  IApplicationService,
 } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { IMainLayoutService } from '@opensumi/ide-main-layout';
@@ -118,6 +119,9 @@ export class TerminalController extends WithEventBus implements ITerminalControl
   @Autowired(IMenuRegistry)
   private readonly menuRegistry: IMenuRegistry;
 
+  @Autowired(IApplicationService)
+  protected readonly applicationService: IApplicationService;
+
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
@@ -177,12 +181,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
     if (this._clientId) {
       return this._clientId;
     }
-    if (this.appConfig.isElectronRenderer) {
-      this._clientId = (global as any).metadata?.windowClientId;
-    } else {
-      const WSHandler = this.injector.get(WSChannelHandler);
-      this._clientId = WSHandler.clientId;
-    }
+    this._clientId = this.applicationService.clientId;
     return this._clientId;
   }
 

--- a/packages/terminal-next/src/browser/terminal.service.ts
+++ b/packages/terminal-next/src/browser/terminal.service.ts
@@ -1,9 +1,8 @@
 import { Emitter as Dispatcher } from 'event-kit';
 
 import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
-import { WSChannelHandler as IWSChannelHandler } from '@opensumi/ide-connection/lib/browser/ws-channel-handler';
-import { AppConfig, electronEnv, PreferenceService, OperatingSystem } from '@opensumi/ide-core-browser';
-import { Emitter, ILogger, Event } from '@opensumi/ide-core-common';
+import { PreferenceService, OperatingSystem } from '@opensumi/ide-core-browser';
+import { Emitter, ILogger, Event, IApplicationService } from '@opensumi/ide-core-common';
 
 import {
   generateSessionId,
@@ -46,8 +45,8 @@ export class NodePtyTerminalService implements ITerminalService {
   @Autowired(PreferenceService)
   private preferenceService: PreferenceService;
 
-  @Autowired(AppConfig)
-  private readonly appConfig: AppConfig;
+  @Autowired(IApplicationService)
+  protected readonly applicationService: IApplicationService;
 
   private _onError = new Emitter<ITerminalError>();
   public onError: Event<ITerminalError> = this._onError.event;
@@ -70,14 +69,7 @@ export class NodePtyTerminalService implements ITerminalService {
   >();
 
   generateSessionId() {
-    // Electron 环境下，未指定 isRemote 时默认使用本地连接
-    // 否则使用 WebSocket 连接
-    if (this.appConfig.isElectronRenderer && !this.appConfig.isRemote) {
-      return electronEnv.metadata.windowClientId + TERMINAL_ID_SEPARATOR + generateSessionId();
-    } else {
-      const WSChannelHandler = this.injector.get(IWSChannelHandler);
-      return WSChannelHandler.clientId + TERMINAL_ID_SEPARATOR + generateSessionId();
-    }
+    return this.applicationService.clientId + TERMINAL_ID_SEPARATOR + generateSessionId();
   }
 
   async check(ids: string[]) {


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

[OpenSumi 2023 Roadmap - 移除对 isElectronRenderer 的依赖](https://github.com/opensumi/core/wiki/2023-Roadmap)

这是属于先行的测试改造部分，RFC 还在编写中


### Changelog

Refactored clientId retrieval code into a single function.

