### PR TITLE
fix: on disposeResource delete resourceDecoration

### DIFF
--- a/packages/editor/src/browser/resource.service.ts
+++ b/packages/editor/src/browser/resource.service.ts
@@ -251,6 +251,7 @@ export class ResourceServiceImpl extends WithEventBus implements ResourceService
   disposeResource(resource: IResource<any>) {
     const provider = this.getProvider(resource.uri);
     this.resources.delete(resource.uri.toString());
+    this.resourceDecoration.delete(resource.uri.toString());
     if (!provider || !provider.onDisposeResource) {
       return;
     } else {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 163769b</samp>

* Remove resource decorations when closing a file ([link](https://github.com/opensumi/core/pull/2785/files?diff=unified&w=0#diff-334dffa1728efd68fa6efa97403bf9b3066de14e0f3df14835b473a7c56b423cR254)) in `resource.service.ts`

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 163769b</samp>

Fix a bug that caused resource decorations to remain after closing a file. Remove the decoration from the `ResourceServiceImpl` map in `resource.service.ts` when a resource is closed.
