### PR TITLE
fix: support vscode workbench.action.openGlobalKeybindings commands

### DIFF
--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -461,6 +461,7 @@ export class ExtensionCommandContribution implements CommandContribution {
       VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_SETTINGS,
       VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_GLOBAL_SETTINGS,
       VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_SETTINGS_JSON,
+      VSCodeBuiltinCommands.SETTINGS_COMMAND_OPEN_GLOBAL_OPEN_KEYMAPS,
       VSCodeBuiltinCommands.THEME_COMMAND_QUICK_SELECT,
       // merge editor
       VSCodeBuiltinCommands.OPEN_MERGEEDITOR,

--- a/packages/extension/src/browser/vscode/builtin-commands.ts
+++ b/packages/extension/src/browser/vscode/builtin-commands.ts
@@ -268,6 +268,11 @@ export const SETTINGS_COMMAND_OPEN_SETTINGS_JSON: Command = {
   delegate: 'preference.open.source',
 };
 
+export const SETTINGS_COMMAND_OPEN_GLOBAL_OPEN_KEYMAPS: Command = {
+  id: 'workbench.action.openGlobalKeybindings',
+  delegate: COMMON_COMMANDS.OPEN_KEYMAPS.id,
+};
+
 export const EDITOR_NAVIGATE_BACK: Command = {
   id: 'workbench.action.navigateBack',
   delegate: EDITOR_COMMANDS.GO_BACK.id,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b4871b</samp>

*  Add a new command to register VS Code built-in command for opening global keybindings file ([link](https://github.com/opensumi/core/pull/2970/files?diff=unified&w=0#diff-b09f275754e0faf70db5040b3193f1d05e50016f89bcf82907b98bd52f01b85eR464))
*  Define the new command as a constant and delegate it to the common command provided by the framework ([link](https://github.com/opensumi/core/pull/2970/files?diff=unified&w=0#diff-fbec75cee32aef05f3342200b8b06c8551e26572d3d648883f351b670ae9549aR271-R275))

<!-- Additional content -->
<!-- 补充额外内容 -->

support command `workbench.action.openGlobalKeybindings`

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b4871b</samp>

Added support for the VS Code built-in command `settings.openGlobalKeybindings` that opens the global keybindings file. Implemented the command by delegating to the existing `COMMON_COMMANDS.OPEN_KEYMAPS` command in the `extension` package.
