### PR TITLE
fix: improve modifier keybinding ux

### DIFF
--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -780,8 +780,9 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
       clearTimeout(this.modifierKeySequenceTimer);
     }
     const keyCode = KeyCode.createKeyCode(event);
-    // 当传入的 KeyCode 不是修饰符时，不处理
+    // 当传入的 KeyCode 不是修饰符时，清理当前修饰符队列
     if (!keyCode.isModifierOnly()) {
+      this.modifierKeySequence = [];
       return;
     }
     this.modifierKeySequence.push(keyCode);

--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -780,7 +780,7 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
       clearTimeout(this.modifierKeySequenceTimer);
     }
     const keyCode = KeyCode.createKeyCode(event);
-    // 当传入的 KeyCode 不是修饰符时，清理当前修饰符队列
+    // 当传入的 KeyCode 不是修饰符时，清空当前修饰符队列
     if (!keyCode.isModifierOnly()) {
       this.modifierKeySequence = [];
       return;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6f745d4</samp>

* Fix a bug where modifier key sequence was not cleared on non-modifier key press ([link](https://github.com/opensumi/core/pull/2999/files?diff=unified&w=0#diff-2b8de1e4f6dabe8d6e0808c50f4268af104aedb681ef8536409affa204fedddfL783-R785))

<!-- Additional content -->
<!-- 补充额外内容 -->

优化修饰符快捷键，如 `shift+shift` 在输入驼峰类型文本时的使用体验

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f745d4</samp>

Fix a keybinding bug in `core-browser` that could trigger wrong commands. Clear the modifier key sequence when a non-modifier key is pressed in `keybinding.ts`.
