### PR TITLE
fix(component): remove select component unreasonable span selector

### DIFF
--- a/packages/components/src/select/index.tsx
+++ b/packages/components/src/select/index.tsx
@@ -103,7 +103,7 @@ export const Option: React.FC<
 > = ({ value, children, disabled, onClick, className, ...otherProps }) => (
   <span
     {...otherProps}
-    className={classNames(className, { 'kt-option-disabled': disabled })}
+    className={classNames(className, 'kt-select-option-wrapper', { 'kt-option-disabled': disabled })}
     onClick={() => onClick && !disabled && onClick(value)}
   >
     {children}

--- a/packages/components/src/select/style.less
+++ b/packages/components/src/select/style.less
@@ -130,7 +130,7 @@
   }
 
   .kt-select-option-select {
-    span {
+    & > span {
       display: inline-block;
       margin: 0 2px;
       width: calc(100% - 4px);
@@ -150,7 +150,7 @@
     margin-bottom: -3px;
   }
 
-  span {
+  & > span {
     color: var(--kt-selectDropdown-foreground);
     background-color: var(--kt-selectDropdown-background);
     cursor: pointer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -22729,9 +22729,9 @@ __metadata:
   linkType: hard
 
 "word-wrap@npm:^1.0.3, word-wrap@npm:^1.2.3, word-wrap@npm:~1.2.3":
-  version: 1.2.3
-  resolution: "word-wrap@npm:1.2.3"
-  checksum: 30b48f91fcf12106ed3186ae4fa86a6a1842416df425be7b60485de14bec665a54a68e4b5156647dec3a70f25e84d270ca8bc8cd23182ed095f5c7206a938c1f
+  version: 1.2.4
+  resolution: "word-wrap@npm:1.2.4"
+  checksum: 8f1f2e0a397c0e074ca225ba9f67baa23f99293bc064e31355d426ae91b8b3f6b5f6c1fc9ae5e9141178bb362d563f55e62fd8d5c31f2a77e3ade56cb3e35bd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes


### Background or solution

原来的 select component 会给每一项的任意层级的子 span 都设置上不合理的样式

![image](https://github.com/opensumi/core/assets/13938334/6c375f6c-bdd6-4b20-9559-02b2a792efeb)


### Changelog

remove select component unreasonable span selector
