### PR TITLE
fix: editor tab cannot be scrolled

### DIFF
--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -180,6 +180,7 @@
     overflow-y: hidden;
     display: inline-flex;
     position: relative;
+    height: 100%;
     &.kt_on_drag_over {
       background-color: var(--editorGroup-dropBackground);
     }


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes

fix: https://github.com/opensumi/core/issues/2933

### Background or solution
![image](https://github.com/opensumi/core/assets/1762334/8df49eab-7d3a-4d84-8be5-3b5540f6ef4e)


### Changelog
fix: 修复编辑器Tab菜单无法滚动的问题


