### PR TITLE
style: stop flexbox removing trailing whitespace on menu action

### DIFF
--- a/packages/core-browser/src/components/actions/styles.module.less
+++ b/packages/core-browser/src/components/actions/styles.module.less
@@ -58,6 +58,9 @@
     font-size: @base-font-size;
     display: flex;
     align-items: center;
+    // stop Flexbox removing trailing whitespace
+    // see https://www.mattstobbs.com/flexbox-removing-trailing-whitespace/
+    white-space: pre-wrap;
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25a2ced</samp>

* Preserve trailing whitespace in action buttons to avoid flexbox layout issues ([link](https://github.com/opensumi/core/pull/2784/files?diff=unified&w=0#diff-e0c30a50911943639dd78782678bc9140f085740da214eeb804b1817c310c306R61-R63))
* Add a comment with a link to a blog post explaining the CSS rule ([link](https://github.com/opensumi/core/pull/2784/files?diff=unified&w=0#diff-e0c30a50911943639dd78782678bc9140f085740da214eeb804b1817c310c306R61-R63))

close #2781 

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25a2ced</samp>

Preserve trailing whitespace in action buttons with CSS. This improves the layout and readability of the buttons in the core-browser package.
