### PR TITLE
fix: debug console repl not show

### DIFF
--- a/packages/debug/src/browser/view/console/debug-console.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console.service.ts
@@ -141,6 +141,10 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
     const storage = await this.storageProvider(STORAGE_NAMESPACE.DEBUG);
     this.history = new HistoryNavigator(storage.get(HISTORY_STORAGE_KEY, []), 50);
 
+    if (this.inputEditor?.monacoEditor) {
+      return;
+    }
+
     this._consoleInputElement = e;
     this.inputEditor = this.editorService.createCodeEditor(this._consoleInputElement!, {
       ...consoleInputMonacoOptions,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3bfecd</samp>

*  Prevent re-initializing input editor in `DebugConsoleService` by adding a guard clause ([link](https://github.com/opensumi/core/pull/2898/files?diff=unified&w=0#diff-432739c49418913243d88ef91c4eaa7a720813e3afb158860faf83e6390e6adeR144-R147))
*  Refactor `DebugConsoleView` component to use `useRef` hook instead of `createRef` hook for accessing DOM elements ([link](https://github.com/opensumi/core/pull/2898/files?diff=unified&w=0#diff-a03a3273325db24f694ccaaafac9f260080855a120c8651636f5b75def2499f6L3-R3), [link](https://github.com/opensumi/core/pull/2898/files?diff=unified&w=0#diff-a03a3273325db24f694ccaaafac9f260080855a120c8651636f5b75def2499f6L36), [link](https://github.com/opensumi/core/pull/2898/files?diff=unified&w=0#diff-a03a3273325db24f694ccaaafac9f260080855a120c8651636f5b75def2499f6L42-R62))
*  Move `disposer` variable inside `useEffect` hook to align with component lifecycle ([link](https://github.com/opensumi/core/pull/2898/files?diff=unified&w=0#diff-a03a3273325db24f694ccaaafac9f260080855a120c8651636f5b75def2499f6L42-R62))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/4b41a1a4-d90d-4689-840e-f0c05cbd0b14)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3bfecd</samp>

This pull request improves the stability and performance of the `DebugConsoleView` component and the `DebugConsoleService` class in the `packages/debug` module. It fixes some issues with accessing and cleaning up DOM elements and editor instances.
