### PR TITLE
fix: change extension window.state default true

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.window-state.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.window-state.ts
@@ -24,6 +24,7 @@ export class WindowStateImpl implements types.WindowState {
   public focused: boolean;
 
   constructor() {
-    this.focused = false;
+    // 当插件进程重启时，这里如果默认是 false，会与实际状态不一致，导致依赖该状态的插件处理有问题
+    this.focused = true;
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f24add</samp>

* Fix window focus and activation issues for extensions ([link](https://github.com/opensumi/core/pull/2951/files?diff=unified&w=0#diff-0dcf21ae2a7d0af96f98dd46f446e49966250a1f2fc50e22eb60a8ce9ce91e9eL27-R28),                              F

<!-- Additional content -->
<!-- 补充额外内容 -->

关联 Issue: https://github.com/opensumi/core/issues/2909

有一些插件会依赖这个状态，例如 git 插件：https://github.com/microsoft/vscode/blob/main/extensions/git/src/repository.ts#L2322

这里如果默认 false，会导致一些场景与实际状态不一致，比如：刷新浏览器、重启插件进程。会引起 SCM 面板更新不及时的情况。

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f24add</samp>

Fix window focus and activation issues for extensions. Change the default value of `focused` to `true` in `WindowStateImpl` constructor.
