### PR TITLE
fix: fix select component style

### DIFF
--- a/packages/components/src/select/style.less
+++ b/packages/components/src/select/style.less
@@ -130,7 +130,8 @@
   }
 
   .kt-select-option-select {
-    & > span {
+    & > span,
+    .kt-select-option-wrapper {
       display: inline-block;
       margin: 0 2px;
       width: calc(100% - 4px);
@@ -150,7 +151,8 @@
     margin-bottom: -3px;
   }
 
-  & > span {
+  & > span,
+  .kt-select-option-wrapper {
     color: var(--kt-selectDropdown-foreground);
     background-color: var(--kt-selectDropdown-background);
     cursor: pointer;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes

### Background or solution

#2929 样式修改导致了如下问题：
![image](https://github.com/opensumi/core/assets/13938334/cffcfecb-9e5d-481a-9506-ec044f07208f)

修复后：

<img width="604" alt="CleanShot 2023-07-26 at 17 32 38@2x" src="https://github.com/opensumi/core/assets/13938334/d11556ac-9e7b-4522-93de-9a917a1d84fd">


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6443710</samp>

Improve select component option styling. Add a new class `.kt-select-option-wrapper` in `style.less` to adjust the option wrapper appearance.

fix select component style