### PR TITLE
fix: title-bar add i18n tips (#2903)

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -158,9 +158,19 @@ const EllipsisWidget: React.FC<{
   icon?: string;
   disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLElement>;
-}> = ({ type, icon, disabled, onClick }) => {
+  title?: string;
+}> = ({ type, icon, disabled, onClick, title }) => {
   if (type === 'icon') {
-    return <Icon icon={icon || 'ellipsis'} className={styles.iconAction} onClick={onClick} />;
+    return (
+      <Button
+        size='small'
+        type={type}
+        className={styles.btnAction}
+        onClick={onClick}
+        title={title}
+        icon={icon || 'ellipsis'}
+      ></Button>
+    );
   }
   const props = {};
   if (isBoolean(disabled)) {
@@ -168,7 +178,7 @@ const EllipsisWidget: React.FC<{
   }
 
   return (
-    <Button size='small' type='secondary' className={styles.btnAction} onClick={onClick} {...props}>
+    <Button size='small' type='secondary' className={styles.btnAction} onClick={onClick} {...props} title={title}>
       <Icon icon={icon || 'ellipsis'} />
     </Button>
   );
@@ -330,6 +340,7 @@ export const TitleActionList: React.FC<
     nav: MenuNode[];
     more?: MenuNode[];
     moreIcon?: string;
+    moreTitle?: string;
     className?: string;
     iconService?: IMenubarIconService;
   } & BaseActionListProps
@@ -343,6 +354,7 @@ export const TitleActionList: React.FC<
     nav = [],
     more = [],
     moreIcon,
+    moreTitle,
     context = [],
     extraNavActions = [],
     moreAtFirst = false,
@@ -378,7 +390,13 @@ export const TitleActionList: React.FC<
 
     const moreAction =
       secondary.length > 0 ? (
-        <EllipsisWidget disabled={secondary[0].disabled} icon={moreIcon} type={type} onClick={handleShowMore} />
+        <EllipsisWidget
+          disabled={secondary[0].disabled}
+          icon={moreIcon}
+          type={type}
+          onClick={handleShowMore}
+          title={moreTitle}
+        />
       ) : null;
 
     return (
@@ -491,6 +509,7 @@ interface InlineMenuBarProps<T, U, K, M> extends Omit<BaseActionListProps, 'extr
   context?: TupleContext<T, U, K, M>;
   menus: IContextMenu;
   moreIcon?: string;
+  moreTitle?: string;
   separator?: IMenuSeparator;
   iconService?: IMenubarIconService;
 }
@@ -500,7 +519,7 @@ interface InlineMenuBarProps<T, U, K, M> extends Omit<BaseActionListProps, 'extr
 export function InlineMenuBar<T = undefined, U = undefined, K = undefined, M = undefined>(
   props: InlineMenuBarProps<T, U, K, M>,
 ): React.ReactElement<InlineMenuBarProps<T, U, K, M>> {
-  const { iconService, menus, context, moreIcon, separator = 'navigation', ...restProps } = props;
+  const { iconService, menus, context, moreIcon, moreTitle, separator = 'navigation', ...restProps } = props;
   const [navMenu, moreMenu] = useContextMenus(menus);
 
   // inline 菜单不取第二组，对应内容由关联 context menu 去渲染
@@ -510,6 +529,7 @@ export function InlineMenuBar<T = undefined, U = undefined, K = undefined, M = u
       nav={navMenu}
       more={separator === 'inline' ? [] : moreMenu}
       moreIcon={moreIcon}
+      moreTitle={moreTitle}
       context={context}
       iconService={iconService}
       {...restProps}

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -238,7 +238,7 @@ export const localizationBundle = {
     'scm.title': '源代码管理',
     'scm.action.git.refresh': '刷新',
     'scm.action.git.commit': '提交',
-    'scm.action.git.more': '提交',
+    'scm.action.git.more': '更多操作...',
     'scm.statusbar.repo': '当前仓库',
     'scm.provider.title': '代码仓库列表',
     'scm.provider.empty': '没有可用的源代码仓库',

--- a/packages/scm/src/browser/scm-view-container.tsx
+++ b/packages/scm/src/browser/scm-view-container.tsx
@@ -234,6 +234,7 @@ export const SCMViewContainer: FC<{ viewState: ViewState }> = (props) => {
             <InlineMenuBar
               menus={titleMenu}
               context={selectedRepo && selectedRepo.provider && [selectedRepo.provider]}
+              moreTitle={localize('scm.action.git.more', 'More Actions')}
             />
           ) : null
         }


### PR DESCRIPTION
### Types

- [ ] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a53e3f3</samp>

* Replace `EllipsisWidget` with `Button` component for more actions button in browser actions, and add `title` prop for tooltip ([link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L161-R173), [link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L171-R181))
* Add `moreTitle` prop to `EllipsisWidgetProps`, `ActionWidget`, `ActionGroup`, and `InlineMenuBarProps` interfaces to allow custom tooltip text for more actions button ([link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R343), [link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R357), [link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L381-R399), [link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R512))
* Pass `moreTitle` prop to `EllipsisWidget`, `ActionGroup`, and `InlineMenuBar` components from their parent components, using localized text from `i18n` module ([link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L503-R522), [link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R532), [link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-d39f067de76cf60473e10678e244136f8cfa5fab80c7b0f754b30628f62c2eaeR237))
* Change localization text for `scm.action.git.more` key from '提交' to '更多操作...' in `zh-CN.lang.ts` file to match more actions button meaning ([link](https://github.com/opensumi/core/pull/2905/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7L241-R241))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a53e3f3</samp>

Improved the usability and consistency of the action buttons in the browser UI. Used `Button` components with tooltips instead of `EllipsisWidget` for clarity. Updated the localization text for the more actions button in the SCM view.
