### PR TITLE
style: improve secondary button hover style

### DIFF
--- a/packages/theme/src/common/color-tokens/custom/button.ts
+++ b/packages/theme/src/common/color-tokens/custom/button.ts
@@ -144,26 +144,31 @@ export const ktSecondaryButtonHoverBackground = registerColor(
 );
 export const ktSecondaryButtonHoverForeground = registerColor(
   'kt.secondaryButton.hoverForeground',
-  { dark: buttonSecondaryHoverBackground, light: buttonSecondaryHoverBackground, hcDark: null, hcLight: null },
+  {
+    dark: lighten(ktSecondaryButtonForeground, 0.2),
+    light: darken(ktSecondaryButtonForeground, 0.2),
+    hcDark: lighten(ktSecondaryButtonForeground, 0.2),
+    hcLight: darken(ktSecondaryButtonForeground, 0.2),
+  },
   localize('ktSecondaryButtonHoverForeground', 'Secondary Button Hover Foreground color'),
 );
 export const ktSecondaryButtonHoverBorder = registerColor(
   'kt.secondaryButton.hoverBorder',
   {
-    dark: buttonSecondaryHoverBackground,
-    light: buttonSecondaryHoverBackground,
-    hcDark: buttonSecondaryHoverBackground,
-    hcLight: buttonSecondaryHoverBackground,
+    dark: lighten(ktSecondaryButtonBorder, 0.2),
+    light: darken(ktSecondaryButtonBorder, 0.2),
+    hcDark: lighten(ktSecondaryButtonBorder, 0.2),
+    hcLight: darken(ktSecondaryButtonBorder, 0.2),
   },
   localize('ktSecondaryButtonHoverBorder', 'Secondary Button Hover Border color'),
 );
 export const ktSecondaryButtonClickForeground = registerColor(
   'kt.secondaryButton.clickForeground',
   {
-    dark: ktSecondaryButtonHoverForeground,
-    light: ktSecondaryButtonHoverForeground,
-    hcDark: ktSecondaryButtonHoverForeground,
-    hcLight: ktSecondaryButtonHoverForeground,
+    dark: lighten(ktSecondaryButtonForeground, 0.2),
+    light: darken(ktSecondaryButtonForeground, 0.2),
+    hcDark: lighten(ktSecondaryButtonForeground, 0.2),
+    hcLight: darken(ktSecondaryButtonForeground, 0.2),
   },
   localize('ktSecondaryButtonClickForeground', 'Secondary Button Click Foreground color'),
 );


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec94bae</samp>

* Improve the hover and click effects of the secondary button by adjusting the foreground and border color tokens based on the theme ([link](https://github.com/opensumi/core/pull/2890/files?diff=unified&w=0#diff-9214a3dc5c4c38c6e785959cdcef4fb9f64a432e06321b8f03405bdcc81dbc9bL147-R152), [link](https://github.com/opensumi/core/pull/2890/files?diff=unified&w=0#diff-9214a3dc5c4c38c6e785959cdcef4fb9f64a432e06321b8f03405bdcc81dbc9bL153-R161), [link](https://github.com/opensumi/core/pull/2890/files?diff=unified&w=0#diff-9214a3dc5c4c38c6e785959cdcef4fb9f64a432e06321b8f03405bdcc81dbc9bL163-R171)) in `button.ts`

<!-- Additional content -->
<!-- 补充额外内容 -->
解决 SecondaryButton 在部分主题下 Hover 后样式异常问题 
<img width="107" alt="image" src="https://github.com/opensumi/core/assets/9823838/bfdcad0c-db36-4dce-a36c-8f0b8f655865">

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec94bae</samp>

This pull request enhances the secondary button component's appearance and usability by changing its color tokens. It modifies the file `button.ts` in the `theme` package to apply different shades of colors for hover and click states.
