### PR TITLE
feat: editor tab support revealInExplorer

### DIFF
--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -1173,6 +1173,15 @@ export class EditorContribution
     });
 
     menus.registerMenuItem(MenuId.EditorTitleContext, {
+      command: {
+        id: FILE_COMMANDS.REVEAL_IN_EXPLORER.id,
+        label: localize('file.revealInExplorer'),
+      },
+      group: '6_file',
+      order: 3,
+    });
+
+    menus.registerMenuItem(MenuId.EditorTitleContext, {
       command: EDITOR_COMMANDS.SPLIT_TO_LEFT.id,
       group: '9_split',
     });

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -937,7 +937,9 @@ export class FileTreeContribution
     }
 
     commands.registerCommand(FILE_COMMANDS.REVEAL_IN_EXPLORER, {
-      execute: (uri?: URI) => {
+      execute: (uriOrResource?: URI | { uri?: URI }) => {
+        let uri = uriOrResource instanceof URI ? uriOrResource : uriOrResource?.uri;
+
         const handler = this.mainLayoutService.getTabbarHandler(EXPLORER_CONTAINER_ID);
         if (handler && !handler.isVisible) {
           handler.activate();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2652619</samp>

* Add a menu item to reveal the current file in the explorer view ([link](https://github.com/opensumi/core/pull/2848/files?diff=unified&w=0#diff-60c8ffba5d20bbdd47538937244790320be906aa61ff9c7acb732dc640ab5bb5R1176-R1184))
* Make the `FILE_COMMANDS.REVEAL_IN_EXPLORER` command accept either a URI or a resource object with a URI property ([link](https://github.com/opensumi/core/pull/2848/files?diff=unified&w=0#diff-bdf4535ed45e87a7f0e14a93bcdfa4cb8e15897afab8509f9a4cdf7f433f2645L940-R942))
* Extract the URI from the resource object if needed in `file-tree-contribution.ts` ([link](https://github.com/opensumi/core/pull/2848/files?diff=unified&w=0#diff-bdf4535ed45e87a7f0e14a93bcdfa4cb8e15897afab8509f9a4cdf7f433f2645L940-R942))

<!-- Additional content -->
<!-- 补充额外内容 -->

ISSUE: #2845 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2652619</samp>

This pull request adds a new feature to reveal the current file in the explorer view from the editor title context menu, and improves the flexibility of the `FILE_COMMANDS.REVEAL_IN_EXPLORER` command by allowing different types of file URI inputs. The changes affect the files `editor.contribution.ts` and `file-tree-contribution.ts`.
