### PR TITLE
fix: add keys for fragment

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -98,12 +98,9 @@ export const MenuActionList: React.FC<{
     (dataSource: MenuNode[], key?: string) =>
       dataSource.map((menuNode, index) => {
         if (menuNode.id === SeparatorMenuItemNode.ID) {
-          if (dataSource[index - 1]?.id === SeparatorMenuItemNode.ID) {
-            return null;
-          }
-          return <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} />;
+          return null;
         }
-
+        const hasSeparator = dataSource[index + 1] && dataSource[index + 1].id === SeparatorMenuItemNode.ID;
         if (menuNode.id === SubmenuItemNode.ID) {
           // 子菜单项为空时不渲染
           if (!Array.isArray(menuNode.children) || !menuNode.children.length) {
@@ -111,26 +108,32 @@ export const MenuActionList: React.FC<{
           }
 
           return (
-            <Menu.SubMenu
-              className={styles.submenuItem}
-              key={`${(menuNode as SubmenuItemNode).submenuId}-${index}`}
-              popupClassName='kt-menu'
-              title={<MenuAction hasSubmenu data={menuNode} iconService={iconService} />}
-            >
-              {recursiveRender(menuNode.children, menuNode.label)}
-            </Menu.SubMenu>
+            <React.Fragment key={`${menuNode.id}-${(menuNode as SubmenuItemNode).submenuId}-${index}`}>
+              <Menu.SubMenu
+                key={`${menuNode.id}-${(menuNode as SubmenuItemNode).submenuId}-${index}`}
+                className={styles.submenuItem}
+                popupClassName='kt-menu'
+                title={<MenuAction hasSubmenu data={menuNode} iconService={iconService} />}
+              >
+                {recursiveRender(menuNode.children, menuNode.label)}
+              </Menu.SubMenu>
+              {hasSeparator ? <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} /> : null}
+            </React.Fragment>
           );
         }
 
         return (
-          <Menu.Item
-            id={`${menuNode.id}-${index}`}
-            key={`${menuNode.id}-${key}-${index}`}
-            className={styles.menuItem}
-            disabled={menuNode.disabled}
-          >
-            <MenuAction data={menuNode} disabled={menuNode.disabled} iconService={iconService} />
-          </Menu.Item>
+          <React.Fragment key={`${menuNode.id}-${index}`}>
+            <Menu.Item
+              id={`${menuNode.id}-${index}`}
+              key={`${menuNode.id}-${index}`}
+              className={styles.menuItem}
+              disabled={menuNode.disabled}
+            >
+              <MenuAction data={menuNode} disabled={menuNode.disabled} iconService={iconService} />
+            </Menu.Item>
+            {hasSeparator ? <Menu.Divider key={`divider-${index}`} className={styles.menuItemDivider} /> : null}
+          </React.Fragment>
         );
       }),
     [],


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c2a739</samp>

*  Simplify the logic for rendering separators in the menu data source by using a `hasSeparator` variable instead of checking for consecutive separators ([link](https://github.com/opensumi/core/pull/2812/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L101-R103), [link](https://github.com/opensumi/core/pull/2812/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L114-R136))
*  Wrap each menu node in a `React.Fragment` component with a unique key and conditionally render a `Menu.Divider` component after each node if `hasSeparator` is true, to avoid duplicate keys and unnecessary dividers in the `actions/index.tsx` file ([link](https://github.com/opensumi/core/pull/2812/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L114-R136))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c2a739</samp>

Simplify and fix menu separators in `core-browser` package. Use a variable and fragments to avoid duplicate or missing dividers between menu nodes in `actions/index.tsx`.
