### PR TITLE
chore: optimize menuaction list renderer

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -88,9 +88,9 @@ export const MenuActionList: React.FC<{
     (dataSource: MenuNode[], key?: string) =>
       dataSource.map((menuNode, index) => {
         if (menuNode.id === SeparatorMenuItemNode.ID) {
-          return <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} />;
+          return null;
         }
-
+        const hasSeparator = dataSource[index + 1] && dataSource[index + 1].id === SeparatorMenuItemNode.ID;
         if (menuNode.id === SubmenuItemNode.ID) {
           // 子菜单项为空时不渲染
           if (!Array.isArray(menuNode.children) || !menuNode.children.length) {
@@ -98,26 +98,32 @@ export const MenuActionList: React.FC<{
           }
 
           return (
-            <Menu.SubMenu
-              key={`${(menuNode as SubmenuItemNode).submenuId}-${index}`}
-              className={styles.submenuItem}
-              popupClassName='kt-menu'
-              title={<MenuAction hasSubmenu data={menuNode} />}
-            >
-              {recursiveRender(menuNode.children, menuNode.label)}
-            </Menu.SubMenu>
+            <>
+              <Menu.SubMenu
+                key={`${(menuNode as SubmenuItemNode).submenuId}-${index}`}
+                className={styles.submenuItem}
+                popupClassName='kt-menu'
+                title={<MenuAction hasSubmenu data={menuNode} />}
+              >
+                {recursiveRender(menuNode.children, menuNode.label)}
+              </Menu.SubMenu>
+              {hasSeparator ? <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} /> : null}
+            </>
           );
         }
 
         return (
-          <Menu.Item
-            id={`${menuNode.id}-${index}`}
-            key={`${menuNode.id}-${key}-${index}`}
-            className={styles.menuItem}
-            disabled={menuNode.disabled}
-          >
-            <MenuAction data={menuNode} disabled={menuNode.disabled} />
-          </Menu.Item>
+          <>
+            <Menu.Item
+              id={`${menuNode.id}-${index}`}
+              key={`${menuNode.id}-${key}-${index}`}
+              className={styles.menuItem}
+              disabled={menuNode.disabled}
+            >
+              <MenuAction data={menuNode} disabled={menuNode.disabled} />
+            </Menu.Item>
+            {hasSeparator ? <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} /> : null}
+          </>
         );
       }),
     [],
@@ -453,7 +459,10 @@ export function InlineActionBar<T = undefined, U = undefined, K = undefined, M =
   // 因为这里的 context 塞到 useMenus 之后会自动把参数加入到 MenuItem.execute 里面
   const [navMenu, moreMenu] = useMenus(menus, separator, context, debounce);
 
-  const navMenus = useMemo(() => isFlattenMenu ? [...navMenu, ...moreMenu] : navMenu, [navMenu, moreMenu, isFlattenMenu]);
+  const navMenus = useMemo(
+    () => (isFlattenMenu ? [...navMenu, ...moreMenu] : navMenu),
+    [navMenu, moreMenu, isFlattenMenu],
+  );
 
   // inline 菜单不取第二组，对应内容由关联 context menu 去渲染
   return (


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before
 
![image](https://github.com/opensumi/core/assets/17701805/c2688330-ca37-49c1-bba5-17607bc9ef03)

after

![image](https://github.com/opensumi/core/assets/17701805/cff93f89-a265-4012-ac94-736320af990d)

原有的 menulist 的渲染逻辑中，是将所有 menunodes 包括分割线循环渲染出来，而对于没有子菜单项的则会渲染为空，但实际上由于原本菜单项间插入的分割线，导致这种情况下，即使菜单没有被渲染，但菜单的分割线也会被渲染出来，出现连续的两条分割线

优化方式是跳过每次循环对分割线的处理，而是在渲染菜单项时判断下一个菜单项是否为分割线，与菜单项一起渲染

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b097c57</samp>

*  Simplify the rendering of menu items and submenus by avoiding unnecessary dividers ([link](https://github.com/opensumi/core/pull/2775/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L91-R93), [link](https://github.com/opensumi/core/pull/2775/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L101-R126))
*  Format the code of the `MenuActionGroup` component to improve readability and consistency ([link](https://github.com/opensumi/core/pull/2775/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L456-R465))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b097c57</samp>

This pull request enhances the appearance and usability of the menu actions component in the core-browser package. It adjusts the logic for adding dividers between menu items and submenus based on the `MenuActionGroup` data source.
