### PR TITLE
feat: support xterm render type select

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -471,6 +471,9 @@ export const localizationBundle = {
     'preference.terminal.integrated.localEchoStyle': 'Local Echo Style',
     'preference.terminal.integrated.localEchoStyleDesc':
       'Terminal style of locally echoed text; either a font style or an RGB color.',
+    'preference.terminal.integrated.xtermRenderType': 'Xterm Render Type',
+    'preference.terminal.integrated.xtermRenderTypeDesc':
+      'Choose Xterm render type, Webgl for better performance, Canvas better compatibility',
     'preference.terminal.integrated.cursorStyle': 'Terminal > Cursor Style',
     'preference.terminal.integrated.cursorStyleDesc': 'Control the style of terminal cursor',
     'common.preference.open': 'Settings',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -452,6 +452,8 @@ export const localizationBundle = {
       '当在终端标题中找到其中一个程序名称时，将禁用本地回显。',
     'preference.terminal.integrated.localEchoStyle': '本地回显字体样式',
     'preference.terminal.integrated.localEchoStyleDesc': '本地回显文本的终端样式；字体样式或 RGB 颜色。',
+    'preference.terminal.integrated.xtermRenderType': 'Xterm 渲染类型',
+    'preference.terminal.integrated.xtermRenderTypeDesc': '选择 Xterm 渲染类型，WebGL 性能更强，Canvas 兼容性更佳。',
     'preference.terminal.integrated.cursorStyle': '终端输入指针样式',
     'preference.terminal.integrated.cursorStyleDesc': '修改终端输入指针样式',
     'settings.group.general': '常规',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -808,6 +808,7 @@ export const defaultSettingSections: {
           localized: 'preference.terminal.integrated.cursorStyle',
         },
         { id: 'terminal.integrated.localEchoStyle', localized: 'preference.terminal.integrated.localEchoStyle' },
+        { id: 'terminal.integrated.xtermRenderType', localized: 'preference.terminal.integrated.xtermRenderType' },
       ],
     },
   ],

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -8,7 +8,7 @@ import type { WebglAddon as WebglAddonType } from 'xterm-addon-webgl';
 import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
 import { IClipboardService } from '@opensumi/ide-core-browser';
 import { PreferenceService } from '@opensumi/ide-core-browser/lib/preferences/types';
-import { Disposable, isSafari } from '@opensumi/ide-core-common';
+import { Disposable } from '@opensumi/ide-core-common';
 import { MessageService } from '@opensumi/ide-overlay/lib/browser/message.service';
 import { WorkbenchThemeService } from '@opensumi/ide-theme/lib/browser/workbench.theme.service';
 import { PANEL_BACKGROUND } from '@opensumi/ide-theme/lib/common/color-registry';
@@ -54,7 +54,7 @@ export class XTerm extends Disposable implements IXTerm {
 
   container: HTMLDivElement;
 
-  protected raw: Terminal;
+  raw: Terminal;
 
   xtermOptions: ITerminalOptions & SupportedOptions;
 

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -80,10 +80,6 @@ export class XTerm extends Disposable implements IXTerm {
     this.raw.onSelectionChange(this.onSelectionChange.bind(this));
   }
 
-  private loadWebGLAddon() {
-    return !isSafari;
-  }
-
   protected async enableCanvasRenderer() {
     try {
       if (!this._canvasAddon) {

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -35,6 +35,12 @@ export interface XTermOptions {
   xtermOptions: SupportedOptions & ITerminalOptions;
 }
 
+enum RenderType {
+  Canvas = 'canvas',
+  WebGL = 'webgl',
+  Dom = 'dom',
+}
+
 @Injectable({ multiple: true })
 export class XTerm extends Disposable implements IXTerm {
   @Autowired(INJECTOR_TOKEN)
@@ -189,15 +195,16 @@ export class XTerm extends Disposable implements IXTerm {
 
   open() {
     this.raw.open(this.container);
-    const renderType = this.preferenceService.get<'canvas' | 'webgl' | 'dom'>(
+    const renderType = this.preferenceService.get<RenderType>(
       CodeTerminalSettingId.XtermRenderType,
-      'webgl',
+      RenderType.WebGL,
     );
-    if (renderType === 'webgl') {
+    if (renderType === RenderType.WebGL) {
       this.enableWebglRenderer();
-    } else if (renderType === 'canvas') {
+    } else if (renderType === RenderType.Canvas) {
       this.enableCanvasRenderer();
     }
+    // 不设置 enableWebGL/Canvas render 的话，默认就会 fallback 到 DOM Render
   }
 
   fit() {

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -15,7 +15,7 @@ import { PANEL_BACKGROUND } from '@opensumi/ide-theme/lib/common/color-registry'
 import { IThemeService } from '@opensumi/ide-theme/lib/common/theme.service';
 
 import { SupportedOptions, CodeTerminalSettingId } from '../common/preference';
-import { IXTerm } from '../common/xterm';
+import { IXTerm, RenderType } from '../common/xterm';
 
 import styles from './component/terminal.module.less';
 import {
@@ -33,12 +33,6 @@ export interface XTermOptions {
   // 要传给 xterm 的参数和一些我们自己的参数（如 copyOnSelection）
   // 现在混在一起，也不太影响使用
   xtermOptions: SupportedOptions & ITerminalOptions;
-}
-
-enum RenderType {
-  Canvas = 'canvas',
-  WebGL = 'webgl',
-  Dom = 'dom',
 }
 
 @Injectable({ multiple: true })
@@ -195,10 +189,7 @@ export class XTerm extends Disposable implements IXTerm {
 
   open() {
     this.raw.open(this.container);
-    const renderType = this.preferenceService.get<RenderType>(
-      CodeTerminalSettingId.XtermRenderType,
-      RenderType.WebGL,
-    );
+    const renderType = this.preferenceService.get<RenderType>(CodeTerminalSettingId.XtermRenderType, RenderType.WebGL);
     if (renderType === RenderType.WebGL) {
       this.enableWebglRenderer();
     } else if (renderType === RenderType.Canvas) {

--- a/packages/terminal-next/src/common/preference.ts
+++ b/packages/terminal-next/src/common/preference.ts
@@ -1,6 +1,9 @@
 import { Event, TerminalSettingsId } from '@opensumi/ide-core-common';
 import { localize } from '@opensumi/ide-core-common';
 import { PreferenceSchema } from '@opensumi/ide-core-common/lib/preferences';
+
+import { RenderType } from './xterm';
+
 export interface IPreferenceValue {
   name: string;
   value: string | number | boolean | Array<string | number | boolean>;
@@ -338,7 +341,7 @@ export const terminalPreferenceSchema: PreferenceSchema = {
     [CodeTerminalSettingId.XtermRenderType]: {
       type: 'string',
       description: '%preference.terminal.integrated.xtermRenderTypeDesc%',
-      enum: ['webgl', 'canvas', 'dom'],
+      enum: [RenderType.WebGL, RenderType.Canvas, RenderType.Dom],
       default: 'webgl',
     },
   },

--- a/packages/terminal-next/src/common/preference.ts
+++ b/packages/terminal-next/src/common/preference.ts
@@ -121,6 +121,7 @@ export const enum CodeTerminalSettingId {
   LocalEchoEnabled = 'terminal.integrated.localEchoEnabled',
   LocalEchoExcludePrograms = 'terminal.integrated.localEchoExcludePrograms',
   LocalEchoStyle = 'terminal.integrated.localEchoStyle',
+  XtermRenderType = 'terminal.integrated.xtermRenderType',
   EnablePersistentSessions = 'terminal.integrated.enablePersistentSessions',
   PersistentSessionReviveProcess = 'terminal.integrated.persistentSessionReviveProcess',
   CustomGlyphs = 'terminal.integrated.customGlyphs',
@@ -325,6 +326,7 @@ export const terminalPreferenceSchema: PreferenceSchema = {
     [CodeTerminalSettingId.LocalEchoStyle]: {
       type: 'string',
       description: '%preference.terminal.integrated.localEchoStyleDesc%',
+      enum: ['bold', 'dim', 'italic', 'underlined', 'inverted'],
       default: 'dim',
     },
     [CodeTerminalSettingId.CursorStyle]: {
@@ -332,6 +334,12 @@ export const terminalPreferenceSchema: PreferenceSchema = {
       description: '%preference.terminal.integrated.cursorStyleDesc%',
       enum: [TerminalCursorStyle.BLOCK, TerminalCursorStyle.LINE, TerminalCursorStyle.UNDERLINE],
       default: TerminalCursorStyle.BLOCK,
+    },
+    [CodeTerminalSettingId.XtermRenderType]: {
+      type: 'string',
+      description: '%preference.terminal.integrated.xtermRenderTypeDesc%',
+      enum: ['webgl', 'canvas', 'dom'],
+      default: 'webgl',
     },
   },
 };

--- a/packages/terminal-next/src/common/preference.ts
+++ b/packages/terminal-next/src/common/preference.ts
@@ -342,7 +342,7 @@ export const terminalPreferenceSchema: PreferenceSchema = {
       type: 'string',
       description: '%preference.terminal.integrated.xtermRenderTypeDesc%',
       enum: [RenderType.WebGL, RenderType.Canvas, RenderType.Dom],
-      default: 'webgl',
+      default: RenderType.WebGL,
     },
   },
 };

--- a/packages/terminal-next/src/common/xterm.ts
+++ b/packages/terminal-next/src/common/xterm.ts
@@ -2,6 +2,12 @@ import { ITerminalOptions, ITheme, Terminal } from 'xterm';
 
 import { SupportedOptions } from './preference';
 
+export enum RenderType {
+  Canvas = 'canvas',
+  WebGL = 'webgl',
+  Dom = 'dom',
+}
+
 export interface IXTerm {
   raw: Terminal;
   container: HTMLDivElement;


### PR DESCRIPTION
### Types

支持切换 Xterm 的渲染模式： WebGL / Canvas / DOM

另外修改 TypeAhead 的不同渲染模式设置到枚举模式

- [x] 🎉 New Features


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1073207</samp>

*  Add xterm render type preference to terminal module
  * Define localization keys for preference name and description in English and Chinese languages ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R474-R476), [link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R455-R456))
  * Define preference id in `CodeTerminalSettingId` enum in `packages/terminal-next/src/common/preference.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c1ed5d78a386f847107e56bdfa1704981305b09002593d3285e27eabbd50d8dcR124))
  * Define preference schema with description, constraint, and default value in `packages/terminal-next/src/common/preference.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c1ed5d78a386f847107e56bdfa1704981305b09002593d3285e27eabbd50d8dcR338-R343))
  * Register preference in preference settings service in `packages/preferences/src/browser/preference-settings.service.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR811))
  * Import preference service and preference id in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36R10), [link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L16-R17))
  * Inject preference service as a dependency in `XTerm` class using `Autowired` decorator in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L51-R57))
  * Change visibility of `enableCanvasRenderer` and `enableWebglRenderer` methods from private to protected in `XTerm` class in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L79-R83), [link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L102-R102))
  * Add logic to get preference value and call corresponding enable method in `open` method of `XTerm` class in `packages/terminal-next/src/browser/xterm.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c0fa7b9d8ca7f7ccc298f511357563f0e5957a84ad18b44077bcef2e79726e36L192-R199))
  * Define enum values for valid cursor styles in `packages/terminal-next/src/common/preference.ts` ([link](https://github.com/opensumi/core/pull/2754/files?diff=unified&w=0#diff-c1ed5d78a386f847107e56bdfa1704981305b09002593d3285e27eabbd50d8dcR329))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1073207</samp>

This pull request adds a new user preference for the terminal module to choose the xterm render type, which can be either `canvas` or `dom`. It also updates the preference schema, the localization files, and the preference settings service to support this new option. The changes affect the files `xterm.ts`, `preference.ts`, `en-US.lang.ts`, `zh-CN.lang.ts`, and `preference-settings.service.ts`.
