### PR TITLE
feat: support xterm render type select

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -471,6 +471,9 @@ export const localizationBundle = {
     'preference.terminal.integrated.localEchoStyle': 'Local Echo Style',
     'preference.terminal.integrated.localEchoStyleDesc':
       'Terminal style of locally echoed text; either a font style or an RGB color.',
+    'preference.terminal.integrated.xtermRenderType': 'Xterm Render Type',
+    'preference.terminal.integrated.xtermRenderTypeDesc':
+      'Choose Xterm render type, Webgl for better performance, Canvas better compatibility',
     'preference.terminal.integrated.cursorStyle': 'Terminal > Cursor Style',
     'preference.terminal.integrated.cursorStyleDesc': 'Control the style of terminal cursor',
     'common.preference.open': 'Settings',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -452,6 +452,8 @@ export const localizationBundle = {
       '当在终端标题中找到其中一个程序名称时，将禁用本地回显。',
     'preference.terminal.integrated.localEchoStyle': '本地回显字体样式',
     'preference.terminal.integrated.localEchoStyleDesc': '本地回显文本的终端样式；字体样式或 RGB 颜色。',
+    'preference.terminal.integrated.xtermRenderType': 'Xterm 渲染类型',
+    'preference.terminal.integrated.xtermRenderTypeDesc': '选择 Xterm 渲染类型，WebGL 性能更强，Canvas 兼容性更佳。',
     'preference.terminal.integrated.cursorStyle': '终端输入指针样式',
     'preference.terminal.integrated.cursorStyleDesc': '修改终端输入指针样式',
     'settings.group.general': '常规',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -808,6 +808,7 @@ export const defaultSettingSections: {
           localized: 'preference.terminal.integrated.cursorStyle',
         },
         { id: 'terminal.integrated.localEchoStyle', localized: 'preference.terminal.integrated.localEchoStyle' },
+        { id: 'terminal.integrated.xtermRenderType', localized: 'preference.terminal.integrated.xtermRenderType' },
       ],
     },
   ],

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -80,10 +80,6 @@ export class XTerm extends Disposable implements IXTerm {
     this.raw.onSelectionChange(this.onSelectionChange.bind(this));
   }
 
-  private loadWebGLAddon() {
-    return !isSafari;
-  }
-
   protected async enableCanvasRenderer() {
     try {
       if (!this._canvasAddon) {

--- a/packages/terminal-next/src/common/preference.ts
+++ b/packages/terminal-next/src/common/preference.ts
@@ -121,6 +121,7 @@ export const enum CodeTerminalSettingId {
   LocalEchoEnabled = 'terminal.integrated.localEchoEnabled',
   LocalEchoExcludePrograms = 'terminal.integrated.localEchoExcludePrograms',
   LocalEchoStyle = 'terminal.integrated.localEchoStyle',
+  XtermRenderType = 'terminal.integrated.xtermRenderType',
   EnablePersistentSessions = 'terminal.integrated.enablePersistentSessions',
   PersistentSessionReviveProcess = 'terminal.integrated.persistentSessionReviveProcess',
   CustomGlyphs = 'terminal.integrated.customGlyphs',
@@ -325,6 +326,7 @@ export const terminalPreferenceSchema: PreferenceSchema = {
     [CodeTerminalSettingId.LocalEchoStyle]: {
       type: 'string',
       description: '%preference.terminal.integrated.localEchoStyleDesc%',
+      enum: ['bold', 'dim', 'italic', 'underlined', 'inverted'],
       default: 'dim',
     },
     [CodeTerminalSettingId.CursorStyle]: {
@@ -332,6 +334,12 @@ export const terminalPreferenceSchema: PreferenceSchema = {
       description: '%preference.terminal.integrated.cursorStyleDesc%',
       enum: [TerminalCursorStyle.BLOCK, TerminalCursorStyle.LINE, TerminalCursorStyle.UNDERLINE],
       default: TerminalCursorStyle.BLOCK,
+    },
+    [CodeTerminalSettingId.XtermRenderType]: {
+      type: 'string',
+      description: '%preference.terminal.integrated.xtermRenderTypeDesc%',
+      enum: ['webgl', 'canvas', 'dom'],
+      default: 'webgl',
     },
   },
 };


### PR DESCRIPTION
### Types

支持切换 Xterm 的渲染模式： WebGL / Canvas / DOM

另外修改 TypeAhead 的不同渲染模式设置到枚举模式

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b1a8e9</samp>

*  Add xterm render type preference to terminal module
  * Define preference id and schema in `packages/terminal-next/src/common/preference.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c1ed5d78a386f847107e56bdfa1704981305b09002593d3285e27eabbd50d8dcR124), [link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c1ed5d78a386f847107e56bdfa1704981305b09002593d3285e27eabbd50d8dcR338-R343))
  * Import preference id and service in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36R10), [link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L16-R17))
  * Inject preference service and use preference value to enable render type in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L51-R57), [link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L192-R199))
  * Change visibility of enable methods for render types in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L79-R83), [link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L102-R102))
  * Add preference to preference settings service in `packages/preferences/src/browser/preference-settings.service.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR811))
  * Add keys to `packages/i18n/src/common/en-US.lang.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R474-R476))
  * Add keys to `packages/i18n/src/common/zh-CN.lang.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R455-R456))
* Add enum constraint to cursorStyle preference in `packages/terminal-next/src/common/preference.ts` ([link](https://github.com/opensumi/core/pull/2752/files?diff=unified&w=0#diff-c1ed5d78a386f847107e56bdfa1704981305b09002593d3285e27eabbd50d8dcR329))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b1a8e9</samp>

This pull request adds a new user preference for the terminal module to choose the xterm render type, which affects how the terminal output is displayed. It also updates the localization files and the preference settings service to support the new preference. The changes improve the terminal performance and customization.
