### PR TITLE
refactor: extract platform specific code

### DIFF
--- a/packages/webview/src/browser/abstract-webview.ts
+++ b/packages/webview/src/browser/abstract-webview.ts
@@ -159,21 +159,6 @@ export abstract class AbstractWebviewPanel extends Disposable implements IWebvie
     await this.doUpdateContent();
   }
 
-  protected preprocessHtml(html: string): string {
-    if (this.appConfig.isElectronRenderer) {
-      // 将vscode-resource:/User/xxx 转换为 vscode-resource:///User/xxx
-      return html.replace(
-        /(["'])vscode-resource:(\/\/|)([^\s'"]+?)(["'])/gi,
-        (_, startQuote, slash, path, endQuote) => `${startQuote}vscode-resource://${path}${endQuote}`,
-      );
-    }
-    return html.replace(
-      /(["'])vscode-resource:([^\s'"]+?)(["'])/gi,
-      (_, startQuote, path, endQuote) =>
-        `${startQuote}${this.staticResourceService.resolveStaticResource(URI.file(path))}${endQuote}`,
-    );
-  }
-
   protected doUpdateContent() {
     return this._sendToWebview('content', {
       contents: this.preprocessHtml(this._html),
@@ -184,8 +169,8 @@ export abstract class AbstractWebviewPanel extends Disposable implements IWebvie
 
   public abstract appendTo(container: HTMLElement);
 
+  protected abstract preprocessHtml(html: string): string;
   protected abstract _sendToWebview(channel: string, data: any);
-
   protected abstract _onWebviewMessage(channel: string, listener: (data: any) => any): IDisposable;
 
   updateOptions(options: IWebviewContentOptions): void {

--- a/packages/webview/src/browser/contribution.ts
+++ b/packages/webview/src/browser/contribution.ts
@@ -1,28 +1,19 @@
 /* istanbul ignore file */
 import { Autowired } from '@opensumi/di';
-import { Domain, URI, CommandContribution, CommandRegistry, AppConfig } from '@opensumi/ide-core-browser';
-import { localize } from '@opensumi/ide-core-common';
+import { Domain, URI } from '@opensumi/ide-core-browser';
 import { ResourceService, IResource } from '@opensumi/ide-editor';
 import { BrowserEditorContribution, EditorComponentRegistry } from '@opensumi/ide-editor/lib/browser';
 
 import { EDITOR_WEBVIEW_SCHEME, IWebviewService, IEditorWebviewMetaData, isWebview } from './types';
 import { WebviewServiceImpl } from './webview.service';
 
-const WEBVIEW_DEVTOOLS_COMMAND = {
-  id: 'workbench.action.webview.openDeveloperTools',
-  label: localize('openToolsLabel', 'Open Webview Developer Tools'),
-};
-
-@Domain(BrowserEditorContribution, CommandContribution)
-export class WebviewModuleContribution implements BrowserEditorContribution, CommandContribution {
+@Domain(BrowserEditorContribution)
+export class WebviewModuleContribution implements BrowserEditorContribution {
   @Autowired(IWebviewService)
   webviewService: WebviewServiceImpl;
 
   @Autowired(EditorComponentRegistry)
   editorComponentRegistry: EditorComponentRegistry;
-
-  @Autowired(AppConfig)
-  private readonly appConfig: AppConfig;
 
   registerResource(resourceService: ResourceService) {
     resourceService.registerResourceProvider({
@@ -58,23 +49,6 @@ export class WebviewModuleContribution implements BrowserEditorContribution, Com
 
         return true;
       },
-    });
-  }
-
-  registerCommands(commandRegistry: CommandRegistry) {
-    commandRegistry.registerCommand(WEBVIEW_DEVTOOLS_COMMAND, {
-      execute: () => {
-        const elements = document.querySelectorAll<Electron.WebviewTag>('webview');
-        // eslint-disable-next-line @typescript-eslint/prefer-for-of
-        for (let i = 0; i < elements.length; i += 1) {
-          try {
-            elements[i].openDevTools();
-          } catch (e) {
-            // noop
-          }
-        }
-      },
-      isEnabled: () => this.appConfig.isElectronRenderer,
     });
   }
 }

--- a/packages/webview/src/browser/electron-webview-webview.ts
+++ b/packages/webview/src/browser/electron-webview-webview.ts
@@ -110,6 +110,14 @@ export class ElectronWebviewWebviewPanel extends AbstractWebviewPanel implements
     }
   }
 
+  protected preprocessHtml(html: string): string {
+    // 将vscode-resource:/User/xxx 转换为 vscode-resource:///User/xxx
+    return html.replace(
+      /(["'])vscode-resource:(\/\/|)([^\s'"]+?)(["'])/gi,
+      (_, startQuote, slash, path, endQuote) => `${startQuote}vscode-resource://${path}${endQuote}`,
+    );
+  }
+
   remove() {
     if (this.webview) {
       this.webview.remove();

--- a/packages/webview/src/browser/electron.contribution.ts
+++ b/packages/webview/src/browser/electron.contribution.ts
@@ -1,0 +1,33 @@
+import { Autowired } from '@opensumi/di';
+import { Domain, CommandContribution, CommandRegistry } from '@opensumi/ide-core-browser';
+import { localize } from '@opensumi/ide-core-common';
+
+import { IWebviewService } from './types';
+import { WebviewServiceImpl } from './webview.service';
+
+const WEBVIEW_DEVTOOLS_COMMAND = {
+  id: 'workbench.action.webview.openDeveloperTools',
+  label: localize('openToolsLabel', 'Open Webview Developer Tools'),
+};
+
+@Domain(CommandContribution)
+export class ElectronWebviewModuleContribution implements CommandContribution {
+  @Autowired(IWebviewService)
+  webviewService: WebviewServiceImpl;
+
+  registerCommands(commandRegistry: CommandRegistry) {
+    commandRegistry.registerCommand(WEBVIEW_DEVTOOLS_COMMAND, {
+      execute: () => {
+        const elements = document.querySelectorAll<Electron.WebviewTag>('webview');
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < elements.length; i += 1) {
+          try {
+            elements[i].openDevTools();
+          } catch (e) {
+            // noop
+          }
+        }
+      },
+    });
+  }
+}

--- a/packages/webview/src/browser/iframe-webview.ts
+++ b/packages/webview/src/browser/iframe-webview.ts
@@ -1,9 +1,8 @@
 import { Injectable, Autowired } from '@opensumi/di';
-import { Disposable, DomListener, getDebugLogger, IDisposable, AppConfig } from '@opensumi/ide-core-browser';
+import { Disposable, DomListener, getDebugLogger, IDisposable, AppConfig, URI } from '@opensumi/ide-core-browser';
 
 import { AbstractWebviewPanel } from './abstract-webview';
 import { IWebview, IWebviewContentOptions } from './types';
-
 
 @Injectable({ multiple: true })
 export class IFrameWebviewPanel extends AbstractWebviewPanel implements IWebview {
@@ -110,6 +109,14 @@ export class IFrameWebviewPanel extends AbstractWebviewPanel implements IWebview
         this.doUpdateContent();
       }
     }
+  }
+
+  protected preprocessHtml(html: string): string {
+    return html.replace(
+      /(["'])vscode-resource:([^\s'"]+?)(["'])/gi,
+      (_, startQuote, path, endQuote) =>
+        `${startQuote}${this.staticResourceService.resolveStaticResource(URI.file(path))}${endQuote}`,
+    );
   }
 
   remove() {

--- a/packages/webview/src/browser/index.ts
+++ b/packages/webview/src/browser/index.ts
@@ -2,6 +2,7 @@ import { Provider, Injectable } from '@opensumi/di';
 import { BrowserModule } from '@opensumi/ide-core-browser';
 
 import { WebviewModuleContribution } from './contribution';
+import { ElectronWebviewModuleContribution } from './electron.contribution';
 import { IWebviewService } from './types';
 import { WebviewServiceImpl } from './webview.service';
 export * from './types';
@@ -16,4 +17,5 @@ export class WebviewModule extends BrowserModule {
     },
     WebviewModuleContribution,
   ];
+  electronProviders: Provider[] = [ElectronWebviewModuleContribution];
 }

--- a/packages/webview/src/browser/webview.service.ts
+++ b/packages/webview/src/browser/webview.service.ts
@@ -22,7 +22,7 @@ import {
   EditorGroupChangeEvent,
   EditorOpenType,
 } from '@opensumi/ide-editor/lib/browser';
-import { LIGHT, DARK, HIGH_CONTRAST_DARK, HIGH_CONTRAST_LIGHT, ITheme } from '@opensumi/ide-theme';
+import { ITheme } from '@opensumi/ide-theme';
 import { getColorRegistry } from '@opensumi/ide-theme/lib/common/color-registry';
 
 import { EditorWebviewComponentView } from './editor-webview';

--- a/packages/webview/src/browser/webview.service.ts
+++ b/packages/webview/src/browser/webview.service.ts
@@ -14,6 +14,7 @@ import {
   STORAGE_SCHEMA,
   AppConfig,
 } from '@opensumi/ide-core-browser';
+import { throwNonElectronError } from '@opensumi/ide-core-common/lib/error';
 import { IEditorGroup, WorkbenchEditorService, ResourceNeedUpdateEvent, IResource } from '@opensumi/ide-editor';
 import {
   EditorComponentRegistry,
@@ -284,7 +285,7 @@ export class WebviewServiceImpl implements IWebviewService {
     if (this.appConfig.isElectronRenderer) {
       return this.injector.get(ElectronPlainWebviewWindow, [options, env]);
     }
-    throw new Error('not supported!');
+    throwNonElectronError('WebviewServiceImpl.createWebviewWindow');
   }
 }
 


### PR DESCRIPTION
### Types


- [x] 🪚 Refactors


### Background or solution

[OpenSumi 2023 Roadmap - 移除对 isElectronRenderer 的依赖](https://github.com/opensumi/core/wiki/2023-Roadmap)

优化代码中对于 isElectronRenderer 的依赖，将 isElectronRenderer 相关的代码都抽离出独立的函数。

### Changelog

extract platform specific code