### PR TITLE
fix: extra whitespace view-zone

### DIFF
--- a/packages/comments/src/browser/comments.service.ts
+++ b/packages/comments/src/browser/comments.service.ts
@@ -481,22 +481,24 @@ export class CommentsService extends Disposable implements ICommentsService {
       onDidDecorationChange: this.decorationChangeEmitter.event,
       provideEditorDecoration: (uri: URI) =>
         this.commentsThreads
-          .filter((thread) => {
-            const isCurrentThread = thread.uri.isEqual(uri) && thread.comments.length > 0;
-            if (this.filterThreadDecoration) {
-              return isCurrentThread && this.filterThreadDecoration(thread);
-            }
-            return isCurrentThread;
-          })
           .map((thread) => {
             if (thread.uri.isEqual(uri)) {
-              // 恢复之前的现场
-              thread.showWidgetsIfShowed();
+              if (thread.comments.length) {
+                // 存在评论内容 恢复之前的现场
+                thread.showWidgetsIfShowed();
+              }
             } else {
               // 临时隐藏，当切回来时会恢复
               thread.hideWidgetsByDispose();
             }
             return thread;
+          })
+          .filter((thread) => {
+            const isCurrentThread = thread.uri.isEqual(uri);
+            if (this.filterThreadDecoration) {
+              return isCurrentThread && this.filterThreadDecoration(thread);
+            }
+            return isCurrentThread;
           })
           .map((thread) => ({
             range: thread.range,

--- a/packages/comments/src/browser/comments.service.ts
+++ b/packages/comments/src/browser/comments.service.ts
@@ -481,6 +481,13 @@ export class CommentsService extends Disposable implements ICommentsService {
       onDidDecorationChange: this.decorationChangeEmitter.event,
       provideEditorDecoration: (uri: URI) =>
         this.commentsThreads
+          .filter((thread) => {
+            const isCurrentThread = thread.uri.isEqual(uri) && thread.comments.length > 0;
+            if (this.filterThreadDecoration) {
+              return isCurrentThread && this.filterThreadDecoration(thread);
+            }
+            return isCurrentThread;
+          })
           .map((thread) => {
             if (thread.uri.isEqual(uri)) {
               // 恢复之前的现场
@@ -490,13 +497,6 @@ export class CommentsService extends Disposable implements ICommentsService {
               thread.hideWidgetsByDispose();
             }
             return thread;
-          })
-          .filter((thread) => {
-            const isCurrentThread = thread.uri.isEqual(uri);
-            if (this.filterThreadDecoration) {
-              return isCurrentThread && this.filterThreadDecoration(thread);
-            }
-            return isCurrentThread;
           })
           .map((thread) => ({
             range: thread.range,
@@ -552,7 +552,7 @@ export class CommentsService extends Disposable implements ICommentsService {
     const uri = this.workbenchEditorService.currentEditor?.currentUri;
     uri && this.decorationChangeEmitter.fire(uri);
     // diffeditor 的 originalUri 也需要更新 Decoration
-    const originalUri = this.workbenchEditorService.currentEditorGroup?.diffEditor.originalEditor.currentUri;
+    const originalUri = this.workbenchEditorService.currentEditorGroup?.diffEditor?.originalEditor.currentUri;
     originalUri && this.decorationChangeEmitter.fire(originalUri);
   }
 


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 40a11c6</samp>

*  Filter out comment threads that have no comments to avoid showing empty comment decorations in the editor ([link](https://github.com/opensumi/core/pull/2954/files?diff=unified&w=0#diff-964880a5a3453fde6e41dffaceb5accf42909aea62ca14651f76517ae950127cR484-R490))
*  Simplify the code by removing the redundant condition that checks if the thread has comments ([link](https://github.com/opensumi/core/pull/2954/files?diff=unified&w=0#diff-964880a5a3453fde6e41dffaceb5accf42909aea62ca14651f76517ae950127cL494-L500))
*  Prevent a possible error when the current editor group is not a diff editor by adding an optional chaining operator to access the `diffEditor` property ([link](https://github.com/opensumi/core/pull/2954/files?diff=unified&w=0#diff-964880a5a3453fde6e41dffaceb5accf42909aea62ca14651f76517ae950127cL555-R555))
*  Update comment decorations in diff editors as part of a bug fix ([link](https://github.com/opensumi/core/pull/2954/files?diff=unified&w=0#diff-964880a5a3453fde6e41dffaceb5accf42909aea62ca14651f76517ae950127cL555-R555))

<!-- Additional content -->
<!-- 补充额外内容 -->
偶现评论内容出现额外的空白
原因是此处 https://github.com/opensumi/core/blob/main/packages/comments/src/browser/comments.service.ts#L217
createThread 会创建冗余数据 

![ABC60B2C-4B08-44A5-A4D9-19C7C290FB71](https://github.com/opensumi/core/assets/31676999/5868c888-893e-4144-a9c2-72a28bbc213f)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40a11c6</samp>

Improve comment filtering and decoration in `comments.service.ts`. Fix diff editor bug and hide empty threads.
