### PR TITLE
feat: location opened editor when open file

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -248,6 +248,11 @@ export namespace OPEN_EDITORS_COMMANDS {
     id: 'opened.editors.copyPath',
     category: CATEGORY,
   };
+
+  export const LOCATION: Command = {
+    id: 'opened.editors.location',
+    category: CATEGORY,
+  };
 }
 
 export namespace COMMON_COMMANDS {

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -3,6 +3,7 @@ import { observable } from 'mobx';
 import { Injectable, Autowired, Injector, INJECTOR_TOKEN } from '@opensumi/di';
 import {
   FILE_COMMANDS,
+  OPEN_EDITORS_COMMANDS,
   ResizeEvent,
   getSlotLocation,
   AppConfig,
@@ -1340,11 +1341,8 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
             this.currentEditor?.monacoEditor.revealRangeInCenter(options.range as monaco.IRange, 0);
           }, 0);
         }
-        if ((options && options.disableNavigate) || (options && options.backend)) {
-          // no-op
-        } else {
-          this.locateInFileTree(uri);
-        }
+        // 执行定位逻辑
+        this.locationInTree(options, uri);
         this.notifyTabChanged();
         return {
           group: this,
@@ -1434,11 +1432,8 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
             resource,
           }),
         );
-        if ((options && options.disableNavigate) || (options && options.backend)) {
-          // no-op
-        } else {
-          this.locateInFileTree(uri);
-        }
+        // 执行定位逻辑
+        this.locationInTree(options, uri);
         this.eventBus.fire(
           new EditorGroupChangeEvent({
             group: this,
@@ -1464,9 +1459,26 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
     }
   }
 
+  private locationInTree(options: IResourceOpenOptions, uri: URI) {
+    if (!options?.backend) {
+      if (!options?.disableNavigate) {
+        this.locateInFileTree(uri);
+      }
+      if (!options.disableNavigateOnOpendEditor) {
+        this.locateInOpenedEditor(uri);
+      }
+    }
+  }
+
   private locateInFileTree(uri: URI) {
     if (this.explorerAutoRevealConfig) {
       this.commands.tryExecuteCommand(FILE_COMMANDS.LOCATION.id, uri);
+    }
+  }
+
+  private locateInOpenedEditor(uri: URI) {
+    if (this.explorerAutoRevealConfig) {
+      this.commands.tryExecuteCommand(OPEN_EDITORS_COMMANDS.LOCATION.id, uri);
     }
   }
 

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -482,6 +482,11 @@ export interface IResourceOpenOptions {
   disableNavigate?: boolean;
 
   /**
+   * 不尝试在已打开的编辑器中的 uri 进行定位
+   */
+  disableNavigateOnOpendEditor?: boolean;
+
+  /**
    * 是否使用preview模式
    * 如果是undefined，使用editor.previewMode配置作为默认值
    */

--- a/packages/opened-editor/src/browser/opened-editor.contribution.ts
+++ b/packages/opened-editor/src/browser/opened-editor.contribution.ts
@@ -8,6 +8,7 @@ import {
   CommandService,
   FILE_COMMANDS,
   EDITOR_COMMANDS,
+  URI,
 } from '@opensumi/ide-core-browser';
 import { ClientAppContribution } from '@opensumi/ide-core-browser';
 import { ToolbarRegistry, TabBarToolbarContribution } from '@opensumi/ide-core-browser/lib/layout';
@@ -129,6 +130,12 @@ export class OpenedEditorContribution
     commands.registerCommand(OPEN_EDITORS_COMMANDS.COPY_RELATIVE_PATH, {
       execute: (node: EditorFile) => {
         this.commandService.executeCommand(FILE_COMMANDS.COPY_RELATIVE_PATH.id, node.uri, [node.uri]);
+      },
+    });
+
+    commands.registerCommand(OPEN_EDITORS_COMMANDS.LOCATION, {
+      execute: (uri: URI) => {
+        this.openedEditorModelService.location(uri);
       },
     });
   }

--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -446,7 +446,7 @@ export class OpenedEditorModelService {
     if (node.parent && EditorFileGroup.is(node.parent as EditorFileGroup)) {
       groupIndex = (node.parent as EditorFileGroup).group.index;
     }
-    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, node.uri, { groupIndex, preserveFocus: true });
+    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, node.uri, { groupIndex, preserveFocus: true, disableNavigateOnOpendEditor: true });
   };
 
   public closeFile = (node: EditorFile) => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf53536</samp>

*  Add a new command `LOCATION` to locate a URI in the opened editors view ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-a688102e10b7d594a046a44531865122eaa41ed5f4b5bd53eeb7f1f9f499507cR251-R255))
*  Import the `OPEN_EDITORS_COMMANDS` object and use the `LOCATION` command in the `EditorGroup` class ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8R6))
*  Replace the conditional logic for locating a URI in the file tree with a call to the `locationInTree` method in the `open` and `openToSide` methods of the `EditorGroup` class ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8L1343-R1345), [link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8L1437-R1436))
*  Add the `locationInTree` method to the `EditorGroup` class to handle locating a URI in both the file tree and the opened editors view, depending on the options ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8R1462-R1472))
*  Add the `locateInOpenedEditor` method to the `EditorGroup` class to execute the `LOCATION` command with a URI ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8R1479-R1484))
*  Add a new property `disableNavigateOnOpendEditor` to the `IResourceOpenOptions` interface to control whether to skip locating the URI in the opened editors view ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-facd3d42d2462c820f4ba41b1e1a790886245e80540f1a4efdccd2acc6a3a60dR485-R489))
*  Register the `LOCATION` command handler in the `opened-editor.contribution.ts` file and call the `location` method of the `OpenedEditorModelService` with a URI ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-88a9866c0507ed42d50e97257e49d1aff32cb6a57e06eb91b514f2ebbaab7c5fR11), [link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-88a9866c0507ed42d50e97257e49d1aff32cb6a57e06eb91b514f2ebbaab7c5fR135-R140))
*  Modify the `openResource` method of the `OpenedEditorModelService` class to pass the `disableNavigateOnOpendEditor` option to the `executeCommand` call ([link](https://github.com/opensumi/core/pull/2853/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L449-R449))

<!-- Additional content -->
<!-- 补充额外内容 -->

效果是点击 editor tab 后，opened editors 中文件同步选中状态 #2849 
同时依赖 https://github.com/opensumi/core/pull/2842 合并

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf53536</samp>

This pull request adds a new feature and a new command to locate a URI in the opened editors view. It also refactors some existing code to use a common method for locating a URI in different views. It introduces a new option to disable locating a URI in the opened editors view when opening a resource from the view itself. The affected files are `workbench-editor.service.ts`, `opened-editor.contribution.ts`, `common.command.ts`, `editor.ts`, and `opened-editor-model.service.ts`.
