### PR TITLE
feat: extHost log format refactor

### DIFF
--- a/packages/extension/src/node/extension.service.ts
+++ b/packages/extension/src/node/extension.service.ts
@@ -386,7 +386,7 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
             util.format(
               output.data
                 .split('\n')
-                .map((data) => (data ? `[Extension Host] ${data}` : ''))
+                .map((data) => (data ? `\x1b[32m[Extension Host]\x1b[0m ${data}` : ''))
                 .join('\n'),
               ...output.format,
             ),

--- a/packages/extension/src/node/extension.service.ts
+++ b/packages/extension/src/node/extension.service.ts
@@ -376,7 +376,7 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
             util.format(
               output.data
                 .split('\n')
-                .map((data) => (data ? `[Extension Host] ${data}` : ''))
+                .map((data) => (data ? `\x1b[31m[Extension Host]\x1b[0m ${data}` : ''))
                 .join('\n'),
               ...output.format,
             ),

--- a/packages/extension/src/node/extension.service.ts
+++ b/packages/extension/src/node/extension.service.ts
@@ -62,7 +62,7 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
   @Autowired(INodeLogger)
   private readonly logger: INodeLogger;
 
-  private readonly extHostLogger = getDebugLogger(SupportLogNamespace.ExtensionHost);
+  private readonly extHostLogger = console;
 
   @Autowired(AppConfig)
   private appConfig: AppConfig;
@@ -372,9 +372,25 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
       } else {
         // 输出插件进程日志
         if (output.type === OutputType.STDERR) {
-          this.extHostLogger.error(util.format(output.data, ...output.format));
+          this.extHostLogger.error(
+            util.format(
+              output.data
+                .split('\n')
+                .map((data) => (data ? `[Extension Host] ${data}` : ''))
+                .join('\n'),
+              ...output.format,
+            ),
+          );
         } else {
-          this.extHostLogger.log(util.format(output.data, ...output.format));
+          this.extHostLogger.log(
+            util.format(
+              output.data
+                .split('\n')
+                .map((data) => (data ? `[Extension Host] ${data}` : ''))
+                .join('\n'),
+              ...output.format,
+            ),
+          );
         }
       }
     });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
#2816
before:
<img width="603" alt="image" src="https://github.com/opensumi/core/assets/87003751/3ccf9d5d-8315-4dbf-8c48-8e482a5b21a7">

after:
<img width="690" alt="image" src="https://github.com/opensumi/core/assets/87003751/bcf5a56d-df62-4cca-94f0-906dea1de9b0">

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dfca83a</samp>

*  Add RPC functionality for logging messages from the server side to the client side via the `ILogServiceForClient` service ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-7dea0fd7105dc76ae2efb54ce4f8351bb2665805ae1d6eefc1aab3b3019f2333R280), [link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-7dea0fd7105dc76ae2efb54ce4f8351bb2665805ae1d6eefc1aab3b3019f2333R355-R360))
   * Define the `clientLog` method in the `IRPCLogService` interface in `packages/logs-core/src/node/log.service.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-7dea0fd7105dc76ae2efb54ce4f8351bb2665805ae1d6eefc1aab3b3019f2333R280))
   * Implement the `clientLog` method in the `LogServiceForClient` class in `packages/logs-core/src/node/log.service.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-7dea0fd7105dc76ae2efb54ce4f8351bb2665805ae1d6eefc1aab3b3019f2333R355-R360))
* Add service definition and implementation for logging messages from different namespaces to the client side via the `LogManage` class ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-a41cfad7bf17e19132249ddb239ca12cde91edc96b4d4c909d5b9ddcdc35ea7fR16), [link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-7b5f365639312b02977bd28ab6a7ae70ec603d26fc7687bd2570e332d189ef85R49-R52))
   * Declare the `clientLog` method in the `ILogServiceForClient` interface in `packages/logs-core/src/common/log-core.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-a41cfad7bf17e19132249ddb239ca12cde91edc96b4d4c909d5b9ddcdc35ea7fR16))
   * Define the `clientLog` method in the `LogManage` class in `packages/logs-core/src/browser/log-manage.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-7b5f365639312b02977bd28ab6a7ae70ec603d26fc7687bd2570e332d189ef85R49-R52))
* Add dependency injection and feature enhancement for logging messages from the extension host process to the client side via the `ExtensionNodeServiceImpl` class ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-96a7edbadf689ce6f8bd685ced0e2a3868a623e7ee060b6692a440d74490dac1R38), [link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-96a7edbadf689ce6f8bd685ced0e2a3868a623e7ee060b6692a440d74490dac1R66-R68), [link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-96a7edbadf689ce6f8bd685ced0e2a3868a623e7ee060b6692a440d74490dac1L376-R383))
   * Import the `ILogServiceForClient` interface from the `@opensumi/ide-logs` package to `packages/extension/src/node/extension.service.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-96a7edbadf689ce6f8bd685ced0e2a3868a623e7ee060b6692a440d74490dac1R38))
   * Add the `logService` property of type `ILogServiceForClient` to the `ExtensionNodeServiceImpl` class and annotate it with the `@Autowired` decorator ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-96a7edbadf689ce6f8bd685ced0e2a3868a623e7ee060b6692a440d74490dac1R66-R68))
   * Call the `clientLog` method of the `logService` property in the `handleOutput` method of the `ExtensionNodeServiceImpl` class ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-96a7edbadf689ce6f8bd685ced0e2a3868a623e7ee060b6692a440d74490dac1L376-R383))
* Replace the `arguments` object with the rest parameter syntax `...args` in the `_wrapConsoleMethod` function in `packages/extension/src/hosted/ext.process-base.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L133-R134))
* Remove a trailing whitespace in the interface `ExtProcessConfig` in `packages/extension/src/hosted/ext.process-base.ts` ([link](https://github.com/opensumi/core/pull/2966/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L73-R77))

<!-- Additional content -->
<!-- 补充额外内容 --

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfca83a</samp>

This pull request adds a feature to log extension host output messages to the client side using the `ILogServiceForClient` service. It defines and implements the `clientLog` method in the `ILogServiceForClient` interface and its subclasses, and uses it in the `ExtensionNodeServiceImpl` class. It also improves the code style of the `ExtProcessConfig` interface and the `_wrapConsoleMethod` function.
