### PR TITLE
fix: opened editor reveal error

### DIFF
--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -1,11 +1,5 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import {
-  DecorationsManager,
-  Decoration,
-  IRecycleTreeHandle,
-  TreeNodeType,
-  WatchEvent,
-} from '@opensumi/ide-components';
+import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeNodeType, WatchEvent } from '@opensumi/ide-components';
 import {
   URI,
   DisposableCollection,
@@ -84,7 +78,7 @@ export class OpenedEditorModelService {
   private _whenReady: Promise<void>;
 
   private _decorations: DecorationsManager;
-  private _openedEditorTreeHandle: IEditorTreeHandle;
+  private _openedEditorTreeHandle?: IEditorTreeHandle;
 
   public flushEventQueueDeferred: Deferred<void> | null;
   private _eventFlushTimeout: number;
@@ -427,6 +421,9 @@ export class OpenedEditorModelService {
       if (!node) {
         return;
       }
+      if (!this.editorTreeHandle) {
+        return;
+      }
       node = (await this.editorTreeHandle.ensureVisible(node as EditorFile)) as EditorFile;
       if (node) {
         if (this.focusedFile === node) {
@@ -443,7 +440,11 @@ export class OpenedEditorModelService {
     if (node.parent && EditorFileGroup.is(node.parent as EditorFileGroup)) {
       groupIndex = (node.parent as EditorFileGroup).group.index;
     }
-    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, node.uri, { groupIndex, preserveFocus: true, disableNavigateOnOpendEditor: true });
+    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, node.uri, {
+      groupIndex,
+      preserveFocus: true,
+      disableNavigateOnOpendEditor: true,
+    });
   };
 
   public closeFile = (node: EditorFile) => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9614923</samp>

*  Made `_openedEditorTreeHandle` property optional and added guard clause to `updateDecorations` method to prevent errors when accessing undefined properties ([link](https://github.com/opensumi/core/pull/2947/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L87-R81), [link](https://github.com/opensumi/core/pull/2947/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2R424-R426), [link](https://github.com/opensumi/core/pull/2947/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L446-R447))
* Reformatted import statement for `@opensumi/ide-components` to fit in one line ([link](https://github.com/opensumi/core/pull/2947/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L2-R3))
* Improved readability of arguments for `commandService.executeCommand` method ([link](https://github.com/opensumi/core/pull/2947/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L446-R447))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9614923</samp>

Improve `OpenedEditorModelService` class in `opened-editor-model.service.ts`. Format imports, handle optional property, add guard clause, and fix command arguments.
