### PR TITLE
fix: get wrong state in toolbar action delegate

### DIFF
--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -28,8 +28,13 @@ enum BUTTON_TITLE_STYLE {
 export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionElementProps) => {
   const context = useInjectable<AppConfig>(AppConfig);
   const ref = React.useRef<HTMLDivElement>();
+
   const [viewState, setViewState] = React.useState(props.defaultState || 'default');
-  const [title, setTitle] = React.useState(undefined);
+
+  const viewStateRef = React.useRef<string>(viewState);
+  viewStateRef.current = viewState;
+
+  const [title, setTitle] = React.useState<string>('');
   const preferenceService: PreferenceService = useInjectable(PreferenceService);
   const [, updateState] = React.useState<any>();
   const forceUpdate = React.useCallback(() => updateState({}), []);
@@ -74,11 +79,11 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       delegate.current = context.injector.get(ToolbarBtnDelegate, [
         ref.current,
         props.id,
-        (state, title) => {
+        (state: string, title: string) => {
           setViewState(state);
           setTitle(title);
         },
-        () => viewState,
+        () => viewStateRef.current,
         context,
         getPopoverParent,
         props.popoverComponent,
@@ -301,6 +306,10 @@ class ToolbarBtnDelegate implements IToolbarActionBtnDelegate {
         }
       }
     });
+  }
+
+  getState() {
+    return this._getState();
   }
 
   setState(to, title?) {

--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -225,6 +225,7 @@ export interface IToolbarActionBtnDelegate {
   onDidChangePopoverVisibility: Event<boolean>;
 
   setState(state: string, title?: string): void;
+  getState(): string;
 
   setContext(context: any): void;
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

这段代码修复了 ToolbarAction 的 delegate 中获取错误状态的问题。它通过修改 setState() 函数和 getState() 函数来确保获取正确的状态并将状态更新到界面上。同时，还修复了一些变量类型的错误。

### Changelog

fix get wrong state in toolbar action delegate
