### PR TITLE
style: input disabled style

### DIFF
--- a/packages/components/src/input/input.less
+++ b/packages/components/src/input/input.less
@@ -21,10 +21,13 @@
     border-color: var(--focusBorder);
   }
 
-  &:disabled {
+  &-disabled {
     color: var(--kt-input-disableForeground);
     background-color: var(--kt-input-disableBackground);
-    cursor: default;
+
+    input {
+      cursor: not-allowed;
+    }
   }
 
   &-box {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dba44df</samp>

*  Add a modifier class `.input-disabled` to the input component style and apply a `not-allowed` cursor to the input element ([link](https://github.com/opensumi/core/pull/2861/files?diff=unified&w=0#diff-016bd7405db219b6e916ebdeb6c1f133beddbf8928c369e808590b8ded0b855cL24-R30))

<!-- Additional content -->

之前 input 的 disabled 样式是不生效的，现调整成正确的方式

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dba44df</samp>

Refactored the input component style to use a modifier class for the disabled state and added a `not-allowed` cursor. This improves the component's usability and alignment with other components.
