### PR TITLE
fix: less import css path

### DIFF
--- a/packages/core-browser/src/style/icon.less
+++ b/packages/core-browser/src/style/icon.less
@@ -1,7 +1,7 @@
 // 本地 IDE 集成时需引入该文件: @opensumi/ide-core-browser/lib/style/icon.less
-@import '@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
+@import '~@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
 @import './octicons/octicons.css';
-@import '@vscode/codicons/dist/codicon.css';
+@import '~@vscode/codicons/dist/codicon.css';
 
 .kaitian-icon {
   font-size: 14px;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->



<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e478846</samp>

Fixed icon imports in `icon.less` to use webpack aliases. This improves compatibility with local IDE integration.
