### PR TITLE
fix: input component defaultValue failed

### DIFF
--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -104,8 +104,8 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
   const [isDirty, setIsDirty] = React.useState(false);
 
   // handle initial value from `value` or `defaultValue`
-  const [inputValue, setInputValue] = React.useState<string>(() => (value ?? defaultValue) || '');
-  const [preValue, setPrevValue] = React.useState<string>(() => (value ?? defaultValue) || '');
+  const [inputValue, setInputValue] = React.useState<string>(() => (defaultValue ?? value) || '');
+  const [preValue, setPrevValue] = React.useState<string>(() => (defaultValue ?? value) || '');
 
   // make `ref` to input works
   React.useImperativeHandle(ref, () => inputRef.current!);

--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -91,7 +91,7 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
     persistFocus = true,
     hasClear,
     afterClear,
-    value = '',
+    value,
     onValueChange,
     onPressEnter,
     onKeyDown,
@@ -104,8 +104,8 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
   const [isDirty, setIsDirty] = React.useState(false);
 
   // handle initial value from `value` or `defaultValue`
-  const [inputValue, setInputValue] = React.useState<string>(() => (defaultValue ?? value) || '');
-  const [preValue, setPrevValue] = React.useState<string>(() => (defaultValue ?? value) || '');
+  const [inputValue, setInputValue] = React.useState<string>(() => (value ?? defaultValue) || '');
+  const [preValue, setPrevValue] = React.useState<string>(() => (value ?? defaultValue) || '');
 
   // make `ref` to input works
   React.useImperativeHandle(ref, () => inputRef.current!);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88e7ca1</samp>

*  Swap the order of `value` and `defaultValue` in the `useState` hooks for `inputValue` and `preValue` to fix a bug where the input value would not update when the `value` prop changes ([link](https://github.com/opensumi/core/pull/2751/files?diff=unified&w=0#diff-bb1200d7ed8bb83c25174fe4873865d715373eb69ee26d66eae4779bad778611L107-R108))

<!-- Additional content -->
由于 value 值默认是 '' 空字符串，导致 defaultValue 值永远都不会生效，这里调整 defaultValue 和 value 的优先级

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88e7ca1</samp>

Fix a bug in the `Input` component that prevented it from responding to external `value` changes. Swap the order of `value` and `defaultValue` in the `useState` hooks for `inputValue` and `preValue` in `Input.tsx`.
