### PR TITLE
chore: add lint rules for ignore warning

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -20,3 +20,5 @@ packages/core-browser/src/style/octicons
 packages/extension/__mocks__/extension/browser-new.js
 packages/extension/__mocks__/extension/browser.js
 packages/extension/__mocks__/extension-error/browser.js
+
+__mocks__

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,6 +147,7 @@ module.exports = {
     'no-prototype-builtins': 'warn',
     'prefer-rest-params': 'warn',
     'no-control-regex': 'warn',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     // 让 import 中的内部包和外部包分组，看起来更美观
     'import/order': [
       'error',

--- a/packages/opened-editor/__tests__/browser/opened-editor-model.service.test.ts
+++ b/packages/opened-editor/__tests__/browser/opened-editor-model.service.test.ts
@@ -1,4 +1,4 @@
-import { URI, Disposable, IContextKeyService, StorageProvider, ILogger } from '@opensumi/ide-core-browser';
+import { URI, Disposable, IContextKeyService, StorageProvider } from '@opensumi/ide-core-browser';
 import { ICtxMenuRenderer } from '@opensumi/ide-core-browser/lib/menu/next';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { IDecorationsService } from '@opensumi/ide-decoration';

--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -392,7 +392,6 @@ export class OpenedEditorModelService {
   }
 
   public flushEventQueue = () => {
-    let promise: Promise<any>;
     if (!this._changeEventDispatchQueue || this._changeEventDispatchQueue.length === 0) {
       return;
     }
@@ -409,7 +408,7 @@ export class OpenedEditorModelService {
         roots.push(path);
       }
     }
-    promise = pSeries(
+    const promise = pSeries(
       roots.map((path) => async () => {
         const watcher = this.treeModel?.root?.watchEvents.get(path);
         if (watcher && typeof watcher.callback === 'function') {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Code Style Changes
- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 05f71c2</samp>

*  Disable `@typescript-eslint/no-non-null-assertion` rule in ESLint configuration ([link](https://github.com/opensumi/core/pull/2855/files?diff=unified&w=0#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5R150))
*  Remove unused `promise` variable from `OpenedEditorModelService` class ([link](https://github.com/opensumi/core/pull/2855/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L395))
*  Move `promise` variable declaration to inner scope of loop in `OpenedEditorModelService` class ([link](https://github.com/opensumi/core/pull/2855/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L412-R411))
*  Remove unused `ILogger` imports from `opened-editor-model.service.test.ts` file ([link](https://github.com/opensumi/core/pull/2855/files?diff=unified&w=0#diff-4b2909732feb07a1ba77a71fc19c7b64b8936037cbf7b24585d465236d9d60e3L1-R1))
*  Add `__mocks__` folder to `.eslintignore` file ([link](https://github.com/opensumi/core/pull/2855/files?diff=unified&w=0#diff-a0fdacd2ade87c5238dde44378f574f7e123e669acdf8b740878b14b33b20275R23-R24))

<!-- Additional content -->
<!-- 补充额外内容 -->
before: 
![image](https://github.com/opensumi/core/assets/9477255/33b850f4-70b3-4e4e-8daa-f9fe87cb01b6)
after:
![lint-after](https://github.com/opensumi/core/assets/9477255/5cf098a2-a13c-44a7-aa44-18ec83eaf08d)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05f71c2</samp>

This pull request refactors and cleans up the code of the `OpenedEditorModelService` class and its related files. It also adjusts the ESLint configuration and ignores the mock files for testing.
