### PR TITLE
style: merge editor left view padding

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -2,6 +2,7 @@
   height: 100%;
   overflow: hidden;
   position: relative;
+  padding-left: 8px;
 
   .merge_actions {
     position: absolute;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f38b8e</samp>

*  Add left padding to merge editor title ([link](https://github.com/opensumi/core/pull/2837/files?diff=unified&w=0#diff-1c44596746fd7ac18b3a6476363c06d222d28b064cf82282d4afd90593a82bfdR5))

<!-- Additional content -->
适当给 merge editor 添加左边边距，否则看起来太拥挤了

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f38b8e</samp>

Improve merge editor UI by adjusting title padding. This change modifies the `merge-editor.module.less` file to add some left padding to the `merge-editor-title` class.
