### PR TITLE
fix: terminal search box supports toggle switching

### DIFF
--- a/packages/terminal-next/src/browser/contribution/terminal.command.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.command.ts
@@ -91,6 +91,10 @@ export class TerminalCommandContribution implements CommandContribution {
       },
       {
         execute: () => {
+          if (this.search.show) {
+            this.search.close();
+            return;
+          }
           this.search.open();
         },
       },


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

fix: https://github.com/opensumi/core/issues/3040

### Background or solution
![image](https://github.com/opensumi/core/assets/1762334/9a2fa375-1f4f-4ac0-8895-f670dc0bbfb6)

### Changelog

fix: 终端点击搜索时支持toggle模式
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58045b8</samp>

Fixed a bug that caused multiple terminal search widgets to appear when using the find command. Added code to `executeTerminalFind` in `terminal.command.ts` to close the existing widget before opening a new one.
