### PR TITLE
fix: make panel view as observable

### DIFF
--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -90,7 +90,7 @@ const ContainerView: React.FC<{
   component: ComponentRegistryInfo;
   side: string;
   titleMenu: IMenu;
-}> = ({ component, titleMenu, side }) => {
+}> = observer(({ component, titleMenu, side }) => {
   const ref = React.useRef<HTMLElement | null>();
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const configContext = useInjectable<AppConfig>(AppConfig);
@@ -143,13 +143,13 @@ const ContainerView: React.FC<{
       </div>
     </div>
   );
-};
+});
 
 const BottomPanelView: React.FC<{
   component: ComponentRegistryInfo;
   side: string;
   titleMenu: IMenu;
-}> = ({ component, titleMenu, side }) => {
+}> = observer(({ component, titleMenu, side }) => {
   const ref = React.useRef<HTMLElement | null>();
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const configContext = useInjectable<AppConfig>(AppConfig);
@@ -201,7 +201,7 @@ const BottomPanelView: React.FC<{
       </div>
     </div>
   );
-};
+});
 
 export const RightTabPanelRenderer: React.FC = () => <BaseTabPanelView PanelView={ContainerView} />;
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

之前 Panelview 没有使用 `observer` 包裹，导致内部依赖的 mobx observable 状态更新并不生效，之前看似生效实际只是 re-render 太多顺便刷新

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cee758</samp>

*  Make panel components reactive to observable state changes using `observer` function from `mobx-react` ([link](https://github.com/opensumi/core/pull/2943/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L93-R93), [link](https://github.com/opensumi/core/pull/2943/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L146-R146), [link](https://github.com/opensumi/core/pull/2943/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L152-R152), [link](https://github.com/opensumi/core/pull/2943/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L204-R204))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cee758</samp>

Improved the main layout UI by making the panel components reactive to the active tab state using the `observer` function. Modified the file `panel.view.tsx` in the `main-layout` package.
