### PR TITLE
fix: diff editor type

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -353,7 +353,7 @@ export abstract class BaseMonacoEditorWrapper extends WithEventBus implements IE
       ...this._specialEditorOptions,
     };
 
-    if (this.type > EditorType.CODE) {
+    if (this.type !== EditorType.CODE) {
       editorOptions = {
         ...editorOptions,
         ...options.diffOptions,


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97a4835</samp>

* Change the condition for applying non-code editor options to all editor types except `CODE` ([link](https://github.com/opensumi/core/pull/2978/files?diff=unified&w=0#diff-c0d0f058ba7138472d4432426af4cc7f4e0ab38de65fdefd5564c65225f485a0L356-R356))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97a4835</samp>

Fix non-code editor options for markdown and diff editors. Change the condition for applying non-code editor options in `editor-collection.service.ts` to exclude only `CODE` editors.
