### PR TITLE
WIP: 仅做触发构建发包

### DIFF
--- a/packages/core-browser/src/bootstrap/connection.ts
+++ b/packages/core-browser/src/bootstrap/connection.ts
@@ -35,17 +35,18 @@ export async function createClientConnection2(
   const wsChannelHandler = new WSChannelHandler(wsPath, initialLogger, protocols, clientId);
   wsChannelHandler.setReporter(reporterService);
   wsChannelHandler.connection.addEventListener('open', async () => {
-    await stateService.reachedState('core_module_initialized');
+    // 状态机处于 'core_module_initialized' ｜ 'started_contributions' ｜ 'ready' 状态时，事件触发
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionOpenEvent());
   });
 
   wsChannelHandler.connection.addEventListener('close', async () => {
-    await stateService.reachedState('core_module_initialized');
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionCloseEvent());
   });
 
   wsChannelHandler.connection.addEventListener('error', async (e) => {
-    await stateService.reachedState('core_module_initialized');
+    await stateService.reachedAnyState('core_module_initialized', 'started_contributions', 'ready');
     eventBus.fire(new BrowserConnectionErrorEvent(e));
   });
 

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -17,6 +17,7 @@ import {
   REPORT_NAME,
   SaveTaskErrorCause,
   SaveTaskResponseState,
+  Throttler,
   URI,
 } from '@opensumi/ide-core-browser';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
@@ -114,6 +115,8 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
 
   @Autowired(IHashCalculateService)
   private readonly hashCalculateService: IHashCalculateService;
+
+  private saveQueue = new Throttler();
 
   private monacoModel: ITextModel;
 
@@ -356,6 +359,62 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
   }
 
   async save(force = false, reason: SaveReason = SaveReason.Manual): Promise<boolean> {
+    const doSave = async (force = false, reason: SaveReason = SaveReason.Manual) => {
+      await this.formatOnSave(reason);
+      // 发送willSave并等待完成
+      await this.eventBus.fireAndAwait(
+        new EditorDocumentModelWillSaveEvent({
+          uri: this.uri,
+          reason,
+          language: this.languageId,
+        }),
+      );
+      if (!this.editorPreferences['editor.askIfDiff']) {
+        force = true;
+      }
+      if (!this.dirty) {
+        return false;
+      }
+      const versionId = this.monacoModel.getVersionId();
+      const lastSavingTask = this.savingTasks[this.savingTasks.length - 1];
+      if (lastSavingTask && lastSavingTask.versionId === versionId) {
+        lastSavingTask.cancel();
+        const task = this.savingTasks.pop();
+        task?.dispose();
+      }
+      const task = new SaveTask(this.uri, versionId, this.monacoModel.getAlternativeVersionId(), this.getText(), force);
+      this.savingTasks.push(task);
+      if (this.savingTasks.length > 0) {
+        this.initSave();
+      }
+      const res = await task.finished;
+      if (res.state === SaveTaskResponseState.SUCCESS) {
+        this.monacoModel.pushStackElement();
+        return true;
+      } else if (res.state === SaveTaskResponseState.ERROR) {
+        if (res.errorMessage !== SaveTaskErrorCause.CANCEL) {
+          this.logger.error(res.errorMessage);
+          this.messageService.error(localize('doc.saveError.failed') + '\n' + res.errorMessage);
+        }
+        return false;
+      } else if (res.state === SaveTaskResponseState.DIFF) {
+        const diffAndSave = localize('doc.saveError.diffAndSave');
+        const overwrite = localize('doc.saveError.overwrite');
+        this.messageService
+          .error(formatLocalize('doc.saveError.diff', this.uri.toString()), [diffAndSave, overwrite])
+          .then((res) => {
+            if (res === diffAndSave) {
+              this.compareAndSave();
+            } else if (res === overwrite) {
+              doSave(true);
+            }
+          });
+        this.logger.error('The file cannot be saved, the version is inconsistent with the disk');
+        return false;
+      }
+      return false;
+    };
+    return this.saveQueue.queue(doSave);
     await this.formatOnSave(reason);
     // 发送willSave并等待完成
     await this.eventBus.fireAndAwait(


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e55d66</samp>

*  Modify the `createClientConnection2` function to fire the WebSocket connection events when the state machine is in any of the three possible states: 'core_module_initialized', 'started_contributions', or 'ready' ([link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-72cd9a42da470f763e84667041d85a2f10877599232b1d13f418b0629e6d0a71L38-R49))
*  Import the `Throttler` class from `@opensumi/core-common` to implement a save queue for the editor document model and the file scheme document service ([link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510R20), [link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-e411e181b061d60664c492101e2e842d80d2d29cdc4191ebd50c540035b1543dR16))
*  Add the `saveQueue` property to the `EditorDocumentModel` class to queue and execute the save tasks for the editor document model ([link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510R119-R120))
*  Modify the `save` method of the `EditorDocumentModel` class to use the `saveQueue` property and define the save tasks as async functions that perform various steps to save the document ([link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510R362-R417))
*  Add the `saveQueueByUri` property to the `FileSchemeDocNodeServiceImpl` class to queue and execute the save tasks for the file scheme document service ([link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-e411e181b061d60664c492101e2e842d80d2d29cdc4191ebd50c540035b1543dR30-R31))
*  Modify the `saveByContent` method of the `FileSchemeDocNodeServiceImpl` class to use the `saveQueueByUri` property and define the save tasks as async functions that perform various steps to save the file ([link](https://github.com/opensumi/core/pull/2958/files?diff=unified&w=0#diff-e411e181b061d60664c492101e2e842d80d2d29cdc4191ebd50c540035b1543dL87-R138))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e55d66</samp>

The pull request adds a save queue feature to the `EditorDocumentModel` and the file scheme document service, using the `Throttler` utility class. This improves the performance and reliability of saving documents in the editor. It also fixes a bug in the WebSocket connection events by using the `reachedAnyState` method of the `stateService`. This ensures that all the features that depend on the connection events work correctly.
