### PR TITLE
fix: title-bar add i18n tips (#2903)

### DIFF
--- a/packages/scm/src/browser/scm-view-container.tsx
+++ b/packages/scm/src/browser/scm-view-container.tsx
@@ -234,6 +234,7 @@ export const SCMViewContainer: FC<{ viewState: ViewState }> = (props) => {
             <InlineMenuBar
               menus={titleMenu}
               context={selectedRepo && selectedRepo.provider && [selectedRepo.provider]}
+              moreTitle={localize('scm.action.git.more', 'more actions')}
             />
           ) : null
         }


### PR DESCRIPTION
### Types

- [ ] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1efe2e2</samp>

*  Remove `iconService` prop from `MenuAction`, `Menu`, and `recursiveRender` components, as it is no longer needed to render codicon icons ([link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L32-R36), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L65-R56), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L111-R120))
* Simplify `key` prop of `Menu.SubMenu` and `Menu.Item` components to use only submenu id or menu id, and remove `React.Fragment` wrapper ([link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L111-R120))
* Move `Menu.Divider` component from `recursiveRender` function to `dataSource.map` function, and remove `hasSeparator` variable ([link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L101-R93))
* Change `EllipsisWidget` component to use `Button` component instead of `Icon` component, and add `title` prop for tooltip text ([link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L161-R157), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L171-R165), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R327), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R341), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L381-R383))
* Add `moreTitle` prop to `InlineMenuBarProps` interface, and pass it to `EllipsisWidget` component in `InlineMenuBar` and `SCMViewContainer` components ([link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R496), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L503-R506), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R516), [link](https://github.com/opensumi/core/pull/2904/files?diff=unified&w=0#diff-d39f067de76cf60473e10678e244136f8cfa5fab80c7b0f754b30628f62c2eaeR237))


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1efe2e2</samp>

Simplified the rendering of menu actions and added tooltip texts for ellipsis buttons in the core-browser and scm packages. This improves the usability and accessibility of the UI components.
