### PR TITLE
feat: support overwrite when editor save

### DIFF
--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -394,11 +394,15 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
       }
       return false;
     } else if (res.state === SaveTaskResponseState.DIFF) {
+      const diffAndSave = localize('doc.saveError.diffAndSave');
+      const overwrite = localize('doc.saveError.overwrite');
       this.messageService
-        .error(formatLocalize('doc.saveError.diff', this.uri.toString()), [localize('doc.saveError.diffAndSave')])
+        .error(formatLocalize('doc.saveError.diff', this.uri.toString()), [diffAndSave, overwrite])
         .then((res) => {
-          if (res) {
+          if (res === diffAndSave) {
             this.compareAndSave();
+          } else if (res === overwrite) {
+            this.save(true);
           }
         });
       this.logger.error('The file cannot be saved, the version is inconsistent with the disk');

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1166,6 +1166,7 @@ export const localizationBundle = {
     'doc.saveError.failed': 'File Saving Failed. Reason: ',
     'doc.saveError.diff': '{0} cannot be saved because it has been modified by other editors.',
     'doc.saveError.diffAndSave': 'Compare...',
+    'doc.saveError.overwrite': 'Overwrite',
     'editor.compareAndSave.title': '{0} (on Disk) <=> {1} (Editing) ',
 
     'workspace.openDirectory': 'Open Directory',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -794,6 +794,7 @@ export const localizationBundle = {
     'doc.saveError.failed': '文件保存失败， 原因:',
     'doc.saveError.diff': '{0} 已经在磁盘上被修改，不能保存',
     'doc.saveError.diffAndSave': '进行比较',
+    'doc.saveError.overwrite': '覆盖',
     'editor.compareAndSave.title': '{0} (在磁盘上) <=> {1} (编辑中) ',
 
     'outline.title': '大纲',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fdda6f</samp>

* Add a new option to overwrite the document when saving conflicts occur ([link](https://github.com/opensumi/core/pull/2846/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L397-R405), [link](https://github.com/opensumi/core/pull/2846/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R1169), [link](https://github.com/opensumi/core/pull/2846/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R797))
  * Modify the message service call in `editor-document-model.ts` to handle the overwrite option and pass it to the document service ([link](https://github.com/opensumi/core/pull/2846/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L397-R405))
  * Add the 'Overwrite' option to the localization bundles in `en-US.lang.ts` and `zh-CN.lang.ts` ([link](https://github.com/opensumi/core/pull/2846/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R1169), [link](https://github.com/opensumi/core/pull/2846/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R797))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fdda6f</samp>

Add an option to overwrite the document when saving conflicts occur. Update the localization bundles for English and Chinese to include the new option.

<img width="445" alt="截屏2023-06-28 11 44 41" src="https://github.com/opensumi/core/assets/19860190/f5e89a13-4801-448d-bd0d-677981afbb21">
保存内容时如果和磁盘文件内容有差异，提供直接覆盖的按钮
close #2470 

