### PR TITLE
fix: auto open tab when expend bottom

### DIFF
--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -509,6 +509,12 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
   // TODO 这样很耦合，不能做到tab renderer自由拆分
   expandBottom(expand: boolean): void {
     const tabbarService = this.getTabbarService(SlotLocation.bottom);
+    if (!tabbarService.currentContainerId) {
+      tabbarService.currentContainerId =
+        tabbarService.currentContainerId ||
+        tabbarService.previousContainerId ||
+        tabbarService.containersMap.keys().next().value;
+    }
     tabbarService.doExpand(expand);
     this.contextKeyService.createKey('bottomFullExpanded', tabbarService.isExpanded);
   }


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes
### Background or solution
- auto open tab when expend bottom 



https://github.com/opensumi/core/assets/31676999/ebdfe316-e45c-49f7-b966-dcbcb0c107f9



<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f753b50</samp>

* Ensure that the current tab container id is always defined ([link](https://github.com/opensumi/core/pull/2800/files?diff=unified&w=0#diff-44758cd89b398dcea101472d9dc2de120b9c97709ed7a5de48d8a5317f1c1ccbR512-R517)) in `layout.service.ts`

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f753b50</samp>

Fix errors when switching tabs or layouts by ensuring `tabbarService.currentContainerId` is always defined. Update `layout.service.ts` to assign it to the first available container id if it is falsy.
