### PR TITLE
v2.26: fix: fix save sequence for editor to avoid conflict when save frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,42 @@
 
 **Full Changelog**: https://github.com/opensumi/core/compare/v2.25.4...v2.26.0
 
+<a name="breaking_changes_2.26.0">[Breaking Changes:](#breaking_changes_2.26.0)</a>
+
+#### 1. Remove `~` prefix in the less file [#2906](https://github.com/opensumi/core/pull/2906)
+
+The `~` expression is deprecated on the latest less-loader, see [less-loader/#webpack-resolver](https://webpack.js.org/loaders/less-loader/#webpack-resolver).
+
+If you have the `Module not found` error, you can update your webpack config like this:
+
+```ts
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.less$/i,
+        use: [
+          {
+            loader: 'style-loader',
+          },
+          {
+            loader: 'css-loader',
+          },
+          {
+            loader: 'less-loader',
+            options: {
+              lessOptions: {
+                paths: [path.resolve(__dirname, 'node_modules')],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ## v2.25.0
 
 ### What's New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@
 - [Previous Changelogs](https://github.com/opensumi/core/releases)
 - [Previous Breaking Changes](https://github.com/opensumi/core/wiki/Breaking-Changes)
 
+## v2.26.0
+
+### What's New Features
+
+- feat: bottom panel support accordion by @Aaaaash in https://github.com/opensumi/core/pull/2798
+- feat: support InlineCompletionItemProvider.handleDidShowCompletionItem API by @erha19 in https://github.com/opensumi/core/pull/2799
+- feat: support search preference by @ext expression by @erha19 in https://github.com/opensumi/core/pull/2813
+- feat: support overwrite when editor save by @winjo in https://github.com/opensumi/core/pull/2846
+- feat: support use npmmirror cdn url by @bytemain in https://github.com/opensumi/core/pull/2830
+- feat: editor tab support revealInExplorer by @pipiiiiii in https://github.com/opensumi/core/pull/2848
+- feat: support merge editor accept left or right by @Ricbet in https://github.com/opensumi/core/pull/2839
+- feat: improve render blank lines breakpoints by @Ricbet in https://github.com/opensumi/core/pull/2832
+- fix: merge editor not support wordwrap by @Ricbet in https://github.com/opensumi/core/pull/2836
+- feat: support resolve in merge editor by @Ricbet in https://github.com/opensumi/core/pull/2819
+- feat: improve merge editor result title by @Ricbet in https://github.com/opensumi/core/pull/2835
+- feat: support register view container in bottom panel by @Aaaaash in https://github.com/opensumi/core/pull/2847
+- feat: support merge editor reset by @Ricbet in https://github.com/opensumi/core/pull/2841
+- feat: support scm setInputBoxEnablement API & getSourceControl API by @Ricbet in https://github.com/opensumi/core/pull/2863
+- feat: support merge editor minimap by @Ricbet in https://github.com/opensumi/core/pull/2859
+- feat: implement scm contributes by @Ricbet in https://github.com/opensumi/core/pull/2867
+- feat: infer second terminal cwd from the first one by @bytemain in https://github.com/opensumi/core/pull/2852
+- feat: support showBreakpointsInOverviewRuler by @Ricbet in https://github.com/opensumi/core/pull/2902
+
+### Style Changes
+
+- fix: left panel style lower right menu style by @wangxiaojuan in https://github.com/opensumi/core/pull/2818
+- fix: update the style of the currently selected file menu by @wangxiaojuan in https://github.com/opensumi/core/pull/2810
+- fix: navigation menu style rendering problem by @wangxiaojuan in https://github.com/opensumi/core/pull/2807
+- fix: button white-space style by @Aaaaash in https://github.com/opensumi/core/pull/2817
+- style: merge editor left view padding by @Ricbet in https://github.com/opensumi/core/pull/2837
+- style: input disabled style by @Ricbet in https://github.com/opensumi/core/pull/2861
+- style: change resize handler z-index by @erha19 in https://github.com/opensumi/core/pull/2868
+- fix: left panel style lower right menu style by @wangxiaojuan in https://github.com/opensumi/core/pull/2888
+- style: improve secondary button hover style by @erha19 in https://github.com/opensumi/core/pull/2890
+- chore: remove deprecated usage of less expression by @erha19 in https://github.com/opensumi/core/pull/2906
+
+### Other Changes
+
+- chore: add lint rules for ignore warning by @pipiiiiii in https://github.com/opensumi/core/pull/2855
+- chore: remove unused import vars by @pipiiiiii in https://github.com/opensumi/core/pull/2856
+- chore: fix warnings and remove some useless code by @erha19 in https://github.com/opensumi/core/pull/2795
+- fix: add key for MenuActionList by @winjo in https://github.com/opensumi/core/pull/2809
+- fix: worker api not execute by @AhkunTa in https://github.com/opensumi/core/pull/2879
+- fix: add keys for fragment by @Aaaaash in https://github.com/opensumi/core/pull/2812
+- fix: plugin panel height adjustment by @wangxiaojuan in https://github.com/opensumi/core/pull/2823
+- fix: terminal adds top whitespace by @wangxiaojuan in https://github.com/opensumi/core/pull/2821
+- fix: check undefined of preference item default value by @winjo in https://github.com/opensumi/core/pull/2834
+- fix: add key for preference item description list by @winjo in https://github.com/opensumi/core/pull/2840
+- chore: update xterm.js by @Aaaaash in https://github.com/opensumi/core/pull/2825
+- chore: optimize split panel re-render by @Aaaaash in https://github.com/opensumi/core/pull/2851
+- chore(deps): bump semver from 6.3.0 to 7.5.2 by @dependabot in https://github.com/opensumi/core/pull/2826
+- chore: remove sanitize in marked options by @bytemain in https://github.com/opensumi/core/pull/2850
+- fix: unwatchFileChanges api do not work on file service by @miserylee in https://github.com/opensumi/core/pull/2824
+- chore(deps): bump semver from 5.7.1 to 5.7.2 in /tools/electron by @dependabot in https://github.com/opensumi/core/pull/2882
+- fix: add version to download-extension targetDirName by @pipiiiiii in https://github.com/opensumi/core/pull/2877
+- fix: except breakpoint blank description by @Ricbet in https://github.com/opensumi/core/pull/2878
+- fix(ext): extension cannot reset validateMessage to undefined by @bytemain in https://github.com/opensumi/core/pull/2889
+- fix: debug console repl not show by @Ricbet in https://github.com/opensumi/core/pull/2898
+- fix: title-bar add i18n tips (#2903) by @zhuzeyu22 in https://github.com/opensumi/core/pull/2905
+- fix(preference): rerender Select component if localized string changed by @bytemain in https://github.com/opensumi/core/pull/2892
+- chore: optimize treeview re-render by @Aaaaash in https://github.com/opensumi/core/pull/2833
+
+## New Contributors
+
+- @zhuzeyu22 made their first contribution in https://github.com/opensumi/core/pull/2905
+
+**Full Changelog**: https://github.com/opensumi/core/compare/v2.25.4...v2.26.0
+
 ## v2.25.0
 
 ### What's New Features

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.25.4",
+  "version": "2.26.0",
   "npmClient": "npm",
   "packages": ["packages/*", "tools/dev-tool", "tools/playwright", "tools/cli-engine"],
   "command": {

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-addons",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-collaboration",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-comments",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/order */
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeModel } from '@opensumi/ide-components';
-import { DisposableCollection, Emitter, Event, Disposable } from '@opensumi/ide-core-browser';
+import { DisposableCollection, Emitter, Event, Disposable, runWhenIdle } from '@opensumi/ide-core-browser';
 import { WorkbenchEditorService } from '@opensumi/ide-editor/lib/common/index';
 import { ICommentsService } from '../../common/index';
 
@@ -185,7 +185,9 @@ export class CommentModelService extends Disposable {
 
   async refresh() {
     await this.whenReady;
-    this.treeModel.root.refresh();
+    runWhenIdle(() => {
+      this.treeModel.root.refresh();
+    });
   }
 
   async collapsedAll() {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-components",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "@opensumi/ide-components",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -827,22 +827,22 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
             }
           }
         } else if (CompositeTreeNode.is(child)) {
+          // 如果节点默认展开，则忽略后续操作
           if (!(child as CompositeTreeNode).expanded) {
-            // 如果节点没有默认展开，则设置一下展开状态
             (child as CompositeTreeNode).isExpanded = true;
-          }
-          const extraExpandedPaths = await (child as CompositeTreeNode).resolveChildrens(token);
-          if (token?.isCancellationRequested) {
-            return;
-          }
-          if (extraExpandedPaths) {
-            toExpandPaths = toExpandPaths.filter((path) => !extraExpandedPaths.find((a) => a.includes(path)));
-          }
-          if (toExpandPaths.length > 0 && !token?.isCancellationRequested) {
-            toExpandPaths =
-              (await (child as CompositeTreeNode).refreshTreeNodeByPaths([...toExpandPaths], token, origin)) || [];
+            const extraExpandedPaths = await (child as CompositeTreeNode).resolveChildrens(token);
             if (token?.isCancellationRequested) {
               return;
+            }
+            if (extraExpandedPaths) {
+              toExpandPaths = toExpandPaths.filter((path) => !extraExpandedPaths.find((a) => a.includes(path)));
+            }
+            if (toExpandPaths.length > 0 && !token?.isCancellationRequested) {
+              toExpandPaths =
+                (await (child as CompositeTreeNode).refreshTreeNodeByPaths([...toExpandPaths], token, origin)) || [];
+              if (token?.isCancellationRequested) {
+                return;
+              }
             }
           }
         }

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-connection",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-browser",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "@opensumi/ide-core-browser",
   "files": [
     "lib",

--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -321,7 +321,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
         );
         return result;
       }),
-    [children, childList, resizeHandleClassName, dynamicTarget, resizeDelegates.current, hides],
+    [children, childList, resizeHandleClassName, dynamicTarget, resizeDelegates.current, hides, locks],
   );
 
   React.useEffect(() => {

--- a/packages/core-browser/src/style/icon.less
+++ b/packages/core-browser/src/style/icon.less
@@ -1,7 +1,7 @@
 // 本地 IDE 集成时需引入该文件: @opensumi/ide-core-browser/lib/style/icon.less
-@import '@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
+@import '~@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
 @import './octicons/octicons.css';
-@import '@vscode/codicons/dist/codicon.css';
+@import '~@vscode/codicons/dist/codicon.css';
 
 .kaitian-icon {
   font-size: 14px;

--- a/packages/core-common/package.json
+++ b/packages/core-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-common",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "@opensumi/ide-core-common",
   "files": [
     "lib",

--- a/packages/core-electron-main/package.json
+++ b/packages/core-electron-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-electron-main",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "browser-preload"

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-node",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "@opensumi/ide-core-node",
   "files": [
     "lib",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-debug",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/decoration/package.json
+++ b/packages/decoration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-decoration",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,6 +22,7 @@
     "@opensumi/ide-file-service": "workspace:*",
     "@opensumi/ide-monaco": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
+    "p-queue": "^6.6.2",
     "vscode-oniguruma": "1.5.1"
   },
   "devDependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,7 +22,6 @@
     "@opensumi/ide-file-service": "workspace:*",
     "@opensumi/ide-monaco": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
-    "p-queue": "^6.6.2",
     "vscode-oniguruma": "1.5.1"
   },
   "devDependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-editor",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -1,5 +1,4 @@
 import debounce from 'lodash/debounce';
-import PQueue from 'p-queue';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import {

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -1,4 +1,5 @@
 import debounce from 'lodash/debounce';
+import PQueue from 'p-queue';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import {
@@ -114,6 +115,8 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
 
   @Autowired(IHashCalculateService)
   private readonly hashCalculateService: IHashCalculateService;
+
+  private saveQueue = new PQueue({ concurrency: 1 });
 
   private monacoModel: ITextModel;
 
@@ -356,59 +359,62 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
   }
 
   async save(force = false, reason: SaveReason = SaveReason.Manual): Promise<boolean> {
-    await this.formatOnSave(reason);
-    // 发送willSave并等待完成
-    await this.eventBus.fireAndAwait(
-      new EditorDocumentModelWillSaveEvent({
-        uri: this.uri,
-        reason,
-        language: this.languageId,
-      }),
-    );
-    if (!this.editorPreferences['editor.askIfDiff']) {
-      force = true;
-    }
-    if (!this.dirty) {
-      return false;
-    }
-    const versionId = this.monacoModel.getVersionId();
-    const lastSavingTask = this.savingTasks[this.savingTasks.length - 1];
-    if (lastSavingTask && lastSavingTask.versionId === versionId) {
-      lastSavingTask.cancel();
-      const task = this.savingTasks.pop();
-      task?.dispose();
-    }
-    const task = new SaveTask(this.uri, versionId, this.monacoModel.getAlternativeVersionId(), this.getText(), force);
-    this.savingTasks.push(task);
-    if (this.savingTasks.length > 0) {
-      this.initSave();
-    }
-    const res = await task.finished;
-    if (res.state === SaveTaskResponseState.SUCCESS) {
-      this.monacoModel.pushStackElement();
-      return true;
-    } else if (res.state === SaveTaskResponseState.ERROR) {
-      if (res.errorMessage !== SaveTaskErrorCause.CANCEL) {
-        this.logger.error(res.errorMessage);
-        this.messageService.error(localize('doc.saveError.failed') + '\n' + res.errorMessage);
+    const doSave = async (force = false, reason: SaveReason = SaveReason.Manual) => {
+      await this.formatOnSave(reason);
+      // 发送willSave并等待完成
+      await this.eventBus.fireAndAwait(
+        new EditorDocumentModelWillSaveEvent({
+          uri: this.uri,
+          reason,
+          language: this.languageId,
+        }),
+      );
+      if (!this.editorPreferences['editor.askIfDiff']) {
+        force = true;
+      }
+      if (!this.dirty) {
+        return false;
+      }
+      const versionId = this.monacoModel.getVersionId();
+      const lastSavingTask = this.savingTasks[this.savingTasks.length - 1];
+      if (lastSavingTask && lastSavingTask.versionId === versionId) {
+        lastSavingTask.cancel();
+        const task = this.savingTasks.pop();
+        task?.dispose();
+      }
+      const task = new SaveTask(this.uri, versionId, this.monacoModel.getAlternativeVersionId(), this.getText(), force);
+      this.savingTasks.push(task);
+      if (this.savingTasks.length > 0) {
+        this.initSave();
+      }
+      const res = await task.finished;
+      if (res.state === SaveTaskResponseState.SUCCESS) {
+        this.monacoModel.pushStackElement();
+        return true;
+      } else if (res.state === SaveTaskResponseState.ERROR) {
+        if (res.errorMessage !== SaveTaskErrorCause.CANCEL) {
+          this.logger.error(res.errorMessage);
+          this.messageService.error(localize('doc.saveError.failed') + '\n' + res.errorMessage);
+        }
+        return false;
+      } else if (res.state === SaveTaskResponseState.DIFF) {
+        const diffAndSave = localize('doc.saveError.diffAndSave');
+        const overwrite = localize('doc.saveError.overwrite');
+        this.messageService
+          .error(formatLocalize('doc.saveError.diff', this.uri.toString()), [diffAndSave, overwrite])
+          .then((res) => {
+            if (res === diffAndSave) {
+              this.compareAndSave();
+            } else if (res === overwrite) {
+              doSave(true);
+            }
+          });
+        this.logger.error('The file cannot be saved, the version is inconsistent with the disk');
+        return false;
       }
       return false;
-    } else if (res.state === SaveTaskResponseState.DIFF) {
-      const diffAndSave = localize('doc.saveError.diffAndSave');
-      const overwrite = localize('doc.saveError.overwrite');
-      this.messageService
-        .error(formatLocalize('doc.saveError.diff', this.uri.toString()), [diffAndSave, overwrite])
-        .then((res) => {
-          if (res === diffAndSave) {
-            this.compareAndSave();
-          } else if (res === overwrite) {
-            this.save(true);
-          }
-        });
-      this.logger.error('The file cannot be saved, the version is inconsistent with the disk');
-      return false;
-    }
-    return false;
+    };
+    return this.saveQueue.add(doSave.bind(this));
   }
 
   private async compareAndSave() {

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -18,6 +18,7 @@ import {
   REPORT_NAME,
   SaveTaskErrorCause,
   SaveTaskResponseState,
+  Throttler,
   URI,
 } from '@opensumi/ide-core-browser';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
@@ -116,7 +117,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
   @Autowired(IHashCalculateService)
   private readonly hashCalculateService: IHashCalculateService;
 
-  private saveQueue = new PQueue({ concurrency: 1 });
+  private saveQueue = new Throttler();
 
   private monacoModel: ITextModel;
 
@@ -414,7 +415,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
       }
       return false;
     };
-    return this.saveQueue.add(doSave.bind(this));
+    return this.saveQueue.queue(doSave);
   }
 
   private async compareAndSave() {

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-electron-basic",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-explorer",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/express-file-server/package.json
+++ b/packages/express-file-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-express-file-server",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-manager",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/extension-storage/package.json
+++ b/packages/extension-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-storage",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "hosted"

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-scheme",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "@opensumi/ide-core-common": "workspace:*",
     "@opensumi/ide-core-node": "workspace:*",
-    "@opensumi/ide-file-service": "workspace:*",
-    "p-queue": "^6.6.2"
+    "@opensumi/ide-file-service": "workspace:*"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "workspace:*",

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@opensumi/ide-core-common": "workspace:*",
     "@opensumi/ide-core-node": "workspace:*",
-    "@opensumi/ide-file-service": "workspace:*"
+    "@opensumi/ide-file-service": "workspace:*",
+    "p-queue": "^6.6.2"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "workspace:*",

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-search",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-service",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -332,8 +332,14 @@ export class FileServiceClient implements IFileServiceClient {
   // 添加监听文件
   async watchFileChanges(uri: URI, excludes?: string[]): Promise<IFileServiceWatcher> {
     const _uri = this.convertUri(uri.toString());
-    if (this.uriWatcherMap.has(_uri.toString())) {
-      return this.uriWatcherMap.get(_uri.toString())!;
+    const originWatcher = this.uriWatcherMap.get(_uri.toString());
+    if (originWatcher) {
+      // 这里兼容重连逻辑，重连时 watcher 会 disposed，需要重新生成
+      if (!originWatcher.isDisposed()) {
+        return originWatcher;
+      } else {
+        this.uriWatcherMap.delete(_uri.toString());
+      }
     }
 
     const id = this.watcherId++;

--- a/packages/file-service/src/browser/watcher.ts
+++ b/packages/file-service/src/browser/watcher.ts
@@ -43,4 +43,8 @@ export class FileSystemWatcher implements IFileServiceWatcher {
       this.fileServiceClient.unwatchFileChanges(this.watchId),
     ]) as any;
   }
+
+  isDisposed() {
+    return this.toDispose.disposed;
+  }
 }

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-tree-next",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -224,11 +224,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
 
   public startWatchFileEvent() {
     this._readyToWatch = true;
-    return Promise.all(
-      this._watchRootsQueue.map(async (uri) => {
-        await this.watchFilesChange(uri);
-      }),
-    );
+    return Promise.all(this._watchRootsQueue.map((uri) => this.watchFilesChange(uri)));
   }
 
   async resolveChildren(parent?: Directory) {

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -382,7 +382,8 @@ export class FileTreeModelService {
         });
       }),
     );
-    await this.fileTreeService.startWatchFileEvent();
+    // 文件变化的监听不应该阻塞渲染
+    this.fileTreeService.startWatchFileEvent();
     this.onFileTreeModelChangeEmitter.fire(this._treeModel);
 
     this._whenReady.resolve();

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-i18n",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-keymaps",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/logs-core/package.json
+++ b/packages/logs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-logs",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/main-layout/package.json
+++ b/packages/main-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-main-layout",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "@opensumi/ide-main-layout",
   "files": [
     "lib",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markdown",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markers",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/markers/src/browser/tree/tree-model.service.ts
+++ b/packages/markers/src/browser/tree/tree-model.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector, Optional } from '@opensumi/di';
 import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeModel } from '@opensumi/ide-components';
-import { DisposableCollection, Deferred, Emitter, Event, URI } from '@opensumi/ide-core-browser';
+import { DisposableCollection, Deferred, Emitter, Event, URI, runWhenIdle } from '@opensumi/ide-core-browser';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 
 import { IMarkerService } from '../../common/types';
@@ -194,7 +194,9 @@ export class MarkerModelService {
 
   async refresh() {
     await this.whenReady;
-    this.treeModel.root.refresh();
+    runWhenIdle(() => {
+      this.treeModel.root.refresh();
+    });
   }
 
   dispose() {

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-menu-bar",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "@opensumi/ide-menu-bar",
   "files": [
     "lib",

--- a/packages/monaco-enhance/package.json
+++ b/packages/monaco-enhance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco-enhance",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/opened-editor/package.json
+++ b/packages/opened-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-opened-editor",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/outline/package.json
+++ b/packages/outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-outline",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-output",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-overlay",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-preferences",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-process",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/quick-open/package.json
+++ b/packages/quick-open/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-quick-open",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/remote-opener/package.json
+++ b/packages/remote-opener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-remote-opener",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-scm",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-search",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -9,6 +9,7 @@ import {
   formatLocalize,
   Schemes,
   Disposable,
+  runWhenIdle,
 } from '@opensumi/ide-core-browser';
 import { AbstractContextMenuService, ICtxMenuRenderer, MenuId } from '@opensumi/ide-core-browser/lib/menu/next/index';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
@@ -313,7 +314,9 @@ export class SearchModelService extends Disposable {
 
   async refresh() {
     await this.whenReady;
-    this.treeModel.root.refresh();
+    runWhenIdle(() => {
+      this.treeModel.root.refresh();
+    });
   }
 
   collapsedAll() {

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-startup",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/static-resource/package.json
+++ b/packages/static-resource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-static-resource",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/status-bar/package.json
+++ b/packages/status-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-status-bar",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-storage",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-task",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-terminal-next",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-testing",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-theme",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-toolbar",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/sumi",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "typings": "index.d.ts",
   "license": "MIT",
   "repository": {

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-userstorage",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-utils",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/variable/package.json
+++ b/packages/variable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-variable",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-webview",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/workspace-edit/package.json
+++ b/packages/workspace-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace-edit",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "files": [
     "lib",
     "src"

--- a/tools/cli-engine/package.json
+++ b/tools/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/cli-engine",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "Integration engine runtime for opensumi-cli and opensumi extension",
   "license": "MIT",
   "files": [

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/playwright",
-  "version": "2.25.4",
+  "version": "2.26.0",
   "description": "E2E test module for OpenSumi",
   "files": [
     "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,7 @@ __metadata:
     "@opensumi/ide-theme": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
+    p-queue: ^6.6.2
     vscode-oniguruma: 1.5.1
   languageName: unknown
   linkType: soft
@@ -3057,6 +3058,7 @@ __metadata:
     "@opensumi/ide-file-service": "workspace:*"
     "@opensumi/ide-monaco": "workspace:*"
     "@opensumi/ide-overlay": "workspace:*"
+    p-queue: ^6.6.2
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,7 +2916,6 @@ __metadata:
     "@opensumi/ide-theme": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
-    p-queue: ^6.6.2
     vscode-oniguruma: 1.5.1
   languageName: unknown
   linkType: soft
@@ -3058,7 +3057,6 @@ __metadata:
     "@opensumi/ide-file-service": "workspace:*"
     "@opensumi/ide-monaco": "workspace:*"
     "@opensumi/ide-overlay": "workspace:*"
-    p-queue: ^6.6.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

duplicated PR of https://github.com/opensumi/core/pull/2927 merging to v2.26:
<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4451cfb</samp>

*  Bump the project and package versions to 2.26.0 for the new release ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-2d72bdead8afa0798d18995311992d684348a694c2d5e214e8e4d2b6153e4821L2-R2), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-df3cd802ef2ee0d19e9faf149e6fbbd15e63eefa2014e3ba429e640198ff6d98L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-fbbeadafb0b171ebe551b70f17529dd1a139ee78bac808994b0c71117d3dba58L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-73ace1e36fc4344d2281ce9fb5322c481d33b3b14124d090df41a53b83add843L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-3b3cdcfb595936698c30bafbbd6ed21e5ee505ba3ce4edc9cc92b4c1c56de13eL3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-4b41fb9ee9b0ae16a09c6433f584405eb7504ca74aff934d142539c60d832ec7L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-6ae140bb4089c086c24ea2f46c4641810da08bb624a519b48aac99c89ffab6c1L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-0fbcbe6a4539d0cf31056cadc94edc00345da1c4e24194cd6b3da328d9b5ca26L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-2752b9165a97768ed32ff72f5107017c64ea8aa0e9d80e54f3103fed6c3befefL3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-4ab5bf726d0813cd862123b2515e4201cc0c9b67031365c01107c10a0daf6b4bL3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-e278e797e6f9750ac0aeb3957b4c54b297c496e94c996fe29774b75c3a987611L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-f4eedd0a8aaf55cc64de9e66438e075fb5c0c992b6fd2039bf5863b06cea99a0L3-R3), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-a47158dde10eabf64c58fe317a1b353a277fd1993c8ac7cb08e9a0f5e7c6de45L3-R3))
*  Add a new section to the `CHANGELOG.md` file to summarize the new features, style changes, and other changes in the v2.26.0 release ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R113))
*  Optimize the tree view rendering by skipping the refresh of the child nodes that are already expanded by default in the `CompositeTreeNode` class ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-e06f6e62a0aec13e178cf8da9849199b77cb52168b1f794591f7ced4a2e1d109L830-R846))
*  Throttle the save operations of the editor document model by using the `Throttler` class and a `saveQueue` in the `EditorDocumentModel` class ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510R20), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510R119-R120), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L359-R417))
*  Throttle the refresh of the comment tree model by using the `Throttler` class in the `CommentModelService` class ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aL4-R4), [link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aL188-R190))
*  Defer the refresh of the comment tree model until the browser is idle by using the `runWhenIdle` function in the `CommentModelService` class ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aL4-R4))
*  Include the `locks` prop as a dependency of the `useMemo` hook in the `SplitPanel` component to trigger a re-render when the lock state of the split panel handles changes ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-0ba57727cf1cb6b9943e69eb29748565c7838180ba86afdab95c6f9476e9c13bL324-R324))
*  Fix the import statement of the `icon.less` file to use the `~` prefix to indicate that the imported file is a module and not a relative path ([link](https://github.com/opensumi/core/pull/2931/files?diff=unified&w=0#diff-ed9322c6c5533fc2b9c68b6d7bbc37cd25d85ffb6f0086a1fe4595ca6b61641bL2-R4))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4451cfb</samp>

This pull request updates the project and package versions to 2.26.0 and adds a new section to the `CHANGELOG.md` file for the release. It also improves the performance and responsiveness of the comment tree model and the editor document model by using `Throttler` and `runWhenIdle` utilities. Additionally, it fixes a bug in the `SplitPanel` component and a style issue in the `icon.less` file.
