### PR TITLE
fix: connect eventBus block

### DIFF
--- a/packages/core-browser/src/bootstrap/connection.ts
+++ b/packages/core-browser/src/bootstrap/connection.ts
@@ -35,17 +35,18 @@ export async function createClientConnection2(
   const wsChannelHandler = new WSChannelHandler(wsPath, initialLogger, protocols, clientId);
   wsChannelHandler.setReporter(reporterService);
   wsChannelHandler.connection.addEventListener('open', async () => {
-    await stateService.reachedState('core_module_initialized');
+    // 状态机处于 'core_module_initialized' ｜ 'started_contributions' ｜ 'ready' 状态时，事件触发
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionOpenEvent());
   });
 
   wsChannelHandler.connection.addEventListener('close', async () => {
-    await stateService.reachedState('core_module_initialized');
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionCloseEvent());
   });
 
   wsChannelHandler.connection.addEventListener('error', async (e) => {
-    await stateService.reachedState('core_module_initialized');
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionErrorEvent(e));
   });
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution
eventBus 中长链接状态中断或错误消息一直被阻塞，无法发出：

https://github.com/opensumi/core/issues/2828




<!-- Additional content -->
<!-- 补充额外内容 -->
ClientAppStateService 是一个标准的状态机，看起来设计之初并不保证下一个生命周期 的状态是链式的。因此这里应该使用 reachedAnyState 方法，而不是用reachedState方法。

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

