### PR TITLE
fix: add rpcMessageTimeout option in appConfig

### DIFF
--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -266,6 +266,6 @@ describe('connection', () => {
     });
 
     await expect(timeoutBProtocol.getProxy(testTimeoutIdentifier).$test()).resolves.toBe(void 0);
-    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(new Error('RPC Timeout'));
+    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(new Error('RPC Timeout: 1'));
   });
 });

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -266,6 +266,6 @@ describe('connection', () => {
     });
 
     await expect(timeoutBProtocol.getProxy(testTimeoutIdentifier).$test()).resolves.toBe(void 0);
-    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toBe('RPC Timeout');
+    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(new Error('RPC Timeout'));
   });
 });

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -139,6 +139,7 @@ export class ClientApp implements IClientApp, IDisposable {
       editorBackgroundImage: opts.editorBackgroundImage || editorBackgroundImage,
       allowSetDocumentTitleFollowWorkspaceDir,
       devtools: opts.devtools ?? false,
+      rpcMessageTimeout: opts.rpcMessageTimeout || -1,
     };
 
     if (this.config.devtools) {

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -247,6 +247,11 @@ export interface AppConfig {
    * 需要带端口号, 默认是 12345，可使用 COLLABORATION_PORT 字段来指定
    */
   collaborationWsPath?: string;
+  /**
+   * 通过 rpcProtocol 传递消息的超时时间
+   * 默认 -1，即不配置超时时间
+   */
+  rpcMessageTimeout?: number;
 }
 
 export const ConfigContext = React.createContext<AppConfig>({

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -248,8 +248,8 @@ export interface AppConfig {
    */
   collaborationWsPath?: string;
   /**
-   * 通过 rpcProtocol 传递消息的超时时间
-   * 默认 -1，即不配置超时时间
+   * control rpcProtocol message timeout
+   * default -1，it means disable
    */
   rpcMessageTimeout?: number;
 }

--- a/packages/core-node/src/bootstrap/app.ts
+++ b/packages/core-node/src/bootstrap/app.ts
@@ -78,6 +78,7 @@ export class ServerApp implements IServerApp {
       blockPatterns: opts.blockPatterns,
       extHostIPCSockPath: opts.extHostIPCSockPath,
       extHostForkOptions: opts.extHostForkOptions,
+      rpcMessageTimeout: opts.rpcMessageTimeout || -1,
     };
     this.bindProcessHandler();
     this.initBaseProvider();

--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -108,6 +108,11 @@ interface Config {
    * 配置关闭 keytar 校验能力，默认开启
    */
   disableKeytar?: boolean;
+  /**
+   * 通过 rpcProtocol 传递消息的超时时间
+   * 默认 -1，即不配置超时时间
+   */
+  rpcMessageTimeout?: number;
 }
 
 export interface AppConfig extends Partial<Config> {

--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -109,8 +109,8 @@ interface Config {
    */
   disableKeytar?: boolean;
   /**
-   * 通过 rpcProtocol 传递消息的超时时间
-   * 默认 -1，即不配置超时时间
+   * control rpcProtocol message timeout
+   * default -1，it means disable
    */
   rpcMessageTimeout?: number;
 }

--- a/packages/extension/src/browser/extension-node.service.ts
+++ b/packages/extension/src/browser/extension-node.service.ts
@@ -193,6 +193,7 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
     const mainThreadProtocol = new RPCProtocol({
       onMessage,
       send,
+      timeout: this.appConfig.rpcMessageTimeout,
     });
 
     // 重启/重连时直接覆盖前一个连接

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -193,6 +193,7 @@ export class WorkerExtProcessService
       {
         onMessage,
         send: port.postMessage.bind(port),
+        timeout: this.appConfig.rpcMessageTimeout,
       },
       this.logger,
     );

--- a/packages/extension/src/common/ext.host.proxy.ts
+++ b/packages/extension/src/common/ext.host.proxy.ts
@@ -122,6 +122,11 @@ export interface IExtHostProxyOptions {
    * 默认 1000ms
    */
   retryTime?: number;
+   /**
+   * 通过 rpcProtocol 传递消息的超时时间
+   * 默认 -1，即不配置超时时间
+   */
+   rpcMessageTimeout?: number;
 }
 
 /**

--- a/packages/extension/src/common/ext.host.proxy.ts
+++ b/packages/extension/src/common/ext.host.proxy.ts
@@ -122,9 +122,9 @@ export interface IExtHostProxyOptions {
    * 默认 1000ms
    */
   retryTime?: number;
-   /**
-   * 通过 rpcProtocol 传递消息的超时时间
-   * 默认 -1，即不配置超时时间
+  /**
+   * control rpcProtocol message timeout
+   * default -1，it means disable
    */
    rpcMessageTimeout?: number;
 }

--- a/packages/extension/src/hosted/ext.host.proxy-base.ts
+++ b/packages/extension/src/hosted/ext.host.proxy-base.ts
@@ -142,6 +142,7 @@ export class ExtHostProxy extends Disposable implements IExtHostProxy {
     this.protocol = new RPCProtocol({
       onMessage,
       send,
+      timeout: this.options.rpcMessageTimeout,
     });
     this.extServerProxy = this.protocol.getProxy(EXT_SERVER_IDENTIFIER);
     const extHostProxyRPCService = new ExtHostProxyRPCService(this.extServerProxy);

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -71,8 +71,8 @@ export interface ExtProcessConfig {
   customDebugChildProcess?: CustomChildProcessModule;
   customVSCodeEngineVersion?: string;
    /**
-   * 通过 rpcProtocol 传递消息的超时时间
-   * 默认 -1，即不配置超时时间
+   * control rpcProtocol message timeout
+   * default -1，it means disable
    */
    rpcMessageTimeout?: number;
 }

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -70,9 +70,14 @@ export interface ExtProcessConfig {
   builtinCommands?: IBuiltInCommand[];
   customDebugChildProcess?: CustomChildProcessModule;
   customVSCodeEngineVersion?: string;
+   /**
+   * 通过 rpcProtocol 传递消息的超时时间
+   * 默认 -1，即不配置超时时间
+   */
+   rpcMessageTimeout?: number;
 }
 
-async function initRPCProtocol(extInjector): Promise<any> {
+async function initRPCProtocol(extInjector: Injector): Promise<any> {
   const extCenter = new RPCServiceCenter();
   const { getRPCService } = initRPCService<{
     onMessage(msg: string): void;
@@ -92,9 +97,12 @@ async function initRPCProtocol(extInjector): Promise<any> {
   const onMessage = onMessageEmitter.event;
   const send = service.onMessage;
 
+  const appConfig = extInjector.get(AppConfig);
+
   const extProtocol = new RPCProtocol({
     onMessage,
     send,
+    timeout: appConfig.rpcMessageTimeout,
   });
 
   logger = new ExtensionLogger2(extInjector); // new ExtensionLogger(extProtocol);

--- a/packages/extension/src/node/extension.host.proxy.manager.ts
+++ b/packages/extension/src/node/extension.host.proxy.manager.ts
@@ -4,7 +4,7 @@ import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { getRPCService, RPCProtocol, IRPCProtocol } from '@opensumi/ide-connection';
 import { createSocketConnection } from '@opensumi/ide-connection/lib/node';
 import { MaybePromise, Emitter, IDisposable, toDisposable, Disposable } from '@opensumi/ide-core-common';
-import { RPCServiceCenter, INodeLogger } from '@opensumi/ide-core-node';
+import { RPCServiceCenter, INodeLogger, AppConfig } from '@opensumi/ide-core-node';
 
 import {
   IExtensionHostManager,
@@ -20,6 +20,9 @@ import {
 export class ExtensionHostProxyManager implements IExtensionHostManager {
   @Autowired(INodeLogger)
   private readonly logger: INodeLogger;
+
+  @Autowired(AppConfig)
+  private readonly appconfig: AppConfig;
 
   private callId = 0;
 
@@ -96,6 +99,7 @@ export class ExtensionHostProxyManager implements IExtensionHostManager {
     this.extHostProxyProtocol = new RPCProtocol({
       onMessage,
       send,
+      timeout: this.appconfig.rpcMessageTimeout,
     });
 
     this.extHostProxyProtocol.set(EXT_SERVER_IDENTIFIER, {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c6e488</samp>

*  Removed the default timeout constant for the RPC protocol and made it configurable through an option passed to the RPC protocol constructor ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-522a4882f23d9ac7a77c4ad070bf82b9c120629972de2022a6e242f82835dfc9L206-L207), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-522a4882f23d9ac7a77c4ad070bf82b9c120629972de2022a6e242f82835dfc9L284-R289), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c6afdf1c17d668e4d1713e0457fe67213b43d93fa77d2d3c12f6c00c14264d0fR145), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L95-R105))
* Added a check for the timeout option in the RPC protocol constructor and set a timeout callback for the pending reply only if the option is present and not equal to -1 ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-522a4882f23d9ac7a77c4ad070bf82b9c120629972de2022a6e242f82835dfc9L284-R289))
* Included the callId in the error message when a timeout occurs in the RPC protocol ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-522a4882f23d9ac7a77c4ad070bf82b9c120629972de2022a6e242f82835dfc9L414-R413))
* Modified the app config interface in both the core browser and core node modules to include an optional rpcMessageTimeout property ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c66c7c7b4694041a7ce63e5969c2fc5581d0153e0096dcb7bf2a55e72fb83f16R250-R254), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-ba6113f325d2a25dde9ff86ee60a9f135812350bb241d68d4a0a05c3dc6d3e4cR111-R115))
* Modified the client and server app constructors in the core browser and core node modules to accept an optional rpcMessageTimeout option and pass it to the RPC protocol constructor ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c9fea04c9a1af5f597c5869333d09baa062a5278ae4a0281d2b977d0d0501b2eR142), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-3b0a46e1b06590eb974b8dd6c73d012bce362456f0e1b156c448502d5dd2a892R81))
* Modified the extension host proxy options interface to include an optional rpcMessageTimeout property ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-b46ada9ebb3fd79d7a7f3549bf9334192450436d2a8e7a526522bed260947ec7R125-R129))
* Modified the extension host proxy constructor to pass the rpcMessageTimeout option to the RPC protocol constructor ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c6afdf1c17d668e4d1713e0457fe67213b43d93fa77d2d3c12f6c00c14264d0fR145))
* Modified the extension process config interface to include an optional rpcMessageTimeout property ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L73-R80))
* Modified the extension process RPC protocol initialization function to get the app config from the injector and pass the rpcMessageTimeout value to the RPC protocol constructor ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L95-R105))
* Modified the extension host proxy manager class to inject the app config as a dependency and pass the rpcMessageTimeout value to the extension host proxy constructor ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-d72c5ae35b25af3325da1b927583e801d2f453199bc70571ec6b62c4d989c3e2L7-R7), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-d72c5ae35b25af3325da1b927583e801d2f453199bc70571ec6b62c4d989c3e2R24-R26), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-d72c5ae35b25af3325da1b927583e801d2f453199bc70571ec6b62c4d989c3e2R102))
* Modified the node and worker extension process services in the extension browser module to pass the app config rpcMessageTimeout value to the extension host proxy constructor ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-ab17d1df93e5b972f583aa7d8259d9b6ba87ea06caab00dde62d953b21b496c3R196), [link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-56c70608623e5329d4b53a62c8d82b065f5c5b4ddf3aab359a8c22b6bc354016R196))
* Updated the test case for the RPC timeout scenario in the connection node module to use `toThrow` instead of `toBe` to match the error type thrown by the RPC protocol ([link](https://github.com/opensumi/core/pull/2709/files?diff=unified&w=0#diff-0fd24c44d0810b0cd113f46e99462e64845e46748835ab7442d10a10307d9e7bL269-R269))

<!-- Additional content -->
<!-- 补充额外内容 -->

* 在 appConfig 增加配置项 `rpcMessageTimeout`，用来配置消息超时事件
* 默认不开启超时配置

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c6e488</samp>

This pull request makes the RPC protocol timeout configurable and adds more error details. It introduces an optional `rpcMessageTimeout` property to the app config and the extension host proxy options, and passes it to the RPC protocol constructor. It also includes the callId in the timeout error message and updates the test case accordingly.
