### PR TITLE
feat: support resolve in merge editor

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -1007,3 +1007,14 @@ export namespace QUICK_OPEN_COMMANDS {
     id: 'editor.action.quickView',
   };
 }
+
+export namespace SCM_COMMANDS {
+  // git extension 1.71 版本之前存在下划线，这里为了做兼容处理: https://github.com/microsoft/vscode/blob/1.68.1/extensions/git/src/repository.ts#L613
+  export const _GIT_OPEN_MERGE_EDITOR: Command = {
+    id: '_git.openMergeEditor',
+  };
+  // git extension 1.71 版本之后就去掉了前面的下划线: https://github.com/microsoft/vscode/commit/c0ade8bc816386b7194d69fed878d4b9bb796d6c#diff-da56ff967ab1a9606c01af61dc926332afb862f13c8e5c74a575bc2aa1b15e43R411
+  export const GIT_OPEN_MERGE_EDITOR: Command = {
+    id: 'git.openMergeEditor',
+  };
+}

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -551,3 +551,11 @@
 }
 
 // -------------- styles for editor empty component ends --------------
+
+// -------------- styles for merge editor component starts --------------
+.merge_editor_float_container {
+  position: absolute;
+  right: 50px;
+  bottom: 30px;
+}
+// -------------- styles for merge editor component ends --------------

--- a/packages/editor/src/browser/merge-editor/MergeEditorFloatComponents.tsx
+++ b/packages/editor/src/browser/merge-editor/MergeEditorFloatComponents.tsx
@@ -1,15 +1,22 @@
 import React, { useCallback } from 'react';
 
 import { Button } from '@opensumi/ide-components';
-import { localize } from '@opensumi/ide-core-browser';
+import { CommandService, SCM_COMMANDS, URI, localize } from '@opensumi/ide-core-browser';
 import { useInjectable } from '@opensumi/ide-core-browser';
 
 import styles from '../editor.module.less';
+import { ReactEditorComponent } from '../types';
 
