### PR TITLE
fix: disable minimap for diffEditor

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -345,13 +345,22 @@ export abstract class BaseMonacoEditorWrapper extends WithEventBus implements IE
     const basicEditorOptions: Partial<monaco.editor.IEditorOptions> = {
       readOnly: this.currentDocumentModel?.readonly || false,
     };
+
+    let editorOptions = {
+      ...basicEditorOptions,
+      ...options.editorOptions,
+      ...this._editorOptionsFromContribution,
+      ...this._specialEditorOptions,
+    };
+
+    if (this.type > EditorType.CODE) {
+      editorOptions = {
+        ...editorOptions,
+        ...options.diffOptions,
+      }
+    }
     return {
-      editorOptions: {
-        ...basicEditorOptions,
-        ...options.editorOptions,
-        ...this._editorOptionsFromContribution,
-        ...this._specialEditorOptions,
-      },
+      editorOptions,
       modelOptions: { ...options.modelOptions, ...this._specialModelOptions },
     };
   }

--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -357,8 +357,9 @@ export abstract class BaseMonacoEditorWrapper extends WithEventBus implements IE
       editorOptions = {
         ...editorOptions,
         ...options.diffOptions,
-      }
+      };
     }
+
     return {
       editorOptions,
       modelOptions: { ...options.modelOptions, ...this._specialModelOptions },

--- a/packages/editor/src/browser/preference/converter.ts
+++ b/packages/editor/src/browser/preference/converter.ts
@@ -767,6 +767,16 @@ export const diffEditorOptionsConverters: Map<KaitianPreferenceKey, NoConverter 
    * Defaults to false.
    */
   ['diffEditor.originalEditable', { monaco: 'originalEditable' }],
+
+  [
+    'diffEditor.minimap',
+    {
+      monaco: 'minimap',
+      convert: (value: any) => ({
+        enabled: value,
+      }),
+    },
+  ],
 ]);
 
 function isContainOptionKey(key: string, optionMap: Map<KaitianPreferenceKey, NoConverter | IMonacoOptionsConverter>) {

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1399,6 +1399,10 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     default: true,
     description: '%editor.configuration.renderIndicators%',
   },
+  'diffEditor.minimap': {
+    type: 'boolean',
+    default: false,
+  },
   'editor.defaultFormatter': {
     type: 'string',
     description: '%editor.configuration.defaultFormatter%',


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

editorCollectionService 中将 DiffEditor 中左右两侧的 CodeEditor 包装为 DiffEditorPart，并在一些情况下更新它们的 options，这会将 CodeEditor 的 options 错误的更新到 DiffEditor 中，导致即使 monaco 内部已经在创建 DiffEditor 时关闭了 minimap，也会因为这段逻辑在一些情况下自动开启 minimap。

解决方式是根据 EditorType 区分不同的设置项，对于这种可能混淆的情况，新增了 diffEditor 的自定义配置项，在应用时会自动转换为 editor 配置

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f87b17</samp>

*  Add support for diff editor feature that allows comparing two files side by side ([link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-c0d0f058ba7138472d4432426af4cc7f4e0ab38de65fdefd5564c65225f485a0L348-R363), [link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-59ae6b7805916ab8a928acefb910b9f669f2c2a201c63c9cf38ebeb867733fc2R770-R779), [link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-d2e2b9fe5f9466a2457d8fa83b5be6e7196c166629732594386fad511fb01d6eR1402-R1405))
  - Merge `diffOptions` with `editorOptions` when editor type is greater than `EditorType.CODE` in `editor-collection.service.ts` ([link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-c0d0f058ba7138472d4432426af4cc7f4e0ab38de65fdefd5564c65225f485a0L348-R363))
  - Add converter and schema for `diffEditor.minimap` preference in `converter.ts` and `schema.ts` ([link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-59ae6b7805916ab8a928acefb910b9f669f2c2a201c63c9cf38ebeb867733fc2R770-R779), [link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-d2e2b9fe5f9466a2457d8fa83b5be6e7196c166629732594386fad511fb01d6eR1402-R1405))
  - Allow user to enable or disable minimap for diff editor through preference ([link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-59ae6b7805916ab8a928acefb910b9f669f2c2a201c63c9cf38ebeb867733fc2R770-R779), [link](https://github.com/opensumi/core/pull/2956/files?diff=unified&w=0#diff-d2e2b9fe5f9466a2457d8fa83b5be6e7196c166629732594386fad511fb01d6eR1402-R1405))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f87b17</samp>

This pull request adds support for the diff editor feature that allows comparing two files side by side. It modifies the `editor-collection.service.ts`, `converter.ts`, and `schema.ts` files to handle the `diffOptions`, `diffEditor.minimap` preference, and the minimap option of the Monaco editor.
