### PR TITLE
chore: optimize treeview re-render

### DIFF
--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -9,7 +9,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useState,
+  useRef,
 } from 'react';
 
 import { Injector } from '@opensumi/di';
@@ -38,8 +38,8 @@ export interface ExtensionTabBarTreeViewProps {
 
 export const ExtensionTabBarTreeView = observer(
   ({ viewState, model, dataProvider, treeViewId }: PropsWithChildren<ExtensionTabBarTreeViewProps>) => {
-    const [isReady, setIsReady] = useState<boolean>(false);
-    const [isEmpty, setIsEmpty] = useState(dataProvider.isTreeEmpty);
+    const isReady = useRef<boolean>(false);
+    const isEmpty = useRef<boolean>(dataProvider.isTreeEmpty);
     const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
     const decorationService = useInjectable<IDecorationsService>(IDecorationsService);
     const accordionService = useMemo(() => layoutService.getViewAccordionService(treeViewId), []);
@@ -54,7 +54,7 @@ export const ExtensionTabBarTreeView = observer(
 
     useEffect(() => {
       const disposable = dataProvider.onDidChangeEmpty(() => {
-        setIsEmpty(dataProvider.isTreeEmpty);
+        isEmpty.current = dataProvider.isTreeEmpty;
       });
       return () => disposable.dispose();
     }, []);
@@ -193,7 +193,7 @@ export const ExtensionTabBarTreeView = observer(
           await model.treeModel.ensureReady;
         }
         if (!unmouted) {
-          setIsReady(true);
+          isReady.current = true;
         }
       })();
       return () => {
@@ -222,8 +222,8 @@ export const ExtensionTabBarTreeView = observer(
         data-tree-view-id={treeViewId}
       >
         <TreeView
-          isReady={isReady}
-          isEmpty={isEmpty}
+          isReady={isReady.current}
+          isEmpty={isEmpty.current}
           height={height}
           handleTreeReady={handleTreeReady}
           handleItemClicked={handleItemClicked}

--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -46,8 +46,8 @@ export const FILE_TREE_FILTER_DELAY = 500;
 const FilterableRecycleTree = RecycleTreeFilterDecorator(RecycleTree);
 
 export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState }>) => {
-  const [isReady, setIsReady] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const isReady = useRef<boolean>(false);
+  const isLoading = useRef<boolean>(true);
   const [outerActive, setOuterActive] = useState<boolean>(false);
   const [outerDragOver, setOuterDragOver] = useState<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
@@ -142,13 +142,13 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
       // 首次初始化完成时，监听后续变化，适配工作区变化事件
       // 监听工作区变化
       fileTreeModelService.onFileTreeModelChange(async (treeModel) => {
-        setIsLoading(true);
+        isLoading.current = true;
         if (treeModel) {
           // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
           await treeModel.ensureReady;
         }
         setModel(treeModel);
-        setIsLoading(false);
+        isLoading.current = false;
       });
     }
   }, [isReady]);
@@ -279,9 +279,9 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
           fileTreeService.initContextKey(wrapperRef.current);
         }
       }
-      setIsLoading(false);
+      isReady.current = false;
       if (!disposableRef.current?.disposed) {
-        setIsReady(true);
+        isReady.current = true;
       }
     },
     [fileTreeModelService, disposableRef.current],
@@ -365,8 +365,8 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
       onDrop={handleOuterDrop}
     >
       <FileTreeView
-        isLoading={isLoading}
-        isReady={isReady}
+        isLoading={isLoading.current}
+        isReady={isReady.current}
         height={height}
         model={model}
         iconTheme={iconTheme}

--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -147,8 +147,8 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
           // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
           await treeModel.ensureReady;
         }
-        setModel(treeModel);
         isLoading.current = false;
+        setModel(treeModel);
       });
     }
   }, [isReady]);
@@ -264,27 +264,28 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
 
   const ensureIsReady = useCallback(
     async (token: CancellationToken) => {
+      isReady.current = false;
       await fileTreeModelService.whenReady;
       if (token.isCancellationRequested) {
         return;
       }
+      // 文件服务已经初始化完毕，但文件树数据仍需要加载
+      isReady.current = true;
       if (fileTreeModelService.treeModel) {
         // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
         await fileTreeModelService.treeModel.ensureReady;
-        setModel(fileTreeModelService.treeModel);
         if (token.isCancellationRequested) {
           return;
         }
+        setModel(fileTreeModelService.treeModel);
+        // 文件树数据加载完毕
+        isLoading.current = false;
         if (wrapperRef.current) {
           fileTreeService.initContextKey(wrapperRef.current);
         }
       }
-      isReady.current = false;
-      if (!disposableRef.current?.disposed) {
-        isReady.current = true;
-      }
     },
-    [fileTreeModelService, disposableRef.current],
+    [fileTreeModelService],
   );
 
   const handleTreeReady = useCallback(

--- a/packages/scm/src/browser/components/scm-resource-tree/index.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/index.tsx
@@ -1,6 +1,6 @@
 import clx from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { FC, useState, createRef, RefObject, useEffect, useCallback, memo } from 'react';
+import React, { FC, useState, useRef, createRef, RefObject, useEffect, useCallback, memo } from 'react';
 
 import { RecycleTree, IRecycleTreeHandle, TreeNodeType, TreeModel } from '@opensumi/ide-components';
 import { isOSX } from '@opensumi/ide-core-browser';
@@ -20,7 +20,7 @@ export const SCMResourceTree: FC<{
   width: number;
   height: number;
 }> = observer(({ height }) => {
-  const [isReady, setIsReady] = useState<boolean>(false);
+  const isReady = useRef<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
 
   const wrapperRef: RefObject<HTMLDivElement> = createRef();
@@ -39,7 +39,7 @@ export const SCMResourceTree: FC<{
         // 这里需要重新取一下treeModel的值确保为最新的TreeModel
         await scmTreeModelService.treeModel.ensureReady;
       }
-      setIsReady(true);
+      isReady.current = true;
     })();
   }, []);
 
@@ -142,7 +142,7 @@ export const SCMResourceTree: FC<{
       data-name={TREE_FIELD_NAME}
     >
       <SCMTreeView
-        isReady={isReady}
+        isReady={isReady.current}
         model={model}
         height={height}
         onTreeReady={handleTreeReady}


### PR DESCRIPTION
### Types

- [x] 💄 Code Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3998ef5</samp>

*  Replaced state variables with ref variables to avoid unnecessary re-rendering of components ([link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L12-R12), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L41-R42), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L57-R57), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L196-R196), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L225-R226), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L49-R50), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L145-R145), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L151-R151), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L282-R284), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L368-R369), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L3-R3), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L23-R23), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L42-R42), [link](https://github.com/opensumi/core/pull/2833/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L145-R145))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3998ef5</samp>

The pull request improves the performance of several components that use tree views by replacing state variables with ref variables. This avoids unnecessary re-rendering and state updates when the components are ready or loading. The affected components are `extension-tree-view`, `file-tree`, and `scm-resource-tree`.
