### PR TITLE
fix: use command update status-bar (#2757)

### DIFF
--- a/packages/terminal-next/src/browser/terminal.environment.service.ts
+++ b/packages/terminal-next/src/browser/terminal.environment.service.ts
@@ -3,7 +3,13 @@ import throttle from 'lodash/throttle';
 import React from 'react';
 
 import { Injectable, Autowired } from '@opensumi/di';
-import { getIcon, StatusBarAlignment, StatusBarEntryAccessor, TERMINAL_COMMANDS } from '@opensumi/ide-core-browser';
+import {
+  getIcon,
+  StatusBarAlignment,
+  StatusBarCommand,
+  StatusBarEntryAccessor,
+  TERMINAL_COMMANDS,
+} from '@opensumi/ide-core-browser';
 import {
   CommandService,
   Emitter,
@@ -153,13 +159,19 @@ export class TerminalEnvironmentService implements IEnvironmentVariableService {
       mutators.forEach((mutator) => changes.push(mutatorTypeLabel(mutator.type, mutator.value, variable)));
     });
 
-    this.statusBarEntryAccessor = this.statusbarService.addElement(ENVIRONMENT_VARIABLE_CHANGED_STATUS, {
-      iconClass: getIcon('warning-circle'),
-      color: 'orange',
-      alignment: StatusBarAlignment.RIGHT,
-      tooltip: toMarkdownString(localize('terminal.environment.changed') + '\n\n```\n' + changes.join('\n') + '\n```'),
-      onClick: () => this.onDidClickStatusBarEntry(diff),
-    });
+    this.commandService
+      .tryExecuteCommand(StatusBarCommand.addElement.id, ENVIRONMENT_VARIABLE_CHANGED_STATUS, {
+        iconClass: getIcon('warning-circle'),
+        color: 'orange',
+        alignment: StatusBarAlignment.RIGHT,
+        tooltip: toMarkdownString(
+          localize('terminal.environment.changed') + '\n\n```\n' + changes.join('\n') + '\n```',
+        ),
+        onClick: () => this.onDidClickStatusBarEntry(diff),
+      })
+      .then((res: StatusBarEntryAccessor) => {
+        this.statusBarEntryAccessor = res;
+      });
   }
 
   private notifyCollectionUpdates() {


### PR DESCRIPTION
### Types

- [ ] 🪚 Refactors

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 979c73b</samp>

*  Replace `statusbarService.addElement` with `commandService.tryExecuteCommand` for adding status bar elements in `terminal.environment.service.ts` ([link](https://github.com/opensumi/core/pull/2765/files?diff=unified&w=0#diff-29f97af8e1b429cf535bca2fb05b36468cdc44610c9806af17ba4f2de229681cL6-R13), [link](https://github.com/opensumi/core/pull/2765/files?diff=unified&w=0#diff-29f97af8e1b429cf535bca2fb05b36468cdc44610c9806af17ba4f2de229681cL156-R174))
*  Import `StatusBarCommand` type from `@opensumi/statusbar` in `terminal.environment.service.ts` ([link](https://github.com/opensumi/core/pull/2765/files?diff=unified&w=0#diff-29f97af8e1b429cf535bca2fb05b36468cdc44610c9806af17ba4f2de229681cL6-R13))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 979c73b</samp>

Improved the terminal status bar integration by using the command-based API. This affects the file `terminal.environment.service.ts` in the terminal-next package.

将 TerminalEnvironmentService 中对状态栏的更新方式改为使用命令的方式更新，方便监听对应的更新事件进行一些 AOP 操作
