### PR TITLE
fix: add default input value for TerminalSearchService

### DIFF
--- a/packages/terminal-next/src/browser/terminal.search.ts
+++ b/packages/terminal-next/src/browser/terminal.search.ts
@@ -11,7 +11,7 @@ export class TerminalSearchService implements ITerminalSearchService {
   show: boolean;
 
   @observable
-  input: string;
+  input = '';
 
   @Autowired(ITerminalController)
   controller: ITerminalController;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c377bc</samp>

* Initialize `input` property of `TerminalSearchService` to an empty string to prevent undefined errors ([link](https://github.com/opensumi/core/pull/2762/files?diff=unified&w=0#diff-7067cc8cda18ed9ce6ca11165e9364b7785685dd766f48955e9899398c176d3cL14-R14))

<!-- Additional content -->
<!-- 补充额外内容 -->
![image](https://github.com/opensumi/core/assets/19860190/857372ec-5494-4de2-9b62-abaef06abdb1)
添加初始值，避免值为 undefined 时为非受控组件
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c377bc</samp>

Fixed terminal search issues by initializing `input` property of `TerminalSearchService` and making other minor improvements.
