### PR TITLE
fix: improve comment thread actions UX

### DIFF
--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'classnames';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { Button, CheckBox, Icon } from '@opensumi/ide-components';
 import { ClickParam, Menu } from '@opensumi/ide-components/lib/menu';
@@ -195,19 +195,24 @@ const InlineActionWidget: React.FC<
     iconService?: IMenubarIconService;
   } & React.HTMLAttributes<HTMLElement>
 > = React.memo(({ iconService, type = 'icon', data, context = [], className, afterClick, ...restProps }) => {
+  const [loading, setLoading] = useState(false);
   const handleClick = React.useCallback(
-    (event?: React.MouseEvent<HTMLElement>, ...extraArgs: any[]) => {
+    async (event?: React.MouseEvent<HTMLElement>, ...extraArgs: any[]) => {
       if (event) {
         event.preventDefault();
         event.stopPropagation();
       }
+      if (loading) {
+        return;
+      }
+      setLoading(true);
       if (data.id === SubmenuItemNode.ID && event) {
         const anchor = { x: event.clientX, y: event.clientY };
-        data.execute([anchor, ...context]);
+        await data.execute([anchor, ...context]);
       } else if (typeof data.execute === 'function') {
-        data.execute([...context, ...extraArgs]);
+        await data.execute([...context, ...extraArgs]);
       }
-
+      setLoading(false);
       if (typeof afterClick === 'function') {
         afterClick();
       }
@@ -261,6 +266,7 @@ const InlineActionWidget: React.FC<
 
   return (
     <Button
+      loading={loading}
       className={clsx(className, styles.btnAction)}
       disabled={data.disabled}
       onClick={handleClick}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6648ad</samp>

* Import `useState` hook from React and use it to manage loading state of action buttons ([link](https://github.com/opensumi/core/pull/2965/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L2-R2), [link](https://github.com/opensumi/core/pull/2965/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L198-R212), [link](https://github.com/opensumi/core/pull/2965/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R266))
* Refactor `handleClick` function to use `async/await` syntax and set loading state before and after executing action ([link](https://github.com/opensumi/core/pull/2965/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L198-R212))
* Pass loading state to `Button` component and render loading indicator if true ([link](https://github.com/opensumi/core/pull/2965/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R266))

针对异步函数增加 Loading 状态优化评论按钮提示, 防止重复提交
<img width="255" alt="截屏2023-07-28 16 52 41" src="https://github.com/opensumi/core/assets/9823838/3234cb53-5431-48e6-bf19-839dfc3c4ba6">

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6648ad</samp>

Improved user feedback for action buttons in `core-browser` package. Added loading state and indicator to show when an action is in progress or completed.
