### PR TITLE
fix: improve comment node style and support twistier click

### DIFF
--- a/packages/comments/src/browser/comments-panel.view.tsx
+++ b/packages/comments/src/browser/comments-panel.view.tsx
@@ -42,6 +42,7 @@ export const CommentsPanel: FC<{ viewState: ViewState }> = ({ viewState }) => {
         itemType={props.itemType}
         decorations={commentModelService.decorations.getDecorations(props.item as any)}
         defaultLeftPadding={8}
+        onTwistierClick={commentModelService.handleTwistierClick}
         onClick={commentModelService.handleItemClick}
         leftPadding={8}
       />
@@ -62,7 +63,7 @@ export const CommentsPanel: FC<{ viewState: ViewState }> = ({ viewState }) => {
     [commentsPanelOptions],
   );
 
-  const renderSearchTree = useCallback(() => {
+  const renderCommentTree = useCallback(() => {
     if (model) {
       return (
         <RecycleTree
@@ -83,7 +84,7 @@ export const CommentsPanel: FC<{ viewState: ViewState }> = ({ viewState }) => {
   return (
     <div className={styles.comment_panel} tabIndex={-1} onBlur={handleTreeBlur} ref={wrapperRef}>
       {headerComponent?.component}
-      {renderSearchTree()}
+      {renderCommentTree()}
     </div>
   );
 };

--- a/packages/comments/src/browser/tree/comment-node.tsx
+++ b/packages/comments/src/browser/tree/comment-node.tsx
@@ -12,6 +12,7 @@ export interface ICommentNodeProps {
   defaultLeftPadding?: number;
   leftPadding?: number;
   decorations?: ClasslistComposite;
+  onTwistierClick: (ev: React.MouseEvent, item: CommentContentNode | CommentFileNode) => void;
   onClick: (ev: React.MouseEvent, item: CommentContentNode | CommentFileNode) => void;
 }
 
@@ -23,15 +24,25 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
   leftPadding = 8,
   decorations,
   onClick,
+  onTwistierClick,
 }: ICommentNodeRenderedProps) => {
   const handleClick = useCallback(
     (ev: React.MouseEvent) => {
       if (item.onSelect) {
+        // 当节点绑定了自定义函数时，不通过默认逻辑处理点击事件
         item.onSelect(item);
+      } else {
+        onClick(ev, item as CommentContentNode);
       }
-      onClick(ev, item as CommentContentNode);
     },
     [onClick],
+  );
+
+  const handleTwistierClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onTwistierClick(ev, item as CommentContentNode);
+    },
+    [onTwistierClick],
   );
 
   const paddingLeft = `${
@@ -90,12 +101,13 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
   const renderFolderToggle = useCallback(
     (node: CommentFileNode) => (
       <div
+        onClick={handleTwistierClick}
         className={cls(styles.segment, styles.expansion_toggle, getIcon('arrow-right'), {
           [`${styles.mod_collapsed}`]: !(node as CommentFileNode).expanded,
         })}
       />
     ),
-    [],
+    [handleTwistierClick],
   );
 
   const renderTwice = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
@@ -111,7 +123,7 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
       key={item.id}
       onClick={handleClick}
       title={getItemTooltip()}
-      className={cls(styles.search_node, decorations ? decorations.classlist : null)}
+      className={cls(styles.comment_node, decorations ? decorations.classlist : null)}
       style={renderedNodeStyle}
       data-id={item.id}
     >

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -149,6 +149,12 @@ export class CommentModelService extends Disposable {
     this.removeFocusedDecoration();
   };
 
+  handleTwistierClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {
+      this.toggleDirectory(node as CommentFileNode | CommentContentNode);
+    }
+  };
+
   handleItemClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
     this.applyFocusedDecoration(node);
     if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {

--- a/packages/comments/src/browser/tree/tree-node.module.less
+++ b/packages/comments/src/browser/tree/tree-node.module.less
@@ -1,4 +1,4 @@
-.search_node {
+.comment_node {
   height: 22px;
   line-height: 22px;
   display: flex;
@@ -11,6 +11,10 @@
     margin-right: 6px;
     display: inline;
     white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
   }
 
   .description {
@@ -71,6 +75,7 @@
   }
 
   .overflow_wrap {
+    display: flex;
     flex: 1;
     flex-shrink: 0;
     overflow: hidden;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 10a3875</samp>

*  Add a prop to handle the twistier click event on comment nodes ([link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5R45), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202R15), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L26-R47), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202R104), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L98-R110), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aR152-R157))
* Rename the `renderSearchTree` function to `renderCommentTree` and update its usage in `comments-panel.view.tsx` ([link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5L65-R66), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5L86-R87), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L114-R126), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-0ab74e6e76a6eb5f883702ac075933eb69926d5c34efac114136ecb4b1f594deL1-R1))
* Modify the `handleClick` function in `CommentNode` to support custom `onSelect` functions for comment nodes ([link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L26-R47))
* Update the comment node style to prevent text overflow and align it to the left ([link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-0ab74e6e76a6eb5f883702ac075933eb69926d5c34efac114136ecb4b1f594deR14-R17), [link](https://github.com/opensumi/core/pull/2946/files?diff=unified&w=0#diff-0ab74e6e76a6eb5f883702ac075933eb69926d5c34efac114136ecb4b1f594deR78))

<!-- Additional content -->
<!-- 补充额外内容 -->

避免自定义节点绑定了 onSelect 后，点击依旧打开错误文件的问题，优化样式及样式名

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10a3875</samp>

This pull request improves the functionality and appearance of the comment tree view in the comments package. It adds a new prop and method for handling twistier icon clicks, renames and refactors some components and functions, and fixes some style issues with the comment node elements.
