### PR TITLE
fix: language re-register if disposed

### DIFF
--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -168,7 +168,7 @@ export interface IToolbarAction {
   strictPosition?: IToolbarActionPosition;
 
   /**
-   *  是否永远不被收起
+   * 是否永远不被收起
    */
   neverCollapse?: boolean;
   when?: string;

--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -168,7 +168,7 @@ export interface IToolbarAction {
   strictPosition?: IToolbarActionPosition;
 
   /**
-   * 是否永远不被收起
+   *  是否永远不被收起
    */
   neverCollapse?: boolean;
   when?: string;

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -20,7 +20,7 @@ import {
   electronEnv,
   AppConfig,
 } from '@opensumi/ide-core-browser';
-import { URI, Disposable, isObject, dispose } from '@opensumi/ide-core-common';
+import { URI, Disposable, isObject } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service/lib/common';
 import {
   GrammarsContribution,

--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -20,7 +20,7 @@ import {
   electronEnv,
   AppConfig,
 } from '@opensumi/ide-core-browser';
-import { URI, Disposable, isObject } from '@opensumi/ide-core-common';
+import { URI, Disposable, isObject, dispose } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service/lib/common';
 import {
   GrammarsContribution,
@@ -917,5 +917,10 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
       );
     }
     ruleStack = lineTokens.ruleStack;
+  }
+
+  dispose() {
+    super.dispose();
+    this.monacoLanguageService['_encounteredLanguages'].clear();
   }
 }


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 030c548</samp>

* Fix typo in `neverCollapse` comment ([link](https://github.com/opensumi/core/pull/2857/files?diff=unified&w=0#diff-b9ffff8b7eca64c21c4f21e664738b65432b4ea0fe2025ed29899dbaa872e24aL171-R171))
* Add `dispose` method to `TextmateService` class to clear `_encounteredLanguages` set and prevent memory leaks ([link](https://github.com/opensumi/core/pull/2857/files?diff=unified&w=0#diff-5af6e8d3cdc315542de48fc08f4510a791304733c2c8e8549999d31e7dba78d1R921-R925))

opensumi 内使用 onlanguage 触发语法插件激活事件
https://github.com/opensumi/core/blob/e2bdbeaaf46bdd94474fe164593af098d4f3bb9f/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts#L202-L204
所以 dispose 之后清除 monaco 注册的 languages 以便下次重新触发
  


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 030c548</samp>

This pull request fixes a comment typo in `types.ts` and adds a `dispose` method to `TextmateService` in `textmate.service.ts` to prevent memory leaks and improve textmate tokenizer performance.
