### PR TITLE
fix: new file with compact node

### DIFF
--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -771,16 +771,16 @@ export class FileTreeModelService {
     this.updateExplorerCompressedContextKey(item, activeUri);
 
     this._isMultiSelected = false;
+    // 单选操作默认先更新选中状态
+    if (type === TreeNodeType.CompositeTreeNode || type === TreeNodeType.TreeNode) {
+      this.activeFileDecoration(item);
+    }
     if (this.fileTreeService.isCompactMode && activeUri) {
       this._activeUri = activeUri;
       // 存在 activeUri 的情况默认 explorerResourceIsFolder 的值都为 true
       this.contextKey?.explorerResourceIsFolder.set(true);
     } else if (!activeUri) {
       this._activeUri = null;
-      // 单选操作默认先更新选中状态
-      if (type === TreeNodeType.CompositeTreeNode || type === TreeNodeType.TreeNode) {
-        this.activeFileDecoration(item);
-      }
       this.contextKey?.explorerResourceIsFolder.set(type === TreeNodeType.CompositeTreeNode);
     }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at df5e277</samp>

*  Update the active file decoration when a single node is selected in the file tree ([link](https://github.com/opensumi/core/pull/3053/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1R774-R777))
*  Remove the duplicated logic of updating the active file decoration from the `handleMultiSelect` method ([link](https://github.com/opensumi/core/pull/3053/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L780-L783))

close #3045.

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df5e277</samp>

Fix and refactor active file decoration logic in `file-tree-model.service.ts`. Simplify the code by moving the condition to check for the active file to the single select case only.
