### PR TITLE
chore: add v2.26.0 breakingchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,42 @@
 
 **Full Changelog**: https://github.com/opensumi/core/compare/v2.25.4...v2.26.0
 
+<a name="breaking_changes_2.26.0">[Breaking Changes:](#breaking_changes_2.26.0)</a>
+
+#### 1. Remove `~` prefix in the less file [#2906](https://github.com/opensumi/core/pull/2906)
+
+The `~` expression is deprecated on the latest less-loader, see [less-loader/#webpack-resolver](https://webpack.js.org/loaders/less-loader/#webpack-resolver).
+
+If you have the `Module not found` error, you can update your webpack config like this:
+
+```ts
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.less$/i,
+        use: [
+          {
+            loader: 'style-loader',
+          },
+          {
+            loader: 'css-loader',
+          },
+          {
+            loader: 'less-loader',
+            options: {
+              lessOptions: {
+                paths: [path.resolve(__dirname, 'node_modules')],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ## v2.25.0
 
 ### What's New Features


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c5206d</samp>

* Remove `~` prefix from less imports to avoid module resolution errors ([link](https://github.com/opensumi/core/pull/2916/files?diff=unified&w=0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR78-R113))
  - Update changelog to document the breaking change and provide migration instructions ([link](https://github.com/opensumi/core/pull/2916/files?diff=unified&w=0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR78-R113))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c5206d</samp>

This change updates the changelog to document a breaking change in the less file syntax that affects users of the core package. It explains how to remove the deprecated `~` prefix and adjust the webpack config to resolve modules correctly.
