### PR TITLE
feat: support merge editor reset

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -358,6 +358,12 @@ export namespace EDITOR_COMMANDS {
     category: CATEGORY,
   };
 
+  export const MERGEEDITOR_RESET: Command = {
+    id: 'editor.mergeEditor.reset',
+    category: CATEGORY,
+    label: '%mergeEditor.reset%',
+  };
+
   export const CLOSE: Command = {
     id: 'editor.close',
     category: CATEGORY,

--- a/packages/core-browser/src/menu/next/menu-id.ts
+++ b/packages/core-browser/src/menu/next/menu-id.ts
@@ -84,6 +84,8 @@ export enum MenuId {
   // setting.json
   SettingJSONGlyphMarginContext = 'settingJson/glyphMargin/context',
   SubSettingJSONGlyphMarginContext = 'sub/settingJson/glyphMargin/context',
+  // merge editor context
+  MergeEditorResultTitleContext = 'mergeEditor/result/title/context',
 }
 
 export function getTabbarCommonMenuId(location: string) {

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -43,6 +43,7 @@ import { ICtxMenuRenderer } from '@opensumi/ide-core-browser/lib/menu/next/rende
 import { IRelaxedOpenMergeEditorArgs } from '@opensumi/ide-core-browser/lib/monaco/merge-editor-widget';
 import { isWindows, PreferenceScope, ILogger } from '@opensumi/ide-core-common';
 import { IElectronMainUIService } from '@opensumi/ide-core-common/lib/electron';
+import { MergeEditorService } from '@opensumi/ide-monaco/lib/browser/contrib/merge-editor/merge-editor.service';
 import { ITextmateTokenizer, ITextmateTokenizerService } from '@opensumi/ide-monaco/lib/browser/contrib/tokenizer';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 import { EditorContextKeys } from '@opensumi/monaco-editor-core/esm/vs/editor/common/editorContextKeys';
@@ -166,6 +167,9 @@ export class EditorContribution
 
   @Autowired(CorePreferences)
   private readonly corePreferences: CorePreferences;
+
+  @Autowired(MergeEditorService)
+  private readonly mergeEditorService: MergeEditorService;
 
   @Autowired(IEditorDocumentModelContentRegistry)
   contentRegistry: IEditorDocumentModelContentRegistry;
@@ -515,6 +519,24 @@ export class EditorContribution
             }),
           }),
         );
+      },
+    });
+
+    commands.registerCommand(EDITOR_COMMANDS.MERGEEDITOR_RESET, {
+      execute: () => {
+        const nutrition = this.mergeEditorService.getNutrition();
+
+        if (!nutrition) {
+          return;
+        }
+
+        const { output } = nutrition;
+        const { uri } = output;
+
+        // 重置状态
+        this.mergeEditorService.fireRestoreState(uri);
+        // 然后再重新 compare
+        this.mergeEditorService.compare();
       },
     });
 

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1372,6 +1372,7 @@ export const localizationBundle = {
     // #endregion walkthrough
 
     // #region merge editor
+    'mergeEditor.reset': 'Reset',
     'mergeEditor.workbench.tab.name': 'Merging: {0}',
     'mergeEditor.conflict.action.apply.confirm.title':
       'The file has unresolved conflicts or changes, whether to apply and save the changes?',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1146,6 +1146,7 @@ export const localizationBundle = {
     'walkthroughs.get.started': '打开 `入门` 演示',
 
     // Merge Editor
+    'mergeEditor.reset': '重置',
     'mergeEditor.workbench.tab.name': '正在合并: {0}',
     'mergeEditor.conflict.action.apply.confirm.title': '当前文件还有未处理的冲突或变更，是否应用并保存更改？',
     'mergeEditor.conflict.action.apply.confirm.continue': '继续合并',

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { localize, useInjectable } from '@opensumi/ide-core-browser';
 import { Button, SplitPanel } from '@opensumi/ide-core-browser/lib/components';
+import { InlineActionBar } from '@opensumi/ide-core-browser/lib/components/actions';
+import { AbstractMenuService, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import {
   IMergeEditorInputData,
   IOpenMergeEditorArgs,
@@ -15,6 +17,8 @@ import styles from './merge-editor.module.less';
 import { WithViewStickinessConnectComponent } from './stickiness-connect-manager';
 
 const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType }) => {
+  const menuService = useInjectable<AbstractMenuService>(AbstractMenuService);
+
   const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
   const [head, setHead] = useState<IMergeEditorInputData>();
 
@@ -40,6 +44,16 @@ const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType })
     };
   }, [mergeEditorService]);
 
