### PR TITLE
fix: convertEmbeddedLanguages should not activate language

### DIFF
--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -489,10 +489,6 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
       const scope = scopes[i];
       const langId = languages[scope];
       result[scope] = getEncodedLanguageId(langId);
-      // TODO 后置到 tokenize 使用到对应的 scope 时激活（vscode逻辑），现在先激活一个 language 时激活所有 embed language
-      if (!this.activatedLanguage.has(langId)) {
-        this.activateLanguage(langId);
-      }
     }
     return result;
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22218ec</samp>

* Implement lazy loading of embedded languages for textmate tokenizer (`packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts`)
  - Remove unused code and comment that activates all embedded languages when activating a language ([link](https://github.com/opensumi/core/pull/2717/files?diff=unified&w=0#diff-5af6e8d3cdc315542de48fc08f4510a791304733c2c8e8549999d31e7dba78d1L492-L495))

<!-- Additional content -->


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22218ec</samp>

Improve textmate tokenizer performance by lazy loading embedded languages. Remove unused code and comment from `textmate.service.ts`.
