### PR TITLE
fix: left panel style lower right menu style

### DIFF
--- a/packages/main-layout/src/browser/tabbar/styles.module.less
+++ b/packages/main-layout/src/browser/tabbar/styles.module.less
@@ -397,6 +397,7 @@
     align-items: center;
     color: var(--activityBar-inactiveForeground);
     background-size: cover;
+    margin: 0;
     &:hover {
       transform: scale(1);
       background-color: transparent;


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes

fix: https://github.com/opensumi/core/issues/2887
### Background or solution

开发环境没发现是因为只有一个图标，在全局有个公共样式会影响到多个图标的情况
![image](https://github.com/opensumi/core/assets/1762334/29d62eac-60a6-429e-b80b-e7664d511a26)

### Changelog
fix: 修复左侧sidebar右下角图标偏移
