### PR TITLE
fix: add key for preference item description list

### DIFF
--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -228,7 +228,7 @@ const renderDescriptionExpression = (description: string) => {
     if (preference) {
       const preferenceTitle = getPreferenceItemLabel(preference);
       const [prev, next] = tmp.split(expression, 2);
-      prev && result.push(<span>{prev}</span>);
+      prev && result.push(<span key={result.length}>{prev}</span>);
       tmp = next;
       const link = (
         <a
@@ -243,7 +243,7 @@ const renderDescriptionExpression = (description: string) => {
       result.push(link);
     }
   }
-  tmp && result.push(<span>{tmp}</span>);
+  tmp && result.push(<span key={result.length}>{tmp}</span>);
   return result;
 };
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a066e41</samp>

*  Add `key` props to `<span>` elements in preference item descriptions to avoid React warnings and improve rendering ([link](https://github.com/opensumi/core/pull/2840/files?diff=unified&w=0#diff-13846029778202e9883ae97a33ac171c710a37e78d01f5f542e1d3c5bd5f0ea1L231-R231), [link](https://github.com/opensumi/core/pull/2840/files?diff=unified&w=0#diff-13846029778202e9883ae97a33ac171c710a37e78d01f5f542e1d3c5bd5f0ea1L246-R246))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a066e41</samp>

Fix React key warning and improve rendering performance for preference item descriptions in `preferenceItem.view.tsx`. Add `key` props to `<span>` elements that wrap description parts.
