### PR TITLE
feat: support scm setInputBoxEnablement API & getSourceControl API

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.scm.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.scm.ts
@@ -445,6 +445,16 @@ export class MainThreadSCM extends Disposable implements IMainThreadSCMShape {
     repository.input.placeholder = placeholder;
   }
 
+  $setInputBoxEnablement(sourceControlHandle: number, enabled: boolean): void {
+    const repository = this._repositories.get(sourceControlHandle);
+
+    if (!repository) {
+      return;
+    }
+
+    repository.input.enabled = enabled;
+  }
+
   $setInputBoxVisibility(sourceControlHandle: number, visible: boolean): void {
     const repository = this._repositories.get(sourceControlHandle);
 

--- a/packages/extension/src/common/vscode/scm.ts
+++ b/packages/extension/src/common/vscode/scm.ts
@@ -1,6 +1,9 @@
-import type { IDisposable, UriComponents } from '@opensumi/ide-core-common';
+import type vscode from 'vscode';
+
+import type { IDisposable, Uri, UriComponents } from '@opensumi/ide-core-common';
 import { CancellationToken } from '@opensumi/vscode-jsonrpc/lib/common/cancellation';
 
+import { IExtensionDescription } from './extension';
 import { VSCommand } from './model.api';
 
 export interface ObjectIdentifier {
@@ -77,6 +80,13 @@ export interface IExtHostSCMShape {
     cursorPosition: number,
   ): Promise<[string, number] | undefined>;
   $setSelectedSourceControls(selectedSourceControlHandles: number[]): Promise<void>;
+  createSourceControl(
+    extension: IExtensionDescription,
+    id: string,
+    label: string,
+    rootUri: Uri | undefined,
+  ): vscode.SourceControl;
+  getSourceControl(extensionId: string, id: string): vscode.SourceControl | undefined;
 }
 
 export interface IMainThreadSCMShape extends IDisposable {
@@ -93,6 +103,7 @@ export interface IMainThreadSCMShape extends IDisposable {
 
   $setInputBoxValue(sourceControlHandle: number, value: string): void;
   $setInputBoxPlaceholder(sourceControlHandle: number, placeholder: string): void;
+  $setInputBoxEnablement(sourceControlHandle: number, enabled: boolean): void;
   $setInputBoxVisibility(sourceControlHandle: number, visible: boolean): void;
   $setValidationProviderIsEnabled(sourceControlHandle: number, enabled: boolean): void;
 }

--- a/packages/extension/src/common/vscode/scm.ts
+++ b/packages/extension/src/common/vscode/scm.ts
@@ -86,7 +86,7 @@ export interface IExtHostSCMShape {
     label: string,
     rootUri: Uri | undefined,
   ): vscode.SourceControl;
-  getSourceControl(extensionId: string, id: string): vscode.SourceControl | undefined;
+  getSourceControl(extensionId: string, id: string): vscode.SourceControl[] | undefined;
 }
 
 export interface IMainThreadSCMShape extends IDisposable {

--- a/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.api.impl.ts
@@ -230,6 +230,9 @@ export function createApiFactory(
       createSourceControl(id: string, label: string, rootUri?: extTypes.Uri) {
         return extHostSCM.createSourceControl(extension, id, label, rootUri);
       },
+      getSourceControl(extensionId: string, id: string) {
+        return extHostSCM.getSourceControl(extensionId, id);
+      },
     },
     tests: {
       createTestController(controllerId: string, label: string, refreshHandler?: () => Thenable<void> | void) {

--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -199,6 +199,23 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
     this.updateValue(value);
   }
 
+  private _enabled = true;
+
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  set enabled(enabled: boolean) {
+    enabled = !!enabled;
+
+    if (this._enabled === enabled) {
+      return;
+    }
+
+    this._enabled = enabled;
+    this._proxy.$setInputBoxEnablement(this._sourceControlHandle, enabled);
+  }
+
   private _onDidChange = new Emitter<string>();
 
   get onDidChange(): Event<string> {
@@ -709,6 +726,12 @@ export class ExtHostSCM implements IExtHostSCMShape {
         return arg;
       },
     });
+  }
+
+  getSourceControl(extensionId: string, id: string): vscode.SourceControl | undefined {
+    this.logger.log('ExtHostSCM#$getSourceControl', extensionId, id);
+    const sourceControls = this._sourceControlsByExtension.get(extensionId) || [];
+    return sourceControls.find((source) => source.id === id);
   }
 
   createSourceControl(

--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -728,10 +728,10 @@ export class ExtHostSCM implements IExtHostSCMShape {
     });
   }
 
-  getSourceControl(extensionId: string, id: string): vscode.SourceControl | undefined {
+  getSourceControl(extensionId: string, id: string): vscode.SourceControl[] | undefined {
     this.logger.log('ExtHostSCM#$getSourceControl', extensionId, id);
     const sourceControls = this._sourceControlsByExtension.get(extensionId) || [];
-    return sourceControls.find((source) => source.id === id);
+    return sourceControls.filter((source) => source.id === id);
   }
 
   createSourceControl(

--- a/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
@@ -197,6 +197,9 @@ export function createAPIFactory(
       createSourceControl(id: string, label: string, rootUri: vscode.Uri) {
         return extHostSCM.createSourceControl(extension, id, label, rootUri);
       },
+      cgetSourceControl(extensionId: string, id: string) {
+        return extHostSCM.getSourceControl(extensionId, id);
+      },
     },
     window: createWindowApiFactory(
       extension,

--- a/packages/scm/src/browser/components/scm-resource-input.tsx
+++ b/packages/scm/src/browser/components/scm-resource-input.tsx
@@ -30,6 +30,7 @@ export const SCMResourceInput: FC<{
 
   const [commitMsg, setCommitMsg] = useState('');
   const [placeholder, setPlaceholder] = useState('');
+  const [enabled, setEnabled] = useState(true);
 
   const handleValueChange = useCallback(
     (msg: string) => {
@@ -53,6 +54,13 @@ export const SCMResourceInput: FC<{
         setPlaceholder(getPlaceholder(repository));
       }),
     );
+
+    disposables.add(
+      repository.input.onDidChangeEnablement((value) => {
+        setEnabled(value);
+      }),
+    );
+
     setPlaceholder(getPlaceholder(repository));
 
     return () => {
@@ -84,6 +92,7 @@ export const SCMResourceInput: FC<{
           className={styles.scmInput}
           placeholder={placeholder}
           value={commitMsg}
+          disabled={!enabled}
           onKeyDown={(e) => onKeyDown(e.keyCode)}
           onKeyUp={onKeyUp}
           onValueChange={handleValueChange}

--- a/packages/scm/src/common/scm.service.ts
+++ b/packages/scm/src/common/scm.service.ts
@@ -50,6 +50,20 @@ class SCMInput implements ISCMInput {
   private _onDidChangeVisibility = new Emitter<boolean>();
   readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
 
+  private _enabled = true;
+
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  set enabled(enabled: boolean) {
+    this._enabled = enabled;
+    this._onDidChangeEnablement.fire(enabled);
+  }
+
+  private readonly _onDidChangeEnablement = new Emitter<boolean>();
+  readonly onDidChangeEnablement: Event<boolean> = this._onDidChangeEnablement.event;
+
   private _validateInput: IInputValidator = () => Promise.resolve(undefined);
 
   get validateInput(): IInputValidator {

--- a/packages/scm/src/common/scm.ts
+++ b/packages/scm/src/common/scm.ts
@@ -30,6 +30,9 @@ export interface ISCMInput {
   validateInput: IInputValidator;
   readonly onDidChangeValidateInput: Event<void>;
 
+  enabled: boolean;
+  readonly onDidChangeEnablement: Event<boolean>;
+
   visible: boolean;
   readonly onDidChangeVisibility: Event<boolean>;
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at beb9dc8</samp>

*  Implement the `enabled` property and the `onDidChangeEnablement` event of the `vscode.SourceControlInputBox` API, which control whether the input box of a source control repository is editable or not. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-b6fc72b3ed973c1dc1ba603302fe797c02c559bfe37d93d88558dbdc9c92a3ffR448-R457), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feR202-R218), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R33), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R57-R63), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R95), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-38b9602bcd1e5fa40c0e82b5f43537711b3a1c2302ab69493fa570d814bc3861R53-R66), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-527faf067be61f7526b031487475180346065c5b81e644b85181bb33428e7ec6R33-R35))
  * Add a new method to the `IMainThreadSCMShape` interface and the `MainThreadSCM` class to set the enablement state of the input box of a repository, given a handle and a boolean value. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-a451142769019550bc6c69a691e4e9fecb49c683901ff7f31197b8f247e43163R106), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-b6fc72b3ed973c1dc1ba603302fe797c02c559bfe37d93d88558dbdc9c92a3ffR448-R457))
  * Add a new private property, a getter, a setter, and an event to the `SCMInput` class to store and notify the enablement state of the input model of a repository. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-38b9602bcd1e5fa40c0e82b5f43537711b3a1c2302ab69493fa570d814bc3861R53-R66))
  * Add a new state variable, a setter function, and an effect hook to the `SCMResourceInput` component to synchronize the enablement state of the input box component with the input model object. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R33), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R57-R63))
  * Add a new prop to the `Input` component to pass the enablement state of the input box component to the input element. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R95))
  * Add a new private property, a getter, and a setter to the `ExtHostSCMInputBox` class to store and update the enablement state of the input box of a repository in the extension host. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feR202-R218))
  * Call the `$setInputBoxEnablement` method of the proxy from the extension host when the `enabled` property of the `ExtHostSCMInputBox` is changed. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feR202-R218))
  * Add the `enabled` property and the `onDidChangeEnablement` event to the `ISCMInput` interface to define the contract for the input model of a repository. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-527faf067be61f7526b031487475180346065c5b81e644b85181bb33428e7ec6R33-R35))