+  const renderMoreActions = useCallback(() => {
+    if (contrastType !== EditorViewType.RESULT) {
+      return null;
+    }
+
+    const menus = menuService.createMenu(MenuId.MergeEditorResultTitleContext);
+
+    return <InlineActionBar menus={menus} className={styles.menubar_action} />;
+  }, [contrastType]);
+
   return (
     <div className={styles.title_head_container}>
       {head && (
@@ -55,7 +69,7 @@ const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType })
           </span>
         </div>
       )}
-      {/* more actions */}
+      <div className={styles.actions_container}>{renderMoreActions()}</div>
     </div>
   );
 };

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -176,6 +176,9 @@
     height: 30px;
     min-height: 30px;
     z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 
     & span {
       align-self: center;

--- a/packages/monaco/src/browser/monaco.contribution.ts
+++ b/packages/monaco/src/browser/monaco.contribution.ts
@@ -21,6 +21,8 @@ import {
   IContextKeyService,
   KeyCode,
   KeySequence,
+  FILE_COMMANDS,
+  EDITOR_COMMANDS,
 } from '@opensumi/ide-core-browser';
 import {
   IMenuRegistry,
@@ -434,6 +436,16 @@ export class MonacoClientContribution
         }
       });
     }
+
+    menuRegistry.registerMenuItems(MenuId.MergeEditorResultTitleContext, [
+      {
+        command: {
+          id: EDITOR_COMMANDS.MERGEEDITOR_RESET.id,
+          label: EDITOR_COMMANDS.MERGEEDITOR_RESET.label!,
+        },
+        group: 'navigation',
+      },
+    ]);
   }
 
   registerKeybindings(keybindings: KeybindingRegistry): void {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f6385f8</samp>

*  Add a new command `MERGEEDITOR_RESET` to reset the merge editor state and compare the input files again ([link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-a688102e10b7d594a046a44531865122eaa41ed5f4b5bd53eeb7f1f9f499507cR361-R366), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-60c8ffba5d20bbdd47538937244790320be906aa61ff9c7acb732dc640ab5bb5R525-R542), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R1374), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R1148), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-e7986110e99cc98dcf09014bbffef8bc25a262b580de026f6aad118adb100dc1R439-R448))
*  Inject the `MergeEditorService` to the `EditorContribution` class to manage the merge editor input, output, and events ([link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-60c8ffba5d20bbdd47538937244790320be906aa61ff9c7acb732dc640ab5bb5R46), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-60c8ffba5d20bbdd47538937244790320be906aa61ff9c7acb732dc640ab5bb5R171-R173))
*  Render an `InlineActionBar` component for the result editor panel in the merge editor grid view, using the `menuService` and the `MenuId.MergeEditorResultTitleContext` ([link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-be4a0db6f444a87b652e5269b82de5644091405e14f0f1b1e901a3565f5811b3R87-R88), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L1-R6), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926R20-R21), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926R47-R56), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L58-R72), [link](https://github.com/opensumi/core/pull/2841/files?diff=unified&w=0#diff-1c44596746fd7ac18b3a6476363c06d222d28b064cf82282d4afd90593a82bfdR166-R168))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/482e4a0e-bc13-4154-9803-d006e4c3c5ba)

- [x] merge editor 支持 reset 功能，在 result 视图的顶部位置右侧会提供 reset 按钮

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6385f8</samp>

This pull request adds a new feature to the merge editor that allows users to reset the comparison of the input files. It implements a new command `MERGEEDITOR_RESET`, a new menu id `MergeEditorResultTitleContext`, and a new menu item in the result panel of the merge editor grid view. It also adds the localization and styling for the new feature.
