### PR TITLE
feat: auto expand the comment widget when click comment tree item

### DIFF
--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -164,9 +164,15 @@ export class CommentModelService extends Disposable {
       uri = node.resource;
     }
 
-    this.editorService.open(uri, {
-      range,
-    });
+    this.editorService
+      .open(uri, {
+        range,
+      })
+      .then(() => {
+        if ((node as CommentReplyNode | CommentContentNode).thread) {
+          (node as CommentReplyNode | CommentContentNode).thread.show();
+        }
+      });
   };
 
   toggleDirectory = (item: CommentFileNode | CommentContentNode) => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1149c82</samp>

* Fix a bug where the comment thread would not be visible when opening a file from the comment tree ([link](https://github.com/opensumi/core/pull/2777/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aL167-R175))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1149c82</samp>

Fix comment thread visibility when opening files from comment tree. Use `editorService.open` promise to show comment thread of opened node in `tree-model.service.ts`.