* Implement the `vscode.scm.createSourceControl` and `vscode.scm.getSourceControl` API methods, which create and return source control instances for extensions. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-a451142769019550bc6c69a691e4e9fecb49c683901ff7f31197b8f247e43163R83-R89), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-7fba3489c613a4c4cbfb0edf7eb3dce406d11b5705f13f6da50ffd9c71327b90R233-R235), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feR731-R736), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562R200-R202))
  * Add two new methods to the `IExtHostSCMShape` interface and the `ExtHostSCM` class to create and return source control instances for extensions, given an id, a label, and an optional root URI. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-a451142769019550bc6c69a691e4e9fecb49c683901ff7f31197b8f247e43163R83-R89), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-75e2ad46d2d496bdb03ce19f8e327dca4f4bc06454dbe13255c7ba9bc1e1f2feR731-R736))
  * Add two new properties to the `vscode` API object for the extension host and the web worker host, which delegate to the `createSourceControl` and `getSourceControl` methods of the `extHostSCM` instance. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-7fba3489c613a4c4cbfb0edf7eb3dce406d11b5705f13f6da50ffd9c71327b90R233-R235), [link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562R200-R202))
  * Import the `vscode` type and the `Uri` type from the `@opensumi/ide-core-common` package to the `main.thread.scm.ts` file, and use them to define the return type and the parameter type of the `createSourceControl` and `getSourceControl` methods of the `IExtHostSCMShape` interface. ([link](https://github.com/opensumi/core/pull/2863/files?diff=unified&w=0#diff-a451142769019550bc6c69a691e4e9fecb49c683901ff7f31197b8f247e43163L1-R6))

<!-- Additional content -->

- [x] 实现 setInputBoxEnablement API 用于控制 scm input 的启用/禁用状态
- [x] 开放 getSourceControl 插件 API，可用于在其他插件内获取到 git 插件的 scm source control

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at beb9dc8</samp>

This pull request implements the `enabled` property and the `onDidChangeEnablement` event of the `vscode.SourceControlInputBox` API, which allow extensions to control the editability of the input box of a source control repository. It also implements the `vscode.scm.getSourceControl` API method, which allows extensions to retrieve existing source control instances by extension and id. It updates the SCM interfaces, classes, and components in the `packages/extension`, `packages/scm`, and `packages/common` modules to support these new features.
