### PR TITLE
feat: throw error if get file stat error

### DIFF
--- a/packages/connection/src/common/proxy.ts
+++ b/packages/connection/src/common/proxy.ts
@@ -3,6 +3,10 @@ import type { MessageConnection } from '@opensumi/vscode-jsonrpc/lib/common/conn
 
 import { MessageType, ResponseStatus, ICapturedMessage, getCapturer } from './utils';
 
+export interface ILogger {
+  warn(...args: any[]): void;
+}
+
 export abstract class RPCService<T = any> {
   rpcClient?: T[];
   rpcRegistered?: boolean;
@@ -47,7 +51,7 @@ export class RPCProxy {
   private connectionPromiseResolve: (connection: MessageConnection) => void;
   private connection: MessageConnection;
   private proxyService: any = {};
-  private logger: any;
+  private logger: ILogger;
   // capture messages for opensumi devtools
   private capture(message: ICapturedMessage): void {
     const capturer = getCapturer();
@@ -56,7 +60,7 @@ export class RPCProxy {
     }
   }
 
-  constructor(public target?: RPCService, logger?: any) {
+  constructor(public target?: RPCService, logger?: ILogger) {
     this.waitForConnection();
     this.logger = logger || console;
   }

--- a/packages/core-common/src/types/file.ts
+++ b/packages/core-common/src/types/file.ts
@@ -68,6 +68,17 @@ export interface FileStat {
   realUri?: string;
 }
 
+export interface FileStatOptions {
+  /**
+   * Whether to throw an error if the file in following error(in older version, OpenSumi will eat these errors silently):
+   * - doesn't exist
+   * - no access
+   * - busy
+   * - permission deny.
+   */
+  throwError?: boolean;
+}
+
 export namespace FileStat {
   export function is(candidate: object | undefined): candidate is FileStat {
     return (
@@ -152,10 +163,11 @@ export interface FileSystemProvider {
    * `FileType.SymbolicLink | FileType.Directory`.
    *
    * @param uri The uri of the file to retrieve metadata about.
+   * @param options some options to influence the stat result.
    * @return The file metadata about the file.
    * @throws [`FileNotFound`](#FileSystemError.FileNotFound) when `uri` doesn't exist.
    */
-  stat(uri: Uri): Promise<FileStat | void>;
+  stat(uri: Uri, options?: FileStatOptions): Promise<FileStat | void>;
 
   /**
    * Retrieve all entries of a [directory](#FileType.Directory).

--- a/packages/core-common/src/types/file.ts
+++ b/packages/core-common/src/types/file.ts
@@ -68,13 +68,13 @@ export interface FileStat {
   realUri?: string;
 }
 
-export interface FileStatOptions {
+export interface IFileStatOptions {
   /**
    * Whether to throw an error if the file in following error(in older version, OpenSumi will eat these errors silently):
    * - doesn't exist
    * - no access
    * - busy
-   * - permission deny.
+   * - permission deny
    */
   throwError?: boolean;
 }
@@ -167,7 +167,7 @@ export interface FileSystemProvider {
    * @return The file metadata about the file.
    * @throws [`FileNotFound`](#FileSystemError.FileNotFound) when `uri` doesn't exist.
    */
-  stat(uri: Uri, options?: FileStatOptions): Promise<FileStat | void>;
+  stat(uri: Uri, options?: IFileStatOptions): Promise<FileStat | void>;
 
   /**
    * Retrieve all entries of a [directory](#FileType.Directory).

--- a/packages/file-service/src/common/files.ts
+++ b/packages/file-service/src/common/files.ts
@@ -447,6 +447,25 @@ export function isErrnoException(error: any | NodeJS.ErrnoException): error is N
   return (error as NodeJS.ErrnoException).code !== undefined && (error as NodeJS.ErrnoException).errno !== undefined;
 }
 
+export function handleError(error: any | NodeJS.ErrnoException): never {
+  if (isErrnoException(error)) {
+    switch (error.code) {
+      case 'EEXIST':
+        throw FileSystemError.FileExists(Uri.file(error.path ?? ''));
+      case 'EPERM':
+      case 'EACCESS':
+        throw FileSystemError.FileIsNoPermissions(Uri.file(error.path ?? ''));
+      case 'ENOENT':
+        throw FileSystemError.FileNotFound(Uri.file(error.path ?? ''));
+      case 'ENOTDIR':
+        throw FileSystemError.FileNotADirectory(Uri.file(error.path ?? ''));
+      case 'EISDIR':
+        throw FileSystemError.FileIsADirectory(Uri.file(error.path ?? ''));
+    }
+  }
+  throw error;
+}
+
 export interface IFileSystemProviderRegistrationEvent {
   added: boolean;
   scheme: string;

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -13,7 +13,7 @@ import {
   ILogServiceManager,
   SupportLogNamespace,
   path,
-  FileStatOptions,
+  IFileStatOptions,
 } from '@opensumi/ide-core-node';
 import {
   isLinux,
@@ -148,7 +148,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     }
   }
 
-  async stat(uri: UriComponents, options?: FileStatOptions): Promise<FileStat> {
+  async stat(uri: UriComponents, options?: IFileStatOptions): Promise<FileStat> {
     const _uri = Uri.revive(uri);
     try {
       const stat = await this.doGetStat(_uri, 1, options);
@@ -553,7 +553,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     }
   }
 
-  protected async doGetStat(uri: Uri, depth: number, options?: FileStatOptions): Promise<FileStat | undefined> {
+  protected async doGetStat(uri: Uri, depth: number, options?: IFileStatOptions): Promise<FileStat | undefined> {
     try {
       const filePath = uri.fsPath;
       const lstat = await fse.lstat(filePath);


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

**This PR may bring a breaking change.**

I found that the return value of the function(FileServiceClient.stat) is incorrect while troubleshooting an issue:

![image](https://github.com/opensumi/core/assets/13938334/2edb8b77-1801-4fa0-90b5-73e55bf4a8aa)

the `[]` is the fallback value returned by the RPC boardcast func if it receive no response.

but actually we should throw error if no remote service handled the call.

and the `stat` function actually will eat some errors itself, which is also a bad design.

### Changelog

Throw error if get file stat error(or RPC error)