### PR TITLE
fix: modify the extra button.foreground key

### DIFF
--- a/packages/theme/src/common/color-tokens/button.ts
+++ b/packages/theme/src/common/color-tokens/button.ts
@@ -43,7 +43,7 @@ export const buttonBorder = registerColor(
 );
 /** secondary button */
 export const buttonSecondaryForeground = registerColor(
-  'button.foreground',
+  'button.secondaryForeground',
   {
     dark: Color.white,
     light: Color.white,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8fe2d31</samp>

* Rename the secondary button foreground color token to `button.secondaryForeground` for clarity and consistency ([link](https://github.com/opensumi/core/pull/2715/files?diff=unified&w=0#diff-e784f56b7f92f21e2c646104239d024877941e4cb12e3e8e0b3025fe7f095569L46-R46))

<!-- Additional content -->
<!-- 补充额外内容 -->

issue: https://github.com/opensumi/core/issues/2714

代码里声明了两个`button.foreground`，其中一个应该为`button.secondaryForeground`

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8fe2d31</samp>

Renamed a color token for secondary button foreground to improve clarity and consistency. Updated theme system and button component to use the new token name.
