### PR TITLE
feat: improve render blank lines breakpoints

### DIFF
--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.module.less
@@ -83,6 +83,10 @@
   display: block;
   opacity: 0.85;
   display: inline;
+
+  &.blank {
+    opacity: 0.35;
+  }
 }
 
 .debug_breakpoints_name {

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -347,6 +347,18 @@ export const BreakpointItem = ({ data, toggle }: { data: BreakpointItem; toggle:
     await commandService.executeCommand(DEBUG_COMMANDS.EDIT_BREAKPOINT.id, position);
   };
 
+  const renderDescription = useMemo(() => {
+    if (description) {
+      return <span className={styles.debug_breakpoints_description}>{description}</span>;
+    }
+
+    return (
+      <span className={cls(styles.debug_breakpoints_description, styles.blank)}>{`< ${localize(
+        'debug.breakpoint.blank',
+      )} >`}</span>
+    );
+  }, [description]);
+
   return (
     <div className={cls(styles.debug_breakpoints_item)}>
       <CheckBox
@@ -357,7 +369,7 @@ export const BreakpointItem = ({ data, toggle }: { data: BreakpointItem; toggle:
       ></CheckBox>
       <div className={styles.debug_breakpoints_wrapper} onClick={handleBreakpointClick}>
         {data.name && <span className={styles.debug_breakpoints_name}>{data.name}</span>}
-        <span className={styles.debug_breakpoints_description}>{description}</span>
+        {renderDescription}
       </div>
       {isDebugBreakpoint(data.breakpoint) ? (
         <>

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -337,6 +337,7 @@ export const localizationBundle = {
     'debug.breakpoint.conditionalMessage': 'Conditional Breakpoint',
     'debug.breakpoint.unverified': 'Unverified ',
     'debug.breakpoint.disabled': 'Disabled ',
+    'debug.breakpoint.blank': 'Blank',
     'debug.configuration.comment1': 'Use IntelliSense to learn about possible attributes.',
     'debug.configuration.comment2': 'Hover to view descriptions of existing attributes.',
     'debug.configuration.comment3': 'For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -318,6 +318,7 @@ export const localizationBundle = {
     'debug.breakpoint.conditionalMessage': '条件断点',
     'debug.breakpoint.unverified': '无效的',
     'debug.breakpoint.disabled': '禁用的',
+    'debug.breakpoint.blank': '空行',
     'debug.configuration.comment1': '使用 IntelliSense 了解相关属性。 ',
     'debug.configuration.comment2': '悬停以查看现有属性的描述。',
     'debug.configuration.comment3': '欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed951d4</samp>

*  Add a new CSS class `blank` to style blank breakpoints ([link](https://github.com/opensumi/core/pull/2832/files?diff=unified&w=0#diff-074446186b543c8a610e1b2007953769e9214675864443bfa01abe0fa684ffe0R86-R89))
*  Extract a new function `renderDescription` to return a span element with the breakpoint description or a placeholder text ([link](https://github.com/opensumi/core/pull/2832/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R350-R361))
*  Use `renderDescription` to render the breakpoint description in the `BreakpointItem` component ([link](https://github.com/opensumi/core/pull/2832/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L360-R372))
*  Add a new localization key `debug.breakpoint.blank` and its values for English and Chinese languages ([link](https://github.com/opensumi/core/pull/2832/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R340), [link](https://github.com/opensumi/core/pull/2832/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R321))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/35c62b82-a34e-4fa8-bbad-ab59dec33845)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed951d4</samp>

This pull request improves the display of breakpoints in the debug view by adding a placeholder description for blank breakpoints and localizing the description text. It affects the files `debug-breakpoints.view.tsx`, `debug-breakpoints.module.less`, and the language files `en-US.lang.ts` and `zh-CN.lang.ts`.
