### PR TITLE
fix: rerender select component if label changed

### DIFF
--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -526,7 +526,7 @@ function SelectPreferenceItem({
         </Option>
       );
     });
-  }, [schema.enum]);
+  }, [schema.enum, labels]);
 
   const renderNoneOptions = () => (
     <Option

--- a/packages/preferences/src/browser/preferences.view.tsx
+++ b/packages/preferences/src/browser/preferences.view.tsx
@@ -63,13 +63,11 @@ const usePreferenceGroups = () => {
     const dispose = preferenceService.onSettingsGroupsChange(() => {
       updateGroup.run();
     });
+    updateGroup.run();
+
     return () => {
       dispose.dispose();
     };
-  });
-
-  useEffect(() => {
-    updateGroup.run();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 37a1654</samp>

*  Ensure that the options for the select preference items are updated when the labels change ([link](https://github.com/opensumi/core/pull/2880/files?diff=unified&w=0#diff-13846029778202e9883ae97a33ac171c710a37e78d01f5f542e1d3c5bd5f0ea1L529-R529))
*  Avoid a race condition by moving the initial update of the preference groups inside the effect hook in `preferences.view.tsx` ([link](https://github.com/opensumi/core/pull/2880/files?diff=unified&w=0#diff-12115396b22ebdfd945c189c78b115b65bf3fea11ac1d59fdb8bc6b08d5851d6L66-R70))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->


Preference Panel: Fix the issue where the component does not re-render when the label of a specific Select option changes.