### PR TITLE
chore: update Overlay component props

### DIFF
--- a/packages/components/src/overlay/index.tsx
+++ b/packages/components/src/overlay/index.tsx
@@ -9,8 +9,8 @@ declare type getContainerFunc = () => HTMLElement;
 
 export interface IOverlayProps {
   visible: boolean;
-  afterClose: ModalProps['afterClose'];
-  onClose: ModalProps['onCancel'];
+  afterClose?: ModalProps['afterClose'];
+  onClose?: ModalProps['onCancel'];
   children?: React.ReactNode;
   className?: string;
   width?: number;

--- a/packages/components/src/overlay/index.tsx
+++ b/packages/components/src/overlay/index.tsx
@@ -8,12 +8,13 @@ import './styles.less';
 declare type getContainerFunc = () => HTMLElement;
 
 export interface IOverlayProps {
-  className?: string;
-  width?: number;
-  maskClosable?: boolean;
   visible: boolean;
   afterClose: ModalProps['afterClose'];
   onClose: ModalProps['onCancel'];
+  children?: React.ReactNode;
+  className?: string;
+  width?: number;
+  maskClosable?: boolean;
   closable?: ModalProps['closable'];
   title?: ModalProps['title'];
   footer?: JSX.Element[] | JSX.Element;


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a246f6</samp>

*  Add `children` prop to `IOverlayProps` interface and rearrange prop order ([link](https://github.com/opensumi/core/pull/2922/files?diff=unified&w=0#diff-aaa89ddf059912c20ec07af920fdf478dafd078510e4b7bb17da50afc0a502c1L11-R17))

<!-- Additional content -->
<!-- 补充额外内容 -->
<img width="537" alt="image" src="https://github.com/opensumi/core/assets/9823838/0cf171a3-5e2d-4a11-89fb-57407960c9de">
目前单独引入 Overlay 组件使用严格模式下会有类型报错问题

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a246f6</samp>

Added `children` prop to overlay component and reordered props. This enables the overlay to display any content and makes the props easier to use and understand.
