### PR TITLE
fix: not resolve eacape in message.open

### DIFF
--- a/packages/components/src/utils/marked.ts
+++ b/packages/components/src/utils/marked.ts
@@ -23,6 +23,7 @@ export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => marke
 
 export const parseWithoutEscape = (token: marked.Token) => {
   // 这里兼容下 vscode 的写法，vscode 这里没有处理 markdown 语法
+  // 否则会出现 (\\) 被解析成 () 期望是 (\)
   if (token.type === 'escape') {
     token.text = token.raw;
   }

--- a/packages/components/src/utils/marked.ts
+++ b/packages/components/src/utils/marked.ts
@@ -20,3 +20,12 @@ export const parseMarkdown = (
 };
 
 export const toMarkdownHtml = (value: string, options?: IMarkedOptions) => marked(value, options);
+
+export const parseWithoutEscape = (token: marked.Token) => {
+  // 这里兼容下 vscode 的写法，vscode 这里没有处理 markdown 语法
+  if (token.type === 'escape') {
+    token.text = token.raw;
+  }
+
+  return token;
+};

--- a/packages/core-browser/src/markdown/index.tsx
+++ b/packages/core-browser/src/markdown/index.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
 import { DATA_SET_COMMAND, RenderWrapper } from '@opensumi/ide-components/lib/markdown/render';
-import { createMarkedRenderer, toMarkdownHtml as toHtml } from '@opensumi/ide-components/lib/utils';
+import { createMarkedRenderer, toMarkdownHtml as toHtml, IMarkedOptions } from '@opensumi/ide-components/lib/utils';
 
 import { IOpenerService } from '../opener';
 
-export const toMarkdown = (message: string | React.ReactNode, opener?: IOpenerService): React.ReactNode =>
+export const toMarkdown = (message: string | React.ReactNode, opener?: IOpenerService, options?: IMarkedOptions): React.ReactNode =>
   typeof message === 'string' ? (
-    <RenderWrapper opener={opener} html={toMarkdownHtml(message)}></RenderWrapper>
+    <RenderWrapper opener={opener} html={toMarkdownHtml(message, options)}></RenderWrapper>
   ) : (
     message
   );
 
-export const toMarkdownHtml = (message: string): string => {
+export const toMarkdownHtml = (message: string, options?: IMarkedOptions): string => {
   const renderer = createMarkedRenderer();
 
   renderer.link = (href, title, text) =>
@@ -25,5 +25,6 @@ export const toMarkdownHtml = (message: string): string => {
     smartLists: true,
     smartypants: false,
     renderer,
+    ...(options || {}),
   });
 };

--- a/packages/overlay/src/browser/message.service.tsx
+++ b/packages/overlay/src/browser/message.service.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { notification, open } from '@opensumi/ide-components';
+import { parseWithoutEscape } from '@opensumi/ide-components/lib/utils';
 import { IOpenerService, toMarkdown } from '@opensumi/ide-core-browser';
 import { MessageType, uuid, localize } from '@opensumi/ide-core-common';
 
@@ -64,7 +65,7 @@ export class MessageService extends AbstractMessageService implements IMessageSe
     const description = from && typeof from === 'string' ? `${localize('component.message.origin')}: ${from}` : '';
     const key = uuid();
     const promise = open<T>(
-      toMarkdown(message, this.openerService),
+      toMarkdown(message, this.openerService, { walkTokens: parseWithoutEscape }),
       type,
       closable,
       key,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6a4237</samp>

*  Add a new function `parseWithoutEscape` to prevent escaping backslashes in markdown tokens ([link](https://github.com/opensumi/core/pull/2973/files?diff=unified&w=0#diff-e5650bf072c2b1c0b9197af89121a1100e2fae59216dd21ad036e069d6c3a267R23-R32))
*  Allow passing custom marked options to the `toMarkdown` and `toMarkdownHtml` functions in `packages/core-browser/src/markdown/index.tsx` ([link](https://github.com/opensumi/core/pull/2973/files?diff=unified&w=0#diff-ce0d9a4a7ba728021e210495eac9480b2fdb5e75421447837307b4f65c281b0bL4-R15), [link](https://github.com/opensumi/core/pull/2973/files?diff=unified&w=0#diff-ce0d9a4a7ba728021e210495eac9480b2fdb5e75421447837307b4f65c281b0bR28))
*  Use `parseWithoutEscape` as a walkTokens option in the `MessageService` class in `packages/overlay/src/browser/message.service.tsx` to apply the same escaping logic to the overlay messages ([link](https://github.com/opensumi/core/pull/2973/files?diff=unified&w=0#diff-1a33644b5e09b3099f48a7e34420f1bd71ebf47f039d6244ff71786cf86f9a47R5), [link](https://github.com/opensumi/core/pull/2973/files?diff=unified&w=0#diff-1a33644b5e09b3099f48a7e34420f1bd71ebf47f039d6244ff71786cf86f9a47L67-R68))

<!-- Additional content -->
<!-- 补充额外内容 -->

fix: https://github.com/opensumi/core/issues/2971

![image](https://github.com/opensumi/core/assets/9477255/1d60e49f-ebc6-4f8d-9c09-109e8c207812)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6a4237</samp>

Enhance markdown conversion functions with custom marked options and improve escaping behavior. Add `parseWithoutEscape` function to `marked.ts` and use it in `message.service.tsx` and `toMarkdown` function.
