### PR TITLE
fix: support hidden vertical or horizontal scroller bar

### DIFF
--- a/packages/components/src/recycle-list/RecycleList.tsx
+++ b/packages/components/src/recycle-list/RecycleList.tsx
@@ -342,7 +342,7 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
   );
 
   // 为 List 添加下边距
-  const InnerElementType = useMemo(
+  const innerElementType = useMemo(
     () =>
       forwardRef((props, ref) => {
         const { style, ...rest } = props as any;
@@ -409,7 +409,7 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
                 ...style,
               }}
               className={cls(className, 'kt-recycle-list')}
-              innerElementType={InnerElementType}
+              innerElementType={innerElementType}
               outerElementType={outerElementType}
               estimatedItemSize={calcEstimatedSize}
             >
@@ -434,7 +434,7 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
                 ...style,
               }}
               className={cls(className, 'recycle-list')}
-              innerElementType={InnerElementType}
+              innerElementType={innerElementType}
               outerElementType={outerElementType}
             >
               {renderItem}

--- a/packages/components/src/recycle-list/RecycleList.tsx
+++ b/packages/components/src/recycle-list/RecycleList.tsx
@@ -1,63 +1,47 @@
 import cls from 'classnames';
-import React, { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList, VariableSizeList, Align, ListOnScrollProps } from 'react-window';
 
-import { ScrollbarsVirtualList } from '../scrollbars';
+import { Scrollbars } from '../scrollbars';
 
 export interface IRecycleListProps {
   /**
    * 容器高度
    * height 计算出可视区域渲染数量
-   * @type {number}
-   * @memberof RecycleTreeProps
    */
   height?: number;
   /**
    * 容器宽度
    * height 计算出可视区域渲染数量
-   * @type {number}
-   * @memberof RecycleTreeProps
    */
   width?: number;
   /**
    * 最大容器高度
    * 当容器内容高度大于该值时列表将不再增长，而是出现滚动条
    * maxHeight 匹配优先级高于 height 属性
-   * @type {number}
-   * @memberof RecycleTreeProps
    */
   maxHeight?: number;
   /**
    * 最小容器高度
    * 当容器内容高度小于该值时将不再收缩，而是固定高度，一般需要配合 maxHeight一起使用
    * maxHeight 匹配优先级高于 height 属性
-   * @type {number}
-   * @memberof RecycleTreeProps
    */
   minHeight?: number;
   /**
    * 节点高度
-   * @type {number}
-   * @memberof RecycleTreeProps
    */
   itemHeight?: number;
   /**
    * List外部样式
-   * @type {React.CSSProperties}
-   * @memberof RecycleListProps
    */
   style?: React.CSSProperties;
   /**
    * List外部样式名
-   * @type {string}
-   * @memberof RecycleListProps
    */
   className?: string;
   /**
    * List数据源
-   * @type {any[]}
-   * @memberof IRecycleListProps
    */
   data: any[];
   /**
@@ -65,28 +49,20 @@ export interface IRecycleListProps {
    * 默认传入参数为：(data, index) => {}
    * data 为 this.props.data中的子项
    * index 为当前下标
-   * @type {React.ComponentType<any>}
-   * @memberof IRecycleListProps
    */
   template: React.ComponentType<any>;
   /**
    * 头部组件渲染模板
    * 默认传入参数为：() => {}
-   * @type {React.ComponentType<any>}
-   * @memberof IRecycleListProps
    */
   header?: React.ComponentType<any>;
   /**
    * 底部组件渲染模板
    * 默认传入参数为：() => {}
-   * @type {React.ComponentType<any>}
-   * @memberof IRecycleListProps
    */
   footer?: React.ComponentType<any>;
   /**
    * List 底部边距大小，默认值为 0
-   * @type {React.ComponentType<any>}
-   * @memberof IRecycleListProps
    */
   paddingBottomSize?: number;
   /**
@@ -104,6 +80,15 @@ export interface IRecycleListProps {
    * https://react-window.vercel.app/#/examples/list/variable-size
    */
   getSize?: (index: number) => number;
+  /**
+   * 是否隐藏纵向滚动条，默认 false
+   */
+  hiddenVerticalScrollbar?: boolean;
+  /**
+   * 是否隐藏横向滚动条，默认 false
+   * 在不传入 paddingBottomSize=10 的情况下，底部元素会发生点击遮挡问题
+   */
+  hiddenHorizontalScrollbar?: boolean;
 }
 
 export interface IRecycleListHandler {
@@ -130,6 +115,8 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
   template: Template,
   paddingBottomSize,
   getSize: customGetSize,
+  hiddenVerticalScrollbar,
+  hiddenHorizontalScrollbar,
 }) => {
   const listRef = useRef<FixedSizeList | VariableSizeList>();
   const outerRef = useRef<HTMLDivElement>();
@@ -344,27 +331,48 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
     return estimatedHeight / data.length;
   }, [data]);
 
