### PR TITLE
style: change resize handler z-index

### DIFF
--- a/packages/core-browser/src/components/resize/resize.module.less
+++ b/packages/core-browser/src/components/resize/resize.module.less
@@ -1,10 +1,14 @@
+.resize-handle-horizontal,
+.resize-handle-vertical {
+  z-index: 12;
+}
+
 .resize-handle-horizontal {
   cursor: col-resize;
   position: relative;
   height: 100%;
   margin-right: -2px;
   margin-left: -2px;
-  z-index: 4;
   width: 4px;
   transition: background-color 0.1s ease-out;
   background: transparent;
@@ -31,7 +35,6 @@
   margin-top: -2px;
   margin-bottom: -2px;
   height: 4px;
-  z-index: 4;
   transition: background-color 0.1s ease-out;
   background: transparent;
   &:hover {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1fc1d1</samp>

*  Increase z-index of horizontal and vertical resize handles to ensure visibility and accessibility ([link](https://github.com/opensumi/core/pull/2868/files?diff=unified&w=0#diff-feef68b80aa58a648bf044f5ffcfca488c7879315f26ce678f7d288ee0dd379dR1-R5))
*  Remove z-index of diagonal resize handle to avoid conflicts and make consistent with other handles ([link](https://github.com/opensumi/core/pull/2868/files?diff=unified&w=0#diff-feef68b80aa58a648bf044f5ffcfca488c7879315f26ce678f7d288ee0dd379dL7))
*  Remove z-index of resize container to avoid conflicts and make consistent with other elements ([link](https://github.com/opensumi/core/pull/2868/files?diff=unified&w=0#diff-feef68b80aa58a648bf044f5ffcfca488c7879315f26ce678f7d288ee0dd379dL34))

<!-- Additional content -->
<!-- 补充额外内容 -->

Before:
![image](https://github.com/opensumi/core/assets/9823838/bf787443-797f-4549-accc-22c12a6f9764)
![image](https://github.com/opensumi/core/assets/9823838/b86fc754-bf37-4011-a5ec-99cbbf7d631d)

默认的 `sticky-widget` 层级为 11，会盖住默认拖动条

After:
![image](https://github.com/opensumi/core/assets/9823838/cafaaa93-7f6a-4f84-b57b-d64114db9364)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1fc1d1</samp>

This pull request enhances the resize component in `core-browser` by fixing some z-index issues and making the handles more consistent.
