### PR TITLE
fix: improve file tree render speed

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -224,11 +224,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
 
   public startWatchFileEvent() {
     this._readyToWatch = true;
-    return Promise.all(
-      this._watchRootsQueue.map(async (uri) => {
-        await this.watchFilesChange(uri);
-      }),
-    );
+    return Promise.all(this._watchRootsQueue.map((uri) => this.watchFilesChange(uri)));
   }
 
   async resolveChildren(parent?: Directory) {

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -382,7 +382,8 @@ export class FileTreeModelService {
         });
       }),
     );
-    await this.fileTreeService.startWatchFileEvent();
+    // 文件变化的监听不应该阻塞渲染
+    this.fileTreeService.startWatchFileEvent();
     this.onFileTreeModelChangeEmitter.fire(this._treeModel);
 
     this._whenReady.resolve();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 81fc227</samp>

*  Simplify the code by removing unnecessary promises ([link](https://github.com/opensumi/core/pull/2912/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bL227-R227))

<!-- Additional content -->
<!-- 补充额外内容 -->

fixed https://github.com/opensumi/ide-startup/issues/75.

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 81fc227</samp>

This pull request improves the file tree component by simplifying the code and reducing the blocking of the UI. It removes unnecessary `async` and `await` keywords from `file-tree.service.ts` and moves the file change listener to a non-blocking position in `file-tree-model.service.ts`.
