### PR TITLE
feat: open resource when click comment item

### DIFF
--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -27,6 +27,9 @@ export class CommentModelService extends Disposable {
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
+  @Autowired(WorkbenchEditorService)
+  protected readonly editorService: WorkbenchEditorService;
+
   private _treeModel: CommentTreeModel;
 
   private _whenReady: Promise<void>;
@@ -150,6 +153,19 @@ export class CommentModelService extends Disposable {
     if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {
       this.toggleDirectory(node as CommentFileNode | CommentContentNode);
     }
+    let uri;
+    let range;
+
+    if (node instanceof CommentReplyNode || node instanceof CommentContentNode) {
+      uri = node.thread.uri;
+      range = node.thread.range;
+    } else {
+      uri = node.resource;
+    }
+
+    this.editorService.open(uri, {
+      range,
+    });
   };
 
   toggleDirectory = (item: CommentFileNode | CommentContentNode) => {

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -2,6 +2,7 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeModel } from '@opensumi/ide-components';
 import { DisposableCollection, Emitter, Event, Disposable } from '@opensumi/ide-core-browser';
+import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/common/index';
 import { ICommentsService } from '../../common/index';
 
 import { CommentContentNode, CommentFileNode, CommentReplyNode, CommentRoot } from './tree-node.defined';


### PR DESCRIPTION
### Types
- [x] 🎉 New Features

### Background or solution

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46cb9cb</samp>

*  Inject `WorkbenchEditorService` as a dependency for `CommentModelService` ([link](https://github.com/opensumi/core/pull/2769/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aR30-R32))
*  Add logic to `openEditor` method of `CommentModelService` to open editors for comment nodes and reveal commented code ([link](https://github.com/opensumi/core/pull/2769/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aR156-R168))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46cb9cb</samp>

Enable opening editors for comment nodes in the comment tree feature. Use `WorkbenchEditorService` to handle editor creation and range passing in `tree-model.service.ts`.
