### PR TITLE
feat: support register view container in bottom panel

### DIFF
--- a/packages/core-browser/src/layout/layout.interface.ts
+++ b/packages/core-browser/src/layout/layout.interface.ts
@@ -2,6 +2,7 @@ import type React from 'react';
 
 import { MaybeNull, BasicEvent } from '@opensumi/ide-core-common';
 
+import { Layout } from '../components/layout/index';
 import type { IMenu, IContextMenu } from '../menu/next';
 import type { SlotLocation } from '../react-providers';
 
@@ -75,6 +76,7 @@ export interface ExtViewContainerOptions {
   fromExtension?: boolean;
   // viewContainer 最小高度，默认 120
   miniSize?: number;
+  alignment?: Layout.alignment;
 }
 export const ComponentRegistry = Symbol('ComponentRegistry');
 

--- a/packages/main-layout/src/browser/accordion/section.view.tsx
+++ b/packages/main-layout/src/browser/accordion/section.view.tsx
@@ -68,6 +68,7 @@ export const AccordionSection = ({
   titleMenuContext,
   accordionService,
   onContextMenuHandler,
+  alignment,
 }: CollapsePanelProps) => {
   const iconService = useInjectable<IIconService>(IIconService);
   const contentRef = React.useRef<HTMLDivElement | null>(null);
@@ -134,6 +135,17 @@ export const AccordionSection = ({
   const progressService: IProgressService = useInjectable(IProgressService);
   const indicator = progressService.getIndicator(viewId);
   const Component: any = children;
+  const computedHeaderSize = React.useMemo(() => {
+    if (expanded) {
+      return `${headerSize}px`;
+    }
+
+    if (alignment === 'horizontal') {
+      return '100%';
+    }
+    return `${headerSize}px`;
+  }, [expanded, headerSize, alignment]);
+
   return (
     <div className={styles.kt_split_panel} data-view-id={viewId}>
       {!noHeader && (
@@ -144,7 +156,7 @@ export const AccordionSection = ({
           className={cls(styles.kt_split_panel_header, headerFocused ? styles.kt_panel_focused : '', headerClass)}
           onClick={clickHandler}
           onContextMenu={(e) => onContextMenuHandler(e, viewId)}
-          style={{ height: headerSize + 'px', lineHeight: headerSize + 'px' }}
+          style={{ height: computedHeaderSize, lineHeight: headerSize + 'px' }}
         >
           <div className={styles.label_wrap}>
             <i className={cls(getIcon('arrow-down'), styles.arrow_icon, expanded ? '' : styles.kt_mod_collapsed)}></i>

--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -19,6 +19,7 @@ import {
   slotRendererRegistry,
 } from '@opensumi/ide-core-browser';
 import { LayoutState, LAYOUT_STATE } from '@opensumi/ide-core-browser/lib/layout/layout-state';
+import { ComponentRegistryInfo } from '@opensumi/ide-core-browser/lib/layout/layout.interface';
 import {
   IMenuRegistry,
   AbstractContextMenuService,
@@ -299,6 +300,15 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
       }
     }
     return handler;
+  }
+
+  getConatiner(containerId: string): ComponentRegistryInfo | undefined {
+    for (const service of this.tabbarServices.values()) {
+      const container = service.getContainer(containerId);
+      if (container) {
+        return container;
+      }
+    }
   }
 
   getExtraTopMenu(): IContextMenu {

--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -193,6 +193,7 @@ const BottomPanelView: React.FC<{
         ) : (
           <AccordionContainer
             views={component.views}
+            alignment='horizontal'
             minSize={component.options!.miniSize}
             containerId={component.options!.containerId}
           />

--- a/packages/main-layout/src/common/main-layout.definition.ts
+++ b/packages/main-layout/src/common/main-layout.definition.ts
@@ -1,5 +1,6 @@
 import { BasicEvent, IDisposable, SlotLocation } from '@opensumi/ide-core-browser';
 import { ViewContainerOptions, View, SideStateManager } from '@opensumi/ide-core-browser/lib/layout';
+import { ComponentRegistryInfo } from '@opensumi/ide-core-browser/lib/layout/layout.interface';
 import { IContextMenu } from '@opensumi/ide-core-browser/lib/menu/next';
 import { Deferred, Event } from '@opensumi/ide-core-common';
 import { IContextKeyExpression } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
@@ -41,6 +42,12 @@ export interface IMainLayoutService {
    * @param side 注册的位置，支持left、right、bottom
    */
   collectTabbarComponent(views: View[], options: ViewContainerOptions, side: string): string;
+
+  /**
+   * 获指定 containerId 的注册实例
+   * @param containerId container id
+   */
+  getConatiner(containerId: string): ComponentRegistryInfo | undefined;
   /**
    * 向侧边栏container内附加新的子视图
    * @param view 子视图信息


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

支持通过 contributes 注册底部面板的折叠视图

![image](https://github.com/opensumi/core/assets/17701805/3c161dc0-5a84-42b8-94cd-1381fa4af9e4)


<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e5be8e</samp>

*  Refine the type of `ViewContainersContribution` to use a mapped type with a union of literal types as the key ([link](https://github.com/opensumi/core/pull/2847/files?diff=unified&w=0#diff-a6c3eff426b1eb07d18e75ee6be53202e956a0df558ea9cb7238910672ce536aL9-R14))
*  Add a `convertLocationToSide` method to `ViewContainersContributionPoint` to map location strings to side strings ([link](https://github.com/opensumi/core/pull/2847/files?diff=unified&w=0#diff-a6c3eff426b1eb07d18e75ee6be53202e956a0df558ea9cb7238910672ce536aR38-R44))
*  Use the `convertLocationToSide` method to simplify the registration of view containers in the main layout service in `view-containers.ts` ([link](https://github.com/opensumi/core/pull/2847/files?diff=unified&w=0#diff-a6c3eff426b1eb07d18e75ee6be53202e956a0df558ea9cb7238910672ce536aL44-R74))
*  Add an `alignment` prop to the `Tabbar` component in `panel.view.tsx` to specify the orientation of the tabs in the panel ([link](https://github.com/opensumi/core/pull/2847/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548R196))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e5be8e</samp>

This pull request enhances the support for view containers from VS Code extensions and allows them to be placed in different locations of the main layout. It also adds a new prop to the `Tabbar` component to control the orientation of the tabs in the panel.
