### PR TITLE
feat: improve merge editor result title

### DIFF
--- a/packages/monaco/__tests__/browser/merge-editor/merge-editor.service.test.ts
+++ b/packages/monaco/__tests__/browser/merge-editor/merge-editor.service.test.ts
@@ -7,6 +7,8 @@ import { MergeEditorService } from '@opensumi/ide-monaco/lib/browser/contrib/mer
 import { monaco } from '@opensumi/ide-monaco/lib/browser/monaco-api/index';
 import MonacoServiceImpl from '@opensumi/ide-monaco/lib/browser/monaco.service';
 import { MonacoOverrideServiceRegistryImpl } from '@opensumi/ide-monaco/lib/browser/override.service.registry';
+import { IWorkspaceService } from '@opensumi/ide-workspace';
+import { WorkspaceService } from '@opensumi/ide-workspace/lib/browser/workspace-service';
 
 let injector: MockInjector;
 
@@ -29,6 +31,10 @@ describe('merge editor service test', () => {
       {
         token: MappingManagerService,
         useClass: MappingManagerService,
+      },
+      {
+        token: IWorkspaceService,
+        useClass: WorkspaceService,
       },
     ],
   );

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -26,11 +26,13 @@ const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType })
       const rootUri = new URI(workspaceService.workspace.uri);
       const rootRelative = rootUri.relative(uri);
       if (rootRelative) {
-        return URI.file(rootRelative.toString());
+        return rootRelative.toString();
       }
+
+      return uri.toString();
     }
 
-    return uri;
+    return uri.toString();
   }, []);
 
   React.useEffect(() => {
@@ -46,9 +48,7 @@ const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType })
       } else if (contrastType === EditorViewType.INCOMING) {
         setHead(input2.getRaw());
       } else if (contrastType === EditorViewType.RESULT) {
-        setHead(
-          new MergeEditorInputData(output.uri, 'Result', toRelativePath(output.uri).path.toString(), '').getRaw(),
-        );
+        setHead(new MergeEditorInputData(output.uri, 'Result', toRelativePath(output.uri), '').getRaw());
       }
     });
 

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { localize, useInjectable } from '@opensumi/ide-core-browser';
+import { URI, localize, useInjectable } from '@opensumi/ide-core-browser';
 import { Button, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 import {
   IMergeEditorInputData,
   IOpenMergeEditorArgs,
   MergeEditorInputData,
 } from '@opensumi/ide-core-browser/lib/monaco/merge-editor-widget';
+import { IWorkspaceService } from '@opensumi/ide-workspace';
 
 import { MergeEditorService } from '../merge-editor.service';
 import { EditorViewType } from '../types';
@@ -16,7 +17,21 @@ import { WithViewStickinessConnectComponent } from './stickiness-connect-manager
 
 const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType }) => {
   const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
+  const workspaceService = useInjectable<IWorkspaceService>(IWorkspaceService);
   const [head, setHead] = useState<IMergeEditorInputData>();
+
+  const toRelativePath = useCallback((uri: URI) => {
+    // 获取相对路径
+    if (workspaceService.workspace) {
+      const rootUri = new URI(workspaceService.workspace.uri);
+      const rootRelative = rootUri.relative(uri);
+      if (rootRelative) {
+        return URI.file(rootRelative.toString());
+      }
+    }
+
+    return uri;
+  }, []);
 
   React.useEffect(() => {
     const disposable = mergeEditorService.onDidInputNutrition((nutrition: IOpenMergeEditorArgs) => {
@@ -31,7 +46,9 @@ const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType })
       } else if (contrastType === EditorViewType.INCOMING) {
         setHead(input2.getRaw());
       } else if (contrastType === EditorViewType.RESULT) {
-        setHead(new MergeEditorInputData(output.uri, 'Result', output.uri.toString(), '').getRaw());
+        setHead(
+          new MergeEditorInputData(output.uri, 'Result', toRelativePath(output.uri).path.toString(), '').getRaw(),
+        );
       }
     });
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca2adc1</samp>

* Import modules for memoization and URI manipulation from React and @opensumi/ide-core-browser ([link](https://github.com/opensumi/core/pull/2835/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L1-R3))
* Import interface for workspace service from @opensumi/ide-workspace ([link](https://github.com/opensumi/core/pull/2835/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926R10))
* Create workspace service instance and memoized function to convert absolute URI to relative path based on workspace root ([link](https://github.com/opensumi/core/pull/2835/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L19-R35))
* Apply relative path function to output URI when creating result view input data in `grid.tsx` ([link](https://github.com/opensumi/core/pull/2835/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L34-R51))

<!-- Additional content -->
result 视图 title 展示 fsPath 而不是整个 uri

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca2adc1</samp>

Added a feature to display relative paths of output files in the merge editor. Modified `grid.tsx` to import modules and define a function for this feature.
