### PR TITLE
style: improve statusbar popover tooltip

### DIFF
--- a/packages/status-bar/src/browser/status-bar.module.less
+++ b/packages/status-bar/src/browser/status-bar.module.less
@@ -59,7 +59,9 @@
 .popover_content {
   display: flex;
   font-size: @statusBar-font-size;
-  white-space: nowrap;
+  // stop Flexbox removing trailing whitespace
+  // see https://www.mattstobbs.com/flexbox-removing-trailing-whitespace/
+  white-space: pre-wrap;
 }
 
 .popover_content {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01fc8ab</samp>

* Fix status bar item truncation and misalignment by changing `white-space` property to `pre-wrap` ([link](https://github.com/opensumi/core/pull/2854/files?diff=unified&w=0#diff-49c295b8f44f71b2395b2632fffe98ff064b6c25a080e00d2e696cdb0e7082a8L62-R64))

<!-- Additional content -->
<!-- 补充额外内容 -->
before:
![image](https://github.com/opensumi/core/assets/9823838/8d359802-8c1b-4d2b-b6b0-8af304e7027c)

after:
![image](https://github.com/opensumi/core/assets/9823838/15ac0416-c649-466a-a7af-f8785052d79f)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01fc8ab</samp>

Fixed a bug in the status bar layout by preserving whitespace in `status-bar.module.less`. This ensures that all status bar items are displayed correctly.
