### PR TITLE
feat: terminal split screen operation supports single deletion

### DIFF
--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -35,10 +35,8 @@
       }
     }
     &:hover {
-      :global {
-        .kticon-close {
-          display: block;
-        }
+      .closeBtn {
+        display: block;
       }
     }
   }

--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -21,17 +21,15 @@
     height: 100%;
     overflow: hidden;
     padding: 8px 20px 0 10px;
-    :global {
-      .kticon-close {
-        display: none;
-        position: absolute;
-        right: 5px;
-        top: 10px;
-        cursor: pointer;
-        &:hover {
-          background-color: var(--kt-icon-hoverBackground);
-          transform: scale(1.1);
-        }
+    .closeBtn {
+      display: none;
+      position: absolute;
+      right: 5px;
+      top: 10px;
+      cursor: pointer;
+      &:hover {
+        background-color: var(--kt-icon-hoverBackground);
+        transform: scale(1.1);
       }
     }
     &:hover {

--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -24,9 +24,14 @@
     .closeBtn {
       display: none;
       position: absolute;
-      right: 5px;
+      right: 12px;
       top: 10px;
       cursor: pointer;
+      border-radius: 4px;
+      font-size: 14px;
+      width: 16px;
+      height: 16px;
+      line-height: 16px;
       &:hover {
         background-color: var(--kt-icon-hoverBackground);
         transform: scale(1.1);

--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -16,10 +16,23 @@
   justify-content: flex-end;
 
   .resizeItem {
+    position: relative;
     width: 100%;
     height: 100%;
     overflow: hidden;
-    padding: 8px 2px 0 10px;
+    padding: 8px 20px 0 10px;
+    :global {
+      .kticon-close {
+        position: absolute;
+        right: 5px;
+        top: 10px;
+        cursor: pointer;
+        &:hover {
+          background-color: var(--kt-icon-hoverBackground);
+          transform: scale(1.1);
+        }
+      }
+    }
   }
 }
 

--- a/packages/terminal-next/src/browser/component/resize.module.less
+++ b/packages/terminal-next/src/browser/component/resize.module.less
@@ -23,6 +23,7 @@
     padding: 8px 20px 0 10px;
     :global {
       .kticon-close {
+        display: none;
         position: absolute;
         right: 5px;
         top: 10px;
@@ -30,6 +31,13 @@
         &:hover {
           background-color: var(--kt-icon-hoverBackground);
           transform: scale(1.1);
+        }
+      }
+    }
+    &:hover {
+      :global {
+        .kticon-close {
+          display: block;
         }
       }
     }

--- a/packages/terminal-next/src/browser/component/resize.view.tsx
+++ b/packages/terminal-next/src/browser/component/resize.view.tsx
@@ -1,6 +1,9 @@
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
+import { useInjectable, getIcon } from '@opensumi/ide-core-browser';
+
+import { ITerminalGroupViewService } from '../../common/controller';
 import { IWidget, IWidgetGroup } from '../../common/resize';
 
 import ResizeDelegate from './resize.delegate';
@@ -23,6 +26,7 @@ export default observer((props: IResizeViewProps) => {
   const { group, shadow } = props;
   const [event, setEvent] = React.useState(false);
   const [wholeWidth, setWholeWidth] = React.useState(Infinity);
+  const view = useInjectable<ITerminalGroupViewService>(ITerminalGroupViewService);
   const whole = React.createRef<HTMLDivElement>();
 
   React.useEffect(() => {
@@ -77,6 +81,14 @@ export default observer((props: IResizeViewProps) => {
               className={styles.resizeItem}
             >
               {props.draw(widget)}
+              {group.widgets.length > 1 && (
+                <div
+                  className={getIcon('close')}
+                  onClick={() => {
+                    view.removeWidget(widget.id);
+                  }}
+                />
+              )}
             </div>
           ))}
       </div>

--- a/packages/terminal-next/src/browser/component/resize.view.tsx
+++ b/packages/terminal-next/src/browser/component/resize.view.tsx
@@ -1,3 +1,4 @@
+import clx from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -83,7 +84,7 @@ export default observer((props: IResizeViewProps) => {
               {props.draw(widget)}
               {group.widgets.length > 1 && (
                 <div
-                  className={getIcon('close')}
+                  className={clx(styles.closeBtn, getIcon('close'))}
                   onClick={() => {
                     view.removeWidget(widget.id);
                   }}

--- a/packages/terminal-next/src/browser/component/resize.view.tsx
+++ b/packages/terminal-next/src/browser/component/resize.view.tsx
@@ -36,6 +36,10 @@ export default observer((props: IResizeViewProps) => {
     }
   });
 
+  const handleRemoveWidget = React.useCallback((widgetId: string) => {
+    view.removeWidget(widgetId);
+  }, []);
+
   return (
     <div className={styles.resizeWrapper} ref={whole}>
       <div
@@ -86,7 +90,7 @@ export default observer((props: IResizeViewProps) => {
                 <div
                   className={clx(styles.closeBtn, getIcon('close'))}
                   onClick={() => {
-                    view.removeWidget(widget.id);
+                    handleRemoveWidget(widget.id);
                   }}
                 />
               )}


### PR DESCRIPTION
### Types

- [X] 🎉 New Features


feat: https://github.com/opensumi/core/issues/3042

### Background or solution
![image](https://github.com/opensumi/core/assets/1762334/6d3a4ea3-035b-4015-89e0-690499c83fb3)


### Changelog
feat: 终端分屏时支持单个面板删除

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e22038</samp>

The pull request enhances the terminal tab functionality by adding a close button and improving the style. It also refactors some code to use core browser utilities and hooks in `resize.view.tsx` and `resize.module.less`.
