### PR TITLE
feat: support InlineCompletionItemProvider.handleDidShowCompletionItem API

### DIFF
--- a/packages/addons/src/browser/file-search.contribution.ts
+++ b/packages/addons/src/browser/file-search.contribution.ts
@@ -279,7 +279,7 @@ export class FileSearchQuickCommandHandler {
 
   private async getFindOutItems(alreadyCollected: Set<string>, lookFor: string, token: CancellationToken) {
     let results: QuickOpenItem[];
-    // 有@时进入查找symbol逻辑
+    // 有 @ 时进入查找symbol逻辑
     if (lookFor.indexOf('@') > -1) {
       // save current editor state
       this.trySaveEditorState();

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -3257,3 +3257,28 @@ export class DataTransfer implements vscode.DataTransfer {
     }
   }
 }
+
+@es5ClassCompat
+export class InlineSuggestion implements vscode.InlineCompletionItem {
+  filterText?: string;
+  insertText: string;
+  range?: Range;
+  command?: vscode.Command;
+
+  constructor(insertText: string, range?: Range, command?: vscode.Command) {
+    this.insertText = insertText;
+    this.range = range;
+    this.command = command;
+  }
+}
+
+@es5ClassCompat
+export class InlineSuggestionList implements vscode.InlineCompletionList {
+  items: vscode.InlineCompletionItem[];
+
+  commands: vscode.Command[] | undefined = undefined;
+
+  constructor(items: vscode.InlineCompletionItem[]) {
+    this.items = items;
+  }
+}

--- a/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
@@ -238,6 +238,9 @@ export function createApiFactory(
     },
     // 类型定义
     ...extTypes,
+    // https://github.com/microsoft/vscode/blob/0ba16b83267cbab5811e12e0317fb47fd774324e/src/vs/workbench/api/common/extHost.api.impl.ts#L1288
+    InlineCompletionItem: extTypes.InlineSuggestion,
+    InlineCompletionList: extTypes.InlineSuggestionList,
     ...fileSystemTypes,
     // 参考 VS Code，目前到 1.44 版本为临时兼容，最新版(1.50+)已去除
     Task2: extTypes.Task,

--- a/packages/extension/src/hosted/api/vscode/ext.host.language.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.language.ts
@@ -596,6 +596,7 @@ export class ExtHostLanguages implements IExtHostLanguages {
     this.proxy.$registerInlineCompletionsSupport(callId, this.transformDocumentSelector(selector), true);
     return this.createDisposable(callId);
   }
+
   $provideInlineCompletions(
     handle: number,
     resource: UriComponents,

--- a/packages/extension/src/hosted/api/vscode/language/inlineCompletion.ts
+++ b/packages/extension/src/hosted/api/vscode/language/inlineCompletion.ts
@@ -145,7 +145,7 @@ export class InlineCompletionAdapter extends InlineCompletionAdapterBase {
           disposableStore = new DisposableStore();
         }
         return this._commands.toInternal(c, disposableStore);
-      }),
+      }) as Command[],
     };
   }
 
@@ -154,9 +154,12 @@ export class InlineCompletionAdapter extends InlineCompletionAdapterBase {
     data?.dispose();
   }
 
