### PR TITLE
fix: merge editor not support wordwrap

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -18,6 +18,7 @@ import type {
   ICodeEditor as IMonacoCodeEditor,
   IDiffEditor as IMonacoDiffEditor,
 } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
+import type { IDiffEditorConstructionOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import { IConfigurationService } from '@opensumi/monaco-editor-core/esm/vs/platform/configuration/common/configuration';
 
@@ -146,7 +147,13 @@ export class EditorCollectionServiceImpl extends WithEventBus implements EditorC
 
   public createMergeEditor(dom: HTMLElement, options?: any, overrides?: { [key: string]: any }) {
     const preferenceOptions = getConvertedMonacoOptions(this.configurationService);
-    const mergedOptions = { ...preferenceOptions.editorOptions, ...preferenceOptions.diffOptions, ...options };
+    const mergedOptions: IDiffEditorConstructionOptions = {
+      ...preferenceOptions.editorOptions,
+      ...preferenceOptions.diffOptions,
+      ...options,
+      // merge editor not support wordWrap
+      wordWrap: 'off',
+    };
     const editor = this.monacoService.createMergeEditor(dom, mergedOptions, overrides);
     return editor;
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb3acd2</samp>

*  Import the `IDiffEditorConstructionOptions` type from `@opensumi/monaco-editor-core` to use a more accurate type for the `mergedOptions` variable in the `createMergeEditor` method ([link](https://github.com/opensumi/core/pull/2836/files?diff=unified&w=0#diff-c0d0f058ba7138472d4432426af4cc7f4e0ab38de65fdefd5564c65225f485a0R21))
*  Set the `wordWrap` option to `'off'` in the `mergedOptions` variable to fix a bug that causes incorrect diff indicators in the merge editor ([link](https://github.com/opensumi/core/pull/2836/files?diff=unified&w=0#diff-c0d0f058ba7138472d4432426af4cc7f4e0ab38de65fdefd5564c65225f485a0L149-R156))

<!-- Additional content -->
merge editor 不支持 wordWrap 配置

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb3acd2</samp>

This pull request enhances the merge editor feature of the editor collection service. It uses a more specific type for the editor options and disables word wrapping for better diff visibility.
