### PR TITLE
feat: support search preference by @ext expression

### DIFF
--- a/packages/core-browser/src/preferences/settings.ts
+++ b/packages/core-browser/src/preferences/settings.ts
@@ -50,6 +50,10 @@ export interface IPreferenceViewDesc {
 
 export interface ISettingSection {
   /**
+   * 插件 ID
+   */
+  extensionId?: string;
+  /**
    * 该 Section 的名字
    */
   title?: string;

--- a/packages/extension/src/browser/vscode/contributes/configuration.ts
+++ b/packages/extension/src/browser/vscode/contributes/configuration.ts
@@ -82,6 +82,7 @@ export class ConfigurationContributionPoint extends VSCodeContributePoint<Prefer
           this.updateConfigurationSchema(configuration);
           sections.push({
             title: configuration.title,
+            extensionId,
             preferences: Object.keys(configuration.properties).map((v) => ({
               id: v,
             })),

--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -298,14 +298,22 @@
 
 .preference_status {
   margin-left: 5px;
+  position: relative;
   .preference_overwritten {
     font-size: 12px;
     opacity: 0.75;
-    text-decoration: underline;
-    text-decoration-color: black;
-    text-underline-position: under;
     cursor: pointer;
+  }
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 100%;
+    height: 1px;
     opacity: 0.75;
+    border-bottom: 1px dashed var(--foreground);
   }
   .preference_reset {
     font-size: @base-font-size;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

通过插件 ID 搜索配置

<img width="1057" alt="image" src="https://github.com/opensumi/core/assets/9823838/209c9ef6-fa01-4885-b5ad-b384f9fc0a8d">

优化下划线样式
<img width="513" alt="image" src="https://github.com/opensumi/core/assets/9823838/28b90182-2977-49c1-839f-6993553302c6">


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab47b24</samp>

*  Add support for filtering settings by extension ID ([link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-da6576a995bde55d4d89b924b6c2de94b9fa420c7c03536ba469c3b495fd11e0R53-R56), [link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-eb62139e8a9e9ae80188684de0ef16b097ea0c7f7f5fb6978a2de704e4d68887R85), [link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR57-R58), [link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR337-R341), [link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR347-R354), [link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cL377-R396))
* Improve style of overwritten preference indicator ([link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-fc7e3fea2f737893472d7d0fd250c2efc28c2cb70e525a1f1142de0f2a9fec86L301-R316))
* Fix typo in comment of `getPreferenceViewDesc` ([link](https://github.com/opensumi/core/pull/2813/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cL303-R306))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab47b24</samp>

This pull request adds the ability to filter settings by extension ID in the preferences UI. It introduces a new `extensionId` property to the `ISettingSection` interface and passes it from the extension configuration contributions to the `PreferenceSettingsService` class. It also improves the style of the overwritten preference indicator in the `preferences.module.less` file.
