### PR TITLE
fix: add "locks" dep for split-panel element memo

### DIFF
--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -321,7 +321,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
         );
         return result;
       }),
-    [children, childList, resizeHandleClassName, dynamicTarget, resizeDelegates.current, hides],
+    [children, childList, resizeHandleClassName, dynamicTarget, resizeDelegates.current, hides, locks],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76d4a10</samp>

*  Add `locks` dependency to `useMemo` hook for `panels` array ([link](https://github.com/opensumi/core/pull/2928/files?diff=unified&w=0#diff-0ba57727cf1cb6b9943e69eb29748565c7838180ba86afdab95c6f9476e9c13bL324-R324)). This ensures that the split-panel component re-renders and resizes the panels when the `locks` state changes. The `locks` state is an array of booleans that indicates whether each panel is locked or not. A locked panel cannot be dragged by the handle. This feature allows users to lock and unlock panels in the `split-panel.tsx` file.

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76d4a10</samp>

Added `locks` dependency to `useMemo` hook in `split-panel.tsx`. This enables locking and unlocking panels in the split-panel component.
close #2926 