### PR TITLE
style: improve terminal split view border style

### DIFF
--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -48,7 +48,7 @@
       cursor: ew-resize;
       transform: translateX(1px);
       pointer-events: all;
-      background: var(--terminal-foreground);
+      background: var(--terminal-border);
       opacity: 0.35;
     }
   }

--- a/packages/terminal-next/src/browser/terminal.color.ts
+++ b/packages/terminal-next/src/browser/terminal.color.ts
@@ -43,6 +43,7 @@ export const TERMINAL_FOREGROUND_COLOR = registerColor(
   },
   localize('terminal.foreground', 'The foreground color of the terminal.'),
 );
+
 export const TERMINAL_CURSOR_FOREGROUND_COLOR = registerColor(
   'terminalCursor.foreground',
   null,


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb67b16</samp>

* Changed the background color of the terminal resize handle to match the terminal border color ([link](https://github.com/opensumi/core/pull/2783/files?diff=unified&w=0#diff-bead3beb13c5d7f46af4435d7d740447b1c03667705833f40b3cd135c95d4bb3L51-R51))
* Removed an empty change from `terminal.color.ts` ([link](https://github.com/opensumi/core/pull/2783/files?diff=unified&w=0#diff-f2a20fc67f05e8c75b047ce3cc15b028d47c54883cf2f4a72e59915eae28e265R46))

close #2782

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb67b16</samp>

Improved the visibility and appearance of the terminal resize handle by changing its background color to match the terminal border color. Removed an empty change to `packages/terminal-next/src/browser/terminal.color.ts`.
