### PR TITLE
fix: lazy refresh treeview

### DIFF
--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/order */
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeModel } from '@opensumi/ide-components';
-import { DisposableCollection, Emitter, Event, Disposable } from '@opensumi/ide-core-browser';
+import { DisposableCollection, Emitter, Event, Disposable, runWhenIdle } from '@opensumi/ide-core-browser';
 import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/common/index';
 import { ICommentsService } from '../../common/index';
 
@@ -185,7 +185,9 @@ export class CommentModelService extends Disposable {
 
   async refresh() {
     await this.whenReady;
-    this.treeModel.root.refresh();
+    runWhenIdle(() => {
+      this.treeModel.root.refresh();
+    });
   }
 
   async collapsedAll() {

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -827,22 +827,22 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
             }
           }
         } else if (CompositeTreeNode.is(child)) {
+          // 如果节点默认展开，则忽略后续操作
           if (!(child as CompositeTreeNode).expanded) {
-            // 如果节点没有默认展开，则设置一下展开状态
             (child as CompositeTreeNode).isExpanded = true;
-          }
-          const extraExpandedPaths = await (child as CompositeTreeNode).resolveChildrens(token);
-          if (token?.isCancellationRequested) {
-            return;
-          }
-          if (extraExpandedPaths) {
-            toExpandPaths = toExpandPaths.filter((path) => !extraExpandedPaths.find((a) => a.includes(path)));
-          }
-          if (toExpandPaths.length > 0 && !token?.isCancellationRequested) {
-            toExpandPaths =
-              (await (child as CompositeTreeNode).refreshTreeNodeByPaths([...toExpandPaths], token, origin)) || [];
+            const extraExpandedPaths = await (child as CompositeTreeNode).resolveChildrens(token);
             if (token?.isCancellationRequested) {
               return;
+            }
+            if (extraExpandedPaths) {
+              toExpandPaths = toExpandPaths.filter((path) => !extraExpandedPaths.find((a) => a.includes(path)));
+            }
+            if (toExpandPaths.length > 0 && !token?.isCancellationRequested) {
+              toExpandPaths =
+                (await (child as CompositeTreeNode).refreshTreeNodeByPaths([...toExpandPaths], token, origin)) || [];
+              if (token?.isCancellationRequested) {
+                return;
+              }
             }
           }
         }

--- a/packages/markers/src/browser/tree/tree-model.service.ts
+++ b/packages/markers/src/browser/tree/tree-model.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeModel } from '@opensumi/ide-components';
-import { DisposableCollection, Deferred, Emitter, Event, URI } from '@opensumi/ide-core-browser';
+import { DisposableCollection, Deferred, Emitter, Event, URI, runWhenIdle } from '@opensumi/ide-core-browser';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 
 import { IMarkerService } from '../../common/types';
@@ -194,7 +194,9 @@ export class MarkerModelService {
 
   async refresh() {
     await this.whenReady;
-    this.treeModel.root.refresh();
+    runWhenIdle(() => {
+      this.treeModel.root.refresh();
+    });
   }
 
   dispose() {

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -9,6 +9,7 @@ import {
   formatLocalize,
   Schemes,
   Disposable,
+  runWhenIdle,
 } from '@opensumi/ide-core-browser';
 import { AbstractContextMenuService, ICtxMenuRenderer, MenuId } from '@opensumi/ide-core-browser/lib/menu/next/index';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
@@ -313,7 +314,9 @@ export class SearchModelService extends Disposable {
 
   async refresh() {
     await this.whenReady;
-    this.treeModel.root.refresh();
+    runWhenIdle(() => {
+      this.treeModel.root.refresh();
+    });
   }
 
   collapsedAll() {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e9b526</samp>

* Imported `runWhenIdle` function from `@opensumi/ide-core-browser` to defer tree model refresh tasks until the browser is idle ([link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aL4-R4), [link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-42f83ee327e23a92d792dadfdf5c60ee4747da2046d00b7fa0b216c86617c7b0L3-R3), [link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-c6ccdc698e2af8f106bb6c52f1bff009aae31f8ddb8ba5a8c7b0a54314eacb95R12))
* Modified `refresh` methods of `CommentModelService`, `MarkerModelService`, and `SearchModelService` classes to use `runWhenIdle` and improve performance and responsiveness ([link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aL188-R190), [link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-42f83ee327e23a92d792dadfdf5c60ee4747da2046d00b7fa0b216c86617c7b0L197-R199), [link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-c6ccdc698e2af8f106bb6c52f1bff009aae31f8ddb8ba5a8c7b0a54314eacb95L316-R319))
* Modified `refreshTreeNodeByPaths` method of `CompositeTreeNode` class to skip refresh logic if the node is already expanded by default and avoid unnecessary work ([link](https://github.com/opensumi/core/pull/2915/files?diff=unified&w=0#diff-e06f6e62a0aec13e178cf8da9849199b77cb52168b1f794591f7ced4a2e1d109L830-R846))

<!-- Additional content -->
<!-- 补充额外内容 -->
close #2908

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e9b526</samp>

This pull request enhances the performance and responsiveness of various tree models in the application by using `runWhenIdle` to defer refresh operations until the browser is idle. It also optimizes the `refreshTreeNodeByPaths` method of the `CompositeTreeNode` class to skip unnecessary work.
