### PR TITLE
WIP: fix: error when render markdown

### DIFF
--- a/packages/components/src/markdown/index.tsx
+++ b/packages/components/src/markdown/index.tsx
@@ -1,6 +1,7 @@
-import { sanitize } from 'dompurify';
 import { marked, Renderer } from 'marked';
 import React from 'react';
+
+import { toMarkdownHtml } from '../utils/marked';
 
 import { DATA_SET_COMMAND, IOpenerShape, RenderWrapper } from './render';
 
@@ -20,7 +21,7 @@ export class DefaultMarkedRenderer extends Renderer {
 }
 
 export function Markdown(props: IMarkdownProps) {
-  const parseMarkdown = (text: string, renderer: any) => sanitize(marked.parse(text, { renderer }));
+  const parseMarkdown = (text: string, renderer: any) => toMarkdownHtml(text, { renderer });
 
   const [htmlContent, setHtmlContent] = React.useState(parseMarkdown(props.value, props.renderer));
 

--- a/packages/components/src/utils/dompurify.ts
+++ b/packages/components/src/utils/dompurify.ts
@@ -1,0 +1,20 @@
+import DOMPurify from 'dompurify';
+
+function importModule(requiredModule: any) {
+  return (requiredModule && requiredModule.default) || requiredModule;
+}
+
+function initDOMPurifyWithJSDOM() {
+  const DOMPurifyInitializer = importModule(require('dompurify'));
+  // jsdom 22.0 使用了 esm
+  const { JSDOM } = importModule(require('jsdom'));
+  const { window } = new JSDOM('<!DOCTYPE html>');
+  return DOMPurifyInitializer(window);
+}
+
+export function resolveDOMPurify() {
+  if (DOMPurify.isSupported) {
+    return DOMPurify;
+  }
+  return initDOMPurifyWithJSDOM() as DOMPurify.DOMPurifyI;
+}

--- a/packages/components/src/utils/marked.ts
+++ b/packages/components/src/utils/marked.ts
@@ -1,5 +1,12 @@
-import { sanitize } from 'dompurify';
 import { marked, Renderer } from 'marked';
+
+import { resolveDOMPurify } from './dompurify';
+
+const dompurifyInstance = resolveDOMPurify();
+
+export function sanitizeHtml(value: string) {
+  return dompurifyInstance.sanitize(value);
+}
 
 export type IMarkedOptions = marked.MarkedOptions;
 
@@ -11,10 +18,10 @@ export const parseMarkdown = (
   callback?: (error: any, parseResult: string) => void,
 ) => {
   if (!callback) {
-    return sanitize(marked.parse(value, options));
+    return sanitizeHtml(marked.parse(value, options));
   }
   const wrappedCallback = (error: any, parseResult: string) => {
-    callback(error, sanitize(parseResult));
+    callback(error, sanitizeHtml(parseResult));
   };
   if (options) {
     marked.parse(value, options, wrappedCallback);
@@ -23,4 +30,4 @@ export const parseMarkdown = (
   }
 };
 
-export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => sanitize(marked(value, options));
+export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => sanitizeHtml(marked(value, options));


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

![image](https://github.com/opensumi/core/assets/13938334/f2d24d35-9a8c-43d7-ace1-f949f49fadc8)

2.24 ts 补全函数的时候会报这个错。
查了一下是因为 #2591 引入的 dompurify 包不是这么用的。

<img width="1194" alt="CleanShot 2023-05-18 at 11 13 16@2x" src="https://github.com/opensumi/core/assets/13938334/0e9bd18e-06b5-48cd-acfc-ba84642a2e0f">

![image](https://github.com/opensumi/core/assets/13938334/1a04156e-3978-4317-93b0-f767da6d7fe1)

官方只支持在 Node 环境下搭配 JSDOM 使用 


### Changelog


fix `dompurify` in markdown components and utilities to support server-side rendering.
