### PR TITLE
fix: check if element of popover exists when delayed hidden

### DIFF
--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -142,8 +142,12 @@ export const Popover: React.FC<{
       return;
     }
     hideContentTimer = setTimeout(() => {
-      contentEl.current!.style.display = 'none';
-      contentEl.current!.style.visibility = 'hidden';
+      // 存在延时隐藏时组件已销毁的情况
+      if (!contentEl.current) {
+        return;
+      }
+      contentEl.current.style.display = 'none';
+      contentEl.current.style.visibility = 'hidden';
     }, delay);
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cb6734</samp>

*  Add a null check for `contentEl.current` to avoid errors when the popover is unmounted ([link](https://github.com/opensumi/core/pull/2764/files?diff=unified&w=0#diff-17616836f71aea95243b3f7b4846281ac2502d0bc9d09e13c555fac6d9c1441dL145-R150))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cb6734</samp>

Fix a potential error in `Popover` component when unmounting. Add a null check for `contentEl.current` in `hideContent` function.
