### PR TITLE
fix: check undefined of preference item default value

### DIFF
--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -503,7 +503,7 @@ function SelectPreferenceItem({
   const labels = settingsService.getEnumLabels(preferenceId);
   const renderEnumOptions = useCallback(() => {
     const enums = schema.enum ? [...schema.enum] : [];
-    if (!enums.includes(defaultValue)) {
+    if (defaultValue && !enums.includes(defaultValue)) {
       logger.warn(`default value(${defaultValue}) of ${preferenceId} not found in its enum field`);
       enums.push(defaultValue);
     }
@@ -515,11 +515,11 @@ function SelectPreferenceItem({
       return (
         <Option
           value={item}
-          label={replaceLocalizePlaceholder((labels[item] || item).toString())}
+          label={replaceLocalizePlaceholder((labels[item] || item)?.toString())}
           key={`${idx} - ${item}`}
           className={styles.select_option}
         >
-          {replaceLocalizePlaceholder((labels[item] || item).toString())}
+          {replaceLocalizePlaceholder((labels[item] || item)?.toString())}
           {String(item) === String(defaultValue) && (
             <div className={styles.select_default_option_tips}>{localize('preference.enum.default')}</div>
           )}


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->
偏好设置，如果无默认值，此时为 undefined，enum 目前未判空，加上了 undefined，此时渲染拿到 undefined toString，导致组件崩溃
<img width="955" alt="截屏2023-06-27 16 58 13" src="https://github.com/opensumi/core/assets/19860190/9bc0ab0b-326d-4ad2-b292-92324535fbc4">


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fad7e28</samp>

* Fix a bug that caused the preference panel to crash for some enum preferences by checking for `defaultValue` before using it in the `includes` method ([link](https://github.com/opensumi/core/pull/2834/files?diff=unified&w=0#diff-13846029778202e9883ae97a33ac171c710a37e78d01f5f542e1d3c5bd5f0ea1L506-R506))
* Improve the robustness of the code by adding optional chaining operators to the `toString` methods of `labels[item]` and `item` in `preferenceItem.view.tsx` ([link](https://github.com/opensumi/core/pull/2834/files?diff=unified&w=0#diff-13846029778202e9883ae97a33ac171c710a37e78d01f5f542e1d3c5bd5f0ea1L518-R522))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->
如果无默认值，则不添加到 enum 中，同时对 toString 判空
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fad7e28</samp>

This pull request improves the stability and robustness of the preference panel by fixing a bug in `preferenceItem.view.tsx` and adding more error handling.
