### PR TITLE
fix: editor tab cannot be scrolled

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -178,6 +178,7 @@
   }
   .kt_editor_tabs_content {
     overflow-y: hidden;
+    height: 100%;
     display: inline-flex;
     position: relative;
     &.kt_on_drag_over {

--- a/packages/explorer/src/browser/explorer-contribution.ts
+++ b/packages/explorer/src/browser/explorer-contribution.ts
@@ -19,6 +19,7 @@ export class ExplorerContribution implements ClientAppContribution, ComponentCon
       title: localize('explorer.title'),
       priority: 10,
       containerId: EXPLORER_CONTAINER_ID,
+      activateKeyBinding: 'ctrlcmd+shift+e',
     });
   }
 

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -1124,11 +1124,6 @@ export class FileTreeContribution
       keybinding: 'space',
       when: `${FilesExplorerFocusedContext.raw} && !${FilesExplorerInputFocusedContext.raw} && !${FilesExplorerFilteredContext.raw}`,
     });
-
-    bindings.registerKeybinding({
-      command: FILE_COMMANDS.REVEAL_IN_EXPLORER.id,
-      keybinding: 'ctrlcmd+shift+e',
-    });
   }
 
   registerToolbarItems(registry: ToolbarRegistry) {

--- a/packages/search/src/browser/search.contribution.ts
+++ b/packages/search/src/browser/search.contribution.ts
@@ -307,6 +307,7 @@ export class SearchContribution
       title: localize('search.title'),
       component: Search,
       priority: 9,
+      activateKeyBinding: 'ctrlcmd+shift+f',
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22729,9 +22729,9 @@ __metadata:
   linkType: hard
 
 "word-wrap@npm:^1.0.3, word-wrap@npm:^1.2.3, word-wrap@npm:~1.2.3":
-  version: 1.2.3
-  resolution: "word-wrap@npm:1.2.3"
-  checksum: 30b48f91fcf12106ed3186ae4fa86a6a1842416df425be7b60485de14bec665a54a68e4b5156647dec3a70f25e84d270ca8bc8cd23182ed095f5c7206a938c1f
+  version: 1.2.4
+  resolution: "word-wrap@npm:1.2.4"
+  checksum: 8f1f2e0a397c0e074ca225ba9f67baa23f99293bc064e31355d426ae91b8b3f6b5f6c1fc9ae5e9141178bb362d563f55e62fd8d5c31f2a77e3ade56cb3e35bd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes

fix: https://github.com/opensumi/core/issues/2933
### Background or solution


### Changelog
fix: 修复编辑器Tab菜单无法滚动的问题

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44d2977</samp>

Fix editor height issue on window resize. Change the CSS style of the `editor.module.less` file to make the editor container fill its parent element.
