### PR TITLE
style: improve problem panel style

### DIFF
--- a/packages/markers/src/browser/markers-tree.view.tsx
+++ b/packages/markers/src/browser/markers-tree.view.tsx
@@ -61,7 +61,6 @@ const MarkerList: FC<{ viewState: ViewState }> = ({ viewState }) => {
         height={viewState.height}
         itemHeight={MARKER_TREE_NODE_HEIGHT}
         supportDynamicHeights={true}
-        overflow={'auto'}
         onReady={handleTreeReady}
         model={model}
         placeholder={() => <Empty />}

--- a/packages/markers/src/browser/tree/marker-node.tsx
+++ b/packages/markers/src/browser/tree/marker-node.tsx
@@ -108,7 +108,7 @@ const MarkerItemDescription: FC<{ marker: IRenderableMarker }> = memo(({ marker 
         )}
         {marker.code && ')'}
       </div>
-      <div className={styles.position}>{`[${marker.startLineNumber},${marker.startColumn}]`}</div>
+      <div className={styles.position}>{`[Ln ${marker.startLineNumber}, Col ${marker.startColumn}]`}</div>
     </div>
   );
 });

--- a/packages/markers/src/browser/tree/tree-node.module.less
+++ b/packages/markers/src/browser/tree/tree-node.module.less
@@ -20,12 +20,15 @@
   .detail_name {
     color: var(--foreground);
     margin-right: 6px;
-    display: inline;
     white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .detail_description {
-    display: inline;
+    display: inline-flex;
+    flex-shrink: 0;
     margin-left: 5px;
     color: var(--descriptionForeground);
     .typeContainer {
@@ -116,12 +119,12 @@
 
   .overflow_wrap {
     flex: 1;
+    display: flex;
     flex-shrink: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     text-align: left;
     color: var(--foreground);
+    flex-direction: row;
+    width: 0;
   }
 
   .flex_wrap {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

Preview:
<img width="1163" alt="image" src="https://github.com/opensumi/core/assets/9823838/cf20b98c-1192-4a7d-a0ff-5bab9862445f">

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cec1a1</samp>

* Fix a bug that causes the horizontal scrollbar to appear in the marker tree view by removing the `overflow: auto` property from the `div` element that wraps the tree nodes ([link](https://github.com/opensumi/core/pull/2727/files?diff=unified&w=0#diff-e10b8b7cb6a4c5886d7adfc088c88b37ba0c9f5834d403a43456a654437387dbL64))
* Improve the layout and alignment of the marker details by modifying the CSS styles for the `.detail_label` and `.detail_description` classes ([link](https://github.com/opensumi/core/pull/2727/files?diff=unified&w=0#diff-8b0db778d0b1212cbda2d74c2ffc39b7c77f50ef799408836bafa82f1ff16f4dL23-R31))
* Prevent the tree node label and icon from overlapping or exceeding the container width by making them flex items and setting the width of the wrapper to zero ([link](https://github.com/opensumi/core/pull/2727/files?diff=unified&w=0#diff-8b0db778d0b1212cbda2d74c2ffc39b7c77f50ef799408836bafa82f1ff16f4dL119-R127))
* Truncate the tree node label text if necessary by using the `text-overflow: ellipsis` property ([link](https://github.com/opensumi/core/pull/2727/files?diff=unified&w=0#diff-8b0db778d0b1212cbda2d74c2ffc39b7c77f50ef799408836bafa82f1ff16f4dL119-R127))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cec1a1</samp>

This pull request enhances the appearance and functionality of the marker tree view, which shows diagnostic and other information for the code editor. It fixes the issues of text overflow, alignment, and responsiveness in the `tree-node.module.less` file, and removes the unnecessary horizontal scrollbar in the `markers-tree.view.tsx` file.
