### PR TITLE
fix: connect eventBus block

### DIFF
--- a/packages/core-browser/src/bootstrap/connection.ts
+++ b/packages/core-browser/src/bootstrap/connection.ts
@@ -35,17 +35,18 @@ export async function createClientConnection2(
   const wsChannelHandler = new WSChannelHandler(wsPath, initialLogger, protocols, clientId);
   wsChannelHandler.setReporter(reporterService);
   wsChannelHandler.connection.addEventListener('open', async () => {
-    await stateService.reachedState('core_module_initialized');
+    // 状态机处于 'core_module_initialized' ｜ 'started_contributions' ｜ 'ready' 状态时，事件触发
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionOpenEvent());
   });
 
   wsChannelHandler.connection.addEventListener('close', async () => {
-    await stateService.reachedState('core_module_initialized');
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionCloseEvent());
   });
 
   wsChannelHandler.connection.addEventListener('error', async (e) => {
-    await stateService.reachedState('core_module_initialized');
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionErrorEvent(e));
   });
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes


### Background or solution

此 MR 不合入，这是基于 feat/feishu-ide 发布一个 alpha 版本，后续直接关闭

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->



<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 984e038</samp>

Fixed a bug in `connection.ts` that caused incorrect connection events. Changed the `createClientConnection2` function to use `reachedAnyState` instead of `reachedState` to handle different states of the `stateService`.
