### PR TITLE
fix: fix forced save not working

### DIFF
--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -60,6 +60,7 @@ import {
   IEditorDocumentModelService,
   ORIGINAL_DOC_SCHEME,
   EditorDocumentModelWillSaveEvent,
+  IDocModelUpdateOptions,
 } from './types';
 
 export interface EditorDocumentModelConstructionOptions {
@@ -197,15 +198,15 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
     );
   }
 
-  updateOptions(options) {
+  updateOptions(options: IDocModelUpdateOptions) {
     const finalOptions = {
       tabSize: this.editorPreferences['editor.tabSize'] || 1,
       insertSpaces: this.editorPreferences['editor.insertSpaces'],
       detectIndentation: this.editorPreferences['editor.detectIndentation'],
       ...options,
-    };
+    } as IDocModelUpdateOptions;
     if (finalOptions.detectIndentation) {
-      this.monacoModel.detectIndentation(finalOptions.insertSpaces, finalOptions.tabSize);
+      this.monacoModel.detectIndentation(finalOptions.insertSpaces!, finalOptions.tabSize!);
     } else {
       this.monacoModel.updateOptions(finalOptions);
     }
@@ -308,7 +309,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
   }
 
   set eol(eol) {
-    this.monacoModel.setEOL(eol === EOL.LF ? EndOfLineSequence.LF : (EndOfLineSequence.CRLF as any));
+    this.monacoModel.setEOL(eol === EOL.LF ? EndOfLineSequence.LF : EndOfLineSequence.CRLF);
     if (!this._isInitOption) {
       this.eventBus.fire(
         new EditorDocumentModelOptionChangedEvent({

--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -406,7 +406,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
             if (res === diffAndSave) {
               this.compareAndSave();
             } else if (res === overwrite) {
-              doSave(true);
+              doSave(true, reason);
             }
           });
         this.logger.error('The file cannot be saved, the version is inconsistent with the disk');
@@ -414,7 +414,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
       }
       return false;
     };
-    return this.saveQueue.queue(doSave);
+    return this.saveQueue.queue(doSave.bind(this, force, reason));
   }
 
   private async compareAndSave() {

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1207,7 +1207,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
               resource: this.currentResource!,
               selections: e.selections,
               source: e.source,
-              editorUri: URI.from(editor.monacoEditor.getModel()?.uri!),
+              editorUri: URI.from(editor.monacoEditor.getModel()!.uri!),
               side,
             }),
           );


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7e8752</samp>

*  Import and use `IDocModelUpdateOptions` interface to type the `options` parameter of the `updateOptions` method in `EditorDocumentModel` ([link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510R63), [link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L200-R201))
*  Add type assertions and non-null assertions to the `finalOptions` object and its properties when updating the monaco model options ([link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L206-R209))
*  Remove unnecessary cast of `EndOfLineSequence.CRLF` as `any` when setting the end-of-line sequence of the monaco model ([link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L311-R312))
*  Add `reason` parameter to the `doSave` function call and bind it to the queued function when handling file conflicts in `EditorDocumentModel` ([link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L409-R410), [link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-12ab23abe1fd8cce670ba5012ae877d32db4aaa9928315d7ce279c5acc150510L417-R418))
*  Replace optional chaining operator with non-null assertion operator when accessing the `uri` property of the monaco model in `EditorGroup` ([link](https://github.com/opensumi/core/pull/2979/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8L1210-R1210))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

Fix forced save not working