### PR TITLE
feat: launch UI support delete properties

### DIFF
--- a/packages/debug/src/browser/preferences/components/fields/object-filed.tsx
+++ b/packages/debug/src/browser/preferences/components/fields/object-filed.tsx
@@ -23,7 +23,7 @@ export const ObjectField = <T = any, S extends StrictRJSFSchema = RJSFSchema, F 
 
     // 仅处理 root 节点
     if ($id === 'root') {
-      disabled.addDispose(launchService.onAddNewProperties((newFormData) => onChange(newFormData as T)));
+      disabled.addDispose(launchService.onChangeFormData((newFormData) => onChange(newFormData as T)));
     }
 
     return () => disabled.dispose();

--- a/packages/debug/src/browser/preferences/launch.module.less
+++ b/packages/debug/src/browser/preferences/launch.module.less
@@ -63,7 +63,7 @@
     .launch_schema_body_container {
       overflow: auto;
       height: 100%;
-      padding: 0 16px 12px 16px;
+      padding: 0 16px 12px 0px;
     }
   }
 }

--- a/packages/debug/src/browser/preferences/launch.service.ts
+++ b/packages/debug/src/browser/preferences/launch.service.ts
@@ -72,10 +72,6 @@ export class LaunchService implements ILaunchService {
     const { properties } = this.schema;
     const newFormData = { ...this.formData };
 
-    if (!properties![name] || !newFormData[name]) {
-      return;
-    }
-
     delete newFormData[name];
     delete properties![name];
 

--- a/packages/debug/src/browser/preferences/launch.service.ts
+++ b/packages/debug/src/browser/preferences/launch.service.ts
@@ -1,29 +1,85 @@
-import { RJSFSchema } from '@rjsf/utils';
+import { GenericObjectType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import lodashGet from 'lodash/get';
+import lodashSet from 'lodash/set';
 
 import { Injectable, Autowired } from '@opensumi/di';
 import { Emitter, Event, IJSONSchema } from '@opensumi/ide-core-common';
 
 import { ILaunchService } from '../../common/debug-service';
 
+type TFormData = { [key in string]: any };
+
 @Injectable()
 export class LaunchService implements ILaunchService {
-  private readonly _onChangeSchemaProperties = new Emitter<IJSONSchema>();
-  public readonly onChangeSchemaProperties: Event<IJSONSchema> = this._onChangeSchemaProperties.event;
+  private readonly _onRawSchemaProperties = new Emitter<IJSONSchema>();
+  public readonly onRawSchemaProperties: Event<IJSONSchema> = this._onRawSchemaProperties.event;
 
-  private readonly _onAddNewProperties = new Emitter<IJSONSchema>();
-  public readonly onAddNewProperties: Event<IJSONSchema> = this._onAddNewProperties.event;
+  private readonly _onChangeSchema = new Emitter<StrictRJSFSchema>();
+  public readonly onChangeSchema: Event<StrictRJSFSchema> = this._onChangeSchema.event;
 
-  private _currentSchemaProperties: IJSONSchema;
-  public get currentSchemaProperties(): IJSONSchema {
-    return this._currentSchemaProperties;
+  private readonly _onChangeFormData = new Emitter<TFormData>();
+  public readonly onChangeFormData: Event<TFormData> = this._onChangeFormData.event;
+
+  private _rawSchemaProperties: IJSONSchema;
+  private _schema: StrictRJSFSchema;
+  private _formData: TFormData;
+
+  public get rawSchemaProperties(): IJSONSchema {
+    return this._rawSchemaProperties;
+  }
+  public get schema(): StrictRJSFSchema {
+    return this._schema;
+  }
+  public get formData(): TFormData {
+    return this._formData;
   }
 
-  public setCurrentSchemaProperties(sp: IJSONSchema) {
-    this._currentSchemaProperties = sp;
-    this._onChangeSchemaProperties.fire(sp);
+  public setRawSchemaProperties(sp: IJSONSchema) {
+    this._rawSchemaProperties = sp;
+    this._onRawSchemaProperties.fire(sp);
   }
 
-  public nextNewFormData(data: IJSONSchema): void {
-    this._onAddNewProperties.fire(data);
+  public nextNewSchema(data: StrictRJSFSchema): void {
+    this._schema = data;
+    this._onChangeSchema.fire(data);
+  }
+
+  public nextNewFormData(data: TFormData): void {
+    this._formData = data;
+    this._onChangeFormData.fire(data);
+  }
+
+  public addNewItem(name: string): void {
+    if (name === '') {
+      return;
+    }
+
+    const { properties } = this.rawSchemaProperties;
+    const newFormData = { ...this.formData };
+
+    lodashSet(newFormData as GenericObjectType, name, properties![name]['default'] || '');
+    lodashSet(this.schema.properties!, name, properties![name]);
+
+    this.nextNewSchema(this.schema);
+    this.nextNewFormData(newFormData);
+  }
+
+  public delItem(name: string): void {
+    if (name === '') {
+      return;
+    }
+
+    const { properties } = this.schema;
+    const newFormData = { ...this.formData };
+
+    if (!properties![name] || !newFormData[name]) {
+      return;
+    }
+
+    delete newFormData[name];
+    delete properties![name];
+
+    this.nextNewSchema(this.schema);
+    this.nextNewFormData(newFormData);
   }
 }

--- a/packages/debug/src/browser/preferences/launch.view.tsx
+++ b/packages/debug/src/browser/preferences/launch.view.tsx
@@ -238,8 +238,10 @@ const LaunchBody = ({
       return ajv!.validate(oneOf, body);
     });
 
+    launchService.nextNewFormData(snippetItem.body);
+
     if (findOneOf) {
-      launchService.setCurrentSchemaProperties(findOneOf);
+      launchService.setRawSchemaProperties(findOneOf);
       setSchemaProperties(findOneOf);
     }
   }, [snippetItem, schemaContributions]);
@@ -250,7 +252,7 @@ const LaunchBody = ({
     }
 
     const { label, body, description } = snippetItem;
-    const { properties } = schemaProperties;
+    const { properties, required } = schemaProperties;
 
     const snippetProperties = Object.keys(body).reduce((pre: IJSONSchemaMap, cur: string) => {
       const curProp = properties![cur];
@@ -283,12 +285,17 @@ const LaunchBody = ({
       return pre;
     }, {});
 
-    return {
+    const schema = {
       title: label,
       type: 'object',
+      required,
       description,
       properties: snippetProperties,
     } as StrictRJSFSchema;
+
+    launchService.nextNewSchema(schema);
+
+    return schema;
   }, [snippetItem, schemaProperties]);
 
   const hanldeAddItem = useCallback(
@@ -302,13 +309,7 @@ const LaunchBody = ({
       }
 
       const { label } = item;
-      const { properties } = schemaProperties;
-      const newFormData = { ...snippetItem.body };
-
-      lodashSet(newFormData as GenericObjectType, label, properties[label]['default'] || '');
-      lodashSet(schema.properties, label, properties[label]);
-
-      launchService.nextNewFormData(newFormData);
+      launchService.addNewItem(label);
     },
     [snippetItem, schemaProperties, schema],
   );

--- a/packages/debug/src/browser/preferences/templates/button-template.tsx
+++ b/packages/debug/src/browser/preferences/templates/button-template.tsx
@@ -52,7 +52,7 @@ export const AddItemButton = (props: SubmitButtonProps & { onAddClick: (item: La
   const launchService = useInjectable<LaunchService>(ILaunchService);
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
   const [snippetMenu, setSnippetMenu] = React.useState<MenuNode[]>([]);
-  const { currentSchemaProperties } = launchService;
+  const { rawSchemaProperties: schemaProperties } = launchService;
 
   const handleVisibleChange = useCallback((visible: boolean) => setMenuOpen(visible), []);
 
@@ -62,7 +62,7 @@ export const AddItemButton = (props: SubmitButtonProps & { onAddClick: (item: La
   }, []);
 
   useEffect(() => {
-    if (!currentSchemaProperties || !currentSchemaProperties.properties) {
+    if (!schemaProperties || !schemaProperties.properties) {
       return;
     }
 
@@ -71,7 +71,7 @@ export const AddItemButton = (props: SubmitButtonProps & { onAddClick: (item: La
     }
 
     const disabled = new Disposable();
-    const { properties } = currentSchemaProperties;
+    const { properties } = schemaProperties;
     const { properties: existedProperties } = rootSchema;
 
     const updateMenu = () => {
@@ -83,18 +83,18 @@ export const AddItemButton = (props: SubmitButtonProps & { onAddClick: (item: La
       );
     };
 
-    disabled.addDispose(launchService.onAddNewProperties(() => updateMenu()));
+    disabled.addDispose(launchService.onChangeSchema(() => updateMenu()));
     updateMenu();
 
     return () => disabled.dispose();
-  }, [currentSchemaProperties, rootSchema]);
+  }, [schemaProperties, rootSchema]);
 
   return (
     <Button
       type='secondary'
       icon={defaultIconfont.plus}
       className={styles.add_new_field}
-      menu={<MenuActionList afterClick={handleMenuItemClick} data={snippetMenu} />}
+      menu={<MenuActionList afterClick={handleMenuItemClick} data={snippetMenu} style={{ maxHeight: 600 }} />}
       moreVisible={menuOpen}
       onVisibleChange={handleVisibleChange}
     >

--- a/packages/debug/src/browser/preferences/templates/json-templates.module.less
+++ b/packages/debug/src/browser/preferences/templates/json-templates.module.less
@@ -39,7 +39,41 @@
     }
 
     .property_wrapper {
+      margin-bottom: 0;
+    }
+
+    &.root_object_field_container {
       margin-bottom: 16px;
+
+      .object_title,
+      .object_description {
+        padding-left: 16px;
+      }
+
+      .property_wrapper {
+        padding: 16px;
+        position: relative;
+
+        .wrapper_delete {
+          display: none;
+          position: absolute;
+          cursor: pointer;
+          right: 16px;
+          top: 16px;
+
+          .close_icon {
+            font-size: 21px;
+            color: var(--kt-dangerButton-background);
+          }
+        }
+
+        &:hover {
+          background-color: var(--kt-tree-hoverBackground);
+          .wrapper_delete {
+            display: block;
+          }
+        }
+      }
     }
   }
 }
@@ -58,6 +92,7 @@
   max-width: 500px;
   width: 100%;
   border-style: dashed;
+  margin-left: 16px;
 }
 
 .additional_field_template {

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -168,7 +168,7 @@ export interface IDebugServiceContributionPoint {
 export const ILaunchService = Symbol('ILaunchService');
 
 export interface ILaunchService {
-  currentSchemaProperties: IJSONSchema | null;
+  rawSchemaProperties: IJSONSchema | null;
 }
 /**
  * launch view service end


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 189ad8a</samp>

*  Refactor the `LaunchService` class to use more descriptive and consistent names for its properties and methods, and add type annotations and comments ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322L1-R3),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322L8-R84))
*  Change the `ObjectField` component to listen to the `onChangeFormData` event instead of the `onAddNewProperties` event from the `launchService` ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-2f5bec71888440f0d76a4ffaf9cda0e21c0c188af4a0749a4fdf0a24c6650c3bL26-R26))
*  Change the `LaunchBody` component to use the `rawSchemaProperties`, `required`, `nextNewSchema`, and `addNewItem` properties and methods from the `launchService` to update the schema and the form data with the snippet item ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL241-R244),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL253-R255),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL286-R298),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL305-R312))
*  Change the `AddItemButton` component to use the `rawSchemaProperties` and `onChangeSchema` properties and events from the `launchService`, and add a `style` prop to the `MenuActionList` component to limit the menu height ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967L55-R55),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967L65-R65),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967L74-R74),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967L86-R90),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-44a1e5b7f9df9d26b77afac1161fdfd7150ea048277ed91f0a55763512916967L97-R97))
*  Change the `ObjectFieldTemplate` component to use the `useInjectable` hook to get the `launchService` instance, and render the object fields and properties with the delete button and the hover effect, using the `fieldContainerClass`, `handleDelProperties`, and `renderProperties` variables ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deL12-R26),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deR70),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deL69-R122),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-293c8af0ffda57fcd1e7c10e376a2886b6299fbe7d91deb179215731ea40d3deL96-R149))
*  Add some styles to the `launch.module.less` and `json-templates.module.less` files to adjust the padding, margin, background, and alignment of the launch configuration editor elements ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-1c9f4efbfc56bf5e861ebb6f10ddd4b5e01574289aceee3140b103097513ca47L66-R66),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-0b47ea19c9728a74dab1d95d912bbfb2059e790bb2eeb5d49963010a73ee4b2dL42-R76),[link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-0b47ea19c9728a74dab1d95d912bbfb2059e790bb2eeb5d49963010a73ee4b2dR95))
*  Rename the `currentSchemaProperties` property to `rawSchemaProperties` in the `ILaunchService` interface in the `debug-service.ts` file ([link](https://github.com/opensumi/core/pull/2736/files?diff=unified&w=0#diff-e46ef78aeea2baa9ef9a7eeba249f31bf0f8b947c1dff4454ab5cbe1f980df22L171-R171))

<!-- Additional content -->
![Kapture 2023-05-19 at 17 00 23](https://github.com/opensumi/core/assets/20262815/31843b64-f825-4353-a009-1e935ee521c7)

- [x] 支持删除非必填的配置项
- [x] 改进 UI，优化 hover 样式，便于分辨不同配置项

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 189ad8a</samp>

This pull request refactors and improves the launch configuration editor for the debug extension. It enhances the readability, consistency, and type safety of the `LaunchService` class and its consumers, such as the `LaunchBody` and `ObjectFieldTemplate` components. It also improves the UI and UX of the JSON templates editor by adding styles, layout, and delete functionality. It renames a property in the `ILaunchService` interface to match the implementation.
