### PR TITLE
fix(ext): extension cannot reset validateMessage to undefined

### DIFF
--- a/packages/components/src/input/ValidateInput.tsx
+++ b/packages/components/src/input/ValidateInput.tsx
@@ -9,10 +9,6 @@ import './validate-input.less';
 
 export enum VALIDATE_TYPE {
   INFO = 1,
-  /**
-   * @deprecated
-   */
-  WRANING = 0,
   ERROR = 2,
   WARNING = 3,
   IGNORE = 4,
@@ -42,15 +38,9 @@ export const ValidateInput = React.forwardRef<HTMLInputElement, ValidateInputPro
       setValidateMessage(validateInfo);
     }, [validateInfo]);
 
-    warning(
-      !validateMessage || validateMessage.type !== VALIDATE_TYPE.WRANING,
-      '`VALIDATE_TYPE.WRANING` was a wrong typo, please use `VALIDATE_TYPE.WARNING` instead',
-    );
-
     const validateClx = classNames({
       'validate-error': validateMessage && validateMessage.type === VALIDATE_TYPE.ERROR,
-      'validate-warning':
-        validateMessage && [VALIDATE_TYPE.WRANING, VALIDATE_TYPE.WARNING].includes(validateMessage.type),
+      'validate-warning': validateMessage && validateMessage.type === VALIDATE_TYPE.WARNING,
       'validate-info': validateMessage && validateMessage.type === VALIDATE_TYPE.INFO,
     });
 

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.quickopen.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.quickopen.test.ts
@@ -61,6 +61,8 @@ describe('ext host quickopen test', () => {
       token: QuickOpenService,
       useValue: {
         open: () => Promise.resolve(),
+        updateOptions: () => {},
+        refresh: () => {},
       },
     },
     {
@@ -166,6 +168,14 @@ describe('ext host quickopen test', () => {
     expect($createOrUpdateInputBox).toBeCalledWith(expect.anything(), {
       validationMessage: 'test',
       severity: InputBoxValidationSeverity.Warning,
+    });
+
+    quickInput.validationMessage = undefined;
+    await sleep(50);
+
+    expect($createOrUpdateInputBox).toBeCalledWith(expect.anything(), {
+      validationMessage: null,
+      severity: InputBoxValidationSeverity.Ignore,
     });
   });
 });

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -205,6 +205,7 @@ export enum LanguageStatusSeverity {
 }
 
 export enum InputBoxValidationSeverity {
+  Ignore = 0,
   Info = 1,
   Warning = 2,
   Error = 3,

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -39,7 +39,7 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
     | ((input: string) => MaybePromise<string | vscode.InputBoxValidationMessage | null | undefined>);
 
   private createdQuicks = new Map<number, ExtQuickPick<vscode.QuickPickItem>>(); // Each quick will have a number so that we know where to fire events
-  private createdInputBoxs = new Map<number, ExtQuickInput>();
+  private createdInputBoxes = new Map<number, ExtQuickInput>();
   private currentQuick = 0;
 
   constructor(rpc: IRPCProtocol, private readonly workspace: IExtHostWorkspace) {
@@ -180,9 +180,9 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
   createInputBox(): vscode.InputBox {
     const session = ++this.currentQuick;
     const newInputBox = new ExtInputBox(session, this.proxy, this, () => {
-      this.createdInputBoxs.delete(session);
+      this.createdInputBoxes.delete(session);
     });
-    this.createdInputBoxs.set(session, newInputBox);
+    this.createdInputBoxes.set(session, newInputBox);
     return newInputBox;
   }
 
@@ -194,25 +194,25 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
   }
 
   $onCreatedInputBoxDidChangeValue(sessionId: number, value: string): void {
-    const session = this.createdInputBoxs.get(sessionId);
+    const session = this.createdInputBoxes.get(sessionId);
     if (session) {
       session._fireDidChangeValue(value);
     }
   }
   $onCreatedInputBoxDidAccept(sessionId: number): void {
-    const session = this.createdInputBoxs.get(sessionId);
+    const session = this.createdInputBoxes.get(sessionId);
     if (session) {
       session._fireDidAccept();
     }
   }
   $onCreatedInputBoxDidHide(sessionId: number): void {
-    const session = this.createdInputBoxs.get(sessionId);
+    const session = this.createdInputBoxes.get(sessionId);
     if (session) {
       session._fireDidHide();
     }
   }
   $onCreatedInputBoxDidTriggerButton(sessionId: number, btnHandler: number) {
-    const session = this.createdInputBoxs.get(sessionId);
+    const session = this.createdInputBoxes.get(sessionId);
     if (session) {
       session._fireDidTriggerButton(btnHandler);
     }
@@ -659,7 +659,7 @@ abstract class ExtQuickInput implements vscode.InputBox {
     }
 
     for (const k of Object.keys(data)) {
-      this._pendingUpdate[k] = data[k] === undefined ? null : data[k];
+      data[k] = data[k] === undefined ? null : data[k];
     }
 
     this._pendingUpdate = { ...this._pendingUpdate, ...data };

--- a/packages/types/vscode/typings/vscode.quickpick.d.ts
+++ b/packages/types/vscode/typings/vscode.quickpick.d.ts
@@ -549,6 +549,7 @@ declare module 'vscode' {
    * Impacts the behavior and appearance of the validation message.
    */
   export enum InputBoxValidationSeverity {
+    Ignore = 0,
     Info = 1,
     Warning = 2,
     Error = 3


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

插件调用 createInputBox 展示输入框，如果曾经设置过 error 信息，就无法取消该 error 信息了：

<img width="750" alt="CleanShot 2023-07-13 at 15 51 06@2x" src="https://github.com/opensumi/core/assets/13938334/010d7df7-6e4f-4472-bc51-18e1e4511a8e">

<img width="743" alt="CleanShot 2023-07-13 at 15 50 24@2x" src="https://github.com/opensumi/core/assets/13938334/ece8e444-0623-4426-b57a-df33694c7270">

之前的代码写错了，应该是把 data[k] 重设为 null


<img width="1346" alt="CleanShot 2023-07-13 at 15 47 30@2x" src="https://github.com/opensumi/core/assets/13938334/67cfbcc8-58c2-4c7b-a2c2-27f54836eece">


### Changelog

Fix: extension api `createInputBox` cannot reset validateMessage to undefined