### PR TITLE
feat: support showBreakpointsInOverviewRuler

### DIFF
--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -159,6 +159,11 @@ export const corePreferenceSchema: PreferenceSchema = {
       default: true,
       description: '%preference.debug.breakpoint.editorHint%',
     },
+    'debug.breakpoint.showBreakpointsInOverviewRuler': {
+      type: 'boolean',
+      default: false,
+      description: '%preference.debug.breakpoint.showBreakpointsInOverviewRuler%',
+    },
     'debug.toolbar.top': {
       type: 'number',
       default: 0,
@@ -305,6 +310,7 @@ export interface CoreConfiguration {
   'explorer.compactFolders': boolean;
   'debug.toolbar.float': boolean;
   'debug.breakpoint.editorHint': boolean;
+  'debug.breakpoint.showBreakpointsInOverviewRuler': boolean;
   'debug.toolbar.top': number;
   'debug.toolbar.height': number;
   'files.watcherExclude': { [key: string]: boolean };

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -10,6 +10,7 @@ import {
   AbstractMenuService,
 } from '@opensumi/ide-core-browser/lib/menu/next';
 import { URI, DisposableCollection, isOSX, memoize, Disposable, uuid } from '@opensumi/ide-core-common';
+import { IThemeService, debugIconBreakpointForeground } from '@opensumi/ide-theme';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
 import {
@@ -68,6 +69,9 @@ export class DebugModel implements IDebugModel {
 
   @Autowired(PreferenceService)
   private readonly preferenceService: PreferenceService;
+
+  @Autowired(IThemeService)
+  public readonly themeService: IThemeService;
 
   protected frameDecorations: string[] = [];
   protected topFrameRange: monaco.Range | undefined;
@@ -541,6 +545,20 @@ export class DebugModel implements IDebugModel {
       !!session,
       this.breakpointManager.breakpointsEnabled,
     );
+    const showBreakpointsInOverviewRuler = this.preferenceService.getValid(
+      'debug.breakpoint.showBreakpointsInOverviewRuler',
+      false,
+    );
+
+    let overviewRulerDecoration: monaco.editor.IModelDecorationOverviewRulerOptions | null = null;
+    if (showBreakpointsInOverviewRuler) {
+      overviewRulerDecoration = {
+        color: this.themeService.getColor({
+          id: debugIconBreakpointForeground,
+        }),
+        position: monaco.editor.OverviewRulerLane.Left,
+      } as monaco.editor.IModelDecorationOverviewRulerOptions;
+    }
 
     return {
       range,
@@ -550,6 +568,7 @@ export class DebugModel implements IDebugModel {
         glyphMarginHoverMessage: message.map((value) => ({ value })),
         stickiness: options.STICKINESS,
         beforeContentClassName: renderInline ? 'debug-breakpoint-placeholder' : undefined,
+        overviewRuler: overviewRulerDecoration,
       },
     };
   }

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -530,6 +530,8 @@ export const localizationBundle = {
     'preference.debug.inline.values': 'Show variable values inline in editor while debugging.',
     'preference.debug.breakpoint.editorHint':
       'After enabling, there will be a background color blinking prompt when clicking on the breakpoint list to jump to the editor.',
+    'preference.debug.breakpoint.showBreakpointsInOverviewRuler':
+      'Controls whether breakpoints should be shown in the overview ruler.',
 
     // workbench
     'preference.workbench.refactoringChanges.showPreviewStrategy':

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -411,6 +411,7 @@ export const localizationBundle = {
     'preference.debug.toolbar.float.title': '运行与调试：浮层模式',
     'preference.debug.breakpoint.editorHint.title': '控制是否开启编辑器断点闪烁提示',
     'preference.debug.breakpoint.editorHint': '启用后，点击断点列表跳转到编辑器时，会有背景色闪烁提示',
+    'preference.debug.breakpoint.showBreakpointsInOverviewRuler': '控制是否应在概览标尺中显示断点',
 
     'preference.debug.console.filter.mode': '调试控制台筛选器模式',
     'preference.debug.console.filter.mode.filter': '过滤模式',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -792,6 +792,10 @@ export const defaultSettingSections: {
         { id: 'debug.inline.values', localized: 'preference.debug.inline.values' },
         { id: 'debug.toolbar.float', localized: 'preference.debug.toolbar.float.title' },
         { id: 'debug.breakpoint.editorHint', localized: 'preference.debug.breakpoint.editorHint.title' },
+        {
+          id: 'debug.breakpoint.showBreakpointsInOverviewRuler',
+          localized: 'preference.debug.breakpoint.showBreakpointsInOverviewRuler',
+        },
       ],
     },
   ],

--- a/packages/theme/src/common/color-tokens/debug.ts
+++ b/packages/theme/src/common/color-tokens/debug.ts
@@ -101,3 +101,8 @@ export const debugConsoleInputIconForeground = registerColor(
   { dark: foreground, light: foreground, hcDark: foreground, hcLight: foreground },
   'Foreground color for debug console input marker icon.',
 );
+export const debugIconBreakpointForeground = registerColor(
+  'debugIcon.breakpointForeground',
+  { dark: '#E51400', light: '#E51400', hcDark: '#E51400', hcLight: '#E51400' },
+  'Icon color for breakpoints.',
+);


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc89f5f</samp>

*  Add a new preference for showing breakpoints in the overview ruler ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-d0448c17909c2691ac26d9ed0bb19b3faadc28823c77a5fc61653d8644530b9cR162-R166), [link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-d0448c17909c2691ac26d9ed0bb19b3faadc28823c77a5fc61653d8644530b9cR313), [link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR795-R798))
  * Define a preference schema with a boolean type, a default value, and a localized description in `core-preferences.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-d0448c17909c2691ac26d9ed0bb19b3faadc28823c77a5fc61653d8644530b9cR162-R166))
  * Add a property to the `CoreConfiguration` interface with the same id and type as the preference schema in `core-preferences.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-d0448c17909c2691ac26d9ed0bb19b3faadc28823c77a5fc61653d8644530b9cR313))
  * Register the preference id and the localization key in the preference settings service in `preference-settings.service.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-7a72db174865394cd9a826feb5fe2092d204e13ef8333f83f7c6a5edac12a70cR795-R798))
* Add a new color token for breakpoint icons in the theme package ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-179e2ce4a47f27cfadb59d48fcdb4d41840b49f8dbc683e28735427c10f817dcR104-R108))
  * Register a color with an id, a default value, and a description in `debug.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-179e2ce4a47f27cfadb59d48fcdb4d41840b49f8dbc683e28735427c10f817dcR104-R108))
* Use the preference value and the color token to create overview ruler decorations for breakpoints in the debug model ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR13), [link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR73-R75), [link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL544-R562), [link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR571))
  * Import the `IThemeService` and the color token from the theme package in `debug-model.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR13))
  * Inject the `IThemeService` as a dependency to the `DebugModel` class in `debug-model.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR73-R75))
  * Check the preference value and create an overview ruler decoration with the color token in the `getBreakpointDecoration` method in `debug-model.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL544-R562))
  * Add the overview ruler decoration to the monaco editor decoration options in the `getBreakpointDecoration` method in `debug-model.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR571))
* Add localization entries for the preference description in English and Chinese ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R533-R534), [link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R414))
  * Add a key-value pair of the preference id and the description in English in `en-US.lang.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R533-R534))
  * Add a key-value pair of the preference id and the description in Chinese in `zh-CN.lang.ts` ([link](https://github.com/opensumi/core/pull/2902/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R414))

<!-- Additional content -->
![image](https://github.com/opensumi/core/assets/20262815/5a1d80d0-a17e-4650-b3ca-95e59d8ea9e7)

- [x] 新增 showBreakpointsInOverviewRuler 配置项，默认关闭

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc89f5f</samp>

This pull request adds a new feature to show breakpoints in the overview ruler of the editor, which can be enabled or disabled by a user preference. It also adds the necessary color token, localization, and preference settings for this feature. The main files affected are `core-preferences.ts`, `debug-model.ts`, and `preference-settings.service.ts`.
