### PR TITLE
feat: support use npmmirror cdn url

### DIFF
--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -216,7 +216,7 @@ export interface AppConfig {
    * 视图组件内默认的组件样式资源 CDN 来源
    * 默认值为 'alipay'
    */
-  componentCDNType?: 'unpkg' | 'jsdelivr' | 'alipay';
+  componentCDNType?: TComponentCDNType;
   /**
    * 指定前端是否为 Electron 环境 (Electron Renderer)
    * 为兼容老的逻辑，若不兼容则 fallback 到 isElectronRenderer 的判断
@@ -277,3 +277,5 @@ export function ConfigProvider(props: React.PropsWithChildren<{ value: AppConfig
 
   return React.createElement(extraContextProvider, { children: app });
 }
+
+export type TComponentCDNType = 'unpkg' | 'jsdelivr' | 'alipay' | 'npmmirror';

--- a/packages/extension/src/browser/shadowRoot.tsx
+++ b/packages/extension/src/browser/shadowRoot.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import { ComponentContextProvider, IconContext, IIconResourceOptions } from '@opensumi/ide-components';
-import { DisposableCollection, LabelService, useInjectable } from '@opensumi/ide-core-browser';
+import { DisposableCollection, LabelService, TComponentCDNType, useInjectable } from '@opensumi/ide-core-browser';
 import { ExtensionBrowserStyleSheet, localize, URI } from '@opensumi/ide-core-common';
 import { getThemeTypeSelector, IIconService, IThemeService, ThemeType } from '@opensumi/ide-theme';
 
@@ -19,19 +19,14 @@ function cloneNode<T>(head): T {
   return head.cloneNode(true);
 }
 
-const CDN_TYPE_MAP: CDNTypeMap = {
+type IComponentCDNTypeMap = Record<TComponentCDNType, string>;
+
+const CDN_TYPE_MAP: IComponentCDNTypeMap = {
   alipay: 'https://gw.alipayobjects.com/os/lib',
+  npmmirror: 'https://registry.npmmirror.com',
   unpkg: 'https://unpkg.com/browse',
   jsdelivr: 'https://cdn.jsdelivr.net/npm',
 };
-
-interface CDNTypeMap {
-  alipay: string;
-  unpkg: string;
-  jsdelivr: string;
-}
-
-type CDNType = keyof CDNTypeMap;
 
 /**
  * 由于经过 clone 以后，实际 Shadow DOM 中 head 与原始 proxiedHead 不是同一份引用
@@ -74,9 +69,11 @@ function useMutationObserver(from: HTMLHeadElement, target: HTMLHeadElement) {
 
 const packageName = '@opensumi/ide-components';
 
-function getCdnHref(filePath: string, version: string, cdnType: CDNType = 'alipay') {
+function getCdnHref(filePath: string, version: string, cdnType: TComponentCDNType = 'alipay') {
   if (cdnType === 'alipay') {
     return `${CDN_TYPE_MAP['alipay']}/${packageName.slice(1)}/${version}/${filePath}`;
+  } else if (cdnType === 'npmmirror') {
+    return `${CDN_TYPE_MAP['npmmirror']}/${packageName}/${version}/files/${filePath}`;
   } else {
     return `${CDN_TYPE_MAP[cdnType]}/${packageName}@${version}/${filePath}`;
   }
@@ -101,7 +98,7 @@ const ShadowRoot = ({
   extensionId: string;
   children: any;
   proxiedHead: HTMLHeadElement;
-  cdnType?: CDNType;
+  cdnType?: TComponentCDNType;
   styleSheet?: ExtensionBrowserStyleSheet;
 }) => {
   const shadowRootRef = useRef<HTMLDivElement | null>(null);
@@ -183,7 +180,7 @@ export function getShadowRoot(
   props,
   id,
   proxiedHead,
-  type?: CDNType,
+  type?: TComponentCDNType,
   extensionBrowserStyleSheet?: ExtensionBrowserStyleSheet,
 ) {
   const Component = panel;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

npmmirror supported browse files now, so we can change cdn url to npmmirror

### Changelog

support use npmmirror cdn url