-  // proposed api
-  // 暂不实现
   override handleDidShowCompletionItem(pid: number, idx: number): void {
-    throw new Error('Method not implemented.');
+    const completionItem = this._references.get(pid)?.items[idx];
+    if (completionItem) {
+      if (this._provider.handleDidShowCompletionItem) {
+        this._provider.handleDidShowCompletionItem(completionItem);
+      }
+    }
   }
 }

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -174,7 +174,7 @@ export const localizationBundle = {
     'search.replace.title': '替换',
     'search.input.checkbox': '显示搜索条件',
     'file-search.command.fileOpen.description': '打开文件',
-    'file-search.command.fileOpen.placeholder': '按名称搜索文件（追加:转到行或追加@转到符号）',
+    'file-search.command.fileOpen.placeholder': '按名称搜索文件（追加:转到行或追加 @ 转到符号）',
     'search.includes': '要包含的文件',
     'search.includes.description': '输入文件名或文件夹名，多个用 ", " 分隔',
     'search.excludes': '要排除的文件',

--- a/packages/types/sumi-worker/worker.language.d.ts
+++ b/packages/types/sumi-worker/worker.language.d.ts
@@ -1009,7 +1009,6 @@ declare module 'sumi-worker' {
   /**
    * A document link is a range in a text document that links to an internal or external resource, like another
    * text document or a web site.
-   * @木农
    */
   export class DocumentLink {
     /**

--- a/packages/types/vscode.d.ts
+++ b/packages/types/vscode.d.ts
@@ -32,3 +32,4 @@
 /// <reference path='./vscode/typings/vscode.proposed.task.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.terminalDimensions.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.timeline.d.ts' />
+/// <reference path='./vscode/typings/vscode.proposed.inlineCompletionsAdditions.d.ts' />

--- a/packages/types/vscode/typings/vscode.language.d.ts
+++ b/packages/types/vscode/typings/vscode.language.d.ts
@@ -1388,52 +1388,8 @@ declare module 'vscode' {
   }
 
   /**
-   * An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
-   *
-   * @see {@link InlineCompletionItemProvider.provideInlineCompletionItems}
-   */
-  export class InlineCompletionItem {
-    /**
-     * The text to replace the range with. Must be set.
-     * Is used both for the preview and the accept operation.
-     */
-    insertText: string | SnippetString;
-
-    /**
-     * A text that is used to decide if this inline completion should be shown. When `falsy`
-     * the {@link InlineCompletionItem.insertText} is used.
-     *
-     * An inline completion is shown if the text to replace is a prefix of the filter text.
-     */
-    filterText?: string;
-
-    /**
-     * The range to replace.
-     * Must begin and end on the same line.
-     *
-     * Prefer replacements over insertions to provide a better experience when the user deletes typed text.
-     */
-    range?: Range;
-
-    /**
-     * An optional {@link Command} that is executed *after* inserting this completion.
-     */
-    command?: Command;
-
-    /**
-     * Creates a new inline completion item.
-     *
-     * @param insertText The text to replace the range with.
-     * @param range The range to replace. If not set, the word at the requested position will be used.
-     * @param command An optional {@link Command} that is executed *after* inserting this completion.
-     */
-    constructor(insertText: string | SnippetString, range?: Range, command?: Command);
-  }
-
-  /**
    * A document link is a range in a text document that links to an internal or external resource, like another
    * text document or a web site.
-   * @木农
    */
   export class DocumentLink {
 
@@ -2578,6 +2534,49 @@ declare module 'vscode' {
      */
     Automatic = 1,
   }
+
+  /**
+	 * An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
+	 *
+	 * @see {@link InlineCompletionItemProvider.provideInlineCompletionItems}
+	 */
+	export class InlineCompletionItem {
+		/**
+		 * The text to replace the range with. Must be set.
+		 * Is used both for the preview and the accept operation.
+		 */
+		insertText: string | SnippetString;
+
+		/**
+		 * A text that is used to decide if this inline completion should be shown. When `falsy`
+		 * the {@link InlineCompletionItem.insertText} is used.
+		 *
+		 * An inline completion is shown if the text to replace is a prefix of the filter text.
+		 */
+		filterText?: string;
+
+		/**
+		 * The range to replace.
+		 * Must begin and end on the same line.
+		 *
+		 * Prefer replacements over insertions to provide a better experience when the user deletes typed text.
+		 */
+		range?: Range;
+
+		/**
+		 * An optional {@link Command} that is executed *after* inserting this completion.
+		 */
+		command?: Command;
+
+		/**
+		 * Creates a new inline completion item.
+		 *
+		 * @param insertText The text to replace the range with.
+		 * @param range The range to replace. If not set, the word at the requested position will be used.
+		 * @param command An optional {@link Command} that is executed *after* inserting this completion.
+		 */
+		constructor(insertText: string | SnippetString, range?: Range, command?: Command);
+	}
 
   /**
    * Represents programming constructs like variables, classes, interfaces etc. that appear in a document. Document

--- a/packages/types/vscode/typings/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/124024 @hediet @alexdima
+
+	export interface InlineCompletionItem {
+		/**
+		 * If set to `true`, unopened closing brackets are removed and unclosed opening brackets are closed.
+		 * Defaults to `false`.
+		*/
+		completeBracketPairs?: boolean;
+	}
+
+	export interface InlineCompletionItemProvider {
+		// eslint-disable-next-line local/vscode-dts-provider-naming
+		handleDidShowCompletionItem?(completionItem: InlineCompletionItem): void;
+	}
+
+	// When finalizing `commands`, make sure to add a corresponding constructor parameter.
+	export interface InlineCompletionList {
+		/**
+		 * A list of commands associated with the inline completions of this list.
+		 */
+		commands?: Command[];
+	}
+}

--- a/packages/types/vscode/typings/vscode.workspace.d.ts
+++ b/packages/types/vscode/typings/vscode.workspace.d.ts
@@ -346,7 +346,6 @@ declare module 'vscode' {
     /**
      * The name of the workspace. `undefined` when no folder
      * has been opened.
-     * @魁梧
      */
     export const name: string | undefined;
 
@@ -361,7 +360,6 @@ declare module 'vscode' {
      * workspace folder the name of the workspace is prepended. Defaults to `true` when there are
      * multiple workspace folders and `false` otherwise.
      * @return A path relative to the root or the input.
-     * @魁梧
      */
     export function asRelativePath(pathOrUri: string | Uri, includeWorkspaceFolder?: boolean): string;
 
@@ -405,7 +403,6 @@ declare module 'vscode' {
      * Each workspace is identified with a mandatory URI and an optional name.
      * @return true if the operation was successfully started and false otherwise if arguments were used that would result
      * in invalid workspace folder state (e.g. 2 folders with the same URI).
-     * @魁梧
      */
     export function updateWorkspaceFolders(start: number, deleteCount: number | undefined | null, ...workspaceFoldersToAdd: { uri: Uri, name?: string }[]): boolean;
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a53858</samp>

*  Add classes for inline suggestions in the editor ([link](https://github.com/opensumi/core/pull/2799/files?diff=unified&w=0#diff-8e71e87170d27e5ddfa59996a4236dc1569d59db8957aa4e491c85834ee838b8R3260-R3284), [link](https://github.com/opensumi/core/pull/2799/files?diff=unified&w=0#diff-7fba3489c613a4c4cbfb0edf7eb3dce406d11b5705f13f6da50ffd9c71327b90R241-R243))
* Add spaces between Chinese characters and `@` symbol in comments and localization strings ([link](https://github.com/opensumi/core/pull/2799/files?diff=unified&w=0#diff-e65d2a6e4a380fdcd5a0aca1e16f14aae2cccc5080d6ba71966f186b6bdd8e45L282-R282), [link](https://github.com/opensumi/core/pull/2799/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7L177-R177))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a53858</samp>

This pull request adds support for inline suggestions in the editor, by implementing the `vscode.InlineCompletionItem` and `vscode.InlineCompletionList` interfaces. It also fixes some minor spacing issues in comments and localization strings.
