### PR TITLE
chore: fix warnings and remove some useless code

### DIFF
--- a/packages/components/src/recycle-list/RecycleList.tsx
+++ b/packages/components/src/recycle-list/RecycleList.tsx
@@ -282,7 +282,7 @@ export const RecycleList: React.FC<IRecycleListProps> = ({
     };
     useEffect(() => {
       if (rowRoot.current && listRef.current) {
-        observer.current = new MutationObserver((mutations, observer) => {
+        observer.current = new MutationObserver(() => {
           setItemSize();
         });
         const observerOption = {

--- a/packages/components/src/recycle-tree/TreeNodeRendererWrap.ts
+++ b/packages/components/src/recycle-tree/TreeNodeRendererWrap.ts
@@ -39,7 +39,6 @@ export interface INodeRendererWrapProps {
   depth: number;
   expanded?: boolean;
   hasPrompt?: boolean;
-  setSize: () => void;
   children: INodeRenderer;
 }
 

--- a/packages/extension-manager/src/browser/vsx-extension.view.tsx
+++ b/packages/extension-manager/src/browser/vsx-extension.view.tsx
@@ -71,11 +71,11 @@ export const VSXExtensionView = observer(() => {
       {activeKey === TabActiveKey.MARKETPLACE && (
         <div className={styles.extensions_view}>
           <Progress loading={loading} />
-          {vsxExtensionService.extensions.map((e) => (
+          {vsxExtensionService.extensions.map((e: VSXExtension, index: number) => (
             <Extension
+              key={`${index}:${e.namespace}-${e.name}`}
               onClick={onClick}
               onInstall={onInstall}
-              key={`${e.namespace}-${e.name}`}
               extension={e}
               type={ExtensionViewType.MARKETPLACE}
               installedExtensions={vsxExtensionService.installedExtensions}
@@ -86,11 +86,11 @@ export const VSXExtensionView = observer(() => {
       )}
       {activeKey === TabActiveKey.INSTALLED && (
         <div className={styles.extensions_view}>
-          {vsxExtensionService.installedExtensions.map((e) => (
+          {vsxExtensionService.installedExtensions.map((e: VSXExtension, index: number) => (
             <Extension
+              key={`${index}:${e.namespace}-${e.name}`}
               onClick={onClick}
               onInstall={onInstall}
-              key={`${e.namespace}-${e.name}`}
               extension={e}
               type={ExtensionViewType.INSTALLED}
               openVSXRegistry={vsxExtensionService.openVSXRegistry}


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ada6a20</samp>

*  Remove unused imports and parameters from `RecycleList.tsx` and `RecycleTree.tsx` ([link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-152f9af865030626ce727c31842b427a0b3df2bdde08aba92b504e599868d280L285-R285), [link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L2-R3), [link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L933), [link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-c2c0e6910abd511a424d94db4cf07c2c5733a0ceb21d69a3ffc5e3e291ed7b3bL42))
*  Memoize `setSize` function in `RecycleTree` class with `useMemo` to improve performance and avoid unnecessary re-renders ([link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L903-R924))
*  Delete commented out code that could cause performance issues in `RecycleTree.tsx` ([link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L945))
*  Add `index` to `key` prop of `Extension` component to prevent key conflicts in `vsx-extension.view.tsx` ([link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-2b87d379942b117b7b5a372168f22c75d7f4ac22f002cff4dfbbcd93e1c18994L74-R78), [link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-2b87d379942b117b7b5a372168f22c75d7f4ac22f002cff4dfbbcd93e1c18994L89-R93))
*  Add explicit type annotation for `e` parameter of `map` callback in `vsx-extension.view.tsx` to improve type safety and readability ([link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-2b87d379942b117b7b5a372168f22c75d7f4ac22f002cff4dfbbcd93e1c18994L74-R78), [link](https://github.com/opensumi/core/pull/2795/files?diff=unified&w=0#diff-2b87d379942b117b7b5a372168f22c75d7f4ac22f002cff4dfbbcd93e1c18994L89-R93))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ada6a20</samp>

This pull request enhances the performance and readability of some components in the `components` and `extension-manager` packages. It removes unused or redundant code, memoizes a function, and fixes a prop issue.
