### PR TITLE
style: remove marginRight when button is vertical

### DIFF
--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -95,6 +95,9 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
     }
     return () => disposer.dispose();
   }, []);
+
+  const btnTitleStyle = styles.btnTitleStyle || preferenceService.get('toolbar.buttonTitleStyle');
+  const isVerticalButton = styles.btnStyle === 'button' && btnTitleStyle === BUTTON_TITLE_STYLE.VERTICAL;
   const iconContent = !props.inDropDown ? (
     <div
       className={styles.iconClass + ' kt-toolbar-action-btn-icon'}
@@ -102,7 +105,7 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       style={{
         color: styles.iconForeground,
         backgroundColor: styles.iconBackground,
-        marginRight: styles.showTitle ? 5 : 0,
+        marginRight: styles.showTitle && !isVerticalButton ? 5 : 0,
         // 如果指定了按钮宽度，需要将padding清空，防止按钮比预期大 16px
         ...(styles.width ? { width: styles.width } : null),
         ...(styles.height ? { height: styles.height } : null),
@@ -159,7 +162,6 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       </div>
     );
   } else {
-    const btnTitleStyle = styles.btnTitleStyle || preferenceService.get('toolbar.buttonTitleStyle');
     if (styles.btnStyle === 'button' && btnTitleStyle !== BUTTON_TITLE_STYLE.VERTICAL) {
       buttonElement = (
         <Button type='default' size='small' {...bindings} {...backgroundBindings}>


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb3a18e</samp>

*  Add a variable `isVerticalButton` to determine the toolbar button title style ([link](https://github.com/opensumi/core/pull/2750/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998R98-R100))
*  Adjust the `marginRight` style of the button icon to avoid unnecessary spacing ([link](https://github.com/opensumi/core/pull/2750/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998L105-R108))
*  Remove the redundant declaration of the `btnTitleStyle` variable ([link](https://github.com/opensumi/core/pull/2750/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998L162))

fixed https://github.com/opensumi/core/pull/2699#issuecomment-1562696411.

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb3a18e</samp>

This pull request enhances the toolbar buttons in `core-browser` by refactoring the styling code and adding a new option for vertical titles.
