### PR TITLE
refactor: entension log

### DIFF
--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -22,7 +22,7 @@ import { ProcessMessageType, IExtensionHostService, KT_PROCESS_SOCK_OPTION_KEY, 
 import { CommandHandler } from '../common/vscode';
 
 import { setPerformance } from './api/vscode/language/util';
-import { ExtensionLogger2 } from './extension-log2';
+import { ExtensionLogger } from './extension-log';
 import { ExtensionReporter } from './extension-reporter';
 
 import '@opensumi/ide-i18n';
@@ -70,11 +70,11 @@ export interface ExtProcessConfig {
   builtinCommands?: IBuiltInCommand[];
   customDebugChildProcess?: CustomChildProcessModule;
   customVSCodeEngineVersion?: string;
-   /**
+  /**
    * control rpcProtocol message timeout
    * default -1，it means disable
    */
-   rpcMessageTimeout?: number;
+  rpcMessageTimeout?: number;
 }
 
 async function initRPCProtocol(extInjector: Injector): Promise<any> {
@@ -105,7 +105,7 @@ async function initRPCProtocol(extInjector: Injector): Promise<any> {
     timeout: appConfig.rpcMessageTimeout,
   });
 
-  logger = new ExtensionLogger2(extInjector); // new ExtensionLogger(extProtocol);
+  logger = new ExtensionLogger(extInjector); // new ExtensionLogger(extProtocol);
   logger.log('process extConnection path', argv[KT_PROCESS_SOCK_OPTION_KEY]);
   return { extProtocol, logger };
 }

--- a/packages/extension/src/hosted/extension-log.ts
+++ b/packages/extension/src/hosted/extension-log.ts
@@ -1,46 +1,116 @@
+import { Injector } from '@opensumi/di';
 import { RPCProtocol } from '@opensumi/ide-connection';
-import { DebugLog, IExtensionLogger, SupportLogNamespace } from '@opensumi/ide-core-common';
+import {
+  getNodeRequire,
+  SupportLogNamespace,
+  ILogService,
+  IExtensionLogger,
+  DebugLog,
+} from '@opensumi/ide-core-common';
+import { AppConfig } from '@opensumi/ide-core-node/lib/types';
+import { LogServiceManager } from '@opensumi/ide-logs/lib/node/log-manager';
 
-import { MainThreadExtensionLogIdentifier, IMainThreadExtensionLog } from '../common/extension-log';
+import { IMainThreadExtensionLog, MainThreadExtensionLogIdentifier } from '../common/extension-log';
 
