### PR TITLE
feat: implement scm contributes

### DIFF
--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -186,7 +186,6 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
     if (!addonNodes) {
       return null;
     }
-
     return (
       <div className={clx('kt-input-addon', klassName)} {...persistFocusProps}>
         {React.Children.map(addonNodes, (child) =>

--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -186,6 +186,7 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
     if (!addonNodes) {
       return null;
     }
+
     return (
       <div className={clx('kt-input-addon', klassName)} {...persistFocusProps}>
         {React.Children.map(addonNodes, (child) =>

--- a/packages/extension/src/browser/extension-view.service.ts
+++ b/packages/extension/src/browser/extension-view.service.ts
@@ -286,7 +286,7 @@ export class ViewExtProcessService extends Disposable implements AbstractViewExt
             const component = moduleExports[addonId];
 
             if (!component) {
-              this.logger.error(`Can not find CustomPopover from extension ${extension.id}, id: ${component}`);
+              this.logger.error(`Can not find ${key} from extension ${extension.id}, id: ${component}`);
             }
 
             if (this.appConfig.useExperimentalShadowDom) {

--- a/packages/extension/src/browser/sumi/contributes/index.ts
+++ b/packages/extension/src/browser/sumi/contributes/index.ts
@@ -7,6 +7,7 @@ import { BrowserViewContributionPoint } from './browser-views';
 import { MenuExtendContributionPoint } from './menu-extend';
 import { MenubarsContributionPoint } from './menubar';
 import { NodeMainContributionPoint } from './node-main';
+import { SCMContributionPoint } from './scm';
 import { SubmenusContributionPoint } from './submenu';
 import { ToolbarContributionPoint } from './toolbar';
 import { ViewsProxiesContributionPoint } from './views-proxies';
@@ -26,5 +27,6 @@ export class SumiContributionsService extends ExtensionContributesService {
     SubmenusContributionPoint,
     ToolbarContributionPoint,
     MenuExtendContributionPoint,
-  ] as typeof VSCodeContributePoint[];
+    SCMContributionPoint,
+  ] as (typeof VSCodeContributePoint)[];
 }

--- a/packages/extension/src/browser/sumi/contributes/scm.ts
+++ b/packages/extension/src/browser/sumi/contributes/scm.ts
@@ -58,7 +58,7 @@ export class SCMContributionPoint extends VSCodeContributePoint<any> {
           return;
         }
 
-        this.scmService.setInputProps(input);
+        this.scmService.appendInputProps(input);
       }
     }
   }

--- a/packages/extension/src/browser/sumi/contributes/scm.ts
+++ b/packages/extension/src/browser/sumi/contributes/scm.ts
@@ -13,7 +13,7 @@ export class SCMContributionPoint extends VSCodeContributePoint<any> {
   private readonly scmService: SCMService;
 
   static schema: IJSONSchema = {
-    description: localize('sumiContributes.scm'),
+    description: localize('sumiContributes.SCM'),
     type: 'object',
     defaultSnippets: [
       {
@@ -27,11 +27,11 @@ export class SCMContributionPoint extends VSCodeContributePoint<any> {
     properties: {
       additional: {
         type: 'object',
-        description: localize('sumiContributes.scm.additional'),
+        description: localize('sumiContributes.SCM.additional'),
         properties: {
           input: {
             type: 'object',
-            description: localize('sumiContributes.scm.additional.input'),
+            description: localize('sumiContributes.SCM.additional.input'),
           },
         },
       },

--- a/packages/extension/src/browser/sumi/contributes/scm.ts
+++ b/packages/extension/src/browser/sumi/contributes/scm.ts
@@ -1,0 +1,65 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { IMenuRegistry } from '@opensumi/ide-core-browser/lib/menu/next';
+import { LifeCyclePhase, IJSONSchema, localize } from '@opensumi/ide-core-common';
+import { SCMService } from '@opensumi/ide-scm';
+
+import { VSCodeContributePoint, Contributes, LifeCycle } from '../../../common';
+
+@Injectable()
+@Contributes('scm')
+@LifeCycle(LifeCyclePhase.Starting)
+export class SCMContributionPoint extends VSCodeContributePoint<any> {
+  @Autowired(SCMService)
+  private readonly scmService: SCMService;
+
+  static schema: IJSONSchema = {
+    description: localize('sumiContributes.scm'),
+    type: 'object',
+    defaultSnippets: [
+      {
+        body: {
+          additional: {
+            input: {},
+          },
+        },
+      },
+    ],
+    properties: {
+      additional: {
+        type: 'object',
+        description: localize('sumiContributes.scm.additional'),
+        properties: {
+          input: {
+            type: 'object',
+            description: localize('sumiContributes.scm.additional.input'),
+          },
+        },
+      },
+    },
+  };
+
+  contribute() {
+    for (const contrib of this.contributesMap) {
+      const { contributes } = contrib;
+
+      if (contributes.additional) {
+        const { additional } = contributes;
+
+        if (!additional.input) {
+          return;
+        }
+
+        const { input } = additional;
+
+        /**
+         * addonBefore 和 addonAfter 交给 AbstractViewExtProcessService 处理
+         */
+        if (input.addonAfter || input.addonBefore) {
+          return;
+        }
+
+        this.scmService.setInputProps(input);
+      }
+    }
+  }
+}

--- a/packages/extension/src/common/sumi/extension.ts
+++ b/packages/extension/src/common/sumi/extension.ts
@@ -1,3 +1,4 @@
+import { IInputBaseProps } from '@opensumi/ide-components';
 import { IMenubarItem, ISubmenuItem } from '@opensumi/ide-core-browser/lib/menu/next';
 import { ISumiMenuExtendInfo } from '@opensumi/ide-core-common';
 import { ThemeType } from '@opensumi/ide-theme';
@@ -46,5 +47,10 @@ export interface ISumiExtensionContributions extends IExtensionContributions {
   // 针对 vscode contributes 中的 menus 的一些扩展
   menuExtend?: {
     [menuId: string]: Array<ISumiMenuExtendInfo>;
+  };
+  scm?: {
+    additional?: {
+      input?: Omit<IInputBaseProps, 'addonBefore' | 'addonAfter'> & { addonBefore?: string[]; addonAfter?: string[] };
+    };
   };
 }

--- a/packages/i18n/src/common/contributes/zh-CN.lang.ts
+++ b/packages/i18n/src/common/contributes/zh-CN.lang.ts
@@ -185,4 +185,9 @@ inline 模式 showTitle 会失效, 只显示 icon`,
     '(可选) 用于表示 UI 中的子菜单的图标。文件路径、具有深色和浅色主题的文件路径的对象，或者主题图标引用(如 "$(zap)")',
   'sumiContributes.submenus.icon.light': '使用浅色主题时的图标路径',
   'sumiContributes.submenus.icon.dark': '使用深色主题时的图标路径',
+
+  // scm
+  'sumiContributes.scm': '提供自定义的 scm 控件',
+  'sumiContributes.scm.additional': '需要额外追加的 scm 控件列表',
+  'sumiContributes.scm.additional.input': '对 input 控件追加属性',
 };

--- a/packages/i18n/src/common/contributes/zh-CN.lang.ts
+++ b/packages/i18n/src/common/contributes/zh-CN.lang.ts
@@ -187,7 +187,7 @@ inline 模式 showTitle 会失效, 只显示 icon`,
   'sumiContributes.submenus.icon.dark': '使用深色主题时的图标路径',
 
   // scm
-  'sumiContributes.scm': '提供自定义的 scm 控件',
-  'sumiContributes.scm.additional': '需要额外追加的 scm 控件列表',
-  'sumiContributes.scm.additional.input': '对 input 控件追加属性',
+  'sumiContributes.SCM': '提供自定义的 scm 控件',
+  'sumiContributes.SCM.additional': '需要额外追加的 scm 控件列表',
+  'sumiContributes.SCM.additional.input': '对 input 控件追加属性',
 };

--- a/packages/scm/src/browser/components/scm-resource-input.tsx
+++ b/packages/scm/src/browser/components/scm-resource-input.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 
+import { IInputBaseProps } from '@opensumi/ide-components';
 import { useInjectable } from '@opensumi/ide-core-browser';
 import { strings, isMacintosh, DisposableStore } from '@opensumi/ide-core-browser';
 import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
@@ -31,6 +32,7 @@ export const SCMResourceInput: FC<{
   const [commitMsg, setCommitMsg] = useState('');
   const [placeholder, setPlaceholder] = useState('');
   const [enabled, setEnabled] = useState(true);
+  const [inputProps, setInputProps] = useState<IInputBaseProps>({});
 
   const handleValueChange = useCallback(
     (msg: string) => {
@@ -41,6 +43,29 @@ export const SCMResourceInput: FC<{
 
   useEffect(() => {
     const disposables = new DisposableStore();
+
+    disposables.add(
+      repository.input.onDidChangeProps((props) => {
+        const { addonAfter, addonBefore } = props;
+        const AFC = addonAfter;
+        const ABC = addonBefore;
+
+        setInputProps({
+          ...props,
+          ...(addonAfter
+            ? {
+                addonAfter: typeof AFC === 'function' ? <AFC /> : addonAfter,
+              }
+            : {}),
+          ...(addonBefore
+            ? {
+                addonBefore: typeof ABC === 'function' ? <ABC /> : addonBefore,
+              }
+            : {}),
+        });
+      }),
+    );
+
     // 单向同步 input value
     disposables.add(
       repository.input.onDidChange((value) => {
@@ -96,6 +121,7 @@ export const SCMResourceInput: FC<{
           onKeyDown={(e) => onKeyDown(e.keyCode)}
           onKeyUp={onKeyUp}
           onValueChange={handleValueChange}
+          {...inputProps}
         />
       </div>
       {hasInputMenus && (

--- a/packages/scm/src/browser/components/scm-resource-input.tsx
+++ b/packages/scm/src/browser/components/scm-resource-input.tsx
@@ -41,28 +41,41 @@ export const SCMResourceInput: FC<{
     [repository],
   );
 
+  const handleInputProps = useCallback(
+    (props: IInputBaseProps) => {
+      const { addonAfter, addonBefore } = props;
+      const AFC = addonAfter;
+      const ABC = addonBefore;
+
+      setInputProps({
+        ...props,
+        ...(addonAfter
+          ? {
+              addonAfter: typeof AFC === 'function' ? <AFC /> : addonAfter,
+            }
+          : {}),
+        ...(addonBefore
+          ? {
+              addonBefore: typeof ABC === 'function' ? <ABC /> : addonBefore,
+            }
+          : {}),
+      });
+    },
+    [repository.input.props],
+  );
+
+  useEffect(() => {
+    if (repository.input.props) {
+      handleInputProps(repository.input.props);
+    }
+  }, [repository.input.props]);
+
   useEffect(() => {
     const disposables = new DisposableStore();
 
     disposables.add(
       repository.input.onDidChangeProps((props) => {
-        const { addonAfter, addonBefore } = props;
-        const AFC = addonAfter;
-        const ABC = addonBefore;
-
-        setInputProps({
-          ...props,
-          ...(addonAfter
-            ? {
-                addonAfter: typeof AFC === 'function' ? <AFC /> : addonAfter,
-              }
-            : {}),
-          ...(addonBefore
-            ? {
-                addonBefore: typeof ABC === 'function' ? <ABC /> : addonBefore,
-              }
-            : {}),
-        });
+        handleInputProps(props);
       }),
     );
 

--- a/packages/scm/src/browser/components/scm-resource-input.tsx
+++ b/packages/scm/src/browser/components/scm-resource-input.tsx
@@ -6,7 +6,7 @@ import { strings, isMacintosh, DisposableStore } from '@opensumi/ide-core-browse
 import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { IContextMenu } from '@opensumi/ide-core-browser/lib/menu/next';
 import { useHotKey } from '@opensumi/ide-core-browser/lib/react-hooks/hot-key';
-import { CommandService } from '@opensumi/ide-core-common';
+import { CommandService, isFunction } from '@opensumi/ide-core-common';
 import { AutoFocusedInput } from '@opensumi/ide-main-layout/lib/browser/input';
 import { IIconService } from '@opensumi/ide-theme';
 
@@ -51,12 +51,12 @@ export const SCMResourceInput: FC<{
         ...props,
         ...(addonAfter
           ? {
-              addonAfter: typeof AFC === 'function' ? <AFC /> : addonAfter,
+              addonAfter: isFunction(AFC) ? <AFC /> : addonAfter,
             }
           : {}),
         ...(addonBefore
           ? {
-              addonBefore: typeof ABC === 'function' ? <ABC /> : addonBefore,
+              addonBefore: isFunction(ABC) ? <ABC /> : addonBefore,
             }
           : {}),
       });

--- a/packages/scm/src/common/scm.service.ts
+++ b/packages/scm/src/common/scm.service.ts
@@ -159,8 +159,6 @@ export class SCMService {
 
   private readonly logger = getDebugLogger();
 
-  public viewReady: Deferred<void> = new Deferred();
-
   public registerSCMProvider(provider: ISCMProvider): ISCMRepository {
     this.logger.log('SCMService#registerSCMProvider');
 

--- a/packages/scm/src/common/scm.service.ts
+++ b/packages/scm/src/common/scm.service.ts
@@ -1,6 +1,7 @@
 import { observable, computed, action } from 'mobx';
 
 import { Injectable } from '@opensumi/di';
+import { IInputBaseProps } from '@opensumi/ide-components';
 import { Event, Emitter, arrays, getDebugLogger } from '@opensumi/ide-core-common';
 import { IDisposable, toDisposable } from '@opensumi/ide-core-common';
 
@@ -46,6 +47,25 @@ class SCMInput implements ISCMInput {
     this._visible = visible;
     this._onDidChangeVisibility.fire(visible);
   }
+
+  private _props = {};
+
+  get props(): IInputBaseProps {
+    return this._props;
+  }
+
+  set props(props: IInputBaseProps) {
+    this._props = props;
+    this._onDidChangeProps.fire(this._props);
+  }
+
+  public appendProps(props: IInputBaseProps): void {
+    this._props = { ...this._props, ...props };
+    this._onDidChangeProps.fire(this._props);
+  }
+
+  private _onDidChangeProps = new Emitter<IInputBaseProps>();
+  readonly onDidChangeProps: Event<IInputBaseProps> = this._onDidChangeProps.event;
 
   private _onDidChangeVisibility = new Emitter<boolean>();
   readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
@@ -181,6 +201,18 @@ export class SCMService {
     }
 
     return repository;
+  }
+
+  public setInputProps(props: IInputBaseProps): void {
+    this._repositories.forEach((repo) => {
+      repo.input.props = props;
+    });
+  }
+
+  public appendInputProps(props: IInputBaseProps): void {
+    this._repositories.forEach((repo) => {
+      repo.input.appendProps(props);
+    });
   }
 
   private onDidChangeSelection(repository: ISCMRepository): void {

--- a/packages/scm/src/common/scm.service.ts
+++ b/packages/scm/src/common/scm.service.ts
@@ -2,7 +2,7 @@ import { observable, computed, action } from 'mobx';
 
 import { Injectable } from '@opensumi/di';
 import { IInputBaseProps } from '@opensumi/ide-components';
-import { Event, Emitter, arrays, getDebugLogger } from '@opensumi/ide-core-common';
+import { Event, Emitter, arrays, getDebugLogger, Deferred } from '@opensumi/ide-core-common';
 import { IDisposable, toDisposable } from '@opensumi/ide-core-common';
 
 import { ISCMProvider, ISCMInput, ISCMRepository, IInputValidator } from './scm';
@@ -158,6 +158,8 @@ export class SCMService {
   public readonly onDidRemoveRepository: Event<ISCMRepository> = this._onDidRemoveProvider.event;
 
   private readonly logger = getDebugLogger();
+
+  public viewReady: Deferred<void> = new Deferred();
 
   public registerSCMProvider(provider: ISCMProvider): ISCMRepository {
     this.logger.log('SCMService#registerSCMProvider');

--- a/packages/scm/src/common/scm.ts
+++ b/packages/scm/src/common/scm.ts
@@ -1,3 +1,4 @@
+import { IInputBaseProps } from '@opensumi/ide-components';
 import { Event, IDisposable, ISequence, Uri } from '@opensumi/ide-core-common';
 
 export interface VSCommand {
@@ -35,6 +36,11 @@ export interface ISCMInput {
 
   visible: boolean;
   readonly onDidChangeVisibility: Event<boolean>;
+
+  props: IInputBaseProps;
+  readonly onDidChangeProps: Event<IInputBaseProps>;
+
+  appendProps(props: IInputBaseProps): void;
 }
 
 export interface ISCMRepository extends IDisposable {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b91ede</samp>

*  Add support for custom components for the SCM input box from extension contributions ([link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-7e4610f55daeaaca635b72e1cba7d5548f4d5ad6d5e36466dc1b26052ca015c1R271-R319), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-21a4aa56a7c4522217936bd1b863db24976d36fd1f97fb62ce75fdb01d696cffR10), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-21a4aa56a7c4522217936bd1b863db24976d36fd1f97fb62ce75fdb01d696cffL29-R31), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-b042bb48a2e3674524d4a40fa3a875d719d02925e7ddeb0bdf1c14711f457ebbR1-R65), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-93988976f20baaff79ef4701631c72f4e0faec1b15142189c262dbc6bc50510bR51-R55), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R46-R68), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R124))
*  Add support for custom input props for the SCM input box from extension contributions ([link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-7e4610f55daeaaca635b72e1cba7d5548f4d5ad6d5e36466dc1b26052ca015c1R16), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-7e4610f55daeaaca635b72e1cba7d5548f4d5ad6d5e36466dc1b26052ca015c1R83-R85), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-b042bb48a2e3674524d4a40fa3a875d719d02925e7ddeb0bdf1c14711f457ebbR1-R65), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-93988976f20baaff79ef4701631c72f4e0faec1b15142189c262dbc6bc50510bR1), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-93988976f20baaff79ef4701631c72f4e0faec1b15142189c262dbc6bc50510bR51-R55), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R35), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R46-R68), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-58d6d4cbf584245bfbfd30d022f8ef46f0da79f24bcafc0c4b77e7d69daf1a93R124), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-38b9602bcd1e5fa40c0e82b5f43537711b3a1c2302ab69493fa570d814bc3861R4), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-38b9602bcd1e5fa40c0e82b5f43537711b3a1c2302ab69493fa570d814bc3861R51-R69), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-38b9602bcd1e5fa40c0e82b5f43537711b3a1c2302ab69493fa570d814bc3861R206-R217), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-527faf067be61f7526b031487475180346065c5b81e644b85181bb33428e7ec6R1), [link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-527faf067be61f7526b031487475180346065c5b81e644b85181bb33428e7ec6R39-R43))
*  Add schema and default snippet for the `scm` section of the extension contributions ([link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-b042bb48a2e3674524d4a40fa3a875d719d02925e7ddeb0bdf1c14711f457ebbR1-R65))
*  Add Chinese translations for the `scm` section and its properties ([link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-77fd021913ae53d95584cf31e7a51658aca21ae8f865adf8d0e97b8205d04ac3R188-R192))
*  Add an empty line to the end of the file `packages/components/src/input/Input.tsx` to follow the code style convention ([link](https://github.com/opensumi/core/pull/2867/files?diff=unified&w=0#diff-bb1200d7ed8bb83c25174fe4873865d715373eb69ee26d66eae4779bad778611R189))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b91ede</samp>

This pull request adds support for extensions to contribute custom components for the SCM input box in the browser. It defines a new `SCMContributionPoint` class that handles the `scm` section of the extension contributions and calls the `SCMService` to set the input props. It also enhances the `SCMInput` and `SCMResourceInput` classes to support more input features and options. It updates the `IInputBaseProps` interface and the `Input` component to support the new input props. It also adds the Chinese translations for the `scm` section.
