### PR TITLE
fix: select not current file, need update targets

### DIFF
--- a/packages/opened-editor/__tests__/browser/opened-editor-model.service.test.ts
+++ b/packages/opened-editor/__tests__/browser/opened-editor-model.service.test.ts
@@ -48,6 +48,7 @@ describe('OpenedEditorModelService should be work', () => {
     path: 'testRoot',
     uri: rootUri,
     ensureLoaded: jest.fn(),
+    getTreeNodeByPath: jest.fn(),
   } as any;
   const mockCtxMenuRenderer = {
     show: jest.fn(),

--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -293,7 +293,7 @@ export class OpenedEditorModelService {
     if (this._selectedFiles.length) {
       this._selectedFiles.forEach((oldFile) => {
         const currentFileNode = this.treeModel?.root.getTreeNodeByPath(oldFile.path);
-        this.selectedDecoration.removeTarget(currentFileNode!);
+        this.selectedDecoration.removeTarget(currentFileNode || oldFile);
       });
     }
   }
@@ -301,7 +301,7 @@ export class OpenedEditorModelService {
   removeFocusedDecoration() {
     if (this._focusedFile) {
       const currentFileNode = this.treeModel?.root.getTreeNodeByPath(this._focusedFile.path);
-      this.focusedDecoration.removeTarget(currentFileNode!);
+      this.focusedDecoration.removeTarget(currentFileNode || this._focusedFile);
       this._focusedFile = undefined;
     }
   }

--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -236,14 +236,8 @@ export class OpenedEditorModelService {
       this._contextMenuFile = undefined;
     }
     if (target) {
-      if (this.selectedFiles.length > 0) {
-        this.selectedFiles.forEach((file) => {
-          this.selectedDecoration.removeTarget(file);
-        });
-      }
-      if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
-      }
+      this.removeSelectDecoration();
+      this.removeFocusedDecoration();
       this.selectedDecoration.addTarget(target);
       this.focusedDecoration.addTarget(target);
       this._focusedFile = target;
@@ -263,14 +257,8 @@ export class OpenedEditorModelService {
       this._contextMenuFile = undefined;
     }
     if (target) {
-      if (this.selectedFiles.length > 0) {
-        this.selectedFiles.forEach((file) => {
-          this.selectedDecoration.removeTarget(file);
-        });
-      }
-      if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
-      }
+      this.removeSelectDecoration();
+      this.removeFocusedDecoration();
       this.selectedDecoration.addTarget(target);
       this._selectedFiles = [target];
 
@@ -286,10 +274,7 @@ export class OpenedEditorModelService {
     if (this.contextMenuFile) {
       this.contextMenuDecoration.removeTarget(this.contextMenuFile);
     }
-    if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
-      this._focusedFile = undefined;
-    }
+    this.removeFocusedDecoration();
     this.contextMenuDecoration.addTarget(target);
     this._contextMenuFile = target;
     this.treeModel?.dispatchChange();
@@ -297,15 +282,29 @@ export class OpenedEditorModelService {
 
   // 取消选中节点焦点
   enactiveFileDecoration = () => {
-    if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
-      this._focusedFile = undefined;
-    }
+    this.removeFocusedDecoration();
     if (this.contextMenuFile) {
       this.contextMenuDecoration.removeTarget(this.contextMenuFile);
     }
     this.treeModel?.dispatchChange();
   };
+  // refresh 更新后，原保存节点已经销毁，需要根据 path 获取新的节点
+  removeSelectDecoration() {
+    if (this._selectedFiles.length) {
+      this._selectedFiles.forEach((oldFile) => {
+        const currentFileNode = this.treeModel?.root.getTreeNodeByPath(oldFile.path);
+        this.selectedDecoration.removeTarget(currentFileNode!);
+      });
+    }
+  }
+
+  removeFocusedDecoration() {
+    if (this._focusedFile) {
+      const currentFileNode = this.treeModel?.root.getTreeNodeByPath(this._focusedFile.path);
+      this.focusedDecoration.removeTarget(currentFileNode!);
+      this._focusedFile = undefined;
+    }
+  }
 
   handleContextMenu = (ev: React.MouseEvent, file?: EditorFileGroup | EditorFile) => {
     if (!file) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5081b50</samp>

*  Add a custom event `onWillUpdate` to the `OpenedEditorModel` class that notifies listeners before the model is updated ([link](https://github.com/opensumi/core/pull/2842/files?diff=unified&w=0#diff-b005f5edaf2c7583efb5540b8f48793ea34632ff07e300d0a6381c66c81466cfR17), [link](https://github.com/opensumi/core/pull/2842/files?diff=unified&w=0#diff-b005f5edaf2c7583efb5540b8f48793ea34632ff07e300d0a6381c66c81466cfR24-R27), [link](https://github.com/opensumi/core/pull/2842/files?diff=unified&w=0#diff-b005f5edaf2c7583efb5540b8f48793ea34632ff07e300d0a6381c66c81466cfR41))
*  Subscribe to the `onWillUpdate` event in the `OpenedEditorModelService` class and update the file decoration of the currently shown, focused, or selected file in the tree model ([link](https://github.com/opensumi/core/pull/2842/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2R222-R244))

<!-- Additional content -->
<!-- 补充额外内容 -->

fix: #2838 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5081b50</samp>

This pull request adds a new event and a listener to the `OpenedEditorModel` and its service, to update the file decoration in the opened editor tree before the model changes. This improves the visual feedback and consistency of the file state in the tree.
