### PR TITLE
chore(release): v2.26.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.26.2",
+  "version": "2.26.3",
   "npmClient": "npm",
   "packages": ["packages/*", "tools/dev-tool", "tools/playwright", "tools/cli-engine"],
   "command": {

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-addons",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-collaboration",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-comments",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/comments/src/browser/comments-panel.view.tsx
+++ b/packages/comments/src/browser/comments-panel.view.tsx
@@ -42,6 +42,7 @@ export const CommentsPanel: FC<{ viewState: ViewState }> = ({ viewState }) => {
         itemType={props.itemType}
         decorations={commentModelService.decorations.getDecorations(props.item as any)}
         defaultLeftPadding={8}
+        onTwistierClick={commentModelService.handleTwistierClick}
         onClick={commentModelService.handleItemClick}
         leftPadding={8}
       />
@@ -62,7 +63,7 @@ export const CommentsPanel: FC<{ viewState: ViewState }> = ({ viewState }) => {
     [commentsPanelOptions],
   );
 
-  const renderSearchTree = useCallback(() => {
+  const renderCommentTree = useCallback(() => {
     if (model) {
       return (
         <RecycleTree
@@ -83,7 +84,7 @@ export const CommentsPanel: FC<{ viewState: ViewState }> = ({ viewState }) => {
   return (
     <div className={styles.comment_panel} tabIndex={-1} onBlur={handleTreeBlur} ref={wrapperRef}>
       {headerComponent?.component}
-      {renderSearchTree()}
+      {renderCommentTree()}
     </div>
   );
 };

--- a/packages/comments/src/browser/comments.service.ts
+++ b/packages/comments/src/browser/comments.service.ts
@@ -483,8 +483,10 @@ export class CommentsService extends Disposable implements ICommentsService {
         this.commentsThreads
           .map((thread) => {
             if (thread.uri.isEqual(uri)) {
-              // 恢复之前的现场
-              thread.showWidgetsIfShowed();
+              if (thread.comments.length) {
+                // 存在评论内容 恢复之前的现场
+                thread.showWidgetsIfShowed();
+              }
             } else {
               // 临时隐藏，当切回来时会恢复
               thread.hideWidgetsByDispose();
@@ -552,7 +554,7 @@ export class CommentsService extends Disposable implements ICommentsService {
     const uri = this.workbenchEditorService.currentEditor?.currentUri;
     uri && this.decorationChangeEmitter.fire(uri);
     // diffeditor 的 originalUri 也需要更新 Decoration
-    const originalUri = this.workbenchEditorService.currentEditorGroup?.diffEditor.originalEditor.currentUri;
+    const originalUri = this.workbenchEditorService.currentEditorGroup?.diffEditor?.originalEditor.currentUri;
     originalUri && this.decorationChangeEmitter.fire(originalUri);
   }
 

--- a/packages/comments/src/browser/tree/comment-node.tsx
+++ b/packages/comments/src/browser/tree/comment-node.tsx
@@ -12,6 +12,7 @@ export interface ICommentNodeProps {
   defaultLeftPadding?: number;
   leftPadding?: number;
   decorations?: ClasslistComposite;
+  onTwistierClick: (ev: React.MouseEvent, item: CommentContentNode | CommentFileNode) => void;
   onClick: (ev: React.MouseEvent, item: CommentContentNode | CommentFileNode) => void;
 }
 
@@ -23,15 +24,25 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
   leftPadding = 8,
   decorations,
   onClick,
+  onTwistierClick,
 }: ICommentNodeRenderedProps) => {
   const handleClick = useCallback(
     (ev: React.MouseEvent) => {
       if (item.onSelect) {
+        // 当节点绑定了自定义函数时，不通过默认逻辑处理点击事件
         item.onSelect(item);
+      } else {
+        onClick(ev, item as CommentContentNode);
       }
-      onClick(ev, item as CommentContentNode);
     },
     [onClick],
+  );
+
+  const handleTwistierClick = useCallback(
+    (ev: React.MouseEvent) => {
+      onTwistierClick(ev, item as CommentContentNode);
+    },
+    [onTwistierClick],
   );
 
   const paddingLeft = `${
@@ -90,12 +101,13 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
   const renderFolderToggle = useCallback(
     (node: CommentFileNode) => (
       <div
+        onClick={handleTwistierClick}
         className={cls(styles.segment, styles.expansion_toggle, getIcon('arrow-right'), {
           [`${styles.mod_collapsed}`]: !(node as CommentFileNode).expanded,
         })}
       />
     ),
-    [],
+    [handleTwistierClick],
   );
 
   const renderTwice = useCallback((node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
@@ -111,7 +123,7 @@ export const CommentNodeRendered: React.FC<ICommentNodeRenderedProps> = ({
       key={item.id}
       onClick={handleClick}
       title={getItemTooltip()}
-      className={cls(styles.search_node, decorations ? decorations.classlist : null)}
+      className={cls(styles.comment_node, decorations ? decorations.classlist : null)}
       style={renderedNodeStyle}
       data-id={item.id}
     >

--- a/packages/comments/src/browser/tree/tree-model.service.ts
+++ b/packages/comments/src/browser/tree/tree-model.service.ts
@@ -149,6 +149,12 @@ export class CommentModelService extends Disposable {
     this.removeFocusedDecoration();
   };
 
+  handleTwistierClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
+    if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {
+      this.toggleDirectory(node as CommentFileNode | CommentContentNode);
+    }
+  };
+
   handleItemClick = async (_, node: CommentFileNode | CommentContentNode | CommentReplyNode) => {
     this.applyFocusedDecoration(node);
     if (CommentFileNode.is(node) || (node as CommentContentNode)?.isAllowToggle) {

--- a/packages/comments/src/browser/tree/tree-node.module.less
+++ b/packages/comments/src/browser/tree/tree-node.module.less
@@ -1,4 +1,4 @@
-.search_node {
+.comment_node {
   height: 22px;
   line-height: 22px;
   display: flex;
@@ -11,6 +11,10 @@
     margin-right: 6px;
     display: inline;
     white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: left;
   }
 
   .description {
@@ -71,6 +75,7 @@
   }
 
   .overflow_wrap {
+    display: flex;
     flex: 1;
     flex-shrink: 0;
     overflow: hidden;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-components",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "@opensumi/ide-components",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/components/src/recycle-tree/tree/decoration/Decoration.ts
+++ b/packages/components/src/recycle-tree/tree/decoration/Decoration.ts
@@ -177,6 +177,26 @@ export class Decoration {
   }
 
   /**
+   * 清理所有应用的装饰器
+   */
+  public clearAppliedTarget() {
+    const appliedTargets = Array.from(this._appliedTargets.keys());
+    for (const target of appliedTargets) {
+      this.removeTarget(target);
+    }
+  }
+
+  /**
+   * 清理所有应用的否定装饰器
+   */
+  public clearNegateTarget() {
+    const negatedTargets = Array.from(this._negatedTargets.keys());
+    for (const target of negatedTargets) {
+      this.unNegateTarget(target);
+    }
+  }
+
+  /**
    * 否定装饰器绑定
    * negate 表示 :not修饰符
    * 定义节点不应用样式

--- a/packages/components/src/select/style.less
+++ b/packages/components/src/select/style.less
@@ -130,7 +130,8 @@
   }
 
   .kt-select-option-select {
-    & > span {
+    & > span,
+    .kt-select-option-wrapper {
       display: inline-block;
       margin: 0 2px;
       width: calc(100% - 4px);
@@ -150,7 +151,8 @@
     margin-bottom: -3px;
   }
 
-  & > span {
+  & > span,
+  .kt-select-option-wrapper {
     color: var(--kt-selectDropdown-foreground);
     background-color: var(--kt-selectDropdown-background);
     cursor: pointer;

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-connection",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-browser",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "@opensumi/ide-core-browser",
   "files": [
     "lib",

--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'classnames';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { Button, CheckBox, Icon } from '@opensumi/ide-components';
 import { ClickParam, Menu } from '@opensumi/ide-components/lib/menu';
@@ -195,19 +195,24 @@ const InlineActionWidget: React.FC<
     iconService?: IMenubarIconService;
   } & React.HTMLAttributes<HTMLElement>
 > = React.memo(({ iconService, type = 'icon', data, context = [], className, afterClick, ...restProps }) => {
+  const [loading, setLoading] = useState(false);
   const handleClick = React.useCallback(
-    (event?: React.MouseEvent<HTMLElement>, ...extraArgs: any[]) => {
+    async (event?: React.MouseEvent<HTMLElement>, ...extraArgs: any[]) => {
       if (event) {
         event.preventDefault();
         event.stopPropagation();
       }
+      if (loading) {
+        return;
+      }
+      setLoading(true);
       if (data.id === SubmenuItemNode.ID && event) {
         const anchor = { x: event.clientX, y: event.clientY };
-        data.execute([anchor, ...context]);
+        await data.execute([anchor, ...context]);
       } else if (typeof data.execute === 'function') {
-        data.execute([...context, ...extraArgs]);
+        await data.execute([...context, ...extraArgs]);
       }
-
+      setLoading(false);
       if (typeof afterClick === 'function') {
         afterClick();
       }
@@ -261,6 +266,7 @@ const InlineActionWidget: React.FC<
 
   return (
     <Button
+      loading={loading}
       className={clsx(className, styles.btnAction)}
       disabled={data.disabled}
       onClick={handleClick}

--- a/packages/core-common/package.json
+++ b/packages/core-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-common",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "@opensumi/ide-core-common",
   "files": [
     "lib",

--- a/packages/core-electron-main/package.json
+++ b/packages/core-electron-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-electron-main",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "browser-preload"

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-node",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "@opensumi/ide-core-node",
   "files": [
     "lib",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-debug",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/decoration/package.json
+++ b/packages/decoration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-decoration",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-editor",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -345,13 +345,23 @@ export abstract class BaseMonacoEditorWrapper extends WithEventBus implements IE
     const basicEditorOptions: Partial<monaco.editor.IEditorOptions> = {
       readOnly: this.currentDocumentModel?.readonly || false,
     };
+
+    let editorOptions = {
+      ...basicEditorOptions,
+      ...options.editorOptions,
+      ...this._editorOptionsFromContribution,
+      ...this._specialEditorOptions,
+    };
+
+    if (this.type > EditorType.CODE) {
+      editorOptions = {
+        ...editorOptions,
+        ...options.diffOptions,
+      };
+    }
+
     return {
-      editorOptions: {
-        ...basicEditorOptions,
-        ...options.editorOptions,
-        ...this._editorOptionsFromContribution,
-        ...this._specialEditorOptions,
-      },
+      editorOptions,
       modelOptions: { ...options.modelOptions, ...this._specialModelOptions },
     };
   }

--- a/packages/editor/src/browser/preference/converter.ts
+++ b/packages/editor/src/browser/preference/converter.ts
@@ -767,6 +767,16 @@ export const diffEditorOptionsConverters: Map<KaitianPreferenceKey, NoConverter 
    * Defaults to false.
    */
   ['diffEditor.originalEditable', { monaco: 'originalEditable' }],
+
+  [
+    'diffEditor.minimap',
+    {
+      monaco: 'minimap',
+      convert: (value: any) => ({
+        enabled: value,
+      }),
+    },
+  ],
 ]);
 
 function isContainOptionKey(key: string, optionMap: Map<KaitianPreferenceKey, NoConverter | IMonacoOptionsConverter>) {

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1399,6 +1399,10 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     default: true,
     description: '%editor.configuration.renderIndicators%',
   },
+  'diffEditor.minimap': {
+    type: 'boolean',
+    default: false,
+  },
   'editor.defaultFormatter': {
     type: 'string',
     description: '%editor.configuration.defaultFormatter%',

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-electron-basic",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-explorer",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/express-file-server/package.json
+++ b/packages/express-file-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-express-file-server",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-manager",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/extension-storage/package.json
+++ b/packages/extension-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-storage",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "hosted"

--- a/packages/extension/src/browser/components/extension-tree-view.tsx
+++ b/packages/extension/src/browser/components/extension-tree-view.tsx
@@ -9,7 +9,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
+  useState,
 } from 'react';
 
 import { Injector } from '@opensumi/di';
@@ -38,8 +38,6 @@ export interface ExtensionTabBarTreeViewProps {
 
 export const ExtensionTabBarTreeView = observer(
   ({ viewState, model, dataProvider, treeViewId }: PropsWithChildren<ExtensionTabBarTreeViewProps>) => {
-    const isReady = useRef<boolean>(false);
-    const isEmpty = useRef<boolean>(dataProvider.isTreeEmpty);
     const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
     const decorationService = useInjectable<IDecorationsService>(IDecorationsService);
     const accordionService = useMemo(() => layoutService.getViewAccordionService(treeViewId), []);
@@ -51,13 +49,6 @@ export const ExtensionTabBarTreeView = observer(
       }
       return !state.collapsed && !state.hidden;
     }, [accordionService]);
-
-    useEffect(() => {
-      const disposable = dataProvider.onDidChangeEmpty(() => {
-        isEmpty.current = dataProvider.isTreeEmpty;
-      });
-      return () => disposable.dispose();
-    }, []);
 
     const { height } = viewState;
     const { canSelectMany } = model.treeViewOptions || {};
@@ -186,23 +177,6 @@ export const ExtensionTabBarTreeView = observer(
     );
 
     useEffect(() => {
-      let unmouted = false;
-      (async () => {
-        await model.whenReady;
-        if (model.treeModel && isVisible) {
-          await model.treeModel.ensureReady;
-        }
-        if (!unmouted) {
-          isReady.current = true;
-        }
-      })();
-      return () => {
-        unmouted = true;
-        model && model.removeNodeDecoration();
-      };
-    }, [model, isVisible]);
-
-    useEffect(() => {
       const handleBlur = () => {
         model.handleTreeBlur();
       };
@@ -222,9 +196,8 @@ export const ExtensionTabBarTreeView = observer(
         data-tree-view-id={treeViewId}
       >
         <TreeView
-          isReady={isReady.current}
-          isEmpty={isEmpty.current}
           height={height}
+          isVisible={isVisible}
           handleTreeReady={handleTreeReady}
           handleItemClicked={handleItemClicked}
           handleTwistierClick={handleTwistierClick}
@@ -237,6 +210,7 @@ export const ExtensionTabBarTreeView = observer(
           draggable={model.draggable}
           treeViewId={treeViewId}
           model={model}
+          dataProvider={dataProvider}
           decorationService={decorationService}
         />
       </div>
@@ -245,10 +219,10 @@ export const ExtensionTabBarTreeView = observer(
 );
 
 interface TreeViewProps {
-  isReady: boolean;
-  isEmpty: boolean;
+  isVisible: boolean;
   height: number;
   treeViewId: string;
+  dataProvider: TreeViewDataProvider;
   model: ExtensionTreeViewModel;
   handleTreeReady(handle: IRecycleTreeHandle): void;
   handleItemClicked(ev: MouseEvent, item: ExtensionTreeNode | ExtensionCompositeTreeNode, type: TreeNodeType): void;
@@ -265,8 +239,7 @@ interface TreeViewProps {
 
 function isTreeViewPropsEqual(prevProps: TreeViewProps, nextProps: TreeViewProps) {
   return (
-    prevProps.isReady === nextProps.isReady &&
-    prevProps.isEmpty === nextProps.isEmpty &&
+    prevProps.isVisible === nextProps.isVisible &&
     prevProps.model === nextProps.model &&
     prevProps.treeViewId === nextProps.treeViewId &&
     prevProps.height === nextProps.height
@@ -275,11 +248,11 @@ function isTreeViewPropsEqual(prevProps: TreeViewProps, nextProps: TreeViewProps
 
 const TreeView = memo(
   ({
-    isReady,
-    isEmpty,
     model,
     treeViewId,
     height,
+    isVisible,
+    dataProvider,
     handleTreeReady,
     handleItemClicked,
     handleTwistierClick,
@@ -292,6 +265,35 @@ const TreeView = memo(
     draggable,
     decorationService,
   }: TreeViewProps) => {
+    const [isReady, setIsReady] = useState<boolean>(false);
+    const [isEmpty, setIsEmpty] = useState(false);
+
+    useEffect(() => {
+      let unmouted = false;
+      (async () => {
+        await model.whenReady;
+        if (model.treeModel && isVisible) {
+          await model.treeModel.ensureReady;
+        }
+        if (!unmouted) {
+          setIsReady(true);
+        }
+      })();
+      return () => {
+        unmouted = true;
+        model && model.removeNodeDecoration();
+      };
+    }, [model, isVisible]);
+
+    useEffect(() => {
+      const disposable = dataProvider.onDidChangeEmpty(() => {
+        if (dataProvider.isTreeEmpty !== isEmpty) {
+          setIsEmpty(dataProvider.isTreeEmpty);
+        }
+      });
+      return () => disposable.dispose();
+    }, []);
+
     const renderTreeNode = useCallback(
       (props: INodeRendererProps) => (
         <TreeViewNode

--- a/packages/extension/src/hosted/api/vscode/ext.host.window-state.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.window-state.ts
@@ -24,6 +24,7 @@ export class WindowStateImpl implements types.WindowState {
   public focused: boolean;
 
   constructor() {
-    this.focused = false;
+    // 当插件进程重启时，这里如果默认是 false，会与实际状态不一致，导致依赖该状态的插件处理有问题
+    this.focused = true;
   }
 }

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-scheme",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-search",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-service",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-tree-next",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -46,8 +46,8 @@ export const FILE_TREE_FILTER_DELAY = 500;
 const FilterableRecycleTree = RecycleTreeFilterDecorator(RecycleTree);
 
 export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState }>) => {
-  const isReady = useRef<boolean>(false);
-  const isLoading = useRef<boolean>(true);
+  const [isReady, setIsReady] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [outerActive, setOuterActive] = useState<boolean>(false);
   const [outerDragOver, setOuterDragOver] = useState<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
@@ -142,13 +142,13 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
       // 首次初始化完成时，监听后续变化，适配工作区变化事件
       // 监听工作区变化
       fileTreeModelService.onFileTreeModelChange(async (treeModel) => {
-        isLoading.current = true;
+        setIsLoading(true);
         if (treeModel) {
           // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
           await treeModel.ensureReady;
         }
-        isLoading.current = false;
         setModel(treeModel);
+        setIsLoading(false);
       });
     }
   }, [isReady]);
@@ -264,28 +264,27 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
 
   const ensureIsReady = useCallback(
     async (token: CancellationToken) => {
-      isReady.current = false;
       await fileTreeModelService.whenReady;
       if (token.isCancellationRequested) {
         return;
       }
-      // 文件服务已经初始化完毕，但文件树数据仍需要加载
-      isReady.current = true;
       if (fileTreeModelService.treeModel) {
         // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
         await fileTreeModelService.treeModel.ensureReady;
+        setModel(fileTreeModelService.treeModel);
         if (token.isCancellationRequested) {
           return;
         }
-        setModel(fileTreeModelService.treeModel);
-        // 文件树数据加载完毕
-        isLoading.current = false;
         if (wrapperRef.current) {
           fileTreeService.initContextKey(wrapperRef.current);
         }
       }
+      setIsLoading(false);
+      if (!disposableRef.current?.disposed) {
+        setIsReady(true);
+      }
     },
-    [fileTreeModelService],
+    [fileTreeModelService, disposableRef.current],
   );
 
   const handleTreeReady = useCallback(
@@ -366,8 +365,8 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
       onDrop={handleOuterDrop}
     >
       <FileTreeView
-        isLoading={isLoading.current}
-        isReady={isReady.current}
+        isLoading={isLoading}
+        isReady={isReady}
         height={height}
         model={model}
         iconTheme={iconTheme}

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -357,7 +357,7 @@ export class FileTreeModelService {
     );
     this.disposableCollection.push(
       this.treeModel.root.watcher.on(TreeNodeEvent.DidResolveChildren, (target) => {
-        this.loadingDecoration.removeTarget(target);
+        this.loadingDecoration.clearAppliedTarget();
         this.treeModel.dispatchChange();
       }),
     );
@@ -419,28 +419,22 @@ export class FileTreeModelService {
 
   // 清空所有节点选中态
   clearFileSelectedDecoration = () => {
-    this._selectedFiles.forEach((file) => {
-      this.selectedDecoration.removeTarget(file);
-    });
+    this.selectedDecoration.clearAppliedTarget();
     this._selectedFiles = [];
   };
 
   // 清空其他选中/焦点态节点，更新当前焦点节点
   activeFileDecoration = (target: File | Directory, dispatchChange = true) => {
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
       this.contextMenuFile = undefined;
     }
     if (target) {
       if (this.selectedFiles.length > 0) {
-        // 因为选择装饰器可能通过其他方式添加而不能及时在selectedFiles上更新
-        // 故这里遍历所有选中装饰器的节点进行一次统一清理
-        for (const target of this.selectedDecoration.appliedTargets.keys()) {
-          this.selectedDecoration.removeTarget(target);
-        }
+        this.selectedDecoration.clearAppliedTarget();
       }
       if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       this.selectedDecoration.addTarget(target);
       this.focusedDecoration.addTarget(target);
@@ -461,17 +455,17 @@ export class FileTreeModelService {
     }
 
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
       this.contextMenuFile = undefined;
     }
     if (target) {
       if (this.selectedFiles.length > 0) {
-        this.selectedFiles.forEach((file) => {
-          this.selectedDecoration.removeTarget(file);
-        });
+        // 由于文件树更新较为频繁，容易出现用户点击时刚好节点被更新情况
+        // 故这里需要从 Decoration 内移除节点
+        this.selectedDecoration.clearAppliedTarget();
       }
       if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       this.selectedDecoration.addTarget(target);
       this._selectedFiles = [target];
@@ -485,10 +479,11 @@ export class FileTreeModelService {
   // 右键菜单焦点态切换
   activateFileActivedDecoration = (target: File | Directory) => {
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
+      this.contextMenuFile = undefined;
     }
     if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     }
     this.contextMenuDecoration.addTarget(target);
@@ -499,10 +494,10 @@ export class FileTreeModelService {
   // 右键菜单焦点态切换
   activateFileFocusedDecoration = (target: File | Directory) => {
     if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
     }
     if (this.contextMenuFile) {
-      this.contextMenuDecoration.removeTarget(this.contextMenuFile);
+      this.contextMenuDecoration.clearAppliedTarget();
       this.contextMenuFile = undefined;
     }
     this.focusedDecoration.addTarget(target);
@@ -522,12 +517,12 @@ export class FileTreeModelService {
       if (removePreFocusedDecoration) {
         if (this.focusedFile) {
           // 多选情况下第一次切换焦点文件
-          this.focusedDecoration.removeTarget(this.focusedFile);
+          this.focusedDecoration.clearAppliedTarget();
         }
         this.contextMenuFile = target;
       } else if (this.focusedFile) {
         this.contextMenuFile = undefined;
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       if (target) {
         // 存在多选文件时切换焦点的情况
@@ -549,16 +544,16 @@ export class FileTreeModelService {
     const index = this._selectedFiles.indexOf(target);
     if (index > -1) {
       if (this.focusedFile === target) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
         this.focusedFile = undefined;
       }
       this._selectedFiles.splice(index, 1);
-      this.selectedDecoration.removeTarget(target);
+      this.selectedDecoration.clearAppliedTarget();
     } else {
       this._selectedFiles.push(target);
       this.selectedDecoration.addTarget(target);
       if (this.focusedFile) {
-        this.focusedDecoration.removeTarget(this.focusedFile);
+        this.focusedDecoration.clearAppliedTarget();
       }
       this.focusedFile = target;
       this.focusedDecoration.addTarget(target);
@@ -589,7 +584,7 @@ export class FileTreeModelService {
   // 取消选中节点焦点
   deactivateFileDecoration = () => {
     if (this.focusedFile) {
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     }
     // 失去焦点状态时，仅清理右键菜单的选中态
@@ -899,7 +894,7 @@ export class FileTreeModelService {
     let node;
     if (this.focusedFile) {
       node = this.focusedFile;
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     } else if (this.contextMenuFile) {
       node = this.contextMenuFile;
@@ -934,7 +929,7 @@ export class FileTreeModelService {
     let node;
     if (this.focusedFile) {
       node = this.focusedFile;
-      this.focusedDecoration.removeTarget(this.focusedFile);
+      this.focusedDecoration.clearAppliedTarget();
       this.focusedFile = undefined;
     } else if (this.contextMenuFile) {
       node = this.contextMenuFile;

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-i18n",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-keymaps",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/logs-core/package.json
+++ b/packages/logs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-logs",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/main-layout/package.json
+++ b/packages/main-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-main-layout",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "@opensumi/ide-main-layout",
   "files": [
     "lib",

--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -90,7 +90,7 @@ const ContainerView: React.FC<{
   component: ComponentRegistryInfo;
   side: string;
   titleMenu: IMenu;
-}> = ({ component, titleMenu, side }) => {
+}> = observer(({ component, titleMenu, side }) => {
   const ref = React.useRef<HTMLElement | null>();
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const configContext = useInjectable<AppConfig>(AppConfig);
@@ -143,13 +143,13 @@ const ContainerView: React.FC<{
       </div>
     </div>
   );
-};
+});
 
 const BottomPanelView: React.FC<{
   component: ComponentRegistryInfo;
   side: string;
   titleMenu: IMenu;
-}> = ({ component, titleMenu, side }) => {
+}> = observer(({ component, titleMenu, side }) => {
   const ref = React.useRef<HTMLElement | null>();
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const configContext = useInjectable<AppConfig>(AppConfig);
@@ -201,7 +201,7 @@ const BottomPanelView: React.FC<{
       </div>
     </div>
   );
-};
+});
 
 export const RightTabPanelRenderer: React.FC = () => <BaseTabPanelView PanelView={ContainerView} />;
 

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markdown",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markers",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-menu-bar",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "@opensumi/ide-menu-bar",
   "files": [
     "lib",

--- a/packages/monaco-enhance/package.json
+++ b/packages/monaco-enhance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco-enhance",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/opened-editor/package.json
+++ b/packages/opened-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-opened-editor",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-model.service.ts
@@ -1,11 +1,5 @@
 import { Injectable, Autowired, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import {
-  DecorationsManager,
-  Decoration,
-  IRecycleTreeHandle,
-  TreeNodeType,
-  WatchEvent,
-} from '@opensumi/ide-components';
+import { DecorationsManager, Decoration, IRecycleTreeHandle, TreeNodeType, WatchEvent } from '@opensumi/ide-components';
 import {
   URI,
   DisposableCollection,
@@ -84,7 +78,7 @@ export class OpenedEditorModelService {
   private _whenReady: Promise<void>;
 
   private _decorations: DecorationsManager;
-  private _openedEditorTreeHandle: IEditorTreeHandle;
+  private _openedEditorTreeHandle?: IEditorTreeHandle;
 
   public flushEventQueueDeferred: Deferred<void> | null;
   private _eventFlushTimeout: number;
@@ -427,6 +421,9 @@ export class OpenedEditorModelService {
       if (!node) {
         return;
       }
+      if (!this.editorTreeHandle) {
+        return;
+      }
       node = (await this.editorTreeHandle.ensureVisible(node as EditorFile)) as EditorFile;
       if (node) {
         if (this.focusedFile === node) {
@@ -443,7 +440,11 @@ export class OpenedEditorModelService {
     if (node.parent && EditorFileGroup.is(node.parent as EditorFileGroup)) {
       groupIndex = (node.parent as EditorFileGroup).group.index;
     }
-    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, node.uri, { groupIndex, preserveFocus: true, disableNavigateOnOpendEditor: true });
+    this.commandService.executeCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, node.uri, {
+      groupIndex,
+      preserveFocus: true,
+      disableNavigateOnOpendEditor: true,
+    });
   };
 
   public closeFile = (node: EditorFile) => {

--- a/packages/outline/package.json
+++ b/packages/outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-outline",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-output",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-overlay",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-preferences",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-process",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/quick-open/package.json
+++ b/packages/quick-open/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-quick-open",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/remote-opener/package.json
+++ b/packages/remote-opener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-remote-opener",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-scm",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/scm/src/browser/components/scm-resource-tree/index.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/index.tsx
@@ -1,6 +1,6 @@
 import clx from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { FC, useState, useRef, createRef, RefObject, useEffect, useCallback, memo } from 'react';
+import React, { FC, useState, createRef, RefObject, useEffect, useCallback, memo } from 'react';
 
 import { RecycleTree, IRecycleTreeHandle, TreeNodeType, TreeModel } from '@opensumi/ide-components';
 import { isOSX } from '@opensumi/ide-core-browser';
@@ -20,7 +20,7 @@ export const SCMResourceTree: FC<{
   width: number;
   height: number;
 }> = observer(({ height }) => {
-  const isReady = useRef<boolean>(false);
+  const [isReady, setIsReady] = useState<boolean>(false);
   const [model, setModel] = useState<TreeModel>();
 
   const wrapperRef: RefObject<HTMLDivElement> = createRef();
@@ -39,7 +39,7 @@ export const SCMResourceTree: FC<{
         // 这里需要重新取一下treeModel的值确保为最新的TreeModel
         await scmTreeModelService.treeModel.ensureReady;
       }
-      isReady.current = true;
+      setIsReady(true);
     })();
   }, []);
 
@@ -142,7 +142,7 @@ export const SCMResourceTree: FC<{
       data-name={TREE_FIELD_NAME}
     >
       <SCMTreeView
-        isReady={isReady.current}
+        isReady={isReady}
         model={model}
         height={height}
         onTreeReady={handleTreeReady}

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-search",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-startup",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/static-resource/package.json
+++ b/packages/static-resource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-static-resource",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/status-bar/package.json
+++ b/packages/status-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-status-bar",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-storage",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-task",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-terminal-next",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-testing",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-theme",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-toolbar",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/types/manifest.json
+++ b/packages/types/manifest.json
@@ -1,296 +1,296 @@
 {
   "meta": {
     "@opensumi/ide-addons": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-collaboration": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-comments": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-components": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-connection": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-core-browser": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["common"]
     },
     "@opensumi/ide-core-common": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-core-electron-main": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-core-node": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-debug": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-decoration": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-editor": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-electron-basic": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-explorer": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-express-file-server": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-manager": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-storage": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-file-scheme": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-search": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-file-service": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-tree-next": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-i18n": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-keymaps": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-logs": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-main-layout": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markdown": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markers": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-menu-bar": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-monaco": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-monaco-enhance": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-opened-editor": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-outline": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-output": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-overlay": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-preferences": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-process": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-quick-open": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/remote-cli": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-remote-opener": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-scm": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-search": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-startup": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-static-resource": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser"]
     },
     "@opensumi/ide-status-bar": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-storage": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-task": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-terminal-next": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-testing": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-theme": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-toolbar": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser"]
     },
     "@opensumi/sumi": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-userstorage": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-utils": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": []
     },
     "@opensumi/ide-variable": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-webview": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace-edit": {
-      "version": "2.26.2",
+      "version": "2.26.3",
       "entry": ["browser", "common"]
     }
   },
   "packages": {
-    "@opensumi/ide-addons": "2.26.2",
-    "@opensumi/ide-collaboration": "2.26.2",
-    "@opensumi/ide-comments": "2.26.2",
-    "@opensumi/ide-components": "2.26.2",
-    "@opensumi/ide-connection": "2.26.2",
-    "@opensumi/ide-core-browser": "2.26.2",
-    "@opensumi/ide-core-common": "2.26.2",
-    "@opensumi/ide-core-electron-main": "2.26.2",
-    "@opensumi/ide-core-node": "2.26.2",
-    "@opensumi/ide-debug": "2.26.2",
-    "@opensumi/ide-decoration": "2.26.2",
-    "@opensumi/ide-editor": "2.26.2",
-    "@opensumi/ide-electron-basic": "2.26.2",
-    "@opensumi/ide-explorer": "2.26.2",
-    "@opensumi/ide-express-file-server": "2.26.2",
-    "@opensumi/ide-extension": "2.26.2",
-    "@opensumi/ide-extension-manager": "2.26.2",
-    "@opensumi/ide-extension-storage": "2.26.2",
-    "@opensumi/ide-file-scheme": "2.26.2",
-    "@opensumi/ide-file-search": "2.26.2",
-    "@opensumi/ide-file-service": "2.26.2",
-    "@opensumi/ide-file-tree-next": "2.26.2",
-    "@opensumi/ide-i18n": "2.26.2",
-    "@opensumi/ide-keymaps": "2.26.2",
-    "@opensumi/ide-logs": "2.26.2",
-    "@opensumi/ide-main-layout": "2.26.2",
-    "@opensumi/ide-markdown": "2.26.2",
-    "@opensumi/ide-markers": "2.26.2",
-    "@opensumi/ide-menu-bar": "2.26.2",
-    "@opensumi/ide-monaco": "2.26.2",
-    "@opensumi/ide-monaco-enhance": "2.26.2",
-    "@opensumi/ide-opened-editor": "2.26.2",
-    "@opensumi/ide-outline": "2.26.2",
-    "@opensumi/ide-output": "2.26.2",
-    "@opensumi/ide-overlay": "2.26.2",
-    "@opensumi/ide-preferences": "2.26.2",
-    "@opensumi/ide-process": "2.26.2",
-    "@opensumi/ide-quick-open": "2.26.2",
-    "@opensumi/remote-cli": "2.26.2",
-    "@opensumi/ide-remote-opener": "2.26.2",
-    "@opensumi/ide-scm": "2.26.2",
-    "@opensumi/ide-search": "2.26.2",
-    "@opensumi/ide-startup": "2.26.2",
-    "@opensumi/ide-static-resource": "2.26.2",
-    "@opensumi/ide-status-bar": "2.26.2",
-    "@opensumi/ide-storage": "2.26.2",
-    "@opensumi/ide-task": "2.26.2",
-    "@opensumi/ide-terminal-next": "2.26.2",
-    "@opensumi/ide-testing": "2.26.2",
-    "@opensumi/ide-theme": "2.26.2",
-    "@opensumi/ide-toolbar": "2.26.2",
-    "@opensumi/sumi": "2.26.2",
-    "@opensumi/ide-userstorage": "2.26.2",
-    "@opensumi/ide-utils": "2.26.2",
-    "@opensumi/ide-variable": "2.26.2",
-    "@opensumi/ide-webview": "2.26.2",
-    "@opensumi/ide-workspace": "2.26.2",
-    "@opensumi/ide-workspace-edit": "2.26.2"
+    "@opensumi/ide-addons": "2.26.3",
+    "@opensumi/ide-collaboration": "2.26.3",
+    "@opensumi/ide-comments": "2.26.3",
+    "@opensumi/ide-components": "2.26.3",
+    "@opensumi/ide-connection": "2.26.3",
+    "@opensumi/ide-core-browser": "2.26.3",
+    "@opensumi/ide-core-common": "2.26.3",
+    "@opensumi/ide-core-electron-main": "2.26.3",
+    "@opensumi/ide-core-node": "2.26.3",
+    "@opensumi/ide-debug": "2.26.3",
+    "@opensumi/ide-decoration": "2.26.3",
+    "@opensumi/ide-editor": "2.26.3",
+    "@opensumi/ide-electron-basic": "2.26.3",
+    "@opensumi/ide-explorer": "2.26.3",
+    "@opensumi/ide-express-file-server": "2.26.3",
+    "@opensumi/ide-extension": "2.26.3",
+    "@opensumi/ide-extension-manager": "2.26.3",
+    "@opensumi/ide-extension-storage": "2.26.3",
+    "@opensumi/ide-file-scheme": "2.26.3",
+    "@opensumi/ide-file-search": "2.26.3",
+    "@opensumi/ide-file-service": "2.26.3",
+    "@opensumi/ide-file-tree-next": "2.26.3",
+    "@opensumi/ide-i18n": "2.26.3",
+    "@opensumi/ide-keymaps": "2.26.3",
+    "@opensumi/ide-logs": "2.26.3",
+    "@opensumi/ide-main-layout": "2.26.3",
+    "@opensumi/ide-markdown": "2.26.3",
+    "@opensumi/ide-markers": "2.26.3",
+    "@opensumi/ide-menu-bar": "2.26.3",
+    "@opensumi/ide-monaco": "2.26.3",
+    "@opensumi/ide-monaco-enhance": "2.26.3",
+    "@opensumi/ide-opened-editor": "2.26.3",
+    "@opensumi/ide-outline": "2.26.3",
+    "@opensumi/ide-output": "2.26.3",
+    "@opensumi/ide-overlay": "2.26.3",
+    "@opensumi/ide-preferences": "2.26.3",
+    "@opensumi/ide-process": "2.26.3",
+    "@opensumi/ide-quick-open": "2.26.3",
+    "@opensumi/remote-cli": "2.26.3",
+    "@opensumi/ide-remote-opener": "2.26.3",
+    "@opensumi/ide-scm": "2.26.3",
+    "@opensumi/ide-search": "2.26.3",
+    "@opensumi/ide-startup": "2.26.3",
+    "@opensumi/ide-static-resource": "2.26.3",
+    "@opensumi/ide-status-bar": "2.26.3",
+    "@opensumi/ide-storage": "2.26.3",
+    "@opensumi/ide-task": "2.26.3",
+    "@opensumi/ide-terminal-next": "2.26.3",
+    "@opensumi/ide-testing": "2.26.3",
+    "@opensumi/ide-theme": "2.26.3",
+    "@opensumi/ide-toolbar": "2.26.3",
+    "@opensumi/sumi": "2.26.3",
+    "@opensumi/ide-userstorage": "2.26.3",
+    "@opensumi/ide-utils": "2.26.3",
+    "@opensumi/ide-variable": "2.26.3",
+    "@opensumi/ide-webview": "2.26.3",
+    "@opensumi/ide-workspace": "2.26.3",
+    "@opensumi/ide-workspace-edit": "2.26.3"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/sumi",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "typings": "index.d.ts",
   "license": "MIT",
   "repository": {

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-userstorage",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-utils",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/variable/package.json
+++ b/packages/variable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-variable",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-webview",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/workspace-edit/package.json
+++ b/packages/workspace-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace-edit",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "files": [
     "lib",
     "src"

--- a/tools/cli-engine/package.json
+++ b/tools/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/cli-engine",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "Integration engine runtime for opensumi-cli and opensumi extension",
   "license": "MIT",
   "files": [

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/playwright",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "E2E test module for OpenSumi",
   "files": [
     "lib",


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0be592</samp>

*  Add loading state and indicator to the Action component to prevent multiple clicks and show feedback ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L2-R2),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668L198-R215),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-c85e907dd3496f89fcfa13f8d68e42dea51a53d66b146e1390f91b5e71fff668R269))
*  Add onTwistierClick prop and handler to the comment tree nodes and the CommentsPanelView component to handle the twistier click event ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5R45),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5L65-R66),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5L86-R87),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202R15),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L26-R47),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202R104),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L98-R110),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-d6598f4adb3b702e969b9019347ed31fa8b8172872454d847fae981e34e16e8aR152-R157))
*  Rename the search_node class to comment_node and the renderSearchTree function to renderCommentTree in the comments component to avoid confusion and reflect the purpose ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-5d560aa21afc92d32e78e55c8e2619a1acc68f21b551c228bcc26ffea5799202L114-R126),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-0ab74e6e76a6eb5f883702ac075933eb69926d5c34efac114136ecb4b1f594deL1-R1),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-0ab74e6e76a6eb5f883702ac075933eb69926d5c34efac114136ecb4b1f594deR14-R17),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-0ab74e6e76a6eb5f883702ac075933eb69926d5c34efac114136ecb4b1f594deR78),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5L65-R66),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-771fbb694671a2e19208257f95a835e509ffe69689ff6a5aeaedeb9e70bc13c5L86-R87))
*  Add clearAppliedTarget and clearNegatedTarget methods to the Decoration class to clear all the applied or negated targets of the decoration ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-51c422f7f6e04b1d45e90b0ff387709f7d6ddff0da75ff0ca7371d0a19c39818R180-R199))
*  Replace the removeTarget method with the clearAppliedTarget method in the file tree and scm resource tree models to clear all the applied targets of the decorations instead of iterating or checking ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L360-R360),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L422-R422),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L431-R437),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L464-R468),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L488-R486),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L502-R500),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L525-R525),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L552-R556),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L592-R587),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L902-R897),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L937-R932),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L23-R23),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L42-R42),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L145-R145))
*  Replace the ref hooks with the state hooks for the isReady and isLoading state variables in the file tree and scm resource tree components to use the state hook instead of the ref hook ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L49-R50),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L145-R151),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L267-R287),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-9c85b7ad5fcbf1c46e9e85ec675cd0df18dc53dc2610e2d2195d092112fcabd1L369-R369),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L23-R23),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L42-R42),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L145-R145))
*  Remove the isReady and isEmpty refs and props from the extension tree view component and use the dataProvider prop and the isVisible prop instead ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L12-R12),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L41-L42),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L55-L61),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L189-L205),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L225-R200),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656R213),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L248-R225),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L268-R242),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656L278-R255),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-6fafb66402eb1bdb52b66866e75f69c9cde7e902b6c153c120555846cfe82656R268-R296))
*  Add CSS selectors for the kt-select-option-wrapper element to apply the same properties as the span element in the kt-select-option and kt-select-option-select classes ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-91108f46a344054e61e3ecb0022c13586a40733b044a762f74eb39d02c325084L133-R134),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-91108f46a344054e61e3ecb0022c13586a40733b044a762f74eb39d02c325084L153-R155))
*  Add the observer function from mobx-react-lite to the ContainerView and BottomPanelView components to make them reactive to the observable state changes in the titleMenu prop ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L93-R93),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L146-R146),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L152-R152),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L204-R204))
*  Set the focused property to true by default in the WindowStateImpl class constructor to avoid inconsistency with the actual state when the plugin process restarts ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-0dcf21ae2a7d0af96f98dd46f446e49966250a1f2fc50e22eb60a8ce9ce91e9eL27-R28))
*  Add a check for the editorTreeHandle property in the onEditorGroupChange event handler and format the commandService.executeCommand method call in the openEditor method in the OpenedEditorModelService class ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L87-R81),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2R424-R426),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L446-R447))
*  Remove unused imports from the opened-editor-model.service.ts and index.tsx files ([link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-7a5358c7a580c3f108ff520ba170289fe1df4e4e070b6f0c5cfbf666462071e2L2-R3),[link](https://github.com/opensumi/core/pull/2968/files?diff=unified&w=0#diff-8b3822a9f8c34ec43c873e654b6bd4d02faebdcd66cbc3cf2cc85d67158d60a8L3-R3))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0be592</samp>

This pull request introduces various improvements and fixes to the comments, components, core-browser, extension, file-tree-next, main-layout, opened-editor, and scm packages. It mainly focuses on enhancing the performance, readability, and consistency of the components and services, as well as fixing some styling and logic issues. It also adds some new features such as a twistier click handler for the comments panel, a loading state for the action buttons, and a clearAppliedTarget method for the decorations.