-export const MergeEditorFloatComponents = (_: React.HtmlHTMLAttributes<HTMLDivElement>) => {
-  const handleOpenMergeEditor = useCallback(() => {
-    // not implemented
-  }, []);
+export const MergeEditorFloatComponents: ReactEditorComponent<{ uri: URI }> = ({ resource }) => {
+  const commandService = useInjectable<CommandService>(CommandService);
+
+  const handleOpenMergeEditor = useCallback(async () => {
+    const { uri } = resource;
+
+    [SCM_COMMANDS.GIT_OPEN_MERGE_EDITOR, SCM_COMMANDS._GIT_OPEN_MERGE_EDITOR].forEach(({ id: command }) => {
+      commandService.tryExecuteCommand(command, uri);
+    });
+  }, [resource]);
 
   return (
     <div className={styles.merge_editor_float_container}>

--- a/packages/editor/src/browser/merge-editor/MergeEditorFloatComponents.tsx
+++ b/packages/editor/src/browser/merge-editor/MergeEditorFloatComponents.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { Button } from '@opensumi/ide-components';
-import { CommandService, SCM_COMMANDS, URI, localize } from '@opensumi/ide-core-browser';
+import { CommandRegistry, CommandService, SCM_COMMANDS, URI, localize } from '@opensumi/ide-core-browser';
 import { useInjectable } from '@opensumi/ide-core-browser';
 
 import styles from '../editor.module.less';
@@ -9,12 +9,15 @@ import { ReactEditorComponent } from '../types';
 
 export const MergeEditorFloatComponents: ReactEditorComponent<{ uri: URI }> = ({ resource }) => {
   const commandService = useInjectable<CommandService>(CommandService);
+  const commandRegistry = useInjectable<CommandRegistry>(CommandRegistry);
 
   const handleOpenMergeEditor = useCallback(async () => {
     const { uri } = resource;
 
     [SCM_COMMANDS.GIT_OPEN_MERGE_EDITOR, SCM_COMMANDS._GIT_OPEN_MERGE_EDITOR].forEach(({ id: command }) => {
-      commandService.tryExecuteCommand(command, uri);
+      if (commandRegistry.getCommand(command) && commandRegistry.isEnabled(command)) {
+        commandService.executeCommand(command, uri);
+      }
     });
   }, [resource]);
 

--- a/packages/editor/src/browser/merge-editor/MergeEditorFloatComponents.tsx
+++ b/packages/editor/src/browser/merge-editor/MergeEditorFloatComponents.tsx
@@ -1,0 +1,21 @@
+import React, { useCallback } from 'react';
+
+import { Button } from '@opensumi/ide-components';
+import { localize } from '@opensumi/ide-core-browser';
+import { useInjectable } from '@opensumi/ide-core-browser';
+
+import styles from '../editor.module.less';
+
+export const MergeEditorFloatComponents = (_: React.HtmlHTMLAttributes<HTMLDivElement>) => {
+  const handleOpenMergeEditor = useCallback(() => {
+    // not implemented
+  }, []);
+
+  return (
+    <div className={styles.merge_editor_float_container}>
+      <Button size='large' onClick={handleOpenMergeEditor}>
+        {localize('mergeEditor.open.in.editor')}
+      </Button>
+    </div>
+  );
+};

--- a/packages/editor/src/browser/merge-editor/merge-editor.contribution.ts
+++ b/packages/editor/src/browser/merge-editor/merge-editor.contribution.ts
@@ -1,25 +1,45 @@
 import { Autowired } from '@opensumi/di';
-import { Domain } from '@opensumi/ide-core-browser';
+import { Disposable, Domain, IContextKeyService, Schemes, Uri } from '@opensumi/ide-core-browser';
 
 import { ResourceService } from '../../common';
 import { BrowserEditorContribution, EditorComponentRegistry, EditorOpenType } from '../types';
 
 import { MergeEditorResourceProvider } from './merge-editor.provider';
+import { MergeEditorFloatComponents } from './MergeEditorFloatComponents';
+
+const MERGE_EDITOR_FLOATING_WIDGET = 'merge.editor.floating.widget';
 
 @Domain(BrowserEditorContribution)
-export class MergeEditorContribution implements BrowserEditorContribution {
+export class MergeEditorContribution extends Disposable implements BrowserEditorContribution {
   @Autowired()
   private readonly mergeEditorResourceProvider: MergeEditorResourceProvider;
+
+  @Autowired(IContextKeyService)
+  private readonly contextKeyService: IContextKeyService;
 
   registerResource(resourceService: ResourceService): void {
     resourceService.registerResourceProvider(this.mergeEditorResourceProvider);
   }
 
   registerEditorComponent(registry: EditorComponentRegistry) {
-    registry.registerEditorComponentResolver('mergeEditor', (_, results) => {
+    registry.registerEditorComponentResolver(EditorOpenType.mergeEditor, (_, results) => {
       results.push({
         type: EditorOpenType.mergeEditor,
       });
+    });
+
+    registry.registerEditorSideWidget({
+      id: MERGE_EDITOR_FLOATING_WIDGET,
+      component: MergeEditorFloatComponents as any,
+      displaysOnResource: (resource) => {
+        const { uri } = resource;
+        if (uri.scheme !== Schemes.file) {
+          return false;
+        }
+
+        const mergeChanges = this.contextKeyService.getValue<Uri[]>('git.mergeChanges') || [];
+        return mergeChanges.some((value) => value.toString() === uri.toString());
+      },
     });
   }
 }

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1380,6 +1380,8 @@ export const localizationBundle = {
     'mergeEditor.action.button.apply': 'Apply',
     'mergeEditor.action.button.accept.left': 'Accept Left',
     'mergeEditor.action.button.accept.right': 'Accept Right',
+    'mergeEditor.open.in.editor': 'Resolve in Merge Editor',
+
     // #endregion merge editor
     'workbench.quickOpen.preserveInput':
       'Controls whether the last typed input to Quick Open(include Command Palette) should be preserved.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1153,6 +1153,7 @@ export const localizationBundle = {
     'mergeEditor.action.button.apply': '应用更改',
     'mergeEditor.action.button.accept.left': '接受左边',
     'mergeEditor.action.button.accept.right': '接受右边',
+    'mergeEditor.open.in.editor': '在合并编辑器中解决',
     'workbench.quickOpen.preserveInput': '是否在 QuickOpen 的输入框（包括命令面板）中保留上次输入的内容',
 
     'webview.webviewTagUnavailable': '非 Electron 环境不支持 Webview 标签，请使用 Iframe 标签',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 210d9a1</samp>

*  Add a new feature to allow users to open a merge editor to resolve conflicts in SCM resources ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-a92d3c79f3be1ec7533bcb9d276d6cacbd8a6a9df61391c4cfd7fcf805025ce1R553-R560), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-21dbdf41bfdca1456fc274b1f474ecc83ffdb25fd1593cffe29b3525ed255ebbL2-R2), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-21dbdf41bfdca1456fc274b1f474ecc83ffdb25fd1593cffe29b3525ed255ebbL8-R19), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-21dbdf41bfdca1456fc274b1f474ecc83ffdb25fd1593cffe29b3525ed255ebbL19-R43), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-33cc5f7102e6deb389ad758911f88ca963033f410d4927f73b249534b63b26d2R1-R21), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R1379-R1380), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R1152), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-5379b1a6b05c686b3d175d71e506a0de2afcff763e44ce22ea4502983bf58355L5-R5), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-5379b1a6b05c686b3d175d71e506a0de2afcff763e44ce22ea4502983bf58355R199-R201), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-5379b1a6b05c686b3d175d71e506a0de2afcff763e44ce22ea4502983bf58355R267-R278))
  * Create a new style class for the merge editor floating container in `editor.module.less` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-a92d3c79f3be1ec7533bcb9d276d6cacbd8a6a9df61391c4cfd7fcf805025ce1R553-R560))
  * Import and inject the necessary modules from `core-common` in `merge-editor.contribution.ts` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-21dbdf41bfdca1456fc274b1f474ecc83ffdb25fd1593cffe29b3525ed255ebbL2-R2), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-21dbdf41bfdca1456fc274b1f474ecc83ffdb25fd1593cffe29b3525ed255ebbL8-R19))
  * Register the editor side widget for the merge editor floating container and specify the display conditions based on the resource scheme and the merge changes context key in `merge-editor.contribution.ts` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-21dbdf41bfdca1456fc274b1f474ecc83ffdb25fd1593cffe29b3525ed255ebbL19-R43))
  * Implement the React component for the merge editor floating container that renders the button and handles the click event to open the merge editor in `MergeEditorFloatComponents.tsx` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-33cc5f7102e6deb389ad758911f88ca963033f410d4927f73b249534b63b26d2R1-R21))
  * Add the localization for the merge editor floating container button label in `en-US.lang.ts` and `zh-CN.lang.ts` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R1379-R1380), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R1152))
  * Import and inject the command service in `scm-model.ts` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-5379b1a6b05c686b3d175d71e506a0de2afcff763e44ce22ea4502983bf58355L5-R5), [link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-5379b1a6b05c686b3d175d71e506a0de2afcff763e44ce22ea4502983bf58355R199-R201))
  * Set the context key for the merge changes based on the SCM resource groups in `scm-model.ts` ([link](https://github.com/opensumi/core/pull/2819/files?diff=unified&w=0#diff-5379b1a6b05c686b3d175d71e506a0de2afcff763e44ce22ea4502983bf58355R267-R278))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/35c1d341-f720-410a-ba70-690e74166ecd)

- [x] 支持在冲突文件的右下角提供“前往合并编辑器”的入口

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 210d9a1</samp>

This pull request adds a new feature to the editor and the SCM view that allows users to easily access a merge editor to resolve conflicts. It introduces a new `merge-editor` resource scheme and a `merge-editor-floating-container` style class. It also adds a new React component `MergeEditorFloatComponents` and the corresponding localization files.
