### PR TITLE
fix: terminal panel registered wrong view id

### DIFF
--- a/packages/terminal-next/src/browser/contribution/terminal.view.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.view.ts
@@ -48,7 +48,7 @@ export class TerminalRenderContribution implements ComponentContribution, TabBar
       '@opensumi/ide-terminal-next',
       {
         component: TerminalView,
-        id: 'ide-terminal-next',
+        id: TerminalRenderContribution.viewId,
       },
       {
         title: localize('terminal.name'),


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

这四个按钮不见了：

![CleanShot 2023-08-01 at 17 31 49@2x](https://github.com/opensumi/core/assets/13938334/11bac70a-2dfb-4e51-a0b5-bd3855e32950)


<img width="737" alt="CleanShot 2023-08-01 at 17 31 11@2x" src="https://github.com/opensumi/core/assets/13938334/b4ed42f6-594b-44fe-9678-560f575b1e7a">


### Changelog

Fix missing action buttons on the terminal panel