### PR TITLE
chore(release): v2.24.5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.24.2",
+  "version": "2.24.3",
   "npmClient": "npm",
   "packages": ["packages/*", "tools/dev-tool", "tools/playwright", "tools/cli-engine"],
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.24.3",
+  "version": "2.24.5",
   "npmClient": "npm",
   "packages": ["packages/*", "tools/dev-tool", "tools/playwright", "tools/cli-engine"],
   "command": {

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-addons",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-addons",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-collaboration",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-collaboration",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-comments",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-comments",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/comments/src/browser/comments-body.tsx
+++ b/packages/comments/src/browser/comments-body.tsx
@@ -43,6 +43,7 @@ export const CommentsBody: React.FC<{
                 gfm: true,
                 breaks: false,
                 pedantic: false,
+                sanitize: true,
                 smartLists: true,
                 smartypants: false,
                 renderer,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.4",
     "@opensumi/ide-utils": "workspace:*",
-    "dompurify": "^3.0.2",
     "fuzzy": "^0.1.3",
     "lodash": "^4.17.15",
     "marked": "4.0.10",
@@ -36,7 +35,6 @@
   },
   "devDependencies": {
     "@opensumi/ide-dev-tool": "workspace:*",
-    "@types/dompurify": "^3.0.1",
     "@types/marked": "^4.0.7",
     "@types/react-window": "^1.8.5",
     "prop-types": "^15.8.1"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-components",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "@opensumi/ide-components",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-components",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "@opensumi/ide-components",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/components/src/markdown/index.tsx
+++ b/packages/components/src/markdown/index.tsx
@@ -1,4 +1,3 @@
-import { sanitize } from 'dompurify';
 import { marked, Renderer } from 'marked';
 import React from 'react';
 
@@ -20,7 +19,7 @@ export class DefaultMarkedRenderer extends Renderer {
 }
 
 export function Markdown(props: IMarkdownProps) {
-  const parseMarkdown = (text: string, renderer: any) => sanitize(marked.parse(text, { renderer }));
+  const parseMarkdown = (text: string, renderer: any) => marked.parse(text, { renderer });
 
   const [htmlContent, setHtmlContent] = React.useState(parseMarkdown(props.value, props.renderer));
 

--- a/packages/components/src/recycle-tree/basic/index.tsx
+++ b/packages/components/src/recycle-tree/basic/index.tsx
@@ -1,4 +1,3 @@
-import throttle from 'lodash/throttle';
 import React, { useCallback, useRef, useEffect, useState } from 'react';
 import CtxMenuTrigger from 'react-ctxmenu-trigger';
 
@@ -30,6 +29,7 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
   onClick,
   onContextMenu,
   onTwistierClick,
+  onIconClick,
   onDbClick,
   resolveChildren,
   sortComparator,
@@ -40,7 +40,6 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
   contextMenus,
   contextMenuActuator,
   treeName,
-  getItemClassName,
 }) => {
   const [showMenus, setShowMenus] = useState<{
     show: boolean;
@@ -58,32 +57,24 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
   const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
 
   const renderTreeNode = useCallback(
-    (props: INodeRendererWrapProps) => {
-      let _indent: number | undefined;
-      if (baseIndent) {
-        _indent = baseIndent;
-      }
-      if (indent) {
-        _indent = (_indent ?? 0) + indent;
-      }
-
-      return (
-        <BasicTreeNodeRenderer
-          item={props.item as any}
-          itemType={props.itemType}
-          itemHeight={itemHeight}
-          indent={_indent}
-          className={getItemClassName?.(props.item as any) ?? itemClassname}
-          inlineMenus={inlineMenus}
-          inlineMenuActuator={inlineMenuActuator}
-          onClick={handleItemClick}
-          onDbClick={handleItemDbClick}
-          onContextMenu={handleContextMenu}
-          onTwistierClick={handleTwistierClick}
-          decorations={treeService.current?.decorations.getDecorations(props.item as ITreeNodeOrCompositeTreeNode)}
-        />
-      );
-    },
+    (props: INodeRendererWrapProps) => (
+      <BasicTreeNodeRenderer
+        item={props.item as any}
+        itemType={props.itemType}
+        itemHeight={itemHeight}
+        indent={indent}
+        baseIndent={baseIndent}
+        className={itemClassname}
+        inlineMenus={inlineMenus}
+        inlineMenuActuator={inlineMenuActuator}
+        onClick={handleItemClick}
+        onDbClick={handleItemDbClick}
+        onContextMenu={handleContextMenu}
+        onTwistierClick={handleTwistierClick}
+        onIconClick={handleItemIconClick}
+        decorations={treeService.current?.decorations.getDecorations(props.item as ITreeNodeOrCompositeTreeNode)}
+      />
+    ),
     [model],
   );
 
@@ -156,6 +147,15 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
       }
     },
     [onClick],
+  );
+
+  const handleItemIconClick = useCallback(
+    (event: React.MouseEvent, item: BasicCompositeTreeNode | BasicTreeNode) => {
+      if (onIconClick) {
+        onIconClick(event, item);
+      }
+    },
+    [onIconClick],
   );
 
   const handleItemDbClick = useCallback(

--- a/packages/components/src/recycle-tree/basic/styles.less
+++ b/packages/components/src/recycle-tree/basic/styles.less
@@ -39,7 +39,6 @@
   .icon {
     position: relative;
     color: var(--icon-foreground);
-    margin-right: 4px;
     &:before {
       font-size: 16px;
       text-align: center;
@@ -95,6 +94,7 @@
   }
 
   .display_name {
+    margin-left: 4px;
     margin-right: 6px;
     display: inline;
     white-space: pre;

--- a/packages/components/src/recycle-tree/basic/tree-node.define.ts
+++ b/packages/components/src/recycle-tree/basic/tree-node.define.ts
@@ -60,6 +60,22 @@ export class BasicCompositeTreeNode extends CompositeTreeNode {
     return this.raw.iconClassName;
   }
 
+  get className() {
+    return this.raw.className;
+  }
+
+  get twisterClassName() {
+    return this.raw.twisterClassName;
+  }
+
+  get twisterPlaceholderClassName() {
+    return this.raw.twisterPlaceholderClassName;
+  }
+
+  get indentOffset() {
+    return this.raw.indentOffset;
+  }
+
   get description() {
     return this.raw.description;
   }
@@ -100,6 +116,22 @@ export class BasicTreeNode extends TreeNode {
 
   get iconClassName() {
     return this.raw.iconClassName;
+  }
+
+  get className() {
+    return this.raw.className;
+  }
+
+  get twisterClassName() {
+    return this.raw.twisterClassName;
+  }
+
+  get indentOffset() {
+    return this.raw.indentOffset;
+  }
+
+  get twisterPlaceholderClassName() {
+    return this.raw.twisterPlaceholderClassName;
   }
 
   get raw() {

--- a/packages/components/src/recycle-tree/basic/types.ts
+++ b/packages/components/src/recycle-tree/basic/types.ts
@@ -63,7 +63,13 @@ export interface IBasicTreeData {
    * 图标
    */
   icon?: string;
+  className?: string;
   iconClassName?: string;
+  twisterClassName?: string;
+  /**
+   * if this node is not a composite node, it will use a empty div placeholder to fill the space
+   */
+  twisterPlaceholderClassName?: string;
   /**
    * 描述
    */
@@ -71,9 +77,10 @@ export interface IBasicTreeData {
   /**
    * 子节点
    *
-   * 传入一个空数组可让本节点视为文件夹，同时可以通过 expandable 属性来设置是否展示收起图标
+   * 传入一个空数组可让本节点被视为文件夹，同时可以通过 expandable 属性来设置是否展示收起图标
    */
   children?: IBasicTreeData[] | null;
+  indentOffset?: number;
   /**
    * 是否默认展开
    */
@@ -91,6 +98,8 @@ export interface IBasicTreeData {
    */
   [key: string]: any;
 }
+
+export type TBasicTreeNodeOrCompositeTreeNode = BasicCompositeTreeNode | BasicTreeNode;
 
 export interface IBasicRecycleTreeHandle extends IRecycleTreeHandle {
   selectItem: (item: BasicCompositeTreeNode | BasicTreeNode) => Promise<void>;
@@ -155,6 +164,7 @@ export interface IBasicRecycleTreeProps {
    * 箭头点击事件
    */
   onTwistierClick?: (event: React.MouseEvent, node: ITreeNodeOrCompositeTreeNode) => void;
+  onIconClick?: (event: React.MouseEvent, node: TBasicTreeNodeOrCompositeTreeNode) => void;
   /**
    * 右键菜单定义，但传入了 `onContextMenu` 函数时将有限执行 `onContextMenu` 函数
    */
@@ -181,8 +191,6 @@ export interface IBasicRecycleTreeProps {
    * 指定 RecycleTree 的名字
    */
   treeName?: string;
-
-  getItemClassName?: (item?: ITreeNodeOrCompositeTreeNode) => string | undefined;
 }
 
 export interface IBasicNodeProps {
@@ -198,6 +206,10 @@ export interface IBasicNodeProps {
    * 每层的节点缩进长度
    */
   indent?: number;
+  /**
+   * 基础缩进。即第一层距离左边的距离，默认为 8
+   */
+  baseIndent?: number;
   /**
    * 节点装饰
    */
@@ -218,6 +230,7 @@ export interface IBasicNodeProps {
    * 箭头点击事件
    */
   onTwistierClick?: (event: React.MouseEvent, node: ITreeNodeOrCompositeTreeNode) => void;
+  onIconClick?: (event: React.MouseEvent, node: ITreeNodeOrCompositeTreeNode) => void;
   /**
    * 右键菜单定义，但传入了 `onContextMenu` 函数时将优先执行 `onContextMenu` 函数
    */

--- a/packages/components/src/utils/marked.ts
+++ b/packages/components/src/utils/marked.ts
@@ -1,4 +1,3 @@
-import { sanitize } from 'dompurify';
 import { marked, Renderer } from 'marked';
 
 export type IMarkedOptions = marked.MarkedOptions;
@@ -11,16 +10,13 @@ export const parseMarkdown = (
   callback?: (error: any, parseResult: string) => void,
 ) => {
   if (!callback) {
-    return sanitize(marked.parse(value, options));
+    return marked.parse(value, options);
   }
-  const wrappedCallback = (error: any, parseResult: string) => {
-    callback(error, sanitize(parseResult));
-  };
   if (options) {
-    marked.parse(value, options, wrappedCallback);
+    marked.parse(value, options, callback);
   } else {
-    marked.parse(value, wrappedCallback);
+    marked.parse(value, callback);
   }
 };
 
-export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => sanitize(marked(value, options));
+export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => marked(value, options);

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -266,6 +266,6 @@ describe('connection', () => {
     });
 
     await expect(timeoutBProtocol.getProxy(testTimeoutIdentifier).$test()).resolves.toBe(void 0);
-    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toBe('RPC Timeout');
+    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(new Error('RPC Timeout: 1'));
   });
 });

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-connection",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-connection",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-browser",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "@opensumi/ide-core-browser",
   "files": [
     "lib",

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-browser",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "@opensumi/ide-core-browser",
   "files": [
     "lib",

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -139,6 +139,7 @@ export class ClientApp implements IClientApp, IDisposable {
       editorBackgroundImage: opts.editorBackgroundImage || editorBackgroundImage,
       allowSetDocumentTitleFollowWorkspaceDir,
       devtools: opts.devtools ?? false,
+      rpcMessageTimeout: opts.rpcMessageTimeout || -1,
     };
 
     if (this.config.devtools) {

--- a/packages/core-browser/src/markdown/index.tsx
+++ b/packages/core-browser/src/markdown/index.tsx
@@ -22,6 +22,7 @@ export const toMarkdownHtml = (message: string): string => {
     gfm: true,
     breaks: false,
     pedantic: false,
+    sanitize: true,
     smartLists: true,
     smartypants: false,
     renderer,

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -247,6 +247,11 @@ export interface AppConfig {
    * 需要带端口号, 默认是 12345，可使用 COLLABORATION_PORT 字段来指定
    */
   collaborationWsPath?: string;
+  /**
+   * control rpcProtocol message timeout
+   * default -1，it means disable
+   */
+  rpcMessageTimeout?: number;
 }
 
 export const ConfigContext = React.createContext<AppConfig>({

--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -95,6 +95,9 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
     }
     return () => disposer.dispose();
   }, []);
+
+  const btnTitleStyle = styles.btnTitleStyle || preferenceService.get('toolbar.buttonTitleStyle');
+  const isVerticalButton = styles.btnStyle === 'button' && btnTitleStyle === BUTTON_TITLE_STYLE.VERTICAL;
   const iconContent = !props.inDropDown ? (
     <div
       className={styles.iconClass + ' kt-toolbar-action-btn-icon'}
@@ -102,7 +105,7 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       style={{
         color: styles.iconForeground,
         backgroundColor: styles.iconBackground,
-        marginRight: styles.showTitle ? 5 : 0,
+        marginRight: styles.showTitle && !isVerticalButton ? 5 : 0,
         // 如果指定了按钮宽度，需要将padding清空，防止按钮比预期大 16px
         ...(styles.width ? { width: styles.width } : null),
         ...(styles.height ? { height: styles.height } : null),
@@ -159,7 +162,6 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       </div>
     );
   } else {
-    const btnTitleStyle = styles.btnTitleStyle || preferenceService.get('toolbar.buttonTitleStyle');
     if (styles.btnStyle === 'button' && btnTitleStyle !== BUTTON_TITLE_STYLE.VERTICAL) {
       buttonElement = (
         <Button type='default' size='small' {...bindings} {...backgroundBindings}>

--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -102,7 +102,8 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       style={{
         color: styles.iconForeground,
         backgroundColor: styles.iconBackground,
-        // 如果指定了按钮宽度，需要将padding清空，防止按钮比预期大16px
+        marginRight: styles.showTitle ? 5 : 0,
+        // 如果指定了按钮宽度，需要将padding清空，防止按钮比预期大 16px
         ...(styles.width ? { width: styles.width } : null),
         ...(styles.height ? { height: styles.height } : null),
         ...(styles.iconSize ? { fontSize: styles.iconSize, WebkitMaskSize: styles.iconSize } : null),

--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -255,7 +255,7 @@ export interface IToolbarActionBtnStyle {
   height?: number;
 
   // 是否显示 Title
-  // 20200629改动 - 默认为 true
+  // 默认为 false
   showTitle?: boolean;
 
   // icon 前景色
@@ -280,10 +280,9 @@ export interface IToolbarActionBtnStyle {
   background?: string;
 
   // 样式类型，
-  // inline则不会有外边框
-  // button则为按钮样式
-  // 20200629改动 - 默认为 button
-  // inline 模式showTitle会失效, 只显示icon
+  // inline 不会有外边框
+  // button 为按钮样式
+  // inline 模式 showTitle 会失效, 只显示icon
   btnStyle?: 'inline' | 'button';
 
   // button 的文本位置样式

--- a/packages/core-common/package.json
+++ b/packages/core-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-common",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "@opensumi/ide-core-common",
   "files": [
     "lib",

--- a/packages/core-common/package.json
+++ b/packages/core-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-common",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "@opensumi/ide-core-common",
   "files": [
     "lib",

--- a/packages/core-common/src/command.ts
+++ b/packages/core-common/src/command.ts
@@ -321,7 +321,7 @@ export class CoreCommandRegistryImpl implements CoreCommandRegistry {
     const err = new Error(
       `The command '${commandId}' cannot be executed. There are no active handlers available for the command.${argsMessage}`,
     );
-    err.name = HANDLER_NOT_FOUND;
+    err.name = `${HANDLER_NOT_FOUND}:${commandId}`;
     throw err;
   }
 

--- a/packages/core-electron-main/package.json
+++ b/packages/core-electron-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-electron-main",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "browser-preload"

--- a/packages/core-electron-main/package.json
+++ b/packages/core-electron-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-electron-main",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "browser-preload"

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-node",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "@opensumi/ide-core-node",
   "files": [
     "lib",

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-node",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "@opensumi/ide-core-node",
   "files": [
     "lib",

--- a/packages/core-node/src/bootstrap/app.ts
+++ b/packages/core-node/src/bootstrap/app.ts
@@ -78,6 +78,7 @@ export class ServerApp implements IServerApp {
       blockPatterns: opts.blockPatterns,
       extHostIPCSockPath: opts.extHostIPCSockPath,
       extHostForkOptions: opts.extHostForkOptions,
+      rpcMessageTimeout: opts.rpcMessageTimeout || -1,
     };
     this.bindProcessHandler();
     this.initBaseProvider();

--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -108,6 +108,11 @@ interface Config {
    * 配置关闭 keytar 校验能力，默认开启
    */
   disableKeytar?: boolean;
+  /**
+   * control rpcProtocol message timeout
+   * default -1，it means disable
+   */
+  rpcMessageTimeout?: number;
 }
 
 export interface AppConfig extends Partial<Config> {

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-debug",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-debug",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -3,6 +3,19 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  :global {
+    span.kt-icon.icon.kaitian-icon {
+      min-width: 20px;
+      width: 20px;
+    }
+    .basic_tree .icon:before {
+      font-size: 14px;
+    }
+  }
+
+  .tree_item_twister_placeholder {
+    display: none;
+  }
 }
 
 .debug_breakpoints_disabled {
@@ -37,10 +50,20 @@
 }
 
 .debug_breakpoints_icon {
-  width: 19px;
-  height: 19px;
-  min-width: 19px;
-  margin-right: 3px;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  :global {
+    .kt-checkbox-lump {
+      margin: auto;
+    }
+  }
+}
+
+.debug_breakpoints_checkbox {
+  width: 16px;
+  min-width: 16px;
+  font-size: 16px;
 }
 
 .debug_breakpoints_badge {
@@ -63,10 +86,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: 5px;
+  margin-right: 4px;
+  margin-left: 4px;
   flex: 1;
-}
-
-.debug_breakpoints_item_tree_node {
-  padding-left: 27px !important;
 }

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -1,8 +1,8 @@
 import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-import { BasicRecycleTree, CheckBox, IBasicTreeData, ICompositeTreeNode } from '@opensumi/ide-components';
+import { BasicRecycleTree, CheckBox, IBasicTreeData } from '@opensumi/ide-components';
 import { Badge } from '@opensumi/ide-components';
 import {
   useInjectable,
@@ -13,7 +13,6 @@ import {
   Disposable,
   ViewState,
   Event,
-  isUndefined,
 } from '@opensumi/ide-core-browser';
 import { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
 
@@ -23,7 +22,6 @@ import {
   isDebugBreakpoint,
   isRuntimeBreakpoint,
   getStatus,
-  isDebugExceptionBreakpoint,
   EXCEPTION_BREAKPOINT_URI,
 } from '../../breakpoint';
 import { DebugSessionManager } from '../../debug-session-manager';
@@ -46,6 +44,30 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
   const isDisposed = useRef<boolean>(false);
   const [treeData, setTreeData] = useState<IBasicTreeData[]>([]);
 
+  const getBreakpointClsState = (options: {
+    data: BreakpointItem;
+    inDebugMode: boolean;
+    breakpointEnabled: boolean;
+  }) => {
+    const { data, inDebugMode, breakpointEnabled } = options;
+    if (isDebugBreakpoint(data.breakpoint)) {
+      const verified = !inDebugMode ? true : isDebugBreakpoint(data.breakpoint) && isRuntimeBreakpoint(data.breakpoint);
+
+      if (!verified) {
+        return 'sumi-debug-breakpoint-unverified';
+      }
+
+      const { className } = debugBreakpointsService.getBreakpointDecoration(
+        data.breakpoint as IDebugBreakpoint,
+        inDebugMode,
+        breakpointEnabled,
+      );
+      return className;
+    }
+
+    return '';
+  };
+
   const updateTreeData = useCallback(
     (nodes: [string, BreakpointsTreeNode[]][]) => {
       const { roots } = debugBreakpointsService;
@@ -61,9 +83,7 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
               description: (
                 <BreakpointItem
                   toggle={() => toggleBreakpointEnable(item.breakpoint)}
-                  breakpointEnabled={enable}
                   data={item.rawData}
-                  isDebugMode={debugBreakpointsService.inDebugMode}
                 ></BreakpointItem>
               ),
             });
@@ -81,12 +101,20 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
               ...item,
               label: '',
               expandable: false,
+              twisterPlaceholderClassName: styles.tree_item_twister_placeholder,
+              breakpoint: item.breakpoint,
+              iconClassName: cls(
+                getBreakpointClsState({
+                  data: item.rawData,
+                  inDebugMode: debugBreakpointsService.inDebugMode,
+                  breakpointEnabled: enable,
+                }),
+                styles.debug_breakpoints_icon,
+              ),
               description: (
                 <BreakpointItem
                   toggle={() => toggleBreakpointEnable(item.breakpoint)}
-                  breakpointEnabled={enable}
                   data={item.rawData}
-                  isDebugMode={debugBreakpointsService.inDebugMode}
                 ></BreakpointItem>
               ),
             })),
@@ -123,29 +151,24 @@ export const DebugBreakpointView = observer(({ viewState }: React.PropsWithChild
     }
   }, [treeData]);
 
-  const getItemClassName = useCallback((item: ICompositeTreeNode) => {
-    if (!item.children && isUndefined((item as any).expandable)) {
-      return styles.debug_breakpoints_item_tree_node;
-    }
-  }, []);
   return (
     <div className={cls(styles.debug_breakpoints, !enable && styles.debug_breakpoints_disabled)}>
-      <BasicRecycleTree treeData={treeData} height={viewState.height} getItemClassName={getItemClassName} />
+      <BasicRecycleTree
+        onIconClick={(_, item) => {
+          if (item.raw.breakpoint) {
+            toggleBreakpointEnable(item.raw.breakpoint);
+          }
+        }}
+        indent={20}
+        baseIndent={8}
+        treeData={treeData}
+        height={viewState.height}
+      />
     </div>
   );
 });
 
-export const BreakpointItem = ({
-  data,
-  toggle,
-  isDebugMode,
-  breakpointEnabled,
-}: {
-  data: BreakpointItem;
-  toggle: () => void;
-  isDebugMode: boolean;
-  breakpointEnabled: boolean;
-}) => {
+export const BreakpointItem = ({ data, toggle }: { data: BreakpointItem; toggle: () => void }) => {
   const defaultValue = isDebugBreakpoint(data.breakpoint) ? data.breakpoint.enabled : !!data.breakpoint.default;
   const manager = useInjectable<DebugSessionManager>(IDebugSessionManager);
   const commandService = useInjectable<CommandService>(CommandService);
@@ -209,40 +232,19 @@ export const BreakpointItem = ({
     };
   }, []);
 
-  const verified = !isDebugMode ? true : isDebugBreakpoint(data.breakpoint) && isRuntimeBreakpoint(data.breakpoint);
-
-  const getBreakpointIcon = () => {
-    const { className } = debugBreakpointsService.getBreakpointDecoration(
-      data.breakpoint as IDebugBreakpoint,
-      isDebugMode,
-      breakpointEnabled && enabled,
-    );
-    return className;
-  };
-
-  const converBreakpointClsState = () => {
-    if (isDebugBreakpoint(data.breakpoint)) {
-      if (!verified) {
-        return 'sumi-debug-breakpoint-unverified';
-      }
-
-      return getBreakpointIcon();
-    }
-
-    return '';
-  };
-
   const removeBreakpoint = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     event.stopPropagation();
     debugBreakpointsService.delBreakpoint(data.breakpoint as IDebugBreakpoint);
   };
 
-  const isExceptionBreakpoint = useMemo(() => isDebugExceptionBreakpoint(data.breakpoint), [data]);
-
   return (
     <div className={cls(styles.debug_breakpoints_item)}>
-      {!isExceptionBreakpoint && <div className={cls(converBreakpointClsState(), styles.debug_breakpoints_icon)}></div>}
-      <CheckBox id={data.id} onChange={handleBreakpointChange} checked={enabled}></CheckBox>
+      <CheckBox
+        className={styles.debug_breakpoints_icon}
+        id={data.id}
+        onChange={handleBreakpointChange}
+        checked={enabled}
+      ></CheckBox>
       <div className={styles.debug_breakpoints_wrapper} onClick={handleBreakpointClick}>
         {data.name && <span className={styles.debug_breakpoints_name}>{data.name}</span>}
         <span className={styles.debug_breakpoints_description}>{description}</span>

--- a/packages/decoration/package.json
+++ b/packages/decoration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-decoration",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/decoration/package.json
+++ b/packages/decoration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-decoration",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-editor",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-editor",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/editor/src/browser/monaco-contrib/command/command.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/command/command.service.ts
@@ -111,8 +111,8 @@ export class MonacoCommandService implements IMonacoCommandService {
       this._onDidExecuteCommand.fire({ commandId, args });
       return res;
     } catch (err) {
-      // 如果不是 handler 未找到直接抛错，否则执行 delegate 逻辑
-      if (err?.name !== HANDLER_NOT_FOUND) {
+      // 如果不是当前命令的 handler 未找到直接抛错，否则执行 delegate 逻辑
+      if (err?.name !== `${HANDLER_NOT_FOUND}:${commandId}`) {
         throw err;
       }
     }

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -489,10 +489,6 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
       const scope = scopes[i];
       const langId = languages[scope];
       result[scope] = getEncodedLanguageId(langId);
-      // TODO 后置到 tokenize 使用到对应的 scope 时激活（vscode逻辑），现在先激活一个 language 时激活所有 embed language
-      if (!this.activatedLanguage.has(langId)) {
-        this.activateLanguage(langId);
-      }
     }
     return result;
   }

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-electron-basic",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-electron-basic",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-explorer",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-explorer",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/express-file-server/package.json
+++ b/packages/express-file-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-express-file-server",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/express-file-server/package.json
+++ b/packages/express-file-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-express-file-server",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-manager",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-manager",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/extension-storage/package.json
+++ b/packages/extension-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-storage",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/extension-storage/package.json
+++ b/packages/extension-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-storage",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "hosted"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "hosted"

--- a/packages/extension/src/browser/extension-node.service.ts
+++ b/packages/extension/src/browser/extension-node.service.ts
@@ -193,6 +193,7 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
     const mainThreadProtocol = new RPCProtocol({
       onMessage,
       send,
+      timeout: this.appConfig.rpcMessageTimeout,
     });
 
     // 重启/重连时直接覆盖前一个连接

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -193,6 +193,7 @@ export class WorkerExtProcessService
       {
         onMessage,
         send: port.postMessage.bind(port),
+        timeout: this.appConfig.rpcMessageTimeout,
       },
       this.logger,
     );

--- a/packages/extension/src/common/ext.host.proxy.ts
+++ b/packages/extension/src/common/ext.host.proxy.ts
@@ -122,6 +122,11 @@ export interface IExtHostProxyOptions {
    * 默认 1000ms
    */
   retryTime?: number;
+  /**
+   * control rpcProtocol message timeout
+   * default -1，it means disable
+   */
+   rpcMessageTimeout?: number;
 }
 
 /**

--- a/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
+++ b/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
@@ -67,7 +67,7 @@ export function startDebugAdapter(
 export function connectDebugAdapter(server: vscode.DebugAdapterServer): DebugStreamConnection {
   const socket = net.createConnection({
     port: server.port,
-    host: server.host,
+    host: server.host || '127.0.0.1',
   });
   return {
     input: socket,

--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -456,20 +456,24 @@ class ExtHostSourceControl implements vscode.SourceControl {
     } else if (typeof actionButton?.command === 'string') {
       internal = {
         command: this._commands.converter.toInternal(actionButton as any, this._actionButtonDisposables.value)!,
-        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) => commandGroup.map(
+        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) =>
+          commandGroup.map(
             (command) => this._commands.converter.toInternal(command, this._actionButtonDisposables.value!)!,
-          )),
+          ),
+        ),
         description: (actionButton as any).title,
         enabled: true,
       };
     } else {
       internal = {
         command: this._commands.converter.toInternal(actionButton.command, this._actionButtonDisposables.value)!,
-        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) => commandGroup.map(
+        secondaryCommands: actionButton.secondaryCommands?.map((commandGroup) =>
+          commandGroup.map(
             (command) => this._commands.converter.toInternal(command, this._actionButtonDisposables.value!)!,
-          )),
+          ),
+        ),
         description: actionButton.description || (actionButton as any).tooltip,
-        enabled: actionButton.enabled,
+        enabled: actionButton.enabled ?? true,
       };
     }
     this._proxy.$updateSourceControl(this.handle, { actionButton: internal ?? null });

--- a/packages/extension/src/hosted/ext.host.proxy-base.ts
+++ b/packages/extension/src/hosted/ext.host.proxy-base.ts
@@ -142,6 +142,7 @@ export class ExtHostProxy extends Disposable implements IExtHostProxy {
     this.protocol = new RPCProtocol({
       onMessage,
       send,
+      timeout: this.options.rpcMessageTimeout,
     });
     this.extServerProxy = this.protocol.getProxy(EXT_SERVER_IDENTIFIER);
     const extHostProxyRPCService = new ExtHostProxyRPCService(this.extServerProxy);

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -70,9 +70,14 @@ export interface ExtProcessConfig {
   builtinCommands?: IBuiltInCommand[];
   customDebugChildProcess?: CustomChildProcessModule;
   customVSCodeEngineVersion?: string;
+   /**
+   * control rpcProtocol message timeout
+   * default -1，it means disable
+   */
+   rpcMessageTimeout?: number;
 }
 
-async function initRPCProtocol(extInjector): Promise<any> {
+async function initRPCProtocol(extInjector: Injector): Promise<any> {
   const extCenter = new RPCServiceCenter();
   const { getRPCService } = initRPCService<{
     onMessage(msg: string): void;
@@ -92,9 +97,12 @@ async function initRPCProtocol(extInjector): Promise<any> {
   const onMessage = onMessageEmitter.event;
   const send = service.onMessage;
 
+  const appConfig = extInjector.get(AppConfig);
+
   const extProtocol = new RPCProtocol({
     onMessage,
     send,
+    timeout: appConfig.rpcMessageTimeout,
   });
 
   logger = new ExtensionLogger2(extInjector); // new ExtensionLogger(extProtocol);

--- a/packages/extension/src/node/extension.host.proxy.manager.ts
+++ b/packages/extension/src/node/extension.host.proxy.manager.ts
@@ -4,7 +4,7 @@ import { Injectable, Optional, Autowired } from '@opensumi/di';
 import { getRPCService, RPCProtocol, IRPCProtocol } from '@opensumi/ide-connection';
 import { createSocketConnection } from '@opensumi/ide-connection/lib/node';
 import { MaybePromise, Emitter, IDisposable, toDisposable, Disposable } from '@opensumi/ide-core-common';
-import { RPCServiceCenter, INodeLogger } from '@opensumi/ide-core-node';
+import { RPCServiceCenter, INodeLogger, AppConfig } from '@opensumi/ide-core-node';
 
 import {
   IExtensionHostManager,
@@ -20,6 +20,9 @@ import {
 export class ExtensionHostProxyManager implements IExtensionHostManager {
   @Autowired(INodeLogger)
   private readonly logger: INodeLogger;
+
+  @Autowired(AppConfig)
+  private readonly appconfig: AppConfig;
 
   private callId = 0;
 
@@ -96,6 +99,7 @@ export class ExtensionHostProxyManager implements IExtensionHostManager {
     this.extHostProxyProtocol = new RPCProtocol({
       onMessage,
       send,
+      timeout: this.appconfig.rpcMessageTimeout,
     });
 
     this.extHostProxyProtocol.set(EXT_SERVER_IDENTIFIER, {

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-scheme",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-scheme",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-search",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-search",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-service",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-service",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-tree-next",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-tree-next",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-i18n",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-i18n",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-keymaps",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-keymaps",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/logs-core/package.json
+++ b/packages/logs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-logs",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/logs-core/package.json
+++ b/packages/logs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-logs",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/main-layout/package.json
+++ b/packages/main-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-main-layout",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "@opensumi/ide-main-layout",
   "files": [
     "lib",

--- a/packages/main-layout/package.json
+++ b/packages/main-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-main-layout",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "@opensumi/ide-main-layout",
   "files": [
     "lib",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markdown",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markdown",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markers",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markers",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/markers/src/browser/markers-tree.view.tsx
+++ b/packages/markers/src/browser/markers-tree.view.tsx
@@ -61,7 +61,6 @@ const MarkerList: FC<{ viewState: ViewState }> = ({ viewState }) => {
         height={viewState.height}
         itemHeight={MARKER_TREE_NODE_HEIGHT}
         supportDynamicHeights={true}
-        overflow={'auto'}
         onReady={handleTreeReady}
         model={model}
         placeholder={() => <Empty />}

--- a/packages/markers/src/browser/tree/marker-node.tsx
+++ b/packages/markers/src/browser/tree/marker-node.tsx
@@ -108,7 +108,7 @@ const MarkerItemDescription: FC<{ marker: IRenderableMarker }> = memo(({ marker 
         )}
         {marker.code && ')'}
       </div>
-      <div className={styles.position}>{`[${marker.startLineNumber},${marker.startColumn}]`}</div>
+      <div className={styles.position}>{`[Ln ${marker.startLineNumber}, Col ${marker.startColumn}]`}</div>
     </div>
   );
 });

--- a/packages/markers/src/browser/tree/tree-node.module.less
+++ b/packages/markers/src/browser/tree/tree-node.module.less
@@ -20,12 +20,15 @@
   .detail_name {
     color: var(--foreground);
     margin-right: 6px;
-    display: inline;
     white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .detail_description {
-    display: inline;
+    display: inline-flex;
+    flex-shrink: 0;
     margin-left: 5px;
     color: var(--descriptionForeground);
     .typeContainer {
@@ -116,12 +119,12 @@
 
   .overflow_wrap {
     flex: 1;
+    display: flex;
     flex-shrink: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     text-align: left;
     color: var(--foreground);
+    flex-direction: row;
+    width: 0;
   }
 
   .flex_wrap {

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-menu-bar",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "@opensumi/ide-menu-bar",
   "files": [
     "lib",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-menu-bar",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "@opensumi/ide-menu-bar",
   "files": [
     "lib",

--- a/packages/monaco-enhance/package.json
+++ b/packages/monaco-enhance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco-enhance",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/monaco-enhance/package.json
+++ b/packages/monaco-enhance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco-enhance",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/opened-editor/package.json
+++ b/packages/opened-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-opened-editor",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/opened-editor/package.json
+++ b/packages/opened-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-opened-editor",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/outline/package.json
+++ b/packages/outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-outline",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/outline/package.json
+++ b/packages/outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-outline",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-output",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-output",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-overlay",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-overlay",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-preferences",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-preferences",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -70,6 +70,9 @@ export class PreferenceSettingsService extends Disposable implements IPreference
   @Autowired(CommandService)
   protected readonly commandService: CommandService;
 
+  private onSettingsGroupsChangeEmitter: Emitter<void> = this.registerDispose(new Emitter());
+  public readonly onSettingsGroupsChange: Event<void> = this.onSettingsGroupsChangeEmitter.event;
+
   @observable
   public currentSearch = '';
 
@@ -250,7 +253,11 @@ export class PreferenceSettingsService extends Disposable implements IPreference
       ...group,
       title: replaceLocalizePlaceholder(group.title) || group.title,
     });
-    return disposable;
+    this.onSettingsGroupsChangeEmitter.fire();
+    return Disposable.create(() => {
+      disposable.dispose();
+      this.onSettingsGroupsChangeEmitter.fire();
+    });
   }
 
   /**

--- a/packages/preferences/src/browser/preferences.view.tsx
+++ b/packages/preferences/src/browser/preferences.view.tsx
@@ -44,6 +44,7 @@ interface IPreferenceTreeData extends IBasicTreeData {
 }
 
 const TREE_NAME = 'preferenceViewIndexTree';
+const kBaseIndent = 8;
 
 const usePreferenceGroups = () => {
   const preferenceService: PreferenceSettingsService = useInjectable(IPreferenceSettingsService);
@@ -57,6 +58,15 @@ const usePreferenceGroups = () => {
       setGroups(toJS(_groups, { recurseEverything: true }));
     }
   }, 16);
+
+  useEffect(() => {
+    const dispose = preferenceService.onSettingsGroupsChange(() => {
+      updateGroup.run();
+    });
+    return () => {
+      dispose.dispose();
+    };
+  });
 
   useEffect(() => {
     updateGroup.run();
@@ -179,20 +189,22 @@ export const PreferenceItem = ({ data, index }: { data: ISectionItemData; index:
   }
 };
 
-const parseTreeData = (id: string, section: ISettingSection, i: number) => {
+const parseTreeData = (id: string, section: ISettingSection, order: number, depth: number) => {
   let innerTreeData: IPreferenceTreeData | undefined;
   if (section.title) {
     innerTreeData = {
       label: section.title,
       section: section.title,
       groupId: id,
-      order: i,
+      order,
+      indentOffset: depth === 1 ? -kBaseIndent : -(kBaseIndent >> 1),
+      className: styles.index_item,
     } as IPreferenceTreeData;
   }
   const subTreeData = [] as IPreferenceTreeData[];
   if (section.subSections) {
     section.subSections.forEach((v, _i) => {
-      const _treeData = parseTreeData(id, v, _i);
+      const _treeData = parseTreeData(id, v, _i, depth + 1);
       _treeData && subTreeData.push(_treeData);
     });
   }
@@ -220,11 +232,12 @@ const PreferenceIndexes = observer(() => {
         iconClassName: iconClass,
         groupId: id,
         order: index,
+        className: styles.group_item,
       } as IPreferenceTreeData;
       const children = [] as IPreferenceTreeData[];
       const sections = preferenceService.getResolvedSections(id);
       sections.forEach((sec, i) => {
-        const _treeData = parseTreeData(id, sec, i);
+        const _treeData = parseTreeData(id, sec, i, 1);
         if (_treeData) {
           children.push(_treeData);
         }
@@ -256,13 +269,8 @@ const PreferenceIndexes = observer(() => {
           height={height}
           width={width}
           itemHeight={26}
-          getItemClassName={(item) => {
-            if (item?.depth === 1) {
-              return styles.group_item;
-            }
-            return styles.index_item;
-          }}
-          baseIndent={8}
+          baseIndent={kBaseIndent}
+          indent={12}
           treeData={treeData}
           onClick={(_e, node) => {
             const treeData = node && ((node as any)._raw as IPreferenceTreeData);

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-process",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-process",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/quick-open/package.json
+++ b/packages/quick-open/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-quick-open",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/quick-open/package.json
+++ b/packages/quick-open/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-quick-open",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/remote-opener/package.json
+++ b/packages/remote-opener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-remote-opener",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/remote-opener/package.json
+++ b/packages/remote-opener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-remote-opener",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-scm",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-scm",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-search",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-search",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-startup",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-startup",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/static-resource/package.json
+++ b/packages/static-resource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-static-resource",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/static-resource/package.json
+++ b/packages/static-resource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-static-resource",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/status-bar/package.json
+++ b/packages/status-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-status-bar",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/status-bar/package.json
+++ b/packages/status-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-status-bar",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-storage",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-storage",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-task",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-task",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-terminal-next",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-terminal-next",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-testing",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-testing",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-theme",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-theme",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/theme/src/common/color-tokens/button.ts
+++ b/packages/theme/src/common/color-tokens/button.ts
@@ -43,7 +43,7 @@ export const buttonBorder = registerColor(
 );
 /** secondary button */
 export const buttonSecondaryForeground = registerColor(
-  'button.foreground',
+  'button.secondaryForeground',
   {
     dark: Color.white,
     light: Color.white,

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-toolbar",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-toolbar",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/types/manifest.json
+++ b/packages/types/manifest.json
@@ -1,296 +1,296 @@
 {
   "meta": {
     "@opensumi/ide-addons": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-collaboration": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-comments": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-components": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-connection": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-core-browser": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["common"]
     },
     "@opensumi/ide-core-common": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-core-electron-main": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-core-node": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-debug": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-decoration": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-editor": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-electron-basic": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser"]
     },
     "@opensumi/ide-explorer": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser"]
     },
     "@opensumi/ide-express-file-server": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-manager": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-storage": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-file-scheme": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-search": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-file-service": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-tree-next": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-i18n": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-keymaps": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-logs": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-main-layout": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markdown": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markers": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-menu-bar": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser"]
     },
     "@opensumi/ide-monaco": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-monaco-enhance": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-opened-editor": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-outline": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-output": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-overlay": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-preferences": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-process": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-quick-open": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/remote-cli": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-remote-opener": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-scm": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-search": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-startup": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser"]
     },
     "@opensumi/ide-static-resource": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser"]
     },
     "@opensumi/ide-status-bar": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-storage": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-task": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-terminal-next": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-testing": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-theme": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-toolbar": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser"]
     },
     "@opensumi/sumi": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-userstorage": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-utils": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": []
     },
     "@opensumi/ide-variable": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-webview": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace-edit": {
-      "version": "2.24.3",
+      "version": "2.24.5",
       "entry": ["browser", "common"]
     }
   },
   "packages": {
-    "@opensumi/ide-addons": "2.24.3",
-    "@opensumi/ide-collaboration": "2.24.3",
-    "@opensumi/ide-comments": "2.24.3",
-    "@opensumi/ide-components": "2.24.3",
-    "@opensumi/ide-connection": "2.24.3",
-    "@opensumi/ide-core-browser": "2.24.3",
-    "@opensumi/ide-core-common": "2.24.3",
-    "@opensumi/ide-core-electron-main": "2.24.3",
-    "@opensumi/ide-core-node": "2.24.3",
-    "@opensumi/ide-debug": "2.24.3",
-    "@opensumi/ide-decoration": "2.24.3",
-    "@opensumi/ide-editor": "2.24.3",
-    "@opensumi/ide-electron-basic": "2.24.3",
-    "@opensumi/ide-explorer": "2.24.3",
-    "@opensumi/ide-express-file-server": "2.24.3",
-    "@opensumi/ide-extension": "2.24.3",
-    "@opensumi/ide-extension-manager": "2.24.3",
-    "@opensumi/ide-extension-storage": "2.24.3",
-    "@opensumi/ide-file-scheme": "2.24.3",
-    "@opensumi/ide-file-search": "2.24.3",
-    "@opensumi/ide-file-service": "2.24.3",
-    "@opensumi/ide-file-tree-next": "2.24.3",
-    "@opensumi/ide-i18n": "2.24.3",
-    "@opensumi/ide-keymaps": "2.24.3",
-    "@opensumi/ide-logs": "2.24.3",
-    "@opensumi/ide-main-layout": "2.24.3",
-    "@opensumi/ide-markdown": "2.24.3",
-    "@opensumi/ide-markers": "2.24.3",
-    "@opensumi/ide-menu-bar": "2.24.3",
-    "@opensumi/ide-monaco": "2.24.3",
-    "@opensumi/ide-monaco-enhance": "2.24.3",
-    "@opensumi/ide-opened-editor": "2.24.3",
-    "@opensumi/ide-outline": "2.24.3",
-    "@opensumi/ide-output": "2.24.3",
-    "@opensumi/ide-overlay": "2.24.3",
-    "@opensumi/ide-preferences": "2.24.3",
-    "@opensumi/ide-process": "2.24.3",
-    "@opensumi/ide-quick-open": "2.24.3",
-    "@opensumi/remote-cli": "2.24.3",
-    "@opensumi/ide-remote-opener": "2.24.3",
-    "@opensumi/ide-scm": "2.24.3",
-    "@opensumi/ide-search": "2.24.3",
-    "@opensumi/ide-startup": "2.24.3",
-    "@opensumi/ide-static-resource": "2.24.3",
-    "@opensumi/ide-status-bar": "2.24.3",
-    "@opensumi/ide-storage": "2.24.3",
-    "@opensumi/ide-task": "2.24.3",
-    "@opensumi/ide-terminal-next": "2.24.3",
-    "@opensumi/ide-testing": "2.24.3",
-    "@opensumi/ide-theme": "2.24.3",
-    "@opensumi/ide-toolbar": "2.24.3",
-    "@opensumi/sumi": "2.24.3",
-    "@opensumi/ide-userstorage": "2.24.3",
-    "@opensumi/ide-utils": "2.24.3",
-    "@opensumi/ide-variable": "2.24.3",
-    "@opensumi/ide-webview": "2.24.3",
-    "@opensumi/ide-workspace": "2.24.3",
-    "@opensumi/ide-workspace-edit": "2.24.3"
+    "@opensumi/ide-addons": "2.24.5",
+    "@opensumi/ide-collaboration": "2.24.5",
+    "@opensumi/ide-comments": "2.24.5",
+    "@opensumi/ide-components": "2.24.5",
+    "@opensumi/ide-connection": "2.24.5",
+    "@opensumi/ide-core-browser": "2.24.5",
+    "@opensumi/ide-core-common": "2.24.5",
+    "@opensumi/ide-core-electron-main": "2.24.5",
+    "@opensumi/ide-core-node": "2.24.5",
+    "@opensumi/ide-debug": "2.24.5",
+    "@opensumi/ide-decoration": "2.24.5",
+    "@opensumi/ide-editor": "2.24.5",
+    "@opensumi/ide-electron-basic": "2.24.5",
+    "@opensumi/ide-explorer": "2.24.5",
+    "@opensumi/ide-express-file-server": "2.24.5",
+    "@opensumi/ide-extension": "2.24.5",
+    "@opensumi/ide-extension-manager": "2.24.5",
+    "@opensumi/ide-extension-storage": "2.24.5",
+    "@opensumi/ide-file-scheme": "2.24.5",
+    "@opensumi/ide-file-search": "2.24.5",
+    "@opensumi/ide-file-service": "2.24.5",
+    "@opensumi/ide-file-tree-next": "2.24.5",
+    "@opensumi/ide-i18n": "2.24.5",
+    "@opensumi/ide-keymaps": "2.24.5",
+    "@opensumi/ide-logs": "2.24.5",
+    "@opensumi/ide-main-layout": "2.24.5",
+    "@opensumi/ide-markdown": "2.24.5",
+    "@opensumi/ide-markers": "2.24.5",
+    "@opensumi/ide-menu-bar": "2.24.5",
+    "@opensumi/ide-monaco": "2.24.5",
+    "@opensumi/ide-monaco-enhance": "2.24.5",
+    "@opensumi/ide-opened-editor": "2.24.5",
+    "@opensumi/ide-outline": "2.24.5",
+    "@opensumi/ide-output": "2.24.5",
+    "@opensumi/ide-overlay": "2.24.5",
+    "@opensumi/ide-preferences": "2.24.5",
+    "@opensumi/ide-process": "2.24.5",
+    "@opensumi/ide-quick-open": "2.24.5",
+    "@opensumi/remote-cli": "2.24.5",
+    "@opensumi/ide-remote-opener": "2.24.5",
+    "@opensumi/ide-scm": "2.24.5",
+    "@opensumi/ide-search": "2.24.5",
+    "@opensumi/ide-startup": "2.24.5",
+    "@opensumi/ide-static-resource": "2.24.5",
+    "@opensumi/ide-status-bar": "2.24.5",
+    "@opensumi/ide-storage": "2.24.5",
+    "@opensumi/ide-task": "2.24.5",
+    "@opensumi/ide-terminal-next": "2.24.5",
+    "@opensumi/ide-testing": "2.24.5",
+    "@opensumi/ide-theme": "2.24.5",
+    "@opensumi/ide-toolbar": "2.24.5",
+    "@opensumi/sumi": "2.24.5",
+    "@opensumi/ide-userstorage": "2.24.5",
+    "@opensumi/ide-utils": "2.24.5",
+    "@opensumi/ide-variable": "2.24.5",
+    "@opensumi/ide-webview": "2.24.5",
+    "@opensumi/ide-workspace": "2.24.5",
+    "@opensumi/ide-workspace-edit": "2.24.5"
   }
 }

--- a/packages/types/manifest.json
+++ b/packages/types/manifest.json
@@ -1,296 +1,296 @@
 {
   "meta": {
     "@opensumi/ide-addons": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-collaboration": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-comments": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-components": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-connection": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-core-browser": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["common"]
     },
     "@opensumi/ide-core-common": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-core-electron-main": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-core-node": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-debug": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-decoration": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-editor": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-electron-basic": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-explorer": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-express-file-server": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-manager": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-storage": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-file-scheme": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-search": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-file-service": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-tree-next": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-i18n": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-keymaps": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-logs": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-main-layout": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markdown": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markers": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-menu-bar": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-monaco": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-monaco-enhance": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-opened-editor": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-outline": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-output": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-overlay": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-preferences": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-process": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-quick-open": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/remote-cli": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-remote-opener": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-scm": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-search": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-startup": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-static-resource": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-status-bar": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-storage": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-task": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-terminal-next": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-testing": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-theme": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-toolbar": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser"]
     },
     "@opensumi/sumi": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-userstorage": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-utils": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": []
     },
     "@opensumi/ide-variable": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-webview": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace-edit": {
-      "version": "2.24.2",
+      "version": "2.24.3",
       "entry": ["browser", "common"]
     }
   },
   "packages": {
-    "@opensumi/ide-addons": "2.24.2",
-    "@opensumi/ide-collaboration": "2.24.2",
-    "@opensumi/ide-comments": "2.24.2",
-    "@opensumi/ide-components": "2.24.2",
-    "@opensumi/ide-connection": "2.24.2",
-    "@opensumi/ide-core-browser": "2.24.2",
-    "@opensumi/ide-core-common": "2.24.2",
-    "@opensumi/ide-core-electron-main": "2.24.2",
-    "@opensumi/ide-core-node": "2.24.2",
-    "@opensumi/ide-debug": "2.24.2",
-    "@opensumi/ide-decoration": "2.24.2",
-    "@opensumi/ide-editor": "2.24.2",
-    "@opensumi/ide-electron-basic": "2.24.2",
-    "@opensumi/ide-explorer": "2.24.2",
-    "@opensumi/ide-express-file-server": "2.24.2",
-    "@opensumi/ide-extension": "2.24.2",
-    "@opensumi/ide-extension-manager": "2.24.2",
-    "@opensumi/ide-extension-storage": "2.24.2",
-    "@opensumi/ide-file-scheme": "2.24.2",
-    "@opensumi/ide-file-search": "2.24.2",
-    "@opensumi/ide-file-service": "2.24.2",
-    "@opensumi/ide-file-tree-next": "2.24.2",
-    "@opensumi/ide-i18n": "2.24.2",
-    "@opensumi/ide-keymaps": "2.24.2",
-    "@opensumi/ide-logs": "2.24.2",
-    "@opensumi/ide-main-layout": "2.24.2",
-    "@opensumi/ide-markdown": "2.24.2",
-    "@opensumi/ide-markers": "2.24.2",
-    "@opensumi/ide-menu-bar": "2.24.2",
-    "@opensumi/ide-monaco": "2.24.2",
-    "@opensumi/ide-monaco-enhance": "2.24.2",
-    "@opensumi/ide-opened-editor": "2.24.2",
-    "@opensumi/ide-outline": "2.24.2",
-    "@opensumi/ide-output": "2.24.2",
-    "@opensumi/ide-overlay": "2.24.2",
-    "@opensumi/ide-preferences": "2.24.2",
-    "@opensumi/ide-process": "2.24.2",
-    "@opensumi/ide-quick-open": "2.24.2",
-    "@opensumi/remote-cli": "2.24.2",
-    "@opensumi/ide-remote-opener": "2.24.2",
-    "@opensumi/ide-scm": "2.24.2",
-    "@opensumi/ide-search": "2.24.2",
-    "@opensumi/ide-startup": "2.24.2",
-    "@opensumi/ide-static-resource": "2.24.2",
-    "@opensumi/ide-status-bar": "2.24.2",
-    "@opensumi/ide-storage": "2.24.2",
-    "@opensumi/ide-task": "2.24.2",
-    "@opensumi/ide-terminal-next": "2.24.2",
-    "@opensumi/ide-testing": "2.24.2",
-    "@opensumi/ide-theme": "2.24.2",
-    "@opensumi/ide-toolbar": "2.24.2",
-    "@opensumi/sumi": "2.24.2",
-    "@opensumi/ide-userstorage": "2.24.2",
-    "@opensumi/ide-utils": "2.24.2",
-    "@opensumi/ide-variable": "2.24.2",
-    "@opensumi/ide-webview": "2.24.2",
-    "@opensumi/ide-workspace": "2.24.2",
-    "@opensumi/ide-workspace-edit": "2.24.2"
+    "@opensumi/ide-addons": "2.24.3",
+    "@opensumi/ide-collaboration": "2.24.3",
+    "@opensumi/ide-comments": "2.24.3",
+    "@opensumi/ide-components": "2.24.3",
+    "@opensumi/ide-connection": "2.24.3",
+    "@opensumi/ide-core-browser": "2.24.3",
+    "@opensumi/ide-core-common": "2.24.3",
+    "@opensumi/ide-core-electron-main": "2.24.3",
+    "@opensumi/ide-core-node": "2.24.3",
+    "@opensumi/ide-debug": "2.24.3",
+    "@opensumi/ide-decoration": "2.24.3",
+    "@opensumi/ide-editor": "2.24.3",
+    "@opensumi/ide-electron-basic": "2.24.3",
+    "@opensumi/ide-explorer": "2.24.3",
+    "@opensumi/ide-express-file-server": "2.24.3",
+    "@opensumi/ide-extension": "2.24.3",
+    "@opensumi/ide-extension-manager": "2.24.3",
+    "@opensumi/ide-extension-storage": "2.24.3",
+    "@opensumi/ide-file-scheme": "2.24.3",
+    "@opensumi/ide-file-search": "2.24.3",
+    "@opensumi/ide-file-service": "2.24.3",
+    "@opensumi/ide-file-tree-next": "2.24.3",
+    "@opensumi/ide-i18n": "2.24.3",
+    "@opensumi/ide-keymaps": "2.24.3",
+    "@opensumi/ide-logs": "2.24.3",
+    "@opensumi/ide-main-layout": "2.24.3",
+    "@opensumi/ide-markdown": "2.24.3",
+    "@opensumi/ide-markers": "2.24.3",
+    "@opensumi/ide-menu-bar": "2.24.3",
+    "@opensumi/ide-monaco": "2.24.3",
+    "@opensumi/ide-monaco-enhance": "2.24.3",
+    "@opensumi/ide-opened-editor": "2.24.3",
+    "@opensumi/ide-outline": "2.24.3",
+    "@opensumi/ide-output": "2.24.3",
+    "@opensumi/ide-overlay": "2.24.3",
+    "@opensumi/ide-preferences": "2.24.3",
+    "@opensumi/ide-process": "2.24.3",
+    "@opensumi/ide-quick-open": "2.24.3",
+    "@opensumi/remote-cli": "2.24.3",
+    "@opensumi/ide-remote-opener": "2.24.3",
+    "@opensumi/ide-scm": "2.24.3",
+    "@opensumi/ide-search": "2.24.3",
+    "@opensumi/ide-startup": "2.24.3",
+    "@opensumi/ide-static-resource": "2.24.3",
+    "@opensumi/ide-status-bar": "2.24.3",
+    "@opensumi/ide-storage": "2.24.3",
+    "@opensumi/ide-task": "2.24.3",
+    "@opensumi/ide-terminal-next": "2.24.3",
+    "@opensumi/ide-testing": "2.24.3",
+    "@opensumi/ide-theme": "2.24.3",
+    "@opensumi/ide-toolbar": "2.24.3",
+    "@opensumi/sumi": "2.24.3",
+    "@opensumi/ide-userstorage": "2.24.3",
+    "@opensumi/ide-utils": "2.24.3",
+    "@opensumi/ide-variable": "2.24.3",
+    "@opensumi/ide-webview": "2.24.3",
+    "@opensumi/ide-workspace": "2.24.3",
+    "@opensumi/ide-workspace-edit": "2.24.3"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/sumi",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "typings": "index.d.ts",
   "license": "MIT",
   "repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/sumi",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "typings": "index.d.ts",
   "license": "MIT",
   "repository": {

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-userstorage",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib"
   ],

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-userstorage",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-utils",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-utils",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/variable/package.json
+++ b/packages/variable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-variable",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/variable/package.json
+++ b/packages/variable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-variable",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-webview",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-webview",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/workspace-edit/package.json
+++ b/packages/workspace-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace-edit",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/workspace-edit/package.json
+++ b/packages/workspace-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace-edit",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "files": [
     "lib",
     "src"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "files": [
     "lib",
     "src"

--- a/tools/cli-engine/package.json
+++ b/tools/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/cli-engine",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "Integration engine runtime for opensumi-cli and opensumi extension",
   "license": "MIT",
   "files": [

--- a/tools/cli-engine/package.json
+++ b/tools/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/cli-engine",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "Integration engine runtime for opensumi-cli and opensumi extension",
   "license": "MIT",
   "files": [

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/playwright",
-  "version": "2.24.3",
+  "version": "2.24.5",
   "description": "E2E test module for OpenSumi",
   "files": [
     "lib",

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/playwright",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "E2E test module for OpenSumi",
   "files": [
     "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,10 +2696,8 @@ __metadata:
     "@ant-design/icons": ^4.6.4
     "@opensumi/ide-dev-tool": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
-    "@types/dompurify": ^3.0.1
     "@types/marked": ^4.0.7
     "@types/react-window": ^1.8.5
-    dompurify: ^3.0.2
     fuzzy: ^0.1.3
     lodash: ^4.17.15
     marked: 4.0.10
@@ -4041,16 +4039,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/dompurify@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@types/dompurify@npm:3.0.1"
-  dependencies:
-    "@types/jsdom": "*"
-    "@types/trusted-types": "*"
-  checksum: d4bf881845ac1f4619622b62945f0fda876e6c09d4c958bc7f3a84c4307f7258b9a15e334ae08c7ac5ecfcd0656415328df29d3fb737e9bce2849feaf180c6ab
-  languageName: node
-  linkType: hard
-
 "@types/ejs@npm:^3.0.2":
   version: 3.1.1
   resolution: "@types/ejs@npm:3.1.1"
@@ -4178,17 +4166,6 @@ __metadata:
     expect: ^29.0.0
     pretty-format: ^29.0.0
   checksum: 23760282362a252e6690314584d83a47512d4cd61663e957ed3398ecf98195fe931c45606ee2f9def12f8ed7d8aa102d492ec42d26facdaf8b78094a31e6568e
-  languageName: node
-  linkType: hard
-
-"@types/jsdom@npm:*":
-  version: 21.1.1
-  resolution: "@types/jsdom@npm:21.1.1"
-  dependencies:
-    "@types/node": "*"
-    "@types/tough-cookie": "*"
-    parse5: ^7.0.0
-  checksum: 7450d6e23aa31b837a1682f0e59b06838aacca85c9d030035f40e21d559169c773aee5cee9244f23c3004b78f7064f0c540ceb808d2f187deb3140f2b0449dee
   languageName: node
   linkType: hard
 
@@ -4550,13 +4527,6 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
-  languageName: node
-  linkType: hard
-
-"@types/trusted-types@npm:*":
-  version: 2.0.3
-  resolution: "@types/trusted-types@npm:2.0.3"
-  checksum: 4794804bc4a4a173d589841b6d26cf455ff5dc4f3e704e847de7d65d215f2e7043d8757e4741ce3a823af3f08260a8d04a1a6e9c5ec9b20b7b04586956a6b005
   languageName: node
   linkType: hard
 
@@ -8791,13 +8761,6 @@ __metadata:
   dependencies:
     domelementtype: ^2.2.0
   checksum: 4c665ceed016e1911bf7d1dadc09dc888090b64dee7851cccd2fcf5442747ec39c647bb1cb8c8919f8bbdd0f0c625a6bafeeed4b2d656bbecdbae893f43ffaaa
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "dompurify@npm:3.0.2"
-  checksum: 768c3bb2f139ce1e1a53faf81aae6abe03e24d0b043e2fda0b70e91ef15bb1df854a35e82d8c519adfe5b81c24bfdad3e0b1085534bfbf427137cb742406c47f
   languageName: node
   linkType: hard
 
@@ -17095,7 +17058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.0.0, parse5@npm:^7.1.1":
+"parse5@npm:^7.1.1":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
   dependencies:


### PR DESCRIPTION
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b15684</samp>

This pull request updates the core package and its related packages to version 2.24.3 and introduces several improvements and bug fixes. It removes unnecessary dependencies and sanitization calls for markdown rendering, which improves performance and reduces bundle size. It adds more customization and interactivity options for the recycle-tree component in the `@opensumi/ide-components` package. It also adds an option to disable or configure the RPC timeout feature in the `@opensumi/ide-connection` package and improves the error handling for RPC timeout cases. Finally, it adds a sanitize option to the Markdown component in the `@opensumi/ide-comments` package and the toMarkdownHtml function in the `@opensumi/ide-core-browser` package to prevent XSS attacks from malicious markdown content.
