### PR TITLE
fix: launch editor component rendering exception

### DIFF
--- a/packages/debug/src/browser/preferences/components/text-widget.tsx
+++ b/packages/debug/src/browser/preferences/components/text-widget.tsx
@@ -12,6 +12,7 @@ import React, { useMemo } from 'react';
 
 import { Input } from '@opensumi/ide-components';
 
+import { JSON_SCHEMA_TYPE } from '../../../common';
 import { parseSnippet } from '../../debugUtils';
 
 import styles from './json-widget.module.less';
@@ -63,8 +64,8 @@ export const TextWidget = <T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) => onFocus(id, target.value);
 
   const type = useMemo(() => {
-    if (schema.type !== 'string' && schema.type !== 'number') {
-      return 'string';
+    if (schema.type !== JSON_SCHEMA_TYPE.STRING && schema.type !== JSON_SCHEMA_TYPE.NUMBER) {
+      return JSON_SCHEMA_TYPE.STRING;
     }
 
     return schema.type;

--- a/packages/debug/src/browser/preferences/launch.service.ts
+++ b/packages/debug/src/browser/preferences/launch.service.ts
@@ -8,6 +8,7 @@ import { COMMON_COMMANDS } from '@opensumi/ide-core-browser';
 import { CommandService, Emitter, Event, FileType, IJSONSchema, URI } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 
+import { JSON_SCHEMA_TYPE } from '../../common';
 import { ILaunchService } from '../../common/debug-service';
 
 type TFormData = { [key in string]: any };
@@ -101,17 +102,17 @@ export class LaunchService implements ILaunchService {
 
   private getDefaultValue(type: IJSONSchema['type']): any {
     switch (type) {
-      case 'array':
+      case JSON_SCHEMA_TYPE.ARRAY:
         return [];
-      case 'boolean':
+      case JSON_SCHEMA_TYPE.BOOLEAN:
         return false;
-      case 'null':
+      case JSON_SCHEMA_TYPE.NULL:
         return null;
-      case 'number':
+      case JSON_SCHEMA_TYPE.NUMBER:
         return 0;
-      case 'object':
+      case JSON_SCHEMA_TYPE.OBJECT:
         return {};
-      case 'string':
+      case JSON_SCHEMA_TYPE.STRING:
       default:
         return '';
     }

--- a/packages/debug/src/browser/preferences/launch.view.tsx
+++ b/packages/debug/src/browser/preferences/launch.view.tsx
@@ -31,7 +31,7 @@ import { acquireAjv } from '@opensumi/ide-core-browser/lib/utils/schema';
 import { ReactEditorComponent } from '@opensumi/ide-editor/lib/browser/index';
 
 import { DebugConfiguration, MASSIVE_PROPERTY_FLAG } from '../../common/debug-configuration';
-import { launchExtensionSchemaUri } from '../../common/debug-schema';
+import { JSON_SCHEMA_TYPE, launchExtensionSchemaUri } from '../../common/debug-schema';
 import { ILaunchService } from '../../common/debug-service';
 import { DebugConfigurationManager } from '../debug-configuration-manager';
 import { parseSnippet } from '../debugUtils';
@@ -412,13 +412,13 @@ const LaunchBody = ({
     const snippetProperties = Object.keys(body).reduce((pre: IJSONSchemaMap, cur: string) => {
       const curProp = properties![cur];
 
-      if (curProp?.type === 'array' && isUndefined(curProp?.items)) {
-        curProp.items = { type: 'string' };
+      if (curProp?.type === JSON_SCHEMA_TYPE.ARRAY && isUndefined(curProp?.items)) {
+        curProp.items = { type: JSON_SCHEMA_TYPE.STRING };
       }
 
       // 如果 type 是数组，则取第一个
       if (Array.isArray(curProp?.type)) {
-        curProp.type = curProp.type![0] || 'string';
+        curProp.type = curProp.type![0] || JSON_SCHEMA_TYPE.STRING;
       }
 
       // 去掉 anyof 中的空对象
@@ -427,8 +427,8 @@ const LaunchBody = ({
       }
 
       // 如果 type 是 object 且存在 additionalProperties 时，固定将其设置为 additionalProperties: { type: 'string' }
-      if (curProp?.type === 'object' && !isUndefined(curProp?.additionalProperties)) {
-        curProp.additionalProperties = { type: 'string' };
+      if (curProp?.type === JSON_SCHEMA_TYPE.OBJECT && !isUndefined(curProp?.additionalProperties)) {
+        curProp.additionalProperties = { type: JSON_SCHEMA_TYPE.STRING };
       }
 
       /**
@@ -436,7 +436,7 @@ const LaunchBody = ({
        * 通过添加 MASSIVE_PROPERTY_FLAG 来做标识
        */
       if (
-        curProp?.type === 'object' &&
+        curProp?.type === JSON_SCHEMA_TYPE.OBJECT &&
         !isUndefined(curProp?.properties) &&
         Object.keys(curProp.properties!).length > 6
       ) {
@@ -455,7 +455,7 @@ const LaunchBody = ({
 
     const schema = {
       title: label,
-      type: 'object',
+      type: JSON_SCHEMA_TYPE.OBJECT,
       required,
       description,
       properties: snippetProperties,

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -66,3 +66,5 @@ export const DEFAULT_ADD_CONFIGURATION_KEY = '__ADD_CONF__';
 export const DEFAULT_NO_CONFIGURATION_KEY = '__NO_CONF__';
 export const DEFAULT_CONFIGURATION_NAME_SEPARATOR = '__CONF__';
 export const DEFAULT_CONFIGURATION_INDEX_SEPARATOR = '__INDEX__';
+
+export const MASSIVE_PROPERTY_FLAG = 'massive_property_flag';

--- a/packages/debug/src/common/debug-schema.ts
+++ b/packages/debug/src/common/debug-schema.ts
@@ -3,3 +3,12 @@ import { CodeSchemaId } from '@opensumi/ide-core-common';
 export const launchSchemaUri = CodeSchemaId.launch;
 export const launchExtensionSchemaUri = `${CodeSchemaId.launch}/extension`;
 export const launchDefaultSchemaUri = `${CodeSchemaId.launch}/default`;
+
+export enum JSON_SCHEMA_TYPE {
+  ARRAY = 'array',
+  BOOLEAN = 'boolean',
+  NULL = 'null',
+  NUMBER = 'number',
+  OBJECT = 'object',
+  STRING = 'string',
+}

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -383,6 +383,7 @@ export const localizationBundle = {
     'debug.launch.view.template.button.addItem': 'Add items',
     'debug.launch.view.template.input.placeholder': 'Please enter {0}',
     'debug.launch.view.template.button.submit': 'Add new configuration item',
+    'debug.launch.view.edit.inLaunchJson': 'Edit in launch.json',
 
     'debug.widget.exception.thrownWithId': 'Exception has occurred: {0}',
     'debug.widget.exception.thrown': 'Exception has occurred.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -360,6 +360,7 @@ export const localizationBundle = {
     'debug.launch.view.template.button.addItem': '添加一项',
     'debug.launch.view.template.input.placeholder': '请输入 {0}',
     'debug.launch.view.template.button.submit': '新增配置项',
+    'debug.launch.view.edit.inLaunchJson': '在 launch.json 中编辑',
 
     'debug.widget.exception.thrownWithId': '发生异常: {0}',
     'debug.widget.exception.thrown': '出现异常。',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d11a8e</samp>

*  Added `MASSIVE_PROPERTY_FLAG` constant to mark schema properties that are too large to display in the UI ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-42578da3fc17629cfdec7ee2eb364a03d03d9a586e754162bf6bdc610933ce03R69-R70))
*  Imported `COMMON_COMMANDS` module and `commandService` dependency to use the `OPEN_LAUNCH_CONFIGURATION` command for opening launch.json ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322L7-R8), [link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322R21-R23))
*  Added `openLaunchConfiguration` method to `LaunchService` class to execute the `OPEN_LAUNCH_CONFIGURATION` command ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322R47-R50))
*  Modified `addTwoNumbers` function to use `defaultValue` and `type` properties of `preSchemaValue` object and call `getDefaultValue` method ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322L70-R80))
*  Added `getDefaultValue` method to `LaunchService` class to return a default value based on JSON schema type ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-fa3bf769ebbed0d8e9180ca062c4aed2c8ca63a3afc92ca45d26156a4288c322R102-R119))
*  Initialized `currentConfigurationIndex` state with `0` instead of `undefined` in `LaunchViewContainer` component ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL72-R72))
*  Moved call to `launchService.nextNewFormData` from `LaunchViewContainer` component to `LaunchIndexs` component ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL145-L146), [link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL241-R255))
*  Modified `LaunchIndexs` component to use `launchService` dependency and call `nextNewFormData` method whenever the configuration state changes ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bL241-R255))
*  Modified `LaunchBody` component to check for `MASSIVE_PROPERTY_FLAG` and clear `properties` and display link to launch.json instead of form fields ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86ff74b03299d60f6ecd1dff7353a7b788b4cf82b31a23b34121a6db5b32b00bR434-R446))
*  Imported more modules in `additional-template.tsx` file to use for rendering schema title, description, and link to launch.json ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86b8f1061b6e5516b2cd0d79f787c704e7493273a02fe0c49a82856103a26bb0L7-R19))
*  Added `launchService` variable and dependency to `WrapIfAdditionalTemplate` component ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86b8f1061b6e5516b2cd0d79f787c704e7493273a02fe0c49a82856103a26bb0R42))
*  Modified `WrapIfAdditionalTemplate` component to check for `MASSIVE_PROPERTY_FLAG` and render schema title, description, and link to launch.json using templates and `launchService` method ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-86b8f1061b6e5516b2cd0d79f787c704e7493273a02fe0c49a82856103a26bb0L40-R86))
*  Added localization keys and values for `debug.launch.view.edit.inLaunchJson` in `en-US.lang.ts` and `zh-CN.lang.ts` files ([link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R386), [link](https://github.com/opensumi/core/pull/2808/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R363))

<!-- Additional content -->
<!-- 补充额外内容 -->
- [x] 新增 "在 launch.json 中编辑" 的引导操作
- [x] 默认选中第一个配置

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d11a8e</samp>

Added a feature to open and edit launch.json from the debug preferences page. Improved the UI and logic of the launch view for debug configurations. Added a flag to mark schema properties that are too large for the form view and a custom rendering logic for them. Added localization support for the new UI elements.
