### PR TITLE
fix: navigation menu style rendering problem

### DIFF
--- a/packages/components/src/scrollbars/index.tsx
+++ b/packages/components/src/scrollbars/index.tsx
@@ -30,6 +30,11 @@ export interface ICustomScrollbarProps {
    * 是否隐藏横向滚动条，默认 false
    */
   hiddenHorizontal?: boolean;
+  /**
+   * 通用渲染， 默认 false
+   * https://github.com/malte-wessel/react-custom-scrollbars/blob/master/docs/usage.md#universal-rendering
+   */
+  universal?: boolean;
 }
 
 export const Scrollbars = ({
@@ -44,6 +49,7 @@ export const Scrollbars = ({
   thumbSize = 5,
   hiddenVertical,
   hiddenHorizontal,
+  universal = false,
 }: ICustomScrollbarProps) => {
   const disposableCollection = useRef<DisposableCollection>(new DisposableCollection());
   const scrollerRef = useRef<HTMLDivElement>();
@@ -141,6 +147,7 @@ export const Scrollbars = ({
       className={cls(className, 'kt-scrollbar')}
       onUpdate={handleUpdate}
       onScroll={onScroll}
+      universal={universal}
       renderTrackHorizontal={({ style, ...props }) => {
         const newStyle = { ...style, height: thumbSize, left: 0, right: 0, bottom: 1 };
         if (hiddenHorizontal) {

--- a/packages/editor/src/browser/navigation.view.tsx
+++ b/packages/editor/src/browser/navigation.view.tsx
@@ -137,6 +137,7 @@ export const NavigationMenu = observer(({ model }: { model: NavigationMenuModel 
     >
       <Scrollbars
         className={styles.navigation_menu_items}
+        universal={true}
         forwardedRef={(el) => {
           scrollerContainer.current = el;
           scrollToCurrent();


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution
![image](https://github.com/opensumi/core/assets/1762334/abe1d6ee-4ed6-4ef1-bbe6-0030101e19a1)
开启react-custom-scrollbars组建 universal 的属性

fix: https://github.com/opensumi/core/issues/2806
### Changelog
bugfix: 修复navigation下拉菜单scrollbars样式渲染问题