-  // 为 List 添加下边距
-  const InnerElementType = forwardRef((props, ref) => {
-    const { style, ...rest } = props as any;
-    return (
-      <div
-        ref={ref!}
-        style={{
-          ...style,
-          height: `${parseFloat(style.height) + (paddingBottomSize ? paddingBottomSize : 0)}px`,
-        }}
-        {...rest}
-      />
-    );
-  });
+  const onScroll = useCallback(
+    (props) => {
+      // 当 width/height 改变时，FixedSizeList 会重置 scrollTop
+      // 这里存储一下上次的滚动条高度后用于下次渲染时进行同步
+      prevScrollOffset.current = props.scrollOffset;
+      handleScroll && handleScroll(props);
+    },
+    [handleScroll],
+  );
 
-  const onScroll = (props) => {
-    // 当 width/height 改变时，FixedSizeList 会重置 scrollTop
-    // 这里存储一下上次的滚动条高度后用于下次渲染时进行同步
-    prevScrollOffset.current = props.scrollOffset;
-    handleScroll && handleScroll(props);
-  };
+  // 为 List 添加下边距
+  const InnerElementType = useMemo(
+    () =>
+      forwardRef((props, ref) => {
+        const { style, ...rest } = props as any;
+        return (
+          <div
+            ref={ref}
+            style={{
+              ...style,
+              height: `${parseFloat(style.height) + (paddingBottomSize ? paddingBottomSize : 0)}px`,
+            }}
+            {...rest}
+          />
+        );
+      }),
+    [paddingBottomSize],
+  );
+
+  const outerElementType = useMemo(
+    () =>
+      forwardRef((props, ref) => (
+        <Scrollbars
+          hiddenVertical={hiddenVerticalScrollbar}
+          hiddenHorizontal={hiddenHorizontalScrollbar}
+          {...props}
+          thumbSize={10}
+          forwardedRef={ref}
+        />
+      )),
+    [hiddenVerticalScrollbar, hiddenHorizontalScrollbar],
+  );
 
   const render = () => {
     const isDynamicList = typeof itemHeight !== 'number';
@@ -402,7 +410,7 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
               }}
               className={cls(className, 'kt-recycle-list')}
               innerElementType={InnerElementType}
-              outerElementType={ScrollbarsVirtualList}
+              outerElementType={outerElementType}
               estimatedItemSize={calcEstimatedSize}
             >
               {renderDynamicItem}
@@ -427,7 +435,7 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
               }}
               className={cls(className, 'recycle-list')}
               innerElementType={InnerElementType}
-              outerElementType={ScrollbarsVirtualList}
+              outerElementType={outerElementType}
             >
               {renderItem}
             </FixedSizeList>

