### PR TITLE
feat: change createRef to useRef

### DIFF
--- a/packages/components/src/recycle-tree/basic/index.tsx
+++ b/packages/components/src/recycle-tree/basic/index.tsx
@@ -54,7 +54,7 @@ export const BasicRecycleTree: React.FC<IBasicRecycleTreeProps> = ({
   const isDisposed = useRef<boolean>(false);
   const treeService = useRef<BasicTreeService>();
   const treeHandle = useRef<IRecycleTreeHandle>();
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const renderTreeNode = useCallback(
     (props: INodeRendererWrapProps) => (

--- a/packages/debug/src/browser/editor/debug-hover.view.tsx
+++ b/packages/debug/src/browser/editor/debug-hover.view.tsx
@@ -24,7 +24,7 @@ export const DebugHoverView = observer(() => {
 
   const [model, setModel] = React.useState<{ treeModel?: DebugHoverModel; variable?: DebugVariable }>({});
   const [treeLayoutHeight, setTreeLayoutHeight] = React.useState<number>(DEFAULT_LAYOUT_HEIGHT);
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     debugHoverTreeModelService.onDidUpdateTreeModelOrVariable(async (data: IDebugHoverUpdateData) => {

--- a/packages/debug/src/browser/view/variables/debug-variables.view.tsx
+++ b/packages/debug/src/browser/view/variables/debug-variables.view.tsx
@@ -34,7 +34,7 @@ export const DebugVariableView = observer(({ viewState }: React.PropsWithChildre
 
   const { width, height } = viewState;
 
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
   const [model, setModel] = React.useState<TreeModel>();
 
   const debugVariablesModelService = useInjectable<DebugVariablesModelService>(DebugVariablesModelService);

--- a/packages/debug/src/browser/view/watch/debug-watch.view.tsx
+++ b/packages/debug/src/browser/view/watch/debug-watch.view.tsx
@@ -34,7 +34,7 @@ export const DebugWatchView = observer(({ viewState }: React.PropsWithChildren<{
 
   const { height } = viewState;
 
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
   const [model, setModel] = React.useState<TreeModel>();
 
   const debugWatchModelService = useInjectable<DebugWatchModelService>(DebugWatchModelService);

--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -1,14 +1,13 @@
 import { observer } from 'mobx-react-lite';
 import React, {
-  createRef,
   memo,
   MouseEvent,
   DragEvent,
   PropsWithChildren,
-  RefObject,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -52,7 +51,7 @@ export const ExtensionTabBarTreeView = observer(
 
     const { height } = viewState;
     const { canSelectMany } = model.treeViewOptions || {};
-    const wrapperRef: RefObject<HTMLDivElement> = createRef();
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
 
     const handleTreeReady = useCallback(
       (handle: IRecycleTreeHandle) => {

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
@@ -30,7 +30,7 @@ export const FILE_TREE_DIALOG_HEIGHT = 22;
 
 export const FileDialog = ({ options, model, isOpenDialog }: React.PropsWithChildren<IFileDialogProps>) => {
   const dialogService = useInjectable<IDialogService>(IDialogService);
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
   const [fileName, setFileName] = React.useState<string>('');
   const [isReady, setIsReady] = React.useState<boolean>(false);
   const [selectPath, setSelectPath] = React.useState<string>('');

--- a/packages/markers/src/browser/markers-tree.view.tsx
+++ b/packages/markers/src/browser/markers-tree.view.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useCallback, RefObject, createRef } from 'react';
+import React, { FC, useEffect, useState, useCallback, useRef } from 'react';
 
 import { IRecycleTreeHandle, RecycleTree } from '@opensumi/ide-components';
 import { ViewState, useInjectable, Disposable } from '@opensumi/ide-core-browser';
@@ -101,7 +101,7 @@ const Empty: FC = () => {
  */
 export const MarkerPanel = ({ viewState }: { viewState: ViewState }) => {
   const markerModelService = useInjectable<MarkerModelService>(MarkerModelService);
-  const wrapperRef: RefObject<HTMLDivElement> = createRef();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const handleOuterClick = useCallback(() => {
     // 空白区域点击，取消焦点状态

--- a/packages/opened-editor/src/browser/opened-editor.tsx
+++ b/packages/opened-editor/src/browser/opened-editor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 import {
   RecycleTree,
@@ -24,7 +24,7 @@ export const ExplorerOpenEditorPanel = ({ viewState }: React.PropsWithChildren<{
 
   const { width, height } = viewState;
 
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const openedEditorModelService = useInjectable<OpenedEditorModelService>(OpenedEditorModelService);
   const { decorationService, labelService, commandService } = openedEditorModelService;

--- a/packages/outline/src/browser/outline.tsx
+++ b/packages/outline/src/browser/outline.tsx
@@ -1,14 +1,5 @@
 import debounce from 'lodash/debounce';
-import React, {
-  PropsWithChildren,
-  useCallback,
-  RefObject,
-  MouseEvent,
-  useState,
-  createRef,
-  useEffect,
-  memo,
-} from 'react';
+import React, { PropsWithChildren, useCallback, MouseEvent, useState, useEffect, memo, useRef } from 'react';
 
 import { RecycleTree, IRecycleTreeHandle, INodeRendererWrapProps, TreeNodeType } from '@opensumi/ide-components';
 import { ViewState } from '@opensumi/ide-core-browser';
@@ -25,7 +16,7 @@ import { OutlineModelService } from './services/outline-model.service';
 export const OutlinePanel = ({ viewState }: PropsWithChildren<{ viewState: ViewState }>) => {
   const { height } = viewState;
 
-  const wrapperRef: RefObject<HTMLDivElement> = createRef();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const outlineModelService = useInjectable<OutlineModelService>(OutlineModelService);
   const [model, setModel] = useState<OutlineTreeModel | undefined>(undefined);

--- a/packages/output/src/browser/output.view.tsx
+++ b/packages/output/src/browser/output.view.tsx
@@ -1,6 +1,6 @@
 import { observer } from 'mobx-react-lite';
 import React from 'react';
-import { useEffect, createRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Select, Option } from '@opensumi/ide-components';
 import { useInjectable, ViewState, AppConfig } from '@opensumi/ide-core-browser';
@@ -13,7 +13,7 @@ import { OutputService } from './output.service';
 
 export const Output = observer(({ viewState }: { viewState: ViewState }) => {
   const outputService = useInjectable<OutputService>(OutputService);
-  const outputRef = createRef<HTMLDivElement>();
+  const outputRef = useRef<HTMLDivElement | null>(null);
   const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
 
   useEffect(() => {

--- a/packages/scm/src/browser/components/scm-resource-tree/index.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/index.tsx
@@ -1,6 +1,6 @@
 import clx from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { FC, useState, createRef, RefObject, useEffect, useCallback, memo } from 'react';
+import React, { FC, useState, useRef, useEffect, useCallback, memo } from 'react';
 
 import { RecycleTree, IRecycleTreeHandle, TreeNodeType, TreeModel } from '@opensumi/ide-components';
 import { isOSX } from '@opensumi/ide-core-browser';
@@ -23,7 +23,7 @@ export const SCMResourceTree: FC<{
   const [isReady, setIsReady] = useState<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
 
-  const wrapperRef: RefObject<HTMLDivElement> = createRef();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const scmTreeModelService = useInjectable<SCMTreeModelService>(SCMTreeModelService);
 

--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -1,15 +1,5 @@
 import cls from 'classnames';
-import React, {
-  memo,
-  useCallback,
-  PropsWithChildren,
-  createRef,
-  useState,
-  useMemo,
-  useEffect,
-  FormEvent,
-  useRef,
-} from 'react';
+import React, { memo, useCallback, PropsWithChildren, useState, useMemo, useEffect, FormEvent, useRef } from 'react';
 
 import { ValidateMessage } from '@opensumi/ide-components';
 import { DisposableCollection, Key, ViewState } from '@opensumi/ide-core-browser';
@@ -42,8 +32,8 @@ export interface ISearchContentResult {
 }
 
 export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewState }>) => {
-  const searchOptionRef = createRef<HTMLDivElement>();
-  const wrapperRef = createRef<HTMLDivElement>();
+  const searchOptionRef = useRef<HTMLDivElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   const searchTreeService = useInjectable<SearchTreeService>(ISearchTreeService);
   const searchBrowserService = useInjectable<IContentSearchClientService>(IContentSearchClientService);
   const [offsetTop, setOffsetTop] = useState<number>(0);

--- a/packages/terminal-next/src/browser/component/resize.view.tsx
+++ b/packages/terminal-next/src/browser/component/resize.view.tsx
@@ -23,7 +23,7 @@ export default observer((props: IResizeViewProps) => {
   const { group, shadow } = props;
   const [event, setEvent] = React.useState(false);
   const [wholeWidth, setWholeWidth] = React.useState(Infinity);
-  const whole = React.createRef<HTMLDivElement>();
+  const whole = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     if (whole.current && whole.current.clientHeight !== wholeWidth) {

--- a/packages/terminal-next/src/browser/component/terminal.view.tsx
+++ b/packages/terminal-next/src/browser/component/terminal.view.tsx
@@ -28,7 +28,7 @@ export default observer(() => {
   const { errors } = errorService;
   const { groups, currentGroupIndex, currentGroupId } = view;
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     const dispose = searchService.onOpen(() => {

--- a/packages/terminal-next/src/browser/component/terminal.widget.tsx
+++ b/packages/terminal-next/src/browser/component/terminal.widget.tsx
@@ -63,7 +63,7 @@ function renderError(error: ITerminalError, eService: ITerminalErrorService, vie
 }
 
 export default ({ widget, error, show }: IProps) => {
-  const content = React.createRef<HTMLDivElement>();
+  const content = React.useRef<HTMLDivElement | null>(null);
   const errorService = useInjectable<ITerminalErrorService>(ITerminalErrorService);
   const view = useInjectable<ITerminalGroupViewService>(ITerminalGroupViewService);
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Code Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4caffc</samp>

*  Replaced `createRef` with `useRef` in several components to avoid creating new refs on every render and to be consistent with the React hooks style ([link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L869-R869), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-f395d2cb7e258e73ab294dfc90242f98dd590f5544c9b95163a4938799806892L57-R57), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-a8da7b5898eb365345bbb90739e342fb537ec75d3fec58f7bd4334c52957c914L27-R27), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-5bf455899a9a952a71bdf869bea54fe57bc108438d50405054a649e4e81b4a32L37-R37), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-f60cf7062b56262fae2f49ae20fd57949aacf9154637f8459714e413d565246eL37-R37), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L64-R53), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-24559c9af18a57eeed0d5ec961bce6e772047267cc507f3cd7a7bb0b6a6f37b2L33-R33), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-e10b8b7cb6a4c5886d7adfc088c88b37ba0c9f5834d403a43456a654437387dbL104-R104), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-a588ea5dd58710682735b5229d390392880eeb7cb14240223490b074cf5de27bL27-R27), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-f4655a1356e17f221f3bc6912af2c495eeab17d91ba39f002eaebcc02944ac34L28-R19), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-b1cf2dc7c87bd2911081ab6a43de4c22b35817a11f42683c646c3278aa56e208L16-R16), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L26-R26), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-21c2d67af30c506b54dfa3451a605ec037134cf89487aa3468c0ac56f3851773L45-R36), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-a49bda93eaefef1571fc0c69406539ffaffa964f304ca80ba37499167338a8cbL26-R26), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-153b28379683b6e2dd3153a46fb4cc005e402ba96c7355c38c621175380f293aL31-R31), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-dcca27af441c153f5434db38953d91fe80ba5b7ea9e3d230e686ca763873e255L66-R66))
* Removed unused `createRef` imports from `RecycleTree.tsx`, `extension-tree-view.tsx`, `markers-tree.view.tsx`, `outline.tsx`, and `search.view.tsx` ([link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-705c7d0425e21b23f762710ebf99c06781b1a9525a9fad679a19a989bd69f118L2-R2), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L2-R2), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-e10b8b7cb6a4c5886d7adfc088c88b37ba0c9f5834d403a43456a654437387dbL1-R1), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-f4655a1356e17f221f3bc6912af2c495eeab17d91ba39f002eaebcc02944ac34L2-R2), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-21c2d67af30c506b54dfa3451a605ec037134cf89487aa3468c0ac56f3851773L2-R2))
* Added `useRef` imports to `opened-editor.tsx` and `output.view.tsx` where it was used ([link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-a588ea5dd58710682735b5229d390392880eeb7cb14240223490b074cf5de27bL1-R1), [link](https://github.com/opensumi/core/pull/2932/files?diff=unified&w=0#diff-b1cf2dc7c87bd2911081ab6a43de4c22b35817a11f42683c646c3278aa56e208L3-R3))

<!-- Additional content -->
<!-- 补充额外内容 -->
close #2899 
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4caffc</samp>

This pull request refactors various components in the `opensumi/core` repository to use the `useRef` hook instead of the `createRef` function for creating and accessing refs. This improves performance, readability, and consistency of the code. The pull request also removes some unused imports and adds a missing one.