### PR TITLE
fix: worker api not execute

### DIFF
--- a/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
@@ -179,7 +179,6 @@ export function createAPIFactory(
       ...createWorkerHostEnvAPIFactory(rpcProtocol, extHostEnv),
     },
     languages: createLanguagesApiFactory(extHostLanguages, extension),
-    commands: createCommandsApiFactory(extHostCommands, extHostEditors, extension),
     extensions: createExtensionsApiFactory(extensionService),
     workspace: createWorkspaceApiFactory(
       extHostWorkspace,
@@ -224,6 +223,6 @@ export function createAPIFactory(
     authentication: createAuthenticationApiFactory(extension, extHostAuthentication),
     comments: createCommentsApiFactory(extension, extHostComments),
     // Sumi 扩展 API
-    ...sumiAPI,
+    ...sumiAPI(extension),
   });
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0737384</samp>

*  Remove deprecated `commands` property from API factory object ([link](https://github.com/opensumi/core/pull/2879/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562L182))
*  Refactor `sumiAPI` property to a function that takes extension as argument and returns custom APIs ([link](https://github.com/opensumi/core/pull/2879/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562L224-R223))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0737384</samp>

This pull request updates the API factory object for extensions in `worker.host.api.impl.ts` to use the latest VS Code API and enhance the Sumi APIs. It removes the unused `commands` property and refactors the `sumiAPI` property.
