### PR TITLE
fix: add version to download-extension targetDirName

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -77,7 +77,7 @@ async function downloadExtension(url, namespace, extensionName) {
   await Promise.race([awaitEvent(res.body, 'end'), awaitEvent(res.body, 'error')]);
   tmpStream.close();
 
-  const targetDirName = path.basename(`${namespace}.${extensionName}`);
+  const targetDirName = path.basename(`${namespace}.${extensionName}-${version}`);
 
   return { tmpZipFile, targetDirName };
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fbdcf24</samp>

*  Append extension version to downloaded zip file name to avoid conflicts ([link](https://github.com/opensumi/core/pull/2877/files?diff=unified&w=0#diff-275a1a02d5728cab84d6b7293750aa0656f3f7e082baef38c3f124db45631e2fL80-R80))

<!-- Additional content -->
<!-- 补充额外内容 -->

fix: #2875 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbdcf24</samp>

Improved naming of downloaded extension zip files in `scripts/download.js`. The zip file name now includes the extension version to distinguish different versions.
