### PR TITLE
fix: only add default color once

### DIFF
--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -668,7 +668,7 @@ class Theme implements ITheme {
   private patchTokenColors() {
     // 当默认颜色不在settings当中时，此处不能使用之前那种直接给encodedTokenColors赋值的做法，会导致monaco使用时颜色错位（theia的bug
     // scope 会在后续的流程中被补充为 [''] 所以直接进行初始化，防止判断有误
-    if (this.themeData.themeSettings.filter((setting) => JSON.stringify(setting.scope) === '[""]').length === 0) {
+    if (this.themeData.themeSettings.filter((setting) => setting.scope?.length === 1 && setting.scope[0] === '').length === 0) {
       this.themeData.themeSettings.unshift({
         settings: {
           foreground: this.themeData.colors['editor.foreground']

--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -667,7 +667,8 @@ class Theme implements ITheme {
   // 将encodedTokensColors转为monaco可用的形式
   private patchTokenColors() {
     // 当默认颜色不在settings当中时，此处不能使用之前那种直接给encodedTokenColors赋值的做法，会导致monaco使用时颜色错位（theia的bug
-    if (this.themeData.themeSettings.filter((setting) => !setting.scope).length === 0) {
+    // scope 会在后续的流程中被补充为 [''] 所以直接进行初始化，防止判断有误
+    if (this.themeData.themeSettings.filter((setting) => JSON.stringify(setting.scope) === '[""]').length === 0) {
       this.themeData.themeSettings.unshift({
         settings: {
           foreground: this.themeData.colors['editor.foreground']
@@ -677,6 +678,7 @@ class Theme implements ITheme {
             ? this.themeData.colors['editor.background'].substr(0, 7)
             : Color.Format.CSS.formatHexA(this.colorRegistry.resolveDefaultColor('editor.background', this)!),
         },
+        scope: [''],
       });
     }
   }

--- a/packages/theme/src/browser/workbench.theme.service.ts
+++ b/packages/theme/src/browser/workbench.theme.service.ts
@@ -666,8 +666,8 @@ class Theme implements ITheme {
 
   // 将encodedTokensColors转为monaco可用的形式
   private patchTokenColors() {
-    // 当默认颜色不在settings当中时，此处不能使用之前那种直接给encodedTokenColors赋值的做法，会导致monaco使用时颜色错位（theia的bug
-    // scope 会在后续的流程中被补充为 [''] 所以直接进行初始化，防止判断有误
+    // 当默认颜色不在settings当中时，需要补充至颜色值中，默认颜色设置 scope 为 ['']
+    // 需要注意的是，后续进行取值时，会依赖数组顺序，初始化后，请不要随意修改
     if (this.themeData.themeSettings.filter((setting) => setting.scope?.length === 1 && setting.scope[0] === '').length === 0) {
       this.themeData.themeSettings.unshift({
         settings: {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 588e562</samp>

* Fix a bug that caused wrong token colors in monaco editor by checking for the scope property of the theme settings ([link](https://github.com/opensumi/core/pull/2753/files?diff=unified&w=0#diff-3448736c3c31a91f63f3a686023016388d5c73261dcb1768627c918421304239L670-R671))
* Add a scope property with an empty array to the default theme settings object to match the expected format for the `fillDefaults` function ([link](https://github.com/opensumi/core/pull/2753/files?diff=unified&w=0#diff-3448736c3c31a91f63f3a686023016388d5c73261dcb1768627c918421304239R681))

<!-- Additional content -->
<!-- 补充额外内容 -->

Issue: https://github.com/opensumi/core/issues/2686

每次初始化 theme 时，会修改 `themeSetting`引用，导致 https://github.com/opensumi/core/blob/main/packages/theme/src/browser/theme-data.ts#L576
这里 `index` 会不一致，每次颜色会错位一个
有因为`scope` 会被补充为 `['']`，所以初始化的判断逻辑改一下就可以了

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 588e562</samp>

Fixed a bug in the workbench theme service that affected the monaco editor. Improved the default theme settings with a scope property.
