### PR TITLE
fix: plugin panel height adjustment

### DIFF
--- a/packages/extension-manager/src/browser/extension/extension.module.less
+++ b/packages/extension-manager/src/browser/extension/extension.module.less
@@ -1,5 +1,5 @@
 .extension_item {
-  height: 62px;
+  min-height: 62px;
   font-size: 12px;
   display: flex;
   box-sizing: border-box;


### PR DESCRIPTION
### Types

- [X] 💄 Style Changes


### Background or solution
close: https://github.com/opensumi/core/issues/2822
修改前：
![image](https://user-images.githubusercontent.com/1762334/246841481-112a87c6-6fb9-4dcb-95fa-6ca2ce50bac8.png)
修改后：
![image](https://github.com/opensumi/core/assets/1762334/16341fd6-0b8d-40ba-b572-539e971b9b63)

### Changelog
fix: 调整插件面板中插件的最小高度
