### PR TITLE
fix: add default debug server host

### DIFF
--- a/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
+++ b/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
@@ -67,7 +67,7 @@ export function startDebugAdapter(
 export function connectDebugAdapter(server: vscode.DebugAdapterServer): DebugStreamConnection {
   const socket = net.createConnection({
     port: server.port,
-    host: server.host,
+    host: server.host || '127.0.0.1',
   });
   return {
     input: socket,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86c391b</samp>

*  Fix bug where debug adapter fails to connect to server if host is undefined or empty by using a default value of '127.0.0.1' ([link](https://github.com/opensumi/core/pull/2747/files?diff=unified&w=0#diff-a229a2a198824dfcb3c29558a9d4074f5fb893df37b25bf788c96242e859bffdL70-R70))

close #2745

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86c391b</samp>

Fix debug adapter connection issues in `opensumi/core` extension. Use a default host value in `connectDebugAdapter` function if none is provided by the server.
