### PR TITLE
fix: check if currentGroup is empty when split terminal

### DIFF
--- a/packages/terminal-next/src/browser/contribution/terminal.command.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.command.ts
@@ -105,6 +105,9 @@ export class TerminalCommandContribution implements CommandContribution {
       {
         execute: () => {
           const group = this.view.currentGroup;
+          if (!group) {
+            return;
+          }
           const widget = this.view.createWidget(group);
           this.view.selectWidget(widget.id);
         },


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8da187</samp>

*  Add guard clause to prevent errors when terminal group is undefined ([link](https://github.com/opensumi/core/pull/2766/files?diff=unified&w=0#diff-dbc85461a9648b27059e455e6a0ef9a9b8a30755ef99eb5b2a4f35689f1485ebR108-R110))

<!-- Additional content -->
<!-- 补充额外内容 -->
![image](https://github.com/opensumi/core/assets/19860190/342f683a-f465-4b39-aee7-3aa17ac344ec)
没有 terminal 时如果在菜单点击 split terminal 会报错，此时再打开 terminal 无法创建新的 terminal，因此 split terminal 需要对 view group 进行非空判断

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8da187</samp>

Fix a bug that caused errors when executing terminal commands without a group. Add a guard clause to `executeTerminalFrontendContribution` in `terminal.command.ts`.