--- a/packages/components/src/scrollbars/index.tsx
+++ b/packages/components/src/scrollbars/index.tsx
@@ -22,6 +22,14 @@ export interface ICustomScrollbarProps {
    * 滚动条滑块大小，默认 5px
    */
   thumbSize?: number;
+  /**
+   * 是否隐藏纵向滚动条，默认 false
+   */
+  hiddenVertical?: boolean;
+  /**
+   * 是否隐藏横向滚动条，默认 false
+   */
+  hiddenHorizontal?: boolean;
 }
 
 export const Scrollbars = ({
@@ -34,6 +42,8 @@ export const Scrollbars = ({
   onReachBottom,
   tabBarMode,
   thumbSize = 5,
+  hiddenVertical,
+  hiddenHorizontal,
 }: ICustomScrollbarProps) => {
   const disposableCollection = useRef<DisposableCollection>(new DisposableCollection());
   const scrollerRef = useRef<HTMLDivElement>();
@@ -131,22 +141,34 @@ export const Scrollbars = ({
       className={cls(className, 'kt-scrollbar')}
       onUpdate={handleUpdate}
       onScroll={onScroll}
-      renderTrackHorizontal={({ style, ...props }) => (
-        <div {...props} style={{ ...style, height: thumbSize, left: 0, right: 0, bottom: 1 }} />
-      )}
-      renderTrackVertical={({ style, ...props }) => (
-        <div {...props} style={{ ...style, width: thumbSize, top: 0, right: 1, bottom: 0 }} />
-      )}
-      renderThumbVertical={({ style, className, ...props }) => (
-        <div {...props} style={{ ...style, width: thumbSize }} className={cls(className, 'scrollbar-thumb-vertical')} />
-      )}
-      renderThumbHorizontal={({ style, className, ...props }) => (
-        <div
-          {...props}
-          style={{ ...style, height: thumbSize }}
-          className={cls(className, 'scrollbar-thumb-horizontal')}
-        />
-      )}
+      renderTrackHorizontal={({ style, ...props }) => {
+        const newStyle = { ...style, height: thumbSize, left: 0, right: 0, bottom: 1 };
+        if (hiddenHorizontal) {
+          newStyle.display = 'none';
+        }
+        return <div {...props} style={newStyle} />;
+      }}
+      renderTrackVertical={({ style, ...props }) => {
+        const newStyle = { ...style, width: thumbSize, top: 0, right: 1, bottom: 0 };
+        if (hiddenVertical) {
+          newStyle.display = 'none';
+        }
+        return <div {...props} style={newStyle} />;
+      }}
+      renderThumbVertical={({ style, className, ...props }) => {
+        const newStyle = { ...style, width: thumbSize };
+        if (hiddenVertical) {
+          newStyle.display = 'none';
+        }
+        return <div {...props} style={newStyle} className={cls(className, 'scrollbar-thumb-vertical')} />;
+      }}
+      renderThumbHorizontal={({ style, className, ...props }) => {
+        const newStyle = { ...style, height: thumbSize, display: 'none' };
+        if (hiddenHorizontal) {
+          newStyle.display = 'none';
+        }
+        return <div {...props} style={newStyle} className={cls(className, 'scrollbar-thumb-horizontal')} />;
+      }}
     >
       <div
         ref={(ref) => {
@@ -164,9 +186,11 @@ export const Scrollbars = ({
     </CustomScrollbars>
   );
 };
+
 Scrollbars.displayName = 'CustomScrollbars';
 
 export const ScrollbarsVirtualList = React.forwardRef((props, ref) => (
   <Scrollbars {...props} thumbSize={10} forwardedRef={ref} />
 ));
+
 ScrollbarsVirtualList.displayName = 'ScrollbarsVirtualList';

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -336,6 +336,7 @@ export const QuickOpenList: React.FC<{
       template={QuickOpenItemView}
       getSize={getSize}
       maxHeight={widget.items.length ? widget.MAX_HEIGHT : 0}
+      hiddenHorizontalScrollbar
     />
   ) : null;
 });
@@ -350,7 +351,7 @@ export const QuickOpenProgress = observer(() => {
   }, [widget.busy]);
 
   return (
-    <div id={VIEW_CONTAINERS.QUICKPICK_PROGRESS} className={styles.progress_bar} >
+    <div id={VIEW_CONTAINERS.QUICKPICK_PROGRESS} className={styles.progress_bar}>
       <ProgressBar progressModel={indicator!.progressModel} />
     </div>
   );


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b7bef3</samp>

*  Replace `ScrollbarsVirtualList` component with modified `Scrollbars` component to support hiding scrollbars in `RecycleList` component ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L2-R6), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L347-R375), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L405-R413), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L430-R438))
* Add `hiddenVerticalScrollbar` and `hiddenHorizontalScrollbar` props to `RecycleList` component and pass them to `Scrollbars` component ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280R83-R91), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280R118-R119))
* Remove redundant and inconsistent `@type` and `@memberof` annotations from `RecycleList` props ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L12-L13), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L19-L20), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L27-L28), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L35-R44), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L68-L69), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L75-L76), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L82-R65))
* Wrap `onScroll` and `InnerElementType` functions in `useCallback` and `useMemo` hooks to avoid unnecessary re-rendering in `RecycleList` component ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L347-R375))
* Add `hiddenVertical` and `hiddenHorizontal` props to `ICustomScrollbarProps` interface and use them to set `display` style to `none` for scrollbars in `Scrollbars` component ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-dc1931f460c8f41b516185b80ff3e8fb4a160367e2135c00333adf75ad25a5ccR25-R32), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-dc1931f460c8f41b516185b80ff3e8fb4a160367e2135c00333adf75ad25a5ccR45-R46), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-dc1931f460c8f41b516185b80ff3e8fb4a160367e2135c00333adf75ad25a5ccL134-R171))
* Add empty lines for readability in `Scrollbars` component ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-dc1931f460c8f41b516185b80ff3e8fb4a160367e2135c00333adf75ad25a5ccR189), [link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-dc1931f460c8f41b516185b80ff3e8fb4a160367e2135c00333adf75ad25a5ccR195))
* Hide horizontal scrollbar in `RecycleList` component used in `quick-open.view.tsx` file ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-20e4dc46b94cf72b6e1623d2b69b8567c06aaa6e5ca4d7ef7a56845bde03dff5R339))
* Remove whitespace for consistency in `quick-open.view.tsx` file ([link](https://github.com/opensumi/core/pull/2790/files?diff=unified&w=0#diff-20e4dc46b94cf72b6e1623d2b69b8567c06aaa6e5ca4d7ef7a56845bde03dff5L353-R354))

close #2718 

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b7bef3</samp>

Improved the appearance and performance of the `RecycleList` and `Scrollbars` components by adding props to hide scrollbars and using hooks. Fixed a formatting issue in the `quick-open.view.tsx` file.
