### PR TITLE
feat: support merge editor accept left or right

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1376,7 +1376,9 @@ export const localizationBundle = {
       'The file has unresolved conflicts or changes, whether to apply and save the changes?',
     'mergeEditor.conflict.action.apply.confirm.continue': 'Continue Merge',
     'mergeEditor.conflict.action.apply.confirm.complete': 'Apply Changes',
-    'mergeEditor.button.apply': 'Apply',
+    'mergeEditor.action.button.apply': 'Apply',
+    'mergeEditor.action.button.accept.left': 'Accept Left',
+    'mergeEditor.action.button.accept.right': 'Accept Right',
     // #endregion merge editor
     'workbench.quickOpen.preserveInput':
       'Controls whether the last typed input to Quick Open(include Command Palette) should be preserved.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1149,7 +1149,9 @@ export const localizationBundle = {
     'mergeEditor.conflict.action.apply.confirm.title': '当前文件还有未处理的冲突或变更，是否应用并保存更改？',
     'mergeEditor.conflict.action.apply.confirm.continue': '继续合并',
     'mergeEditor.conflict.action.apply.confirm.complete': '确认保存并更改',
-    'mergeEditor.button.apply': '应用更改',
+    'mergeEditor.action.button.apply': '应用更改',
+    'mergeEditor.action.button.accept.left': '接受左边',
+    'mergeEditor.action.button.accept.right': '接受右边',
     'workbench.quickOpen.preserveInput': '是否在 QuickOpen 的输入框（包括命令面板）中保留上次输入的内容',
 
     'webview.webviewTagUnavailable': '非 Electron 环境不支持 Webview 标签，请使用 Iframe 标签',

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -19,6 +19,7 @@ import { MappingManagerService } from './mapping-manager.service';
 import { IMergeEditorEditorConstructionOptions } from './merge-editor-widget';
 import { ComputerDiffModel } from './model/computer-diff';
 import { LineRangeMapping } from './model/line-range-mapping';
+import { ACCEPT_CURRENT_ACTIONS } from './types';
 import { ActionsManager } from './view/actions-manager';
 import { CurrentCodeEditor } from './view/editors/currentCodeEditor';
 import { IncomingCodeEditor } from './view/editors/incomingCodeEditor';
@@ -115,6 +116,28 @@ export class MergeEditorService extends Disposable {
     this.scrollSynchronizer.dispose();
     this.stickinessConnectManager.dispose();
     this.actionsManager.dispose();
+  }
+
+  public async acceptLeft(): Promise<void> {
+    const mappings = this.mappingManagerService.documentMappingTurnLeft;
+    const lineRanges = mappings.getOriginalRange();
+    lineRanges.forEach((range) => {
+      this.currentView.launchConflictActionsEvent({
+        range,
+        action: ACCEPT_CURRENT_ACTIONS,
+      });
+    });
+  }
+
+  public async acceptRight(): Promise<void> {
+    const mappings = this.mappingManagerService.documentMappingTurnRight;
+    const lineRanges = mappings.getModifiedRange();
+    lineRanges.forEach((range) => {
+      this.incomingView.launchConflictActionsEvent({
+        range,
+        action: ACCEPT_CURRENT_ACTIONS,
+      });
+    });
   }
 
   public async accept(): Promise<void> {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/baseCodeEditor.ts
@@ -49,6 +49,10 @@ export abstract class BaseCodeEditor extends Disposable implements IBaseCodeEdit
     this.mount();
   }
 
+  public launchConflictActionsEvent(eventData: IConflictActionsEvent): void {
+    this._onDidConflictActions.fire(eventData);
+  }
+
   public override dispose(): void {
     super.dispose();
     this.editor.dispose();

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.ts
@@ -82,7 +82,7 @@ export class CurrentCodeEditor extends BaseCodeEditor {
 
   public override launchConflictActionsEvent(eventData: Omit<IConflictActionsEvent, 'withViewType'>): void {
     const { range, action } = eventData;
-    this._onDidConflictActions.fire({
+    super.launchConflictActionsEvent({
       range,
       action,
       withViewType: EditorViewType.CURRENT,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/currentCodeEditor.ts
@@ -17,6 +17,7 @@ import {
   TActionsType,
   IActionsDescription,
   APPEND_ACTIONS,
+  IConflictActionsEvent,
 } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
@@ -79,6 +80,15 @@ export class CurrentCodeEditor extends BaseCodeEditor {
     return EditorViewType.CURRENT;
   }
 
+  public override launchConflictActionsEvent(eventData: Omit<IConflictActionsEvent, 'withViewType'>): void {
+    const { range, action } = eventData;
+    this._onDidConflictActions.fire({
+      range,
+      action,
+      withViewType: EditorViewType.CURRENT,
+    });
+  }
+
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {
     this.mappingManagerService.inputComputeResultRangeMappingTurnLeft(changes);
     this.updateDecorations();
@@ -103,19 +113,24 @@ export class CurrentCodeEditor extends BaseCodeEditor {
       },
       onActionsClick: (range: LineRange, actionType: TActionsType) => {
         if (actionType === ACCEPT_CURRENT_ACTIONS) {
-          this._onDidConflictActions.fire({
+          this.launchConflictActionsEvent({
             range,
-            withViewType: EditorViewType.CURRENT,
             action: ACCEPT_CURRENT_ACTIONS,
           });
         }
 
         if (actionType === IGNORE_ACTIONS) {
-          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.CURRENT, action: IGNORE_ACTIONS });
+          this.launchConflictActionsEvent({
+            range,
+            action: IGNORE_ACTIONS,
+          });
         }
 
         if (actionType === APPEND_ACTIONS) {
-          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.CURRENT, action: APPEND_ACTIONS });
+          this.launchConflictActionsEvent({
+            range,
+            action: APPEND_ACTIONS,
+          });
         }
       },
     });
@@ -126,7 +141,7 @@ export class CurrentCodeEditor extends BaseCodeEditor {
   }
 
   /**
-   * current view 视图需要把 margin 区域放在右边
+   *  current view 视图需要把 margin 区域放在右边
    */
   public layout(): void {
     const editor = this.getEditor();

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.ts
@@ -78,7 +78,7 @@ export class IncomingCodeEditor extends BaseCodeEditor {
 
   public override launchConflictActionsEvent(eventData: Omit<IConflictActionsEvent, 'withViewType'>): void {
     const { range, action } = eventData;
-    this._onDidConflictActions.fire({
+    super.launchConflictActionsEvent({
       range,
       action,
       withViewType: EditorViewType.INCOMING,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/incomingCodeEditor.ts
@@ -15,6 +15,7 @@ import {
   TActionsType,
   IActionsDescription,
   APPEND_ACTIONS,
+  IConflictActionsEvent,
 } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
@@ -75,6 +76,15 @@ export class IncomingCodeEditor extends BaseCodeEditor {
     return EditorViewType.INCOMING;
   }
 
+  public override launchConflictActionsEvent(eventData: Omit<IConflictActionsEvent, 'withViewType'>): void {
+    const { range, action } = eventData;
+    this._onDidConflictActions.fire({
+      range,
+      action,
+      withViewType: EditorViewType.INCOMING,
+    });
+  }
+
   public inputDiffComputingResult(changes: LineRangeMapping[]): void {
     this.mappingManagerService.inputComputeResultRangeMappingTurnRight(changes);
     this.updateDecorations();
@@ -82,19 +92,18 @@ export class IncomingCodeEditor extends BaseCodeEditor {
       provideActionsItems: this.provideActionsItems,
       onActionsClick: (range: LineRange, actionType: TActionsType) => {
         if (actionType === ACCEPT_CURRENT_ACTIONS) {
-          this._onDidConflictActions.fire({
+          this.launchConflictActionsEvent({
             range,
-            withViewType: EditorViewType.INCOMING,
             action: ACCEPT_CURRENT_ACTIONS,
           });
         }
 
         if (actionType === IGNORE_ACTIONS) {
-          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.INCOMING, action: IGNORE_ACTIONS });
+          this.launchConflictActionsEvent({ range, action: IGNORE_ACTIONS });
         }
 
         if (actionType === APPEND_ACTIONS) {
-          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.INCOMING, action: APPEND_ACTIONS });
+          this.launchConflictActionsEvent({ range, action: APPEND_ACTIONS });
         }
       },
     });

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.ts
@@ -19,6 +19,7 @@ import {
   ITimeMachineMetaData,
   ETurnDirection,
   ACCEPT_COMBINATION_ACTIONS,
+  IConflictActionsEvent,
 } from '../../types';
 
 import { BaseCodeEditor } from './baseCodeEditor';
@@ -373,6 +374,15 @@ export class ResultCodeEditor extends BaseCodeEditor {
     };
   }
 
+  public override launchConflictActionsEvent(eventData: Omit<IConflictActionsEvent, 'withViewType'>): void {
+    const { range, action } = eventData;
+    this._onDidConflictActions.fire({
+      range,
+      action,
+      withViewType: EditorViewType.RESULT,
+    });
+  }
+
   /**
    * 由于 compute diff 的源数据都由 document mapping 来处理，所以 result 视图不用单独计算 compute 计算出的 diff changes
    */
@@ -384,13 +394,15 @@ export class ResultCodeEditor extends BaseCodeEditor {
       provideActionsItems: () => this.provideActionsItems(diffRanges),
       onActionsClick: (range: LineRange, actionType: TActionsType) => {
         if (actionType === REVOKE_ACTIONS) {
-          this._onDidConflictActions.fire({ range, withViewType: EditorViewType.RESULT, action: REVOKE_ACTIONS });
+          this.launchConflictActionsEvent({
+            range,
+            action: REVOKE_ACTIONS,
+          });
         }
 
         if (actionType === ACCEPT_COMBINATION_ACTIONS) {
-          this._onDidConflictActions.fire({
+          this.launchConflictActionsEvent({
             range,
-            withViewType: EditorViewType.RESULT,
             action: ACCEPT_COMBINATION_ACTIONS,
           });
         }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/editors/resultCodeEditor.ts
@@ -376,7 +376,7 @@ export class ResultCodeEditor extends BaseCodeEditor {
 
   public override launchConflictActionsEvent(eventData: Omit<IConflictActionsEvent, 'withViewType'>): void {
     const { range, action } = eventData;
-    this._onDidConflictActions.fire({
+    super.launchConflictActionsEvent({
       range,
       action,
       withViewType: EditorViewType.RESULT,

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { localize, useInjectable } from '@opensumi/ide-core-browser';
 import { Button, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
@@ -60,6 +60,42 @@ const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType })
   );
 };
 
+const MergeActions: React.FC = () => {
+  const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
+
+  const handleApply = useCallback(() => {
+    mergeEditorService.accept();
+  }, [mergeEditorService]);
+
+  const handleAcceptLeft = useCallback(() => {
+    mergeEditorService.acceptLeft();
+  }, [mergeEditorService]);
+
+  const handleAcceptRight = useCallback(() => {
+    mergeEditorService.acceptRight();
+  }, [mergeEditorService]);
+
+  return (
+    <div className={styles.merge_actions_container}>
+      <div className={styles.actions}>
+        <div className={styles.left_side}>
+          <Button size='large' type='default' onClick={handleAcceptLeft}>
+            {localize('mergeEditor.action.button.accept.left')}
+          </Button>
+          <Button size='large' type='default' onClick={handleAcceptRight}>
+            {localize('mergeEditor.action.button.accept.right')}
+          </Button>
+        </div>
+        <div className={styles.right_side}>
+          <Button size='large' onClick={handleApply}>
+            {localize('mergeEditor.action.button.apply')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const Grid = () => {
   const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
 
@@ -87,10 +123,6 @@ export const Grid = () => {
     mergeEditorService,
   ]);
 
-  const handleApply = () => {
-    mergeEditorService.accept();
-  };
-
   return (
     <div className={styles.merge_editor_container}>
       <SplitPanel overflow='hidden' id='merge_editor_container' flex={2}>
@@ -115,11 +147,7 @@ export const Grid = () => {
           <div className={styles.editor_container} ref={incomingEditorContainer}></div>
         </div>
       </SplitPanel>
-      <div className={styles.merge_actions}>
-        <Button size='large' onClick={handleApply}>
-          {localize('mergeEditor.button.apply')}
-        </Button>
-      </div>
+      <MergeActions />
     </div>
   );
 };

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -3,10 +3,26 @@
   overflow: hidden;
   position: relative;
 
-  .merge_actions {
+  .merge_actions_container {
     position: absolute;
-    right: 50px;
-    bottom: 30px;
+    bottom: 0;
+    width: 100%;
+    padding: 0 50px;
+    padding-bottom: 30px;
+
+    .actions {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .left_side {
+      * + * {
+        margin-left: 12px;
+      }
+    }
+
+    .right_side {
+    }
   }
 
   .editor_container {

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -20,9 +20,6 @@
         margin-left: 12px;
       }
     }
-
-    .right_side {
-    }
   }
 
   .editor_container {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 116cb9e</samp>

*  Add new localization keys and values for merge editor action buttons in English and Chinese language files ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4L1379-R1381), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7L1152-R1154))
*  Import and use a new constant `ACCEPT_CURRENT_ACTIONS` to indicate the action type of accepting the current side of a conflict in the merge editor service file ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-c84299400ed4df5895b7a82ccfa7cd395da353d4f9bf665044e5b8d6f2cdb293R22))
*  Add new methods `acceptLeft` and `acceptRight` to the merge editor service class to fire a conflict action event with the `ACCEPT_CURRENT_ACTIONS` type for the corresponding view (current or incoming) ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-c84299400ed4df5895b7a82ccfa7cd395da353d4f9bf665044e5b8d6f2cdb293R121-R142))
*  Add a new public method `launchConflictActionsEvent` to the base code editor class to abstract the event firing logic from the subclasses ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-cdac1643ff793fa643e9e1fd6d6c54f3ea970511a983045db97eb42903d271ebR52-R55))
*  Override the `launchConflictActionsEvent` method in the current, incoming, and result code editor classes to add the `withViewType` property to the event data with the corresponding value ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-3d391b5cd4f640e1bd48585468549ccf344fc0d36e776aab84ee94075036a543R83-R91), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-b10d068fac4146e274206ea85c45e8303c9f503c7b46ceb1ad15342b90f27cffR79-R87), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-a57a28cdd4e7a51bbd2c387193a7e4af5d97146a1309aa82a6038ed93e93fa33R377-R385))
*  Replace the direct firing of the `_onDidConflictActions` event emitter with the call to the `launchConflictActionsEvent` method in the current, incoming, and result code editor classes to simplify the code and avoid duplication ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-3d391b5cd4f640e1bd48585468549ccf344fc0d36e776aab84ee94075036a543L106-R117), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-3d391b5cd4f640e1bd48585468549ccf344fc0d36e776aab84ee94075036a543L114-R133), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-b10d068fac4146e274206ea85c45e8303c9f503c7b46ceb1ad15342b90f27cffL85-R96), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-b10d068fac4146e274206ea85c45e8303c9f503c7b46ceb1ad15342b90f27cffL93-R106), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-a57a28cdd4e7a51bbd2c387193a7e4af5d97146a1309aa82a6038ed93e93fa33L387-R405))
*  Import the `IConflictActionsEvent` interface from the types file to the current, incoming, and result code editor files to define the shape of the event data for the conflict actions event ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-3d391b5cd4f640e1bd48585468549ccf344fc0d36e776aab84ee94075036a543R20), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-b10d068fac4146e274206ea85c45e8303c9f503c7b46ceb1ad15342b90f27cffR18), [link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-a57a28cdd4e7a51bbd2c387193a7e4af5d97146a1309aa82a6038ed93e93fa33R22))
*  Fix a typo in the comment of the `layout` method in the current code editor class ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-3d391b5cd4f640e1bd48585468549ccf344fc0d36e776aab84ee94075036a543L129-R144))
*  Add a new functional component `MergeActions` to the grid component file to render and handle the merge editor action buttons (`Apply`, `Accept Left`, and `Accept Right`) using the merge editor service and the localization function ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926R63-R98))
*  Remove the `handleApply` function from the `Grid` component as it is moved to the `MergeActions` component ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L90-L93))
*  Replace the `merge_actions` div with the `MergeActions` component in the `Grid` component to simplify the code and move the buttons to a separate component ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L118-R150))
*  Update the styles for the merge editor action buttons in the less file using flexbox and sub-classes ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-1c44596746fd7ac18b3a6476363c06d222d28b064cf82282d4afd90593a82bfdL6-R25))
*  Add the `useCallback` hook to the import list from React in the grid component file to memoize the callback functions for the merge editor action buttons ([link](https://github.com/opensumi/core/pull/2839/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L1-R1))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/1fffc608-dcac-4f22-9054-bdb5ec6dfe4e)

- [x] 支持一键接受左边或右边的功能

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 116cb9e</samp>

This pull request adds new features and improvements to the merge editor service and its related components. It enables users to accept the left or right side of a conflict with action buttons, and fires events to update the result code editor accordingly. It also refactors some common logic into a base class method and a separate React component, and updates the localization and styles for the merge editor.
