### PR TITLE
fix: delete watcherMap when watcher is disposed

### DIFF
--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -332,8 +332,14 @@ export class FileServiceClient implements IFileServiceClient {
   // 添加监听文件
   async watchFileChanges(uri: URI, excludes?: string[]): Promise<IFileServiceWatcher> {
     const _uri = this.convertUri(uri.toString());
-    if (this.uriWatcherMap.has(_uri.toString())) {
-      return this.uriWatcherMap.get(_uri.toString())!;
+    const originWatcher = this.uriWatcherMap.get(_uri.toString());
+    if (originWatcher) {
+      // 这里兼容重连逻辑，重连时 watcher 会 disposed，需要重新生成
+      if (!originWatcher.isDisposed()) {
+        return originWatcher;
+      } else {
+        this.uriWatcherMap.delete(_uri.toString());
+      }
     }
 
     const id = this.watcherId++;

--- a/packages/file-service/src/browser/watcher.ts
+++ b/packages/file-service/src/browser/watcher.ts
@@ -43,4 +43,8 @@ export class FileSystemWatcher implements IFileServiceWatcher {
       this.fileServiceClient.unwatchFileChanges(this.watchId),
     ]) as any;
   }
+
+  isDisposed() {
+    return this.toDispose.disposed;
+  }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0729dc</samp>

*  Handle file watcher disposal on connection loss ([link](https://github.com/opensumi/core/pull/2910/files?diff=unified&w=0#diff-c58ed466108ee979e7430150d6df721c4699a340d271efa604745034909f5c02L335-R342))
  - Check if the original watcher is still valid using `isDisposed()` method ([link](https://github.com/opensumi/core/pull/2910/files?diff=unified&w=0#diff-b071c3875a7197ddfc014f9b96f649b064ea16ea545963d57db864883bef3f1dR46-R49))
* Add `isDisposed()` method to `FileServiceWatcher` class ([link](https://github.com/opensumi/core/pull/2910/files?diff=unified&w=0#diff-b071c3875a7197ddfc014f9b96f649b064ea16ea545963d57db864883bef3f1dR46-R49))

Issue: #2909 

重连时 node 会 dispose watcher，但是前端没有处理，所以需要加个判断

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0729dc</samp>

This pull request improves the file service's resilience to connection loss by handling the disposal and recreation of file watchers. It modifies `file-service-client.ts` and `watcher.ts` to implement this logic.
