### PR TITLE
chore: remove deprecated usage of less expression

### DIFF
--- a/packages/addons/src/browser/toolbar-customize/style.module.less
+++ b/packages/addons/src/browser/toolbar-customize/style.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 
 .toolbar-customize-overlay {
   position: fixed;

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -57,7 +57,7 @@ renderApp({
   - 不包含对 OpenSumi runtime 依赖
   - 不包含对 OpenSumi 其他包的依赖
   - 自己的依赖自己管理
-- 脱离 ide-fw 去单独使用 `@opensumi/ide-components` 时，应手动 import 字体文件
+- 脱离 OpenSumi 去单独使用 `@opensumi/ide-components` 时，应手动 import 字体文件
 
   ```less
   @import '@opensumi/ide-components/lib/icon/iconfont/iconfont.css';

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -3,17 +3,14 @@
 ## Usage
 
 ### Icon/createFromIconfontCN
+
 ```tsx
 import React from 'react';
 
 import { createFromIconfontCN } from '@opensumi/ide-components/lib/icon/iconfont-cn';
 import { Icon } from '@opensumi/ide-components/lib/icon';
 
-type IconFontMap =
-  'icon-javascript'
-  | 'icon-java'
-  | 'icon-shoppingcart'
-  | 'icon-python';
+type IconFontMap = 'icon-javascript' | 'icon-java' | 'icon-shoppingcart' | 'icon-python';
 
 const IconFont = createFromIconfontCN<IconFontMap>({
   scriptUrl: [
@@ -36,6 +33,7 @@ export const Sample = () => (
 ```
 
 在 ide-framework 中可通过 appConfig 传入新 Icon/覆盖已存在的 Icon
+
 ```js
 renderApp({
   // ...
@@ -53,13 +51,14 @@ renderApp({
 ```
 
 ## Attention
-* components 包的定位是直接能对外使用，不限定于在 ide-framework 运行环境的组件
-* 因此需要注意的是，放到这里的组件应该是纯组件
-  * 不包含对 ide-framework runtime 依赖
-  * 不包含对 ide-framework 其他包的依赖
-  * 自己的依赖自己管理
-* 脱离 ide-fw 去单独使用 `@opensumi/ide-components` 时，应手动 import 字体文件
+
+- components 包的定位是直接能对外使用，不限定于在 ide-framework 运行环境的组件
+- 因此需要注意的是，放到这里的组件应该是纯组件
+  - 不包含对 ide-framework runtime 依赖
+  - 不包含对 ide-framework 其他包的依赖
+  - 自己的依赖自己管理
+- 脱离 ide-fw 去单独使用 `@opensumi/ide-components` 时，应手动 import 字体文件
 
   ```less
-  @import '~@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
+  @import '@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
   ```

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -32,7 +32,7 @@ export const Sample = () => (
 );
 ```
 
-在 ide-framework 中可通过 appConfig 传入新 Icon/覆盖已存在的 Icon
+在 OpenSumi 中可通过 appConfig 传入新 Icon/覆盖已存在的 Icon
 
 ```js
 renderApp({
@@ -52,10 +52,10 @@ renderApp({
 
 ## Attention
 
-- components 包的定位是直接能对外使用，不限定于在 ide-framework 运行环境的组件
+- components 包的定位是直接能对外使用，不限定于在 OpenSumi 运行环境的组件
 - 因此需要注意的是，放到这里的组件应该是纯组件
-  - 不包含对 ide-framework runtime 依赖
-  - 不包含对 ide-framework 其他包的依赖
+  - 不包含对 OpenSumi runtime 依赖
+  - 不包含对 OpenSumi 其他包的依赖
   - 自己的依赖自己管理
 - 脱离 ide-fw 去单独使用 `@opensumi/ide-components` 时，应手动 import 字体文件
 

--- a/packages/connection/README.md
+++ b/packages/connection/README.md
@@ -76,7 +76,7 @@ export default class FileTreeService extends Disposable {
     this.getFiles();
   }
    createFile = async () => {
-    const {content} = await this.fileService.resolveContent('/Users/franklife/work/ide/ac/ide-framework/tsconfig.json');
+    const {content} = await this.fileService.resolveContent('{file_path}');
     const file = await this.fileAPI.createFile({
       name: 'name' + Date.now() + '\n' + content,
       path: 'path' + Date.now(),
@@ -107,7 +107,7 @@ constructor(@Inject(FileServicePath) protected readonly fileService) {
 方法调用会转换成一个远程调用进行响应，返回结果
 
 ```javascript
-const { content } = await this.fileService.resolveContent('/Users/franklife/work/ide/ac/ide-framework/tsconfig.json');
+const { content } = await this.fileService.resolveContent('{file_path}');
 ```
 
 **前端服务(frontService)** 后端服务(backService) 即在 Browser 环境下运行的代码暴露的能力

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -228,7 +228,7 @@ describe('connection', () => {
       return bProtocol.getProxy(testMainIdentifier).$errorFunction();
     }
 
-    const testUri = Uri.file('/Users/franklife/work/ide/ac4/ide-framework/README.md');
+    const testUri = Uri.file('/workspace/README.md');
     await bProtocol.getProxy(testMainIdentifier).$test();
     await bProtocol.getProxy(testMainIdentifier).$getUri(testUri);
     expect(mockMainIndetifierMethod.mock.calls.length).toBe(1);

--- a/packages/core-browser/src/components/actions/styles.module.less
+++ b/packages/core-browser/src/components/actions/styles.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 .icon,
 .submenuIcon {
   width: 12px;

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -160,7 +160,7 @@ export interface AppConfig {
   /**
    * @ClientOption
    * 额外的 ConfigProvider
-   * 可以让 IDE-framework 内部的 ReactDOM.render 调用时
+   * 可以让 OpenSumi 内部的 ReactDOM.render 调用时
    * 都被其包裹一层，以达到额外的 context 传递效果
    */
   extraContextProvider?: React.ComponentType<React.PropsWithChildren<any>>;

--- a/packages/core-browser/src/style/entry.less
+++ b/packages/core-browser/src/style/entry.less
@@ -5,7 +5,7 @@
  * 请不要在这个文件直接添加样式内容
  */
 
-@import '~@opensumi/ide-components/lib/style/base.less';
+@import '@opensumi/ide-components/lib/style/base.less';
 @import './variable.less';
 
 @import './icon/index.less';

--- a/packages/core-browser/src/style/icon.less
+++ b/packages/core-browser/src/style/icon.less
@@ -1,7 +1,7 @@
-// 本地IDE集成时引入该文件: @opensumi/ide-core-browser/lib/style/icon.less
-@import '~@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
+// 本地 IDE 集成时需引入该文件: @opensumi/ide-core-browser/lib/style/icon.less
+@import '@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
 @import './octicons/octicons.css';
-@import '~@vscode/codicons/dist/codicon.css';
+@import '@vscode/codicons/dist/codicon.css';
 
 .kaitian-icon {
   font-size: 14px;

--- a/packages/core-browser/src/style/override.less
+++ b/packages/core-browser/src/style/override.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 @import './variable.less';
 
 .codicon[class*='codicon-'] {

--- a/packages/core-browser/src/style/toolbar.less
+++ b/packages/core-browser/src/style/toolbar.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 
 .kt-toolbar-location {
   position: relative;

--- a/packages/core-common/src/types/reporter.ts
+++ b/packages/core-common/src/types/reporter.ts
@@ -68,7 +68,6 @@ export interface PerformanceData extends PointData {
   duration: number;
 }
 
-// ide-framework 调用
 export const IReporterService = Symbol('IReporterService');
 
 export interface IReporterTimer {

--- a/packages/debug/src/browser/view/configuration/debug-configuration.module.less
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 
 .debug_action_bar_internal {
   padding: 0px 8px;

--- a/packages/debug/src/browser/view/watch/debug-watch.module.less
+++ b/packages/debug/src/browser/view/watch/debug-watch.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .debug_watch_node {
   height: 22px;

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -1,5 +1,5 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .kt_workbench_editor {
   height: 100%;

--- a/packages/editor/src/browser/navigation.module.less
+++ b/packages/editor/src/browser/navigation.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 
 .navigation_container {
   display: flex;

--- a/packages/file-tree-next/src/browser/file-tree-node.module.less
+++ b/packages/file-tree-next/src/browser/file-tree-node.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .file_tree_node {
   height: 22px;

--- a/packages/file-tree-next/src/browser/file-tree.module.less
+++ b/packages/file-tree-next/src/browser/file-tree.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .file_tree {
   overflow: hidden;

--- a/packages/markers/src/browser/markers-filter.module.less
+++ b/packages/markers/src/browser/markers-filter.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .markerFilterContent {
   display: flex;

--- a/packages/menu-bar/src/browser/menu-bar.module.less
+++ b/packages/menu-bar/src/browser/menu-bar.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .menubarWrapper {
   display: flex;

--- a/packages/output/src/browser/output.module.less
+++ b/packages/output/src/browser/output.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .output {
   font-size: @base-font-size;

--- a/packages/scm/src/browser/components/scm-provider-list.module.less
+++ b/packages/scm/src/browser/components/scm-provider-list.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 
 .scmSelect {
   width: 100%;

--- a/packages/scm/src/browser/components/scm-resource-input.module.less
+++ b/packages/scm/src/browser/components/scm-resource-input.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .scmHeader {
   padding: 0 8px;

--- a/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 :global {
   .monaco-editor {

--- a/packages/scm/src/browser/scm.module.less
+++ b/packages/scm/src/browser/scm.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .view {
   width: 100%;

--- a/packages/startup/entry/styles.less
+++ b/packages/startup/entry/styles.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 #main {
   display: flex;

--- a/packages/startup/entry/web-lite/styles.less
+++ b/packages/startup/entry/web-lite/styles.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 #main {
   display: flex;

--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 .resizeWrapper {
   width: 100%;

--- a/packages/terminal-next/src/browser/component/terminal.module.less
+++ b/packages/terminal-next/src/browser/component/terminal.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-components/lib/style/mixins.less';
+@import '@opensumi/ide-components/lib/style/mixins.less';
 
 .terminalWrapper {
   height: 100%;

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -1,5 +1,3 @@
-// @import '@opensumi/ide-monaco-enhance/lib/browser/styles.module.less';
-
 .peekview-widget .head {
   box-sizing: border-box;
   display: flex;

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.less
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.less
@@ -1,4 +1,4 @@
-// @import '~@opensumi/ide-monaco-enhance/lib/browser/styles.module.less';
+// @import '@opensumi/ide-monaco-enhance/lib/browser/styles.module.less';
 
 .peekview-widget .head {
   box-sizing: border-box;


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58eb995</samp>

*  Changed import paths of `@opensumi/ide-components` and `@opensumi/ide-core-browser` from using `~` to using relative paths in various `.less` files to avoid potential conflicts with webpack alias or other loaders ([link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-4c0119657bc88abfae15a129671e5d525d83d43e011da50d917df1e1ccee9cadL1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-e0c30a50911943639dd78782678bc9140f085740da214eeb804b1817c310c306L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-4597d7ec10e6ce2e45ab08755a8583d676de6b76c163d000aa4b100f82e470f8L8-R8), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-ed9322c6c5533fc2b9c68b6d7bbc37cd25d85ffb6f0086a1fe4595ca6b61641bL1-R4), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-620db825c2ddc84072c0fc0983496c29d141287910f61ba3004525619281bd3dL1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-78716d418280bb462c90bbb02a3055c27022ce72c628a02dcefd70d03f7bbc58L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-de3b9f29f1b757cc7f3b63a9728ae7b99dfb3762a06932f572b4f238bf82cbcdL1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-d19dafb38002b9cf10c585b975ee221bbc4ceac775f2635e45cdff8b628b0cecL1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-a92d3c79f3be1ec7533bcb9d276d6cacbd8a6a9df61391c4cfd7fcf805025ce1L1-R2), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-47e5c21acc3df52792bb2d9da11e12675e03e24c4e76d0824f689c6d92f3d9b7L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-1fb3b357c52030563876fcb950ab18a4dcb163724362271de47e29821acd62b7L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-e0b9cac329c9ee96aff82882e1249772e352a20efbf5a5bd0ea211c64c4fdc9aL1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-aee48a3591970fb895cdbe98779e3fbf1eee08c59b4608170f88b13ec7aa6926L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-420086e5466afed9765091eb57763ecf0dcf7d5c416bf8dd8340ca9dd2225f8fL1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-6c53f27ebf14014bc474df3d6fbed11c6e8e5b126608ce5238c9d901ec5dd4e4L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-72cacce28fa24b09c05928131c620bf9fb3f67b0a1268ddf3737c0f425905280L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-34a101b784633edf5acc43308559ca4420f19934d1e51b119329bbc5d7da5499L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-d3a47c29ae29a77aae8603a48d4aa4073e6543bf32b5178faa899c5333085934L1-R1), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-a6ce8684ec41df8e27177c2d9b465ade4e3159b9ee2e462327e2933e62930a6dL1-R1))
* Added blank lines to `packages/components/README.md` to improve readability and formatting in the `Usage` and `Icon/createFromIconfontCN` sections ([link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-4b24799689b090701f0bc36ea0a508a962d448d1feaec58750b8fcd61e150c21R6), [link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-4b24799689b090701f0bc36ea0a508a962d448d1feaec58750b8fcd61e150c21R36))
* Adjusted indentation of the `type IconFontMap` declaration in `packages/components/README.md` to align with the following code block in the `Icon/createFromIconfontCN` section ([link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-4b24799689b090701f0bc36ea0a508a962d448d1feaec58750b8fcd61e150c21L12-R13))
* Added a space between `本地` and `IDE` in the comment of `packages/core-browser/src/style/icon.less` for consistency ([link](https://github.com/opensumi/core/pull/2906/files?diff=unified&w=0#diff-ed9322c6c5533fc2b9c68b6d7bbc37cd25d85ffb6f0086a1fe4595ca6b61641bL1-R4))

<!-- Additional content -->
<!-- 补充额外内容 -->

close #2884

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58eb995</samp>

This pull request fixes some import paths and documentation issues in various packages. It changes the import paths of `@opensumi/ide-components` and `@opensumi/ide-core-browser` from using `~` to using relative paths to avoid potential conflicts with webpack alias or other loaders. It also fixes some formatting and import issues in `packages/components/README.md` and aligns the `type IconFontMap` declaration with the code style of the rest of the file.
