### PR TITLE
fix: file tree decoration render error

### DIFF
--- a/packages/components/src/recycle-tree/tree/decoration/Decoration.ts
+++ b/packages/components/src/recycle-tree/tree/decoration/Decoration.ts
@@ -177,6 +177,26 @@ export class Decoration {
   }
 
   /**
+   * 清理所有应用的装饰器
+   */
+  public clearAppliedTarget() {
+    const appliedTargets = Array.from(this._appliedTargets.keys());
+    for (const target of appliedTargets) {
+      this.removeTarget(target);
+    }
+  }
+
+  /**
+   * 清理所有应用的否定装饰器
+   */
+  public clearNegateTarget() {
+    const negatedTargets = Array.from(this._negatedTargets.keys());
+    for (const target of negatedTargets) {
+      this.unNegateTarget(target);
+    }
+  }
+
+  /**
    * 否定装饰器绑定
    * negate 表示 :not修饰符
    * 定义节点不应用样式

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -357,7 +357,7 @@ export class FileTreeModelService {
     );
     this.disposableCollection.push(
       this.treeModel.root.watcher.on(TreeNodeEvent.DidResolveChildren, (target) => {
-        this.loadingDecoration.removeTarget(target);
+        this.loadingDecoration.clearAppliedTarget();
         this.treeModel.dispatchChange();
       }),
     );
@@ -419,28 +419,22 @@ export class FileTreeModelService {
 
   // 清空所有节点选中态
   clearFileSelectedDecoration = () => {
-    this._selectedFiles.forEach((file) => {
-      this.selectedDecoration.removeTarget(file);
-    });
+    this.selectedDecoration.clearAppliedTarget();
     this._selectedFiles = [];
   };
 
   // 清空其他选中/焦点态节点，更新当前焦点节点
   activeFileDecoration = (target: File | Directory, dispatchChange = true) => {
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
       this.contextMenuFile = undefined;
     }
     if (target) {
       if (this.selectedFiles.length > 0) {
-        // 因为选择装饰器可能通过其他方式添加而不能及时在selectedFiles上更新
-        // 故这里遍历所有选中装饰器的节点进行一次统一清理
-        for (const target of this.selectedDecoration.appliedTargets.keys()) {
-          this.selectedDecoration.removeTarget(target);
-        }
+        this.selectedDecoration.clearAppliedTarget();
       }
       if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       this.selectedDecoration.addTarget(target);
       this.focusedDecoration.addTarget(target);
@@ -461,17 +455,17 @@ export class FileTreeModelService {
     }
 
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
       this.contextMenuFile = undefined;
     }
     if (target) {
       if (this.selectedFiles.length > 0) {
-        this.selectedFiles.forEach((file) => {
-          this.selectedDecoration.removeTarget(file);
-        });
+        // 由于文件树更新较为频繁，容易出现用户点击时刚好节点被更新情况
+        // 故这里需要从 Decoration 内移除节点
+        this.selectedDecoration.clearAppliedTarget();
       }
       if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       this.selectedDecoration.addTarget(target);
       this._selectedFiles = [target];
@@ -485,10 +479,11 @@ export class FileTreeModelService {
   // 右键菜单焦点态切换
   activateFileActivedDecoration = (target: File | Directory) => {
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
+      this.contextMenuFile = undefined;
     }
     if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     }
     this.contextMenuDecoration.addTarget(target);
@@ -499,10 +494,10 @@ export class FileTreeModelService {
   // 右键菜单焦点态切换
   activateFileFocusedDecoration = (target: File | Directory) => {
     if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
     }
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
       this.contextMenuFile = undefined;
     }
     this.focusedDecoration.addTarget(target);
@@ -522,12 +517,12 @@ export class FileTreeModelService {
       if (removePreFocusedDecoration) {
         if (this.focusedFile) {
           // 多选情况下第一次切换焦点文件
-          this.focusedDecoration.removeTarget(this.focusedFile);
+          this.focusedDecoration.clearAppliedTarget();
         }
         this.contextMenuFile = target;
       } else if (this.focusedFile) {
         this.contextMenuFile = undefined;
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       if (target) {
         // 存在多选文件时切换焦点的情况
@@ -549,16 +544,16 @@ export class FileTreeModelService {
     const index = this._selectedFiles.indexOf(target);
     if (index > -1) {
       if (this.focusedFile === target) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
         this.focusedFile = undefined;
       }
       this._selectedFiles.splice(index, 1);
-      this.selectedDecoration.removeTarget(target);
+      this.selectedDecoration.clearAppliedTarget();
     } else {
       this._selectedFiles.push(target);
       this.selectedDecoration.addTarget(target);
       if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       this.focusedFile = target;
       this.focusedDecoration.addTarget(target);
@@ -589,7 +584,7 @@ export class FileTreeModelService {
   // 取消选中节点焦点
   deactivateFileDecoration = () => {
     if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     }
     // 失去焦点状态时，仅清理右键菜单的选中态
@@ -899,7 +894,7 @@ export class FileTreeModelService {
     let node;
     if (this.focusedFile) {
       node = this.focusedFile;
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     } else if (this.contextMenuFile) {
       node = this.contextMenuFile;
@@ -934,7 +929,7 @@ export class FileTreeModelService {
     let node;
     if (this.focusedFile) {
       node = this.focusedFile;
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     } else if (this.contextMenuFile) {
       node = this.contextMenuFile;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32d9643</samp>

*  Add methods to clear applied or negated decorations from targets in `Decoration` class ([link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-51c422f7f6e04b1d45e90b0ff387709f7d6ddff0da75ff0ca7371d0a19c39818R180-R199))
*  Use `clearAppliedTarget` method to clear loading decoration from all targets when resolving children of a tree node in `FileTreeModelService` class ([link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L360-R360))
*  Use `clearAppliedTarget` method to clear selected decoration from all targets when clearing or changing file selection in `FileTreeModelService` class ([link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L422-R422), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L552-R556))
*  Use `clearAppliedTarget` method to clear selected, focused, and context menu decorations from all targets when activating, focusing, or changing context menu file in `FileTreeModelService` class ([link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L431-R437), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L464-R468), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L488-R486), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L502-R500), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L525-R525))
*  Use `clearAppliedTarget` method to clear focused decoration from all targets when deactivating, renaming, or deleting file decoration in `FileTreeModelService` class ([link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L592-R587), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L902-R897), [link](https://github.com/opensumi/core/pull/2963/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L937-R932))

<!-- Additional content -->
<!-- 补充额外内容 -->
close #2959

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32d9643</samp>

This pull request improves the file tree decoration logic by using new methods to clear the decorations from the nodes. It refactors the `FileTreeModelService` class to use the `clearAppliedTarget` method and adds the `clearAppliedTarget` and `clearNegateTarget` methods to the `Decoration` class. These changes simplify the code and ensure the decoration state is consistent.
