### PR TITLE
feat: support merge editor minimap

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -19,7 +19,7 @@ import { MappingManagerService } from './mapping-manager.service';
 import { IMergeEditorEditorConstructionOptions } from './merge-editor-widget';
 import { ComputerDiffModel } from './model/computer-diff';
 import { LineRangeMapping } from './model/line-range-mapping';
-import { ACCEPT_CURRENT_ACTIONS } from './types';
+import { ACCEPT_CURRENT_ACTIONS, IEditorMountParameter } from './types';
 import { ActionsManager } from './view/actions-manager';
 import { CurrentCodeEditor } from './view/editors/currentCodeEditor';
 import { IncomingCodeEditor } from './view/editors/incomingCodeEditor';
@@ -59,6 +59,9 @@ export class MergeEditorService extends Disposable {
 
   private readonly _onDidInputNutrition = new Emitter<IOpenMergeEditorArgs>();
   public readonly onDidInputNutrition: Event<IOpenMergeEditorArgs> = this._onDidInputNutrition.event;
+
+  private readonly _onDidMount = new Emitter<IEditorMountParameter>();
+  public readonly onDidMount: Event<IEditorMountParameter> = this._onDidMount.event;
 
   private readonly _onRestoreState = new Emitter<URI>();
   public readonly onRestoreState: Event<URI> = this._onRestoreState.event;
@@ -104,6 +107,12 @@ export class MergeEditorService extends Disposable {
     this.scrollSynchronizer.mount(this.currentView, this.resultView, this.incomingView);
     this.stickinessConnectManager.mount(this.currentView, this.resultView, this.incomingView);
     this.actionsManager.mount(this.currentView, this.resultView, this.incomingView);
+
+    this._onDidMount.fire({
+      currentView: this.currentView,
+      resultView: this.resultView,
+      incomingView: this.incomingView,
+    });
 
     this.initListenEvent();
   }

--- a/packages/monaco/src/browser/contrib/merge-editor/types.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/types.ts
@@ -6,6 +6,7 @@ import { IModelDecorationOptions } from '../../monaco-api/editor';
 
 import { LineRange } from './model/line-range';
 import { LineRangeMapping } from './model/line-range-mapping';
+import { BaseCodeEditor } from './view/editors/baseCodeEditor';
 import styles from './view/merge-editor.module.less';
 
 export interface IRangeContrast {
@@ -168,4 +169,10 @@ export interface IMergeEditorViewState {
   [EditorViewType.INCOMING]: ICodeEditorViewState | null;
   turnLeft: LineRangeMapping[];
   turnRight: LineRangeMapping[];
+}
+
+export interface IEditorMountParameter {
+  currentView: BaseCodeEditor;
+  resultView: BaseCodeEditor;
+  incomingView: BaseCodeEditor;
 }

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -15,6 +15,7 @@ import { MergeEditorService } from '../merge-editor.service';
 import { EditorViewType } from '../types';
 
 import styles from './merge-editor.module.less';
+import { MiniMap } from './mini-map';
 import { WithViewStickinessConnectComponent } from './stickiness-connect-manager';
 
 const TitleHead: React.FC<{ contrastType: EditorViewType }> = ({ contrastType }) => {
@@ -159,7 +160,12 @@ export const Grid = () => {
       <SplitPanel overflow='hidden' id='merge_editor_container' flex={2}>
         <div className={styles.editor_container_arrange}>
           <TitleHead contrastType={EditorViewType.CURRENT}></TitleHead>
-          <div className={styles.editor_container} ref={currentEditorContainer}></div>
+          <div className={styles.content}>
+            <div className={styles.minimap_container}>
+              <MiniMap contrastType={EditorViewType.CURRENT} />
+            </div>
+            <div className={styles.editor_container} ref={currentEditorContainer}></div>
+          </div>
         </div>
         <div className={styles.editor_container_arrange}>
           <TitleHead contrastType={EditorViewType.RESULT}></TitleHead>
@@ -175,7 +181,12 @@ export const Grid = () => {
         </div>
         <div className={styles.editor_container_arrange}>
           <TitleHead contrastType={EditorViewType.INCOMING}></TitleHead>
-          <div className={styles.editor_container} ref={incomingEditorContainer}></div>
+          <div className={styles.content}>
+            <div className={styles.editor_container} ref={incomingEditorContainer}></div>
+            <div className={styles.minimap_container}>
+              <MiniMap contrastType={EditorViewType.INCOMING} />
+            </div>
+          </div>
         </div>
       </SplitPanel>
       <MergeActions />

--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -2,7 +2,6 @@
   height: 100%;
   overflow: hidden;
   position: relative;
-  padding-left: 8px;
 
   .merge_actions_container {
     position: absolute;
@@ -76,6 +75,40 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+
+    .content {
+      height: inherit;
+      display: flex;
+
+      .minimap_container {
+        height: 100%;
+        width: 15px;
+
+        .minimap_content {
+          position: relative;
+          height: inherit;
+
+          .block {
+            position: absolute;
+            width: 100%;
+
+            &.insert {
+              background-color: var(--mergeEditor-insertedInnerCharColor);
+            }
+            &.modify {
+              background-color: var(--mergeEditor-modifyInnerCharColor);
+            }
+            &.remove {
+              background-color: var(--mergeEditor-removedInnerCharColor);
+            }
+          }
+        }
+      }
+
+      .editor_container {
+        width: calc(100% - 15px);
+      }
+    }
 
     .stickiness_connect_container {
       height: 100%;

--- a/packages/monaco/src/browser/contrib/merge-editor/view/mini-map.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/mini-map.tsx
@@ -1,0 +1,83 @@
+import cls from 'classnames';
+import React, { useCallback, useEffect } from 'react';
+
+import { Disposable, Event, useInjectable } from '@opensumi/ide-core-browser';
+import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
+
+import { MergeEditorService } from '../merge-editor.service';
+import { LineRange } from '../model/line-range';
+import { EditorViewType } from '../types';
+
+import { BaseCodeEditor } from './editors/baseCodeEditor';
+import styles from './merge-editor.module.less';
+
+interface BlockPiece {
+  top: string;
+  height: string;
+  className: string;
+}
+
+export const MiniMap: React.FC<{ contrastType: EditorViewType }> = ({ contrastType }) => {
+  const mergeEditorService = useInjectable<MergeEditorService>(MergeEditorService);
+  const [blocks, setBlocks] = React.useState<BlockPiece[]>([]);
+
+  useEffect(() => {
+    const disposables = new Disposable();
+
+    disposables.addDispose(
+      mergeEditorService.onDidMount((data) => {
+        const { currentView, incomingView } = data;
+
+        if (contrastType === EditorViewType.CURRENT) {
+          disposables.addDispose(
+            Event.debounce(
+              currentView.onDidChangeDecorations,
+              () => {},
+              1,
+            )(() => {
+              computePiece(currentView, currentView.documentMapping.getOriginalRange());
+            }),
+          );
+        } else if (contrastType === EditorViewType.INCOMING) {
+          disposables.addDispose(
+            Event.debounce(
+              incomingView.onDidChangeDecorations,
+              () => {},
+              1,
+            )(() => {
+              computePiece(incomingView, incomingView.documentMapping.getModifiedRange());
+            }),
+          );
+        }
+      }),
+    );
+
+    return () => disposables.dispose();
+  }, [mergeEditorService, contrastType]);
+
+  const computePiece = useCallback((viewEditor: BaseCodeEditor, ranges: LineRange[]) => {
+    const editor = viewEditor.getEditor();
+
+    const lineHeight = editor.getOption(EditorOption.lineHeight);
+    const contentHeight = editor.getContentHeight();
+    const blocks: BlockPiece[] = [];
+
+    ranges.forEach((range) => {
+      blocks.push({
+        top: (((range.startLineNumber - 1) * lineHeight) / contentHeight) * 100 + '%',
+        height: ((range.length * lineHeight) / contentHeight) * 100 + '%',
+        className: styles[range.type],
+      });
+    });
+
+    setBlocks(blocks);
+  }, []);
+
+  return (
+    <div className={styles.minimap_content}>
+      {blocks.map((block) => (
+          <span className={cls(styles.block, block.className)} style={{ top: block.top, height: block.height }}></span>
+        ))}
+    </div>
+  );
+};

--- a/packages/monaco/src/browser/contrib/merge-editor/view/mini-map.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/mini-map.tsx
@@ -63,6 +63,10 @@ export const MiniMap: React.FC<{ contrastType: EditorViewType }> = ({ contrastTy
     const blocks: BlockPiece[] = [];
 
     ranges.forEach((range) => {
+      if (range.isComplete) {
+        return;
+      }
+
       blocks.push({
         top: (((range.startLineNumber - 1) * lineHeight) / contentHeight) * 100 + '%',
         height: ((range.length * lineHeight) / contentHeight) * 100 + '%',
@@ -76,8 +80,8 @@ export const MiniMap: React.FC<{ contrastType: EditorViewType }> = ({ contrastTy
   return (
     <div className={styles.minimap_content}>
       {blocks.map((block) => (
-          <span className={cls(styles.block, block.className)} style={{ top: block.top, height: block.height }}></span>
-        ))}
+        <span className={cls(styles.block, block.className)} style={{ top: block.top, height: block.height }}></span>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b5c53b</samp>

*  Add `onDidMount` event to `MergeEditorService` class to emit editor references ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-c84299400ed4df5895b7a82ccfa7cd395da353d4f9bf665044e5b8d6f2cdb293L22-R22), [link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-c84299400ed4df5895b7a82ccfa7cd395da353d4f9bf665044e5b8d6f2cdb293R63-R65), [link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-c84299400ed4df5895b7a82ccfa7cd395da353d4f9bf665044e5b8d6f2cdb293R111-R116))
*  Define `IEditorMountParameter` type to store editor references ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-ffc874410f2e9291e9914660f2b8a01861c9bc7cafb179ef2e5af8aafa0e8ac2R173-R178))
*  Import `IEditorMountParameter` type and `BaseCodeEditor` class in `./types` and `./merge-editor.service.ts` ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-ffc874410f2e9291e9914660f2b8a01861c9bc7cafb179ef2e5af8aafa0e8ac2R9), [link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-c84299400ed4df5895b7a82ccfa7cd395da353d4f9bf665044e5b8d6f2cdb293L22-R22))
*  Implement `MiniMap` component to show overview of changes in code editors ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-021abb3f0e4f4b7ad7ded115c5dec7d6a002a9b6073ffc14785934939f0ffa02R1-R87))
*  Import and render `MiniMap` component in `Grid` component for current and incoming editors ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926R18), [link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L162-R168), [link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-167730c4e8c47ae93d43b381e2817972ab7a70360b88607f65291fbf60d1b926L178-R189))
*  Remove `padding-left` style from `.editor_container_arrange` class to align editors and mini maps ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-1c44596746fd7ac18b3a6476363c06d222d28b064cf82282d4afd90593a82bfdL5))
*  Add styles for mini map components and children elements in `./view/merge-editor.module.less` ([link](https://github.com/opensumi/core/pull/2859/files?diff=unified&w=0#diff-1c44596746fd7ac18b3a6476363c06d222d28b064cf82282d4afd90593a82bfdR79-R112))

<!-- Additional content -->
- [x] 支持在 minimap 里显示未解决的操作相对位置

![image](https://github.com/opensumi/core/assets/20262815/bbad5835-45c4-4113-a40e-a8a976788564)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b5c53b</samp>

Added mini maps to the merge editor view to show the merge changes in both the current and the incoming code editors. Introduced a new event and a new type in the `MergeEditorService` to expose and represent the code editors. Updated the styles and layout of the merge editor view to accommodate the mini maps.
