### PR TITLE
feat: add activate keybinding for explorer and search view

### DIFF
--- a/packages/explorer/src/browser/explorer-contribution.ts
+++ b/packages/explorer/src/browser/explorer-contribution.ts
@@ -19,6 +19,7 @@ export class ExplorerContribution implements ClientAppContribution, ComponentCon
       title: localize('explorer.title'),
       priority: 10,
       containerId: EXPLORER_CONTAINER_ID,
+      activateKeyBinding: 'ctrlcmd+shift+e',
     });
   }
 

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -1124,11 +1124,6 @@ export class FileTreeContribution
       keybinding: 'space',
       when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
-
-    bindings.registerKeybinding({
-      command: FILE_COMMANDS.REVEAL_IN_EXPLORER.id,
-      keybinding: 'ctrlcmd+shift+e',
-    });
   }
 
   registerToolbarItems(registry: ToolbarRegistry) {

--- a/packages/search/src/browser/search.contribution.ts
+++ b/packages/search/src/browser/search.contribution.ts
@@ -307,6 +307,7 @@ export class SearchContribution
       title: localize('search.title'),
       component: Search,
       priority: 9,
+      activateKeyBinding: 'ctrlcmd+shift+f',
     });
   }
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a01956</samp>

*  Add keybindings for activating the explorer and search views in the sidebar ([link](https://github.com/opensumi/core/pull/2930/files?diff=unified&w=0#diff-1d4a7b2321996a32efc03b6995b327bc0e5b165159104c49906f51093fe042ebR22), [link](https://github.com/opensumi/core/pull/2930/files?diff=unified&w=0#diff-7b41d36021a048f04b5bf401da6544aac088e3e318a52efc7ebac344b9187ca0R310))
* Remove redundant keybinding for revealing the current file in the explorer view ([link](https://github.com/opensumi/core/pull/2930/files?diff=unified&w=0#diff-bdf4535ed45e87a7f0e14a93bcdfa4cb8e15897afab8509f9a4cdf7f433f2645L1127-L1131))

<!-- Additional content -->
<!-- 补充额外内容 -->
![image](https://github.com/opensumi/core/assets/9823838/2fe41650-f6f7-4602-84dd-6deaec8912ae)

为资源管理器和搜索面板添加激活快捷键，需要注意的是，`cmd+shift+e` 快捷键在 Chrome 默认情况下为保留快捷键，无法生效，需要搭配 https://github.com/opensumi/shortcuts-guard 使用（待适配）

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a01956</samp>

This pull request adds or updates keybindings for activating the explorer and search views in the sidebar, following the conventions of VS Code and other IDEs. It also removes a redundant keybinding for revealing the current file in the explorer view.
