### PR TITLE
fix: fix treeview would not render

### DIFF
--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -38,7 +38,6 @@ export interface ExtensionTabBarTreeViewProps {
 
 export const ExtensionTabBarTreeView = observer(
   ({ viewState, model, dataProvider, treeViewId }: PropsWithChildren<ExtensionTabBarTreeViewProps>) => {
-    
     const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
     const decorationService = useInjectable<IDecorationsService>(IDecorationsService);
     const accordionService = useMemo(() => layoutService.getViewAccordionService(treeViewId), []);

--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -9,7 +9,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
+  useState,
 } from 'react';
 
 import { Injector } from '@opensumi/di';
@@ -38,8 +38,8 @@ export interface ExtensionTabBarTreeViewProps {
 
 export const ExtensionTabBarTreeView = observer(
   ({ viewState, model, dataProvider, treeViewId }: PropsWithChildren<ExtensionTabBarTreeViewProps>) => {
-    const isReady = useRef<boolean>(false);
-    const isEmpty = useRef<boolean>(dataProvider.isTreeEmpty);
+    const [isReady, setIsReady] = useState<boolean>(false);
+    const [isEmpty, setIsEmpty] = useState(dataProvider.isTreeEmpty);
     const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
     const decorationService = useInjectable<IDecorationsService>(IDecorationsService);
     const accordionService = useMemo(() => layoutService.getViewAccordionService(treeViewId), []);
@@ -54,7 +54,7 @@ export const ExtensionTabBarTreeView = observer(
 
     useEffect(() => {
       const disposable = dataProvider.onDidChangeEmpty(() => {
-        isEmpty.current = dataProvider.isTreeEmpty;
+        setIsEmpty(dataProvider.isTreeEmpty);
       });
       return () => disposable.dispose();
     }, []);
@@ -193,7 +193,7 @@ export const ExtensionTabBarTreeView = observer(
           await model.treeModel.ensureReady;
         }
         if (!unmouted) {
-          isReady.current = true;
+          setIsReady(true);
         }
       })();
       return () => {
@@ -222,8 +222,8 @@ export const ExtensionTabBarTreeView = observer(
         data-tree-view-id={treeViewId}
       >
         <TreeView
-          isReady={isReady.current}
-          isEmpty={isEmpty.current}
+          isReady={isReady}
+          isEmpty={isEmpty}
           height={height}
           handleTreeReady={handleTreeReady}
           handleItemClicked={handleItemClicked}

--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -38,8 +38,7 @@ export interface ExtensionTabBarTreeViewProps {
 
 export const ExtensionTabBarTreeView = observer(
   ({ viewState, model, dataProvider, treeViewId }: PropsWithChildren<ExtensionTabBarTreeViewProps>) => {
-    const [isReady, setIsReady] = useState<boolean>(false);
-    const [isEmpty, setIsEmpty] = useState(dataProvider.isTreeEmpty);
+    
     const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
     const decorationService = useInjectable<IDecorationsService>(IDecorationsService);
     const accordionService = useMemo(() => layoutService.getViewAccordionService(treeViewId), []);
@@ -51,13 +50,6 @@ export const ExtensionTabBarTreeView = observer(
       }
       return !state.collapsed && !state.hidden;
     }, [accordionService]);
-
-    useEffect(() => {
-      const disposable = dataProvider.onDidChangeEmpty(() => {
-        setIsEmpty(dataProvider.isTreeEmpty);
-      });
-      return () => disposable.dispose();
-    }, []);
 
     const { height } = viewState;
     const { canSelectMany } = model.treeViewOptions || {};
@@ -186,23 +178,6 @@ export const ExtensionTabBarTreeView = observer(
     );
 
     useEffect(() => {
-      let unmouted = false;
-      (async () => {
-        await model.whenReady;
-        if (model.treeModel && isVisible) {
-          await model.treeModel.ensureReady;
-        }
-        if (!unmouted) {
-          setIsReady(true);
-        }
-      })();
-      return () => {
-        unmouted = true;
-        model && model.removeNodeDecoration();
-      };
-    }, [model, isVisible]);
-
-    useEffect(() => {
       const handleBlur = () => {
         model.handleTreeBlur();
       };
@@ -222,9 +197,8 @@ export const ExtensionTabBarTreeView = observer(
         data-tree-view-id={treeViewId}
       >
         <TreeView
-          isReady={isReady}
-          isEmpty={isEmpty}
           height={height}
+          isVisible={isVisible}
           handleTreeReady={handleTreeReady}
           handleItemClicked={handleItemClicked}
           handleTwistierClick={handleTwistierClick}
@@ -237,6 +211,7 @@ export const ExtensionTabBarTreeView = observer(
           draggable={model.draggable}
           treeViewId={treeViewId}
           model={model}
+          dataProvider={dataProvider}
           decorationService={decorationService}
         />
       </div>
@@ -245,10 +220,10 @@ export const ExtensionTabBarTreeView = observer(
 );
 
 interface TreeViewProps {
-  isReady: boolean;
-  isEmpty: boolean;
+  isVisible: boolean;
   height: number;
   treeViewId: string;
+  dataProvider: TreeViewDataProvider;
   model: ExtensionTreeViewModel;
   handleTreeReady(handle: IRecycleTreeHandle): void;
   handleItemClicked(ev: MouseEvent, item: ExtensionTreeNode | ExtensionCompositeTreeNode, type: TreeNodeType): void;
@@ -265,8 +240,7 @@ interface TreeViewProps {
 
 function isTreeViewPropsEqual(prevProps: TreeViewProps, nextProps: TreeViewProps) {
   return (
-    prevProps.isReady === nextProps.isReady &&
-    prevProps.isEmpty === nextProps.isEmpty &&
+    prevProps.isVisible === nextProps.isVisible &&
     prevProps.model === nextProps.model &&
     prevProps.treeViewId === nextProps.treeViewId &&
     prevProps.height === nextProps.height
@@ -275,11 +249,11 @@ function isTreeViewPropsEqual(prevProps: TreeViewProps, nextProps: TreeViewProps
 
 const TreeView = memo(
   ({
-    isReady,
-    isEmpty,
     model,
     treeViewId,
     height,
+    isVisible,
+    dataProvider,
     handleTreeReady,
     handleItemClicked,
     handleTwistierClick,
@@ -292,6 +266,35 @@ const TreeView = memo(
     draggable,
     decorationService,
   }: TreeViewProps) => {
+    const [isReady, setIsReady] = useState<boolean>(false);
+    const [isEmpty, setIsEmpty] = useState(false);
+
+    useEffect(() => {
+      let unmouted = false;
+      (async () => {
+        await model.whenReady;
+        if (model.treeModel && isVisible) {
+          await model.treeModel.ensureReady;
+        }
+        if (!unmouted) {
+          setIsReady(true);
+        }
+      })();
+      return () => {
+        unmouted = true;
+        model && model.removeNodeDecoration();
+      };
+    }, [model, isVisible]);
+
+    useEffect(() => {
+      const disposable = dataProvider.onDidChangeEmpty(() => {
+        if (dataProvider.isTreeEmpty !== isEmpty) {
+          setIsEmpty(dataProvider.isTreeEmpty);
+        }
+      });
+      return () => disposable.dispose();
+    }, []);
+
     const renderTreeNode = useCallback(
       (props: INodeRendererProps) => (
         <TreeViewNode

--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -46,8 +46,8 @@ export const FILE_TREE_FILTER_DELAY = 500;
 const FilterableRecycleTree = RecycleTreeFilterDecorator(RecycleTree);
 
 export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState }>) => {
-  const isReady = useRef<boolean>(false);
-  const isLoading = useRef<boolean>(true);
+  const [isReady, setIsReady] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [outerActive, setOuterActive] = useState<boolean>(false);
   const [outerDragOver, setOuterDragOver] = useState<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
@@ -142,13 +142,13 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
       // 首次初始化完成时，监听后续变化，适配工作区变化事件
       // 监听工作区变化
       fileTreeModelService.onFileTreeModelChange(async (treeModel) => {
-        isLoading.current = true;
+        setIsLoading(true);
         if (treeModel) {
           // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
           await treeModel.ensureReady;
         }
-        isLoading.current = false;
         setModel(treeModel);
+        setIsLoading(false);
       });
     }
   }, [isReady]);
@@ -264,28 +264,27 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
 
   const ensureIsReady = useCallback(
     async (token: CancellationToken) => {
-      isReady.current = false;
       await fileTreeModelService.whenReady;
       if (token.isCancellationRequested) {
         return;
       }
-      // 文件服务已经初始化完毕，但文件树数据仍需要加载
-      isReady.current = true;
       if (fileTreeModelService.treeModel) {
         // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
         await fileTreeModelService.treeModel.ensureReady;
+        setModel(fileTreeModelService.treeModel);
         if (token.isCancellationRequested) {
           return;
         }
-        setModel(fileTreeModelService.treeModel);
-        // 文件树数据加载完毕
-        isLoading.current = false;
         if (wrapperRef.current) {
           fileTreeService.initContextKey(wrapperRef.current);
         }
       }
+      setIsLoading(false);
+      if (!disposableRef.current?.disposed) {
+        setIsReady(true);
+      }
     },
-    [fileTreeModelService],
+    [fileTreeModelService, disposableRef.current],
   );
 
   const handleTreeReady = useCallback(
@@ -366,8 +365,8 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
       onDrop={handleOuterDrop}
     >
       <FileTreeView
-        isLoading={isLoading.current}
-        isReady={isReady.current}
+        isLoading={isLoading}
+        isReady={isReady}
         height={height}
         model={model}
         iconTheme={iconTheme}

--- a/packages/scm/src/browser/components/scm-resource-tree/index.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/index.tsx
@@ -1,6 +1,6 @@
 import clx from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { FC, useState, useRef, createRef, RefObject, useEffect, useCallback, memo } from 'react';
+import React, { FC, useState, createRef, RefObject, useEffect, useCallback, memo } from 'react';
 
 import { RecycleTree, IRecycleTreeHandle, TreeNodeType, TreeModel } from '@opensumi/ide-components';
 import { isOSX } from '@opensumi/ide-core-browser';
@@ -20,7 +20,7 @@ export const SCMResourceTree: FC<{
   width: number;
   height: number;
 }> = observer(({ height }) => {
-  const isReady = useRef<boolean>(false);
+  const [isReady, setIsReady] = useState<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
 
   const wrapperRef: RefObject<HTMLDivElement> = createRef();
@@ -39,7 +39,7 @@ export const SCMResourceTree: FC<{
         // 这里需要重新取一下treeModel的值确保为最新的TreeModel
         await scmTreeModelService.treeModel.ensureReady;
       }
-      isReady.current = true;
+      setIsReady(true);
     })();
   }, []);
 
@@ -142,7 +142,7 @@ export const SCMResourceTree: FC<{
       data-name={TREE_FIELD_NAME}
     >
       <SCMTreeView
-        isReady={isReady.current}
+        isReady={isReady}
         model={model}
         height={height}
         onTreeReady={handleTreeReady}


### PR DESCRIPTION
This reverts commit d988f14827f73e71a29b463f972673809b10efdf.

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e616cd</samp>

*  Replace `useRef` hook with `useState` hook for some variables in three components (`ExtensionTabBarTreeView`, `FileTree`, and `SCMResourceTree`) to ensure proper re-rendering when the variables change ([link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L12-R12), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L41-R42), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L57-R57), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L196-R196), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L225-R226), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L49-R50), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L145-R151), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L267-R287), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L369-R369), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L3-R3), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L23-R23), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L42-R42), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L145-R145))
* Simplify the logic of the `ensureIsReady` function in the `FileTree` component by removing the redundant `isReady` variable and adding a dependency on the `disposableRef.current` variable ([link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L267-R287))
* Pass the updated state variables as props to the child components (`TreeView`, `FileTreeView`, and `SCMTreeView`) instead of the `current` property of the `useRef` hook ([link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L225-R226), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L369-R369), [link](https://github.com/opensumi/core/pull/2945/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L145-R145))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e616cd</samp>

This pull request refactors several components in the `extension`, `file-tree-next`, and `scm` packages to use the `useState` hook instead of the `useRef` hook for managing state variables. This improves the performance, readability, and reliability of the components and their rendering logic.