-export class ExtensionLogger implements IExtensionLogger {
-  private rpcProtocol: RPCProtocol;
-  private logger: IMainThreadExtensionLog;
+export abstract class AbstractExtensionLogger implements IExtensionLogger {
+  logger: IMainThreadExtensionLog | ILogService;
+  methodNames: Record<string, string>;
   private debugLog: DebugLog;
 
-  constructor(rpcProtocol: RPCProtocol) {
-    this.rpcProtocol = rpcProtocol;
-    this.logger = this.rpcProtocol.getProxy(MainThreadExtensionLogIdentifier);
+  constructor() {
+    this.methodNames = {
+      verbose: 'verbose',
+      debug: 'debug',
+      log: 'log',
+      warn: 'warn',
+      error: 'error',
+      critical: 'critical',
+    };
     this.debugLog = new DebugLog(SupportLogNamespace.ExtensionHost);
   }
 
   verbose(...args: any[]) {
     this.debugLog.info(...args);
-    return this.logger.$verbose(...args);
+    return this.logger[this.methodNames.verbose](...args);
   }
 
   debug(...args: any[]) {
     this.debugLog.debug(...args);
-    return this.logger.$debug(...args);
+    return this.logger[this.methodNames.debug](...args);
   }
 
   log(...args: any[]) {
     this.debugLog.log(...args);
-    return this.logger.$log(...args);
+    return this.logger[this.methodNames.log](...args);
   }
 
   warn(...args: any[]) {
     this.debugLog.warn(...args);
-    return this.logger.$warn(...args);
+    return this.logger[this.methodNames.warn](...args);
   }
 
   error(...args: any[]) {
     this.debugLog.error(...args);
-    return this.logger.$error(...args);
+    return this.logger[this.methodNames.error](...args);
   }
 
   critical(...args: any[]) {
     this.debugLog.error(...args);
-    return this.logger.$critical(...args);
+    return this.logger[this.methodNames.critical](...args);
+  }
+}
+
+export class ExtensionWorkerLogger extends AbstractExtensionLogger {
+  private rpcProtocol: RPCProtocol;
+
+  constructor(rpcProtocol: RPCProtocol) {
+    super();
+    this.rpcProtocol = rpcProtocol;
+    this.methodNames = {
+      verbose: '$verbose',
+      debug: '$debug',
+      log: '$log',
+      warn: '$warn',
+      error: '$error',
+      critical: '$critical',
+    };
+    this.logger = this.rpcProtocol.getProxy(MainThreadExtensionLogIdentifier);
+  }
+}
+
+export class ExtensionLogger extends AbstractExtensionLogger {
+  private injector: Injector;
+  private loggerManager: LogServiceManager;
+  private config: any;
+  logger: ILogService;
+
+  constructor(injector) {
+    super();
+    this.injector = injector;
+    this.config = this.injector.get(AppConfig);
+    this.injectLogService();
+
+    this.loggerManager = this.injector.get(LogServiceManager);
+    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionHost, this.config);
+  }
+  injectLogService() {
+    if (this.config.LogServiceClass) {
+      const LogServiceClass = this.config.LogServiceClass;
+
+      this.injector.overrideProviders({
+        token: AppConfig,
+        useValue: Object.assign({}, this.config, { LogServiceClass }),
+      });
+    } else if (this.config.extLogServiceClassPath) {
+      let LogServiceClass = getNodeRequire()(this.config.extLogServiceClassPath);
+
+      if (LogServiceClass.default) {
+        LogServiceClass = LogServiceClass.default;
+      }
+      this.injector.overrideProviders({
+        token: AppConfig,
+        useValue: Object.assign({}, this.config, { LogServiceClass }),
+      });
+    }
   }
 }

--- a/packages/extension/src/hosted/worker.host.ts
+++ b/packages/extension/src/hosted/worker.host.ts
@@ -25,7 +25,7 @@ import { ExtensionContext } from './api/vscode/ext.host.extensions';
 import { ExtHostSecret } from './api/vscode/ext.host.secrets';
 import { ExtHostStorage } from './api/vscode/ext.host.storage';
 import { createAPIFactory } from './api/worker/worker.host.api.impl';
-import { ExtensionLogger } from './extension-log';
+import { ExtensionWorkerLogger } from './extension-log';
 import { KTWorkerExtension } from './vscode.extension';
 
 export function initRPCProtocol() {
@@ -54,7 +54,7 @@ export class ExtensionWorkerHost implements IExtensionWorkerHost {
 
   private sumiAPIFactory: any;
   private sumiExtAPIImpl: Map<string, any> = new Map();
-  public logger: ExtensionLogger;
+  public logger: ExtensionWorkerLogger;
 
   private initDeferred = new Deferred();
 
@@ -74,7 +74,7 @@ export class ExtensionWorkerHost implements IExtensionWorkerHost {
 
   constructor(private rpcProtocol: RPCProtocol, private injector: Injector) {
     const reporter = this.injector.get(IReporter);
-    this.logger = new ExtensionLogger(rpcProtocol);
+    this.logger = new ExtensionWorkerLogger(rpcProtocol);
     this.storage = new ExtHostStorage(rpcProtocol);
     this.secret = new ExtHostSecret(rpcProtocol);
     this.sumiAPIFactory = createAPIFactory(this.rpcProtocol, this);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [x] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 412f060</samp>

*  Refactor the extension logging system to use an abstract class and subclasses for different log service implementations ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-f0653922d754114ca6a51d3ff3c6e466eb32d75b82af8366b31e4421427e30fbL1-R28), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L25-R25), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L108-R108), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL28-R28), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL57-R57), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL77-R77))
  * Move the `ExtensionLogger` class from `./extension-log.ts` to `./ext.process-base.ts` and make it extend the `AbstractExtensionLogger` class that provides common logging methods ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-f0653922d754114ca6a51d3ff3c6e466eb32d75b82af8366b31e4421427e30fbL1-R28), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L25-R25), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L108-R108))
  * Add logic to the `ExtensionLogger` class to inject a custom log service class based on the configuration ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-f0653922d754114ca6a51d3ff3c6e466eb32d75b82af8366b31e4421427e30fbL1-R28))
  * Add a new `ExtensionWorkerLogger` class to `./ext.process-base.ts` that extends the `AbstractExtensionLogger` class and uses the RPC protocol to communicate with the main thread log service ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-f0653922d754114ca6a51d3ff3c6e466eb32d75b82af8366b31e4421427e30fbL1-R28), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL28-R28), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL57-R57), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL77-R77))
  * Change the methods of the `AbstractExtensionLogger` class to use a `methodNames` property that can be overridden by subclasses to use different methods for logging ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-f0653922d754114ca6a51d3ff3c6e466eb32d75b82af8366b31e4421427e30fbL19-R116))
  * Override the `methodNames` property in the `ExtensionWorkerLogger` class to use the prefixed methods of the RPC proxy, such as `$verbose` and `$debug` ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-f0653922d754114ca6a51d3ff3c6e466eb32d75b82af8366b31e4421427e30fbL19-R116))
  * Update the import statements and the type and instantiation of the `logger` property in the `ExtensionWorkerHost` class in `./worker.host.ts` to use the `ExtensionWorkerLogger` class instead of the `ExtensionLogger` class ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL28-R28), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL57-R57), [link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-957921fb34847ea35a1d53cb2e5a304f3d989230afd6dd534bcc6b47b23cc4ceL77-R77))
* Fix the indentation of the comment for the `rpcMessageTimeout` property in the `ExtProcessConfig` interface in `./ext.process-base.ts` ([link](https://github.com/opensumi/core/pull/3005/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L73-R77))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 412f060</samp>

Refactored the extension logging system to use more consistent and descriptive class names and file locations. Extracted an abstract `ExtensionLogger` class and created two subclasses: `ExtensionWorkerLogger` for the extension worker host and `ExtensionLogger` for the extension process. Moved the `ExtensionLogger` classes to `./ext.process-base.ts` and updated their usage in other modules.
