### PR TITLE
style: improve notification multi-button style

### DIFF
--- a/packages/components/src/notification/notification.less
+++ b/packages/components/src/notification/notification.less
@@ -243,14 +243,17 @@
       top: 12px;
     }
 
-    &-btn.tile button {
-      flex: 1;
-    }
-
     &-btn button {
       flex: 0 0 auto;
       margin: 0 0 5px 10px;
       word-break: keep-all;
+      max-width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding: 0 5px;
+      box-sizing: border-box;
+      display: inline-block;
     }
   }
 }

--- a/packages/components/src/notification/notification.tsx
+++ b/packages/components/src/notification/notification.tsx
@@ -191,11 +191,7 @@ function notice(args: ArgsProps) {
             {iconNode}
             <div className={`${prefixCls}-message`}>{args.message}</div>
             <div className={`${prefixCls}-description`}>{args.description}</div>
-            {args.btn ? (
-              <span className={`${prefixCls}-btn ${Array.isArray(args.btn) && args.btn.length >= 3 ? 'tile' : ''}`}>
-                {args.btn}
-              </span>
-            ) : null}
+            {args.btn ? <span className={`${prefixCls}-btn`}>{args.btn}</span> : null}
           </div>
         ),
         duration,

--- a/packages/debug/src/browser/view/variables/debug-variables.module.less
+++ b/packages/debug/src/browser/view/variables/debug-variables.module.less
@@ -112,7 +112,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  overflow: visible;
   &.value {
     color: var(--debugTokenExpression-value);
   }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2dfc89</samp>

*  Prevent notification button overflow and truncate text with ellipsis ([link](https://github.com/opensumi/core/pull/3020/files?diff=unified&w=0#diff-145d8be0a1ec7dcc43a6beebe50891a635a19e960c29d80c99571a11b31dbacbL246-R256))
* Simplify notification button style and remove conditional `tile` class name ([link](https://github.com/opensumi/core/pull/3020/files?diff=unified&w=0#diff-ffecd639306458b956a849d8b50288b600542656f1baf27df988062ea7264a24L194-R194))
* Fix debug variables layout and remove unwanted scrollbars and overlaps ([link](https://github.com/opensumi/core/pull/3020/files?diff=unified&w=0#diff-5a5e1703230993be9c346fe036735933afbf009e2b2e3a8ac68d08e05feb7f24L115))

<!-- Additional content -->
<!-- 补充额外内容 -->
before：
![image](https://github.com/opensumi/core/assets/9823838/a5e672e0-bfbc-496a-81bf-f9318db0e947)

after:
![image](https://github.com/opensumi/core/assets/9823838/c3c7b9ac-0f20-454e-a2d0-ea9cece6844a)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2dfc89</samp>

This pull request improves the styles and layouts of the notification and debug components. It fixes some issues with overflow, truncation, and alignment of the notification buttons and the debug variables. It modifies the files `notification.less`, `notification.tsx`, and `debug-variables.module.less`.
