### PR TITLE
feat: support for mutual open between launch.json and launch editor

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -282,6 +282,7 @@ export namespace COMMON_COMMANDS {
 
   export const OPEN_LAUNCH_CONFIGURATION: Command = {
     id: 'core.launchConfiguration.open',
+    label: '%debug.action.open.configuration%',
   };
 
   export const ENVIRONMENT_VARIABLE: Command = {

--- a/packages/debug/src/browser/components/floating-click-widget/index.module.less
+++ b/packages/debug/src/browser/components/floating-click-widget/index.module.less
@@ -2,4 +2,8 @@
   position: absolute;
   right: 50px;
   bottom: 30px;
+
+  * + * {
+    margin-left: 12px;
+  }
 }

--- a/packages/debug/src/browser/components/floating-click-widget/index.tsx
+++ b/packages/debug/src/browser/components/floating-click-widget/index.tsx
@@ -9,12 +9,15 @@ import { DebugConfigurationService } from '../../view/configuration/debug-config
 import styles from './index.module.less';
 
 export const FloatingClickWidget = (_: React.HtmlHTMLAttributes<HTMLDivElement>) => {
-  const { addConfiguration } = useInjectable<DebugConfigurationService>(DebugConfigurationService);
+  const { addConfiguration, openLaunchEditor } = useInjectable<DebugConfigurationService>(DebugConfigurationService);
 
   return (
     <div className={styles.floating_click_widget}>
       <Button onClick={addConfiguration} size='large'>
         {localize('debug.action.add.configuration')}
+      </Button>
+      <Button onClick={openLaunchEditor} size='large'>
+        {localize('debug.action.open.launch.editor')}
       </Button>
     </div>
   );

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -32,7 +32,7 @@ import { DebugServer, IDebugServer, IDebuggerContribution, launchSchemaUri } fro
 import { DebugSessionOptions } from '../common';
 import { DebugConfiguration } from '../common';
 
-import { CONTEXT_DEBUGGERS_AVAILABLE } from './../common/constants';
+import { CONTEXT_DEBUGGERS_AVAILABLE, LAUNCH_VIEW_SCHEME } from './../common/constants';
 import { DebugConfigurationModel } from './debug-configuration-model';
 import { DebugPreferences } from './debug-preferences';
 
@@ -266,6 +266,21 @@ export class DebugConfigurationManager {
     }
   }
 
+  async openLaunchEditor(): Promise<void> {
+    if (!this.model) {
+      return;
+    }
+
+    const uri = this.model.uri;
+    if (!uri) {
+      return;
+    }
+
+    await this.workbenchEditorService.open(uri.withScheme(LAUNCH_VIEW_SCHEME), {
+      disableNavigate: true,
+    });
+  }
+
   async addConfiguration(uri?: string): Promise<void> {
     let model: DebugConfigurationModel | undefined;
     if (uri) {
@@ -361,7 +376,7 @@ export class DebugConfigurationManager {
     if (!uri) {
       uri = await this.doCreate(model);
     }
-    return this.workbenchEditorService.open(uri.withScheme('launch_view_scheme'), {
+    return this.workbenchEditorService.open(uri, {
       disableNavigate: true,
     });
   }

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -86,6 +86,10 @@ import { DebugVariableView } from './view/variables/debug-variables.view';
 import { DebugWatchView } from './view/watch/debug-watch.view';
 
 const LAUNCH_JSON_REGEX = /launch\.json$/;
+enum LAUNCH_OPEN {
+  json,
+  editor,
+}
 
 export namespace DebugBreakpointWidgetCommands {
   export const ACCEPT = {
@@ -357,7 +361,11 @@ export class DebugContribution
 
   registerCommands(commands: CommandRegistry) {
     commands.registerCommand(COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION, {
-      execute: () => {
+      execute: (type: LAUNCH_OPEN = LAUNCH_OPEN.json) => {
+        if (type === LAUNCH_OPEN.editor) {
+          return this.debugConfigurationService.openLaunchEditor();
+        }
+
         this.debugConfigurationService.openConfiguration();
       },
     });

--- a/packages/debug/src/browser/preferences/launch-preferences-contribution.ts
+++ b/packages/debug/src/browser/preferences/launch-preferences-contribution.ts
@@ -8,7 +8,10 @@ import {
   MaybePromise,
   localize,
   getIcon,
+  COMMON_COMMANDS,
 } from '@opensumi/ide-core-browser';
+import { IMenuRegistry, MenuContribution } from '@opensumi/ide-core-browser/lib/menu/next/base';
+import { MenuId } from '@opensumi/ide-core-browser/lib/menu/next/menu-id';
 import {
   BrowserEditorContribution,
   EditorComponentRegistry,
@@ -18,11 +21,10 @@ import {
   ResourceService,
 } from '@opensumi/ide-editor/lib/browser';
 
+import { LAUNCH_VIEW_COMPONENT_ID, LAUNCH_VIEW_SCHEME } from '../../common/constants';
+
 import { launchPreferencesSchema } from './launch-preferences';
 import { LaunchViewContainer } from './launch.view';
-
-const LAUNCH_VIEW_SCHEME = 'launch_view_scheme';
-const LAUNCH_VIEW_COMPONENT_ID = 'launch-view';
 
 @Injectable()
 export class LaunchResourceProvider implements IResourceProvider {
@@ -46,9 +48,9 @@ export class LaunchResourceProvider implements IResourceProvider {
   }
 }
 
-@Domain(PreferenceContribution, PreferenceConfiguration, BrowserEditorContribution)
+@Domain(PreferenceContribution, PreferenceConfiguration, BrowserEditorContribution, MenuContribution)
 export class LaunchPreferencesContribution
-  implements PreferenceContribution, PreferenceConfiguration, BrowserEditorContribution
+  implements PreferenceContribution, PreferenceConfiguration, BrowserEditorContribution, MenuContribution
 {
   @Autowired(LaunchResourceProvider)
   private readonly prefResourceProvider: LaunchResourceProvider;
@@ -74,6 +76,15 @@ export class LaunchPreferencesContribution
           componentId: LAUNCH_VIEW_COMPONENT_ID,
         },
       ]);
+    });
+  }
+
+  registerMenus(menus: IMenuRegistry) {
+    menus.registerMenuItem(MenuId.EditorTitle, {
+      command: COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION.id,
+      iconClass: getIcon('open'),
+      group: 'navigation',
+      when: `resourceScheme == ${LAUNCH_VIEW_SCHEME}`,
     });
   }
 }

--- a/packages/debug/src/browser/view/configuration/debug-configuration.service.ts
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.service.ts
@@ -129,6 +129,10 @@ export class DebugConfigurationService {
     this.debugConfigurationManager.openConfiguration(uri);
   };
 
+  openLaunchEditor = () => {
+    this.debugConfigurationManager.openLaunchEditor();
+  };
+
   openDebugConsole = () => {
     this.debugConsoleService.activate();
   };

--- a/packages/debug/src/common/constants.ts
+++ b/packages/debug/src/common/constants.ts
@@ -5,6 +5,9 @@ import { DebugState } from './debug-session';
 
 export { DEBUG_CONSOLE_CONTAINER_ID, DEBUG_CONTAINER_ID };
 
+export const LAUNCH_VIEW_SCHEME = 'launch_view_scheme';
+export const LAUNCH_VIEW_COMPONENT_ID = 'launch-view';
+
 export const DEBUG_MEMORY_SCHEME = 'vscode-debug-memory';
 
 export const DEBUG_WATCH_ID = 'debug-watch';

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -278,6 +278,7 @@ export const localizationBundle = {
     'scm.dirtyDiff.changes': '{0} of {1} changes',
 
     'debug.action.add.configuration': 'Add Configuration...',
+    'debug.action.open.launch.editor': 'Open in launch editor',
     'debug.action.no.configuration': 'No Configurations',
     'debug.action.start': 'Start Debugging',
     'debug.action.open.configuration': 'Open launch.json',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -251,6 +251,7 @@ export const localizationBundle = {
     'debug.action.start': '启动调试',
     'debug.action.no.configuration': '暂无配置',
     'debug.action.add.configuration': '添加配置...',
+    'debug.action.open.launch.editor': '在 launch 编辑器中打开',
     'debug.action.open.configuration': '打开 launch.json',
     'debug.action.debug.console': '调试控制台',
     'debug.action.step-into': '单步跳入',


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa5f3e2</samp>

*  Add a label property to the `COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION` command, which is used to display the command name in the UI ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-a688102e10b7d594a046a44531865122eaa41ed5f4b5bd53eeb7f1f9f499507cR285))
*  Add a new enum `LAUNCH_OPEN` to indicate the type of view to open when executing the `COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION` command ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-3c78853637bd4f37b7541026444e751a0505bbb992a41a7a3c102c078a5b52daR89-R92))
*  Modify the `registerCommands` method of the `DebugContribution` class to accept a parameter of type `LAUNCH_OPEN` for the `COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION` command, and call the appropriate method of the `debugConfigurationService` to open the launch editor view or the JSON file of the debug configurations ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-3c78853637bd4f37b7541026444e751a0505bbb992a41a7a3c102c078a5b52daL360-R368))
*  Add a new method `openLaunchEditor` to the `DebugConfigurationManager` class, which opens the launch editor view for editing the debug configurations using a custom URI scheme ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-b27035a578a9c21d5dc65a6ee51452716d34fbb1346ff4a85e467c876245bd57R269-R283))
*  Modify the `addConfiguration` method of the `DebugConfigurationManager` class to open the JSON file of the debug configurations instead of the launch editor view when adding a new configuration ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-b27035a578a9c21d5dc65a6ee51452716d34fbb1346ff4a85e467c876245bd57L364-R379))
*  Add a new property `openLaunchEditor` to the `DebugConfigurationService` class, which exposes the `openLaunchEditor` method of the `debugConfigurationManager` to the `DebugContribution` class ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-656d2f64adc8ddeeb6813a90440a33e6acca8f7803472de2db077370912d4d52R132-R135))
*  Add a new button to the `FloatingClickWidget` component, which calls the `openLaunchEditor` method of the `DebugConfigurationService` to open the launch editor view ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-adb3cebdda901c19e6a689f06fedbc66c64a3e51a25da655ae649961b46099c4R19-R21))
*  Add a dependency injection of the `openLaunchEditor` method to the `FloatingClickWidget` component ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-adb3cebdda901c19e6a689f06fedbc66c64a3e51a25da655ae649961b46099c4L12-R12))
*  Add a new menu item to the `MenuId.EditorTitle` location, which allows the user to switch between the launch editor view and the JSON file of the debug configurations using the `COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION` command ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-469d2164fd977fac513d47f5fdae2bc3ec04d5896e3f576b075504a9c0e981afR81-R89))
*  Add the `MenuContribution` interface to the `@Domain` decorator of the `LaunchPreferencesContribution` class, indicating that the class also provides menu contributions to the workbench ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-469d2164fd977fac513d47f5fdae2bc3ec04d5896e3f576b075504a9c0e981afL49-R53))
*  Add a CSS rule to create some spacing between the buttons in the floating widget ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-3127f12c893dc4252013166129dd674ab7d2dfed9b8a257410585fc7134b33fdR5-R8))
*  Import the `LAUNCH_VIEW_SCHEME` and `LAUNCH_VIEW_COMPONENT_ID` constants from the `packages/debug/src/common/constants.ts` file, where they are defined, instead of duplicating them in the `packages/debug/src/browser/preferences/launch-preferences-contribution.ts` file ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-469d2164fd977fac513d47f5fdae2bc3ec04d5896e3f576b075504a9c0e981afL21-R28))
*  Import the `LAUNCH_VIEW_SCHEME` constant from the `packages/debug/src/common/constants.ts` file, where it is defined, instead of duplicating it in the `packages/debug/src/browser/debug-configuration-manager.ts` file ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-b27035a578a9c21d5dc65a6ee51452716d34fbb1346ff4a85e467c876245bd57L35-R35))
*  Import the `COMMON_COMMANDS`, `IMenuRegistry`, `MenuContribution`, and `MenuId` objects from the `@opensumi/ide-core-browser` package, which are used to access the `COMMON_COMMANDS.OPEN_LAUNCH_CONFIGURATION` command and register menu items to the workbench ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-469d2164fd977fac513d47f5fdae2bc3ec04d5896e3f576b075504a9c0e981afL11-R14))
*  Add new localization keys and values for the label of the button and the menu item that open the launch editor view in English and Chinese languages ([link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R281), [link](https://github.com/opensumi/core/pull/2738/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R254))

<!-- Additional content -->
`launch.json` to `launch editor`
![image](https://github.com/opensumi/core/assets/20262815/9792594c-d2e2-4ee4-b6d7-6c588967858a)

`launch editor` to `launch.json`
![image](https://github.com/opensumi/core/assets/20262815/e0ed3074-2cf7-48ee-b01c-6f8502d79050)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa5f3e2</samp>

This pull request adds a new feature to the debug package that allows users to edit the debug configurations in a launch editor view instead of a JSON file. It also adds a button to the floating widget and a menu item to the editor title bar that enable users to switch between the two views. It updates the command, service, manager, and preference classes to support the new feature, and adds some constants, styles, and localization keys and values.
