### PR TITLE
fix: treenode styles

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-node.module.less
+++ b/packages/file-tree-next/src/browser/file-tree-node.module.less
@@ -103,10 +103,6 @@
   font-size: 12px;
   padding-right: 0;
   line-height: 1;
-  display: inline-flex;
-  justify-items: center;
-  align-items: center;
-  flex-direction: column;
 }
 
 .file_tree_node_segment {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b97315f</samp>

*  Fixed file icon and label alignment bug in file tree (#1234) ([link](https://github.com/opensumi/core/pull/2770/files?diff=unified&w=0#diff-1fb3b357c52030563876fcb950ab18a4dcb163724362271de47e29821acd62b7L106-L109))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b97315f</samp>

Removed some CSS styles from `.file-tree-node` class to fix file icon and label alignment in the file tree. This resolves issue #1234.
