### PR TITLE
fix: execute command will throw wrong error

### DIFF
--- a/packages/core-common/src/command.ts
+++ b/packages/core-common/src/command.ts
@@ -321,7 +321,7 @@ export class CoreCommandRegistryImpl implements CoreCommandRegistry {
     const err = new Error(
       `The command '${commandId}' cannot be executed. There are no active handlers available for the command.${argsMessage}`,
     );
-    err.name = HANDLER_NOT_FOUND;
+    err.name = `${HANDLER_NOT_FOUND}:${commandId}`;
     throw err;
   }
 

--- a/packages/editor/src/browser/monaco-contrib/command/command.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/command/command.service.ts
@@ -111,8 +111,8 @@ export class MonacoCommandService implements IMonacoCommandService {
       this._onDidExecuteCommand.fire({ commandId, args });
       return res;
     } catch (err) {
-      // 如果不是 handler 未找到直接抛错，否则执行 delegate 逻辑
-      if (err?.name !== HANDLER_NOT_FOUND) {
+      // 如果不是当前命令的 handler 未找到直接抛错，否则执行 delegate 逻辑
+      if (err?.name !== `${HANDLER_NOT_FOUND}:${commandId}`) {
         throw err;
       }
     }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

如果 execCommand 执行了一个 command A, 这个 command A 的内部又执行了一次 command B，此时应该是要报出 B 找不到，实际上会报错 A 命令找不到。

### Changelog

execute command will throw wrong error