### PR TITLE
fix: except breakpoint blank description

### DIFF
--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.view.tsx
@@ -352,12 +352,16 @@ export const BreakpointItem = ({ data, toggle }: { data: BreakpointItem; toggle:
       return <span className={styles.debug_breakpoints_description}>{description}</span>;
     }
 
+    if (!isDebugBreakpoint(data.breakpoint)) {
+      return null;
+    }
+
     return (
       <span className={cls(styles.debug_breakpoints_description, styles.blank)}>{`< ${localize(
         'debug.breakpoint.blank',
       )} >`}</span>
     );
-  }, [description]);
+  }, [description, data.breakpoint]);
 
   return (
     <div className={cls(styles.debug_breakpoints_item)}>


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef29069</samp>

*  Prevent rendering non-debug breakpoints in `BreakpointItem` component ([link](https://github.com/opensumi/core/pull/2878/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2R355-R358))
*  Add `data.breakpoint` as a dependency to `useMemo` hook for breakpoint description ([link](https://github.com/opensumi/core/pull/2878/files?diff=unified&w=0#diff-5c78ed8707282f1433e7720dc171c9399cf390504427546cb332986117bd57f2L360-R364))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/3976aa18-8e2a-495c-9532-27df0f054aba)

修复异常断点也出现“空行”字样的问题

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef29069</samp>

This pull request enhances the `BreakpointItem` component in the debug view to avoid errors and reflect breakpoint changes. It filters out non-debug breakpoints and uses a `useEffect` hook to update the description.
