### PR TITLE
fix: add key for MenuActionList

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -98,9 +98,12 @@ export const MenuActionList: React.FC<{
     (dataSource: MenuNode[], key?: string) =>
       dataSource.map((menuNode, index) => {
         if (menuNode.id === SeparatorMenuItemNode.ID) {
-          return null;
+          if (dataSource[index - 1]?.id === SeparatorMenuItemNode.ID) {
+            return null;
+          }
+          return <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} />;
         }
-        const hasSeparator = dataSource[index + 1] && dataSource[index + 1].id === SeparatorMenuItemNode.ID;
+
         if (menuNode.id === SubmenuItemNode.ID) {
           // 子菜单项为空时不渲染
           if (!Array.isArray(menuNode.children) || !menuNode.children.length) {
@@ -108,32 +111,26 @@ export const MenuActionList: React.FC<{
           }
 
           return (
-            <>
-              <Menu.SubMenu
-                key={`${(menuNode as SubmenuItemNode).submenuId}-${index}`}
-                className={styles.submenuItem}
-                popupClassName='kt-menu'
-                title={<MenuAction hasSubmenu data={menuNode} iconService={iconService} />}
-              >
-                {recursiveRender(menuNode.children, menuNode.label)}
-              </Menu.SubMenu>
-              {hasSeparator ? <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} /> : null}
-            </>
+            <Menu.SubMenu
+              className={styles.submenuItem}
+              key={`${(menuNode as SubmenuItemNode).submenuId}-${index}`}
+              popupClassName='kt-menu'
+              title={<MenuAction hasSubmenu data={menuNode} iconService={iconService} />}
+            >
+              {recursiveRender(menuNode.children, menuNode.label)}
+            </Menu.SubMenu>
           );
         }
 
         return (
-          <>
-            <Menu.Item
-              id={`${menuNode.id}-${index}`}
-              key={`${menuNode.id}-${key}-${index}`}
-              className={styles.menuItem}
-              disabled={menuNode.disabled}
-            >
-              <MenuAction data={menuNode} disabled={menuNode.disabled} iconService={iconService} />
-            </Menu.Item>
-            {hasSeparator ? <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} /> : null}
-          </>
+          <Menu.Item
+            id={`${menuNode.id}-${index}`}
+            key={`${menuNode.id}-${key}-${index}`}
+            className={styles.menuItem}
+            disabled={menuNode.disabled}
+          >
+            <MenuAction data={menuNode} disabled={menuNode.disabled} iconService={iconService} />
+          </Menu.Item>
         );
       }),
     [],


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
Optimize MenuActionList  recursiveRender to avoid error of react list key
<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0467eec</samp>

* Fix a bug where two consecutive separators would be rendered in the menu ([link](https://github.com/opensumi/core/pull/2809/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L101-R106))
* Simplify the code by removing unnecessary fragments and the hasSeparator logic ([link](https://github.com/opensumi/core/pull/2809/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L111-R133))
* Remove the redundant key prop from the Menu.SubMenu component ([link](https://github.com/opensumi/core/pull/2809/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L111-R133))


<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0467eec</samp>

Fix menu rendering bug and simplify code in `actions` component. Remove duplicate separators and redundant fragments from menu items in `packages/core-browser/src/components/actions/index.tsx`.
