### PR TITLE
chore(release): v2.26.8

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.26.7",
+  "version": "2.26.8",
   "npmClient": "npm",
   "packages": ["packages/*", "tools/dev-tool", "tools/playwright", "tools/cli-engine"],
   "command": {

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-addons",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-collaboration",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-comments",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-components",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "@opensumi/ide-components",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-connection",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-browser",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "@opensumi/ide-core-browser",
   "files": [
     "lib",

--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -28,8 +28,13 @@ enum BUTTON_TITLE_STYLE {
 export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionElementProps) => {
   const context = useInjectable<AppConfig>(AppConfig);
   const ref = React.useRef<HTMLDivElement>();
+
   const [viewState, setViewState] = React.useState(props.defaultState || 'default');
-  const [title, setTitle] = React.useState(undefined);
+
+  const viewStateRef = React.useRef<string>(viewState);
+  viewStateRef.current = viewState;
+
+  const [title, setTitle] = React.useState<string>('');
   const preferenceService: PreferenceService = useInjectable(PreferenceService);
   const [, updateState] = React.useState<any>();
   const forceUpdate = React.useCallback(() => updateState({}), []);
@@ -74,11 +79,11 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       delegate.current = context.injector.get(ToolbarBtnDelegate, [
         ref.current,
         props.id,
-        (state, title) => {
+        (state: string, title: string) => {
           setViewState(state);
           setTitle(title);
         },
-        () => viewState,
+        () => viewStateRef.current,
         context,
         getPopoverParent,
         props.popoverComponent,
@@ -301,6 +306,10 @@ class ToolbarBtnDelegate implements IToolbarActionBtnDelegate {
         }
       }
     });
+  }
+
+  getState() {
+    return this._getState();
   }
 
   setState(to, title?) {

--- a/packages/core-browser/src/toolbar/types.ts
+++ b/packages/core-browser/src/toolbar/types.ts
@@ -225,6 +225,7 @@ export interface IToolbarActionBtnDelegate {
   onDidChangePopoverVisibility: Event<boolean>;
 
   setState(state: string, title?: string): void;
+  getState(): string;
 
   setContext(context: any): void;
 

--- a/packages/core-common/package.json
+++ b/packages/core-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-common",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "@opensumi/ide-core-common",
   "files": [
     "lib",

--- a/packages/core-electron-main/package.json
+++ b/packages/core-electron-main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-electron-main",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "browser-preload"

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-core-node",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "@opensumi/ide-core-node",
   "files": [
     "lib",

--- a/packages/debug/__tests__/browser/editor/debug-model.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-model.test.ts
@@ -159,13 +159,13 @@ describe('Debug Model', () => {
   it('renderBreakpoints should be work', async () => {
     mockEditor.deltaDecorations.mockClear();
     await debugModel.renderBreakpoints();
-    expect(mockEditor.deltaDecorations).toBeCalledTimes(3);
+    expect(mockEditor.deltaDecorations).toBeCalledTimes(1);
   });
 
   it('render should be work', async () => {
     mockEditor.deltaDecorations.mockClear();
     await debugModel.render();
-    expect(mockEditor.deltaDecorations).toBeCalledTimes(3);
+    expect(mockEditor.deltaDecorations).toBeCalledTimes(1);
   });
 
   it('toggleBreakpoint should be work', () => {

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-debug",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -482,6 +482,10 @@ export class DebugModel implements IDebugModel {
         if (positions.length <= 1) {
           return;
         }
+        const maxLineCount = model.getLineCount();
+        if (lineNumber > maxLineCount) {
+          return;
+        }
         const firstColumn = model.getLineFirstNonWhitespaceColumn(lineNumber);
         const lastColumn = model.getLineLastNonWhitespaceColumn(lineNumber);
         positions.forEach((p) => {
@@ -538,7 +542,8 @@ export class DebugModel implements IDebugModel {
     const lineNumber = status && status.line ? status.line : breakpoint.raw.line;
     const column = breakpoint.raw.column || 0;
     const model = this.editor.getModel()!;
-    const renderInline = column > model.getLineFirstNonWhitespaceColumn(lineNumber);
+    const maxLine = model.getLineCount();
+    const renderInline = lineNumber > maxLine ? false : column > model.getLineFirstNonWhitespaceColumn(lineNumber);
     const range = new monaco.Range(lineNumber, column, lineNumber, column + 1);
     const { className, message } = this.decorator.getDecoration(
       breakpoint,

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -223,8 +223,12 @@ export class DebugBreakpointsService extends WithEventBus {
         if (!monacoModel) {
           return;
         }
-
-        const getContent = monacoModel.instance.getMonacoModel().getLineContent(line);
+        const model = monacoModel.instance.getMonacoModel();
+        const maxLineCount = model.getLineCount();
+        if (line > maxLineCount) {
+          return;
+        }
+        const getContent = model.getLineContent(line);
         node.fireDescriptionChange(getContent.trim());
       }
     }

--- a/packages/decoration/package.json
+++ b/packages/decoration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-decoration",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-editor",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -25,7 +25,7 @@ import {
   ResizeHandleVertical,
 } from '@opensumi/ide-core-browser/lib/components';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
-import { useInjectable } from '@opensumi/ide-core-browser/lib/react-hooks';
+import { useInjectable, useUpdateOnEventBusEvent } from '@opensumi/ide-core-browser/lib/react-hooks';
 
 import { IResource, WorkbenchEditorService } from '../common';
 
@@ -45,6 +45,7 @@ import {
   IEditorComponent,
   CodeEditorDidVisibleEvent,
   EditorOpenType,
+  ResoucesOfActiveComponentChangedEvent,
 } from './types';
 import { EditorGroup, WorkbenchEditorServiceImpl } from './workbench-editor.service';
 
@@ -489,19 +490,22 @@ export const ComponentsWrapper = ({
   component: IEditorComponent;
   resources: IResource[];
   current: MaybeNull<IResource>;
-}) => (
-  <div className={styles.kt_editor_component_wrapper}>
-    {resources.map((resource) => (
-      <ComponentWrapper
-        {...other}
-        key={resource.toString()}
-        component={component}
-        resource={resource}
-        hidden={!(current && current.uri.toString() === resource.uri.toString())}
-      />
-    ))}
-  </div>
-);
+}) => {
+  useUpdateOnEventBusEvent(ResoucesOfActiveComponentChangedEvent, [component], (t) => t.component === component);
+  return (
+    <div className={styles.kt_editor_component_wrapper}>
+      {resources.map((resource) => (
+        <ComponentWrapper
+          {...other}
+          key={resource.uri.toString()}
+          component={component}
+          resource={resource}
+          hidden={!(current && current.uri.toString() === resource.uri.toString())}
+        />
+      ))}
+    </div>
+  );
+};
 
 export const ComponentWrapper = ({ component, resource, hidden, ...other }) => {
   const componentService: EditorComponentRegistryImpl = useInjectable(EditorComponentRegistry);

--- a/packages/editor/src/browser/types.ts
+++ b/packages/editor/src/browser/types.ts
@@ -477,3 +477,8 @@ export class CodeEditorDidVisibleEvent extends BasicEvent<{
   groupName: string;
   editorId: string;
 }> {}
+
+export class ResoucesOfActiveComponentChangedEvent extends BasicEvent<{
+  component: IEditorComponent;
+  resources: IResource[];
+}> {}

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -103,6 +103,7 @@ import {
   AskSaveResult,
   IMergeEditorResource,
   EditorOpenType,
+  ResoucesOfActiveComponentChangedEvent,
 } from './types';
 import { UntitledDocumentIdCounter } from './untitled-resource';
 
@@ -1841,12 +1842,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       } else {
         this.notifyTabChanged();
       }
-      for (const resources of this.activeComponents.values()) {
-        const i = resources.indexOf(resource);
-        if (i !== -1) {
-          resources.splice(i, 1);
-        }
-      }
+      this.removeResouceFromActiveComponents(resource);
       this.disposeDocumentRef(uri);
     }
     if (this.resources.length === 0) {
@@ -1856,6 +1852,16 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       }
       this.availableOpenTypes = [];
     }
+  }
+
+  private removeResouceFromActiveComponents(resource: IResource) {
+    this.activeComponents.forEach((resources, component) => {
+      const i = resources.indexOf(resource);
+      if (i !== -1) {
+        resources.splice(i, 1);
+        this.eventBus.fire(new ResoucesOfActiveComponentChangedEvent({ component, resources }));
+      }
+    });
   }
 
   private async shouldClose(resource: IResource): Promise<boolean> {
@@ -1973,12 +1979,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
         resource,
       }),
     );
-    for (const resources of this.activeComponents.values()) {
-      const i = resources.indexOf(resource);
-      if (i !== -1) {
-        resources.splice(i, 1);
-      }
-    }
+    this.removeResouceFromActiveComponents(resource);
   }
 
   async closeOthers(uri: URI) {

--- a/packages/electron-basic/package.json
+++ b/packages/electron-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-electron-basic",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-explorer",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/express-file-server/package.json
+++ b/packages/express-file-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-express-file-server",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-manager",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/extension-storage/package.json
+++ b/packages/extension-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension-storage",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-extension",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "hosted"

--- a/packages/extension/src/hosted/api/vscode/env/workerEnvApiFactory.ts
+++ b/packages/extension/src/hosted/api/vscode/env/workerEnvApiFactory.ts
@@ -1,13 +1,14 @@
 import type vscode from 'vscode';
 
 import { IRPCProtocol } from '@opensumi/ide-connection/lib/common/rpcProtocol';
+import { Schemes } from '@opensumi/ide-core-common';
 
 import { MainThreadAPIIdentifier, IMainThreadEnv, IExtHostEnv } from '../../../../common/vscode';
 
 export function createWorkerHostEnvAPIFactory(
   rpcProtocol: IRPCProtocol,
   extHostEnv: IExtHostEnv,
-): Pick<typeof vscode.env, 'clipboard' | 'openExternal' | 'language'> {
+): Pick<typeof vscode.env, 'clipboard' | 'openExternal' | 'language' | 'uriScheme'> {
   const mainThreadEnvProxy: IMainThreadEnv = rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadEnv);
   return {
     get language() {
@@ -20,5 +21,6 @@ export function createWorkerHostEnvAPIFactory(
     openExternal(uri) {
       return mainThreadEnvProxy.$openExternal(uri);
     },
+    uriScheme: Schemes.file,
   };
 }

--- a/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
+++ b/packages/extension/src/hosted/api/worker/worker.host.api.impl.ts
@@ -1,7 +1,7 @@
 import type * as vscode from 'vscode';
 
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Emitter, Event, CancellationTokenSource, DefaultReporter, Schemes } from '@opensumi/ide-core-common';
+import { Emitter, Event, CancellationTokenSource, DefaultReporter } from '@opensumi/ide-core-common';
 import { OverviewRulerLane } from '@opensumi/ide-editor';
 
 import { IExtensionHostService, IExtensionWorkerHost, WorkerHostAPIIdentifier } from '../../../common';
@@ -173,11 +173,8 @@ export function createAPIFactory(
     TextEditorCursorStyle,
     TextEditorSelectionChangeKind,
     // VS Code 纯前端插件 API
-    env: {
-      // ENV 用处貌似比较少, 现有的实现依赖 node  模块，后面需要再重新实现
-      uriScheme: Schemes.file,
-      ...createWorkerHostEnvAPIFactory(rpcProtocol, extHostEnv),
-    },
+    // ENV 用处貌似比较少, 现有的实现依赖 node  模块，后面需要再重新实现
+    env: createWorkerHostEnvAPIFactory(rpcProtocol, extHostEnv),
     languages: createLanguagesApiFactory(extHostLanguages, extension),
     extensions: createExtensionsApiFactory(extensionService),
     workspace: createWorkspaceApiFactory(
@@ -196,7 +193,7 @@ export function createAPIFactory(
       createSourceControl(id: string, label: string, rootUri: vscode.Uri) {
         return extHostSCM.createSourceControl(extension, id, label, rootUri);
       },
-      cgetSourceControl(extensionId: string, id: string) {
+      getSourceControl(extensionId: string, id: string) {
         return extHostSCM.getSourceControl(extensionId, id);
       },
     },

--- a/packages/file-scheme/package.json
+++ b/packages/file-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-scheme",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-search",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-service",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-file-tree-next",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -771,16 +771,16 @@ export class FileTreeModelService {
     this.updateExplorerCompressedContextKey(item, activeUri);
 
     this._isMultiSelected = false;
+    // 单选操作默认先更新选中状态
+    if (type === TreeNodeType.CompositeTreeNode || type === TreeNodeType.TreeNode) {
+      this.activeFileDecoration(item);
+    }
     if (this.fileTreeService.isCompactMode && activeUri) {
       this._activeUri = activeUri;
       // 存在 activeUri 的情况默认 explorerResourceIsFolder 的值都为 true
       this.contextKey?.explorerResourceIsFolder.set(true);
     } else if (!activeUri) {
       this._activeUri = null;
-      // 单选操作默认先更新选中状态
-      if (type === TreeNodeType.CompositeTreeNode || type === TreeNodeType.TreeNode) {
-        this.activeFileDecoration(item);
-      }
       this.contextKey?.explorerResourceIsFolder.set(type === TreeNodeType.CompositeTreeNode);
     }
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-i18n",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-keymaps",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/logs-core/package.json
+++ b/packages/logs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-logs",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/main-layout/package.json
+++ b/packages/main-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-main-layout",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "@opensumi/ide-main-layout",
   "files": [
     "lib",

--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -270,7 +270,13 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
         .catch((err) => {
           this.logger.error(`[TabbarService:${location}] restore state error`, err);
         });
-      service.onSizeChange(() => debounce(() => this.storeState(service, service.currentContainerId), 200)());
+      const debouncedStoreState = debounce(() => this.storeState(service, service.currentContainerId), 100);
+      service.onSizeChange(debouncedStoreState);
+      if (location === SlotLocation.bottom) {
+        // use this getter's side effect to set bottomExpanded contextKey
+        const debouncedUpdate = debounce(() => void this.bottomExpanded, 100);
+        service.onSizeChange(() => debouncedUpdate);
+      }
       this.tabbarServices.set(location, service);
     }
     return service;

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markdown",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-markers",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-menu-bar",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "@opensumi/ide-menu-bar",
   "files": [
     "lib",

--- a/packages/monaco-enhance/package.json
+++ b/packages/monaco-enhance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco-enhance",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-monaco",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/opened-editor/package.json
+++ b/packages/opened-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-opened-editor",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/outline/package.json
+++ b/packages/outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-outline",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-output",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-overlay",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-preferences",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-process",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/quick-open/package.json
+++ b/packages/quick-open/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-quick-open",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/remote-opener/package.json
+++ b/packages/remote-opener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-remote-opener",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-scm",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-search",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/startup/package.json
+++ b/packages/startup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-startup",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/static-resource/package.json
+++ b/packages/static-resource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-static-resource",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/status-bar/package.json
+++ b/packages/status-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-status-bar",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-storage",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-task",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-terminal-next",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-testing",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-theme",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-toolbar",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/types/manifest.json
+++ b/packages/types/manifest.json
@@ -1,296 +1,296 @@
 {
   "meta": {
     "@opensumi/ide-addons": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-collaboration": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-comments": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-components": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-connection": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-core-browser": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["common"]
     },
     "@opensumi/ide-core-common": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-core-electron-main": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-core-node": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-debug": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-decoration": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-editor": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-electron-basic": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser"]
     },
     "@opensumi/ide-explorer": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser"]
     },
     "@opensumi/ide-express-file-server": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-manager": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-extension-storage": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-file-scheme": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-search": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-file-service": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-file-tree-next": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-i18n": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-keymaps": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-logs": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-main-layout": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markdown": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-markers": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-menu-bar": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser"]
     },
     "@opensumi/ide-monaco": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-monaco-enhance": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-opened-editor": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-outline": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-output": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-overlay": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-preferences": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-process": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "common"]
     },
     "@opensumi/ide-quick-open": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/remote-cli": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-remote-opener": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-scm": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-search": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-startup": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser"]
     },
     "@opensumi/ide-static-resource": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser"]
     },
     "@opensumi/ide-status-bar": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-storage": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-task": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-terminal-next": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["node", "browser", "common"]
     },
     "@opensumi/ide-testing": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-theme": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-toolbar": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser"]
     },
     "@opensumi/sumi": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-userstorage": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-utils": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": []
     },
     "@opensumi/ide-variable": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-webview": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     },
     "@opensumi/ide-workspace-edit": {
-      "version": "2.26.7",
+      "version": "2.26.8",
       "entry": ["browser", "common"]
     }
   },
   "packages": {
-    "@opensumi/ide-addons": "2.26.7",
-    "@opensumi/ide-collaboration": "2.26.7",
-    "@opensumi/ide-comments": "2.26.7",
-    "@opensumi/ide-components": "2.26.7",
-    "@opensumi/ide-connection": "2.26.7",
-    "@opensumi/ide-core-browser": "2.26.7",
-    "@opensumi/ide-core-common": "2.26.7",
-    "@opensumi/ide-core-electron-main": "2.26.7",
-    "@opensumi/ide-core-node": "2.26.7",
-    "@opensumi/ide-debug": "2.26.7",
-    "@opensumi/ide-decoration": "2.26.7",
-    "@opensumi/ide-editor": "2.26.7",
-    "@opensumi/ide-electron-basic": "2.26.7",
-    "@opensumi/ide-explorer": "2.26.7",
-    "@opensumi/ide-express-file-server": "2.26.7",
-    "@opensumi/ide-extension": "2.26.7",
-    "@opensumi/ide-extension-manager": "2.26.7",
-    "@opensumi/ide-extension-storage": "2.26.7",
-    "@opensumi/ide-file-scheme": "2.26.7",
-    "@opensumi/ide-file-search": "2.26.7",
-    "@opensumi/ide-file-service": "2.26.7",
-    "@opensumi/ide-file-tree-next": "2.26.7",
-    "@opensumi/ide-i18n": "2.26.7",
-    "@opensumi/ide-keymaps": "2.26.7",
-    "@opensumi/ide-logs": "2.26.7",
-    "@opensumi/ide-main-layout": "2.26.7",
-    "@opensumi/ide-markdown": "2.26.7",
-    "@opensumi/ide-markers": "2.26.7",
-    "@opensumi/ide-menu-bar": "2.26.7",
-    "@opensumi/ide-monaco": "2.26.7",
-    "@opensumi/ide-monaco-enhance": "2.26.7",
-    "@opensumi/ide-opened-editor": "2.26.7",
-    "@opensumi/ide-outline": "2.26.7",
-    "@opensumi/ide-output": "2.26.7",
-    "@opensumi/ide-overlay": "2.26.7",
-    "@opensumi/ide-preferences": "2.26.7",
-    "@opensumi/ide-process": "2.26.7",
-    "@opensumi/ide-quick-open": "2.26.7",
-    "@opensumi/remote-cli": "2.26.7",
-    "@opensumi/ide-remote-opener": "2.26.7",
-    "@opensumi/ide-scm": "2.26.7",
-    "@opensumi/ide-search": "2.26.7",
-    "@opensumi/ide-startup": "2.26.7",
-    "@opensumi/ide-static-resource": "2.26.7",
-    "@opensumi/ide-status-bar": "2.26.7",
-    "@opensumi/ide-storage": "2.26.7",
-    "@opensumi/ide-task": "2.26.7",
-    "@opensumi/ide-terminal-next": "2.26.7",
-    "@opensumi/ide-testing": "2.26.7",
-    "@opensumi/ide-theme": "2.26.7",
-    "@opensumi/ide-toolbar": "2.26.7",
-    "@opensumi/sumi": "2.26.7",
-    "@opensumi/ide-userstorage": "2.26.7",
-    "@opensumi/ide-utils": "2.26.7",
-    "@opensumi/ide-variable": "2.26.7",
-    "@opensumi/ide-webview": "2.26.7",
-    "@opensumi/ide-workspace": "2.26.7",
-    "@opensumi/ide-workspace-edit": "2.26.7"
+    "@opensumi/ide-addons": "2.26.8",
+    "@opensumi/ide-collaboration": "2.26.8",
+    "@opensumi/ide-comments": "2.26.8",
+    "@opensumi/ide-components": "2.26.8",
+    "@opensumi/ide-connection": "2.26.8",
+    "@opensumi/ide-core-browser": "2.26.8",
+    "@opensumi/ide-core-common": "2.26.8",
+    "@opensumi/ide-core-electron-main": "2.26.8",
+    "@opensumi/ide-core-node": "2.26.8",
+    "@opensumi/ide-debug": "2.26.8",
+    "@opensumi/ide-decoration": "2.26.8",
+    "@opensumi/ide-editor": "2.26.8",
+    "@opensumi/ide-electron-basic": "2.26.8",
+    "@opensumi/ide-explorer": "2.26.8",
+    "@opensumi/ide-express-file-server": "2.26.8",
+    "@opensumi/ide-extension": "2.26.8",
+    "@opensumi/ide-extension-manager": "2.26.8",
+    "@opensumi/ide-extension-storage": "2.26.8",
+    "@opensumi/ide-file-scheme": "2.26.8",
+    "@opensumi/ide-file-search": "2.26.8",
+    "@opensumi/ide-file-service": "2.26.8",
+    "@opensumi/ide-file-tree-next": "2.26.8",
+    "@opensumi/ide-i18n": "2.26.8",
+    "@opensumi/ide-keymaps": "2.26.8",
+    "@opensumi/ide-logs": "2.26.8",
+    "@opensumi/ide-main-layout": "2.26.8",
+    "@opensumi/ide-markdown": "2.26.8",
+    "@opensumi/ide-markers": "2.26.8",
+    "@opensumi/ide-menu-bar": "2.26.8",
+    "@opensumi/ide-monaco": "2.26.8",
+    "@opensumi/ide-monaco-enhance": "2.26.8",
+    "@opensumi/ide-opened-editor": "2.26.8",
+    "@opensumi/ide-outline": "2.26.8",
+    "@opensumi/ide-output": "2.26.8",
+    "@opensumi/ide-overlay": "2.26.8",
+    "@opensumi/ide-preferences": "2.26.8",
+    "@opensumi/ide-process": "2.26.8",
+    "@opensumi/ide-quick-open": "2.26.8",
+    "@opensumi/remote-cli": "2.26.8",
+    "@opensumi/ide-remote-opener": "2.26.8",
+    "@opensumi/ide-scm": "2.26.8",
+    "@opensumi/ide-search": "2.26.8",
+    "@opensumi/ide-startup": "2.26.8",
+    "@opensumi/ide-static-resource": "2.26.8",
+    "@opensumi/ide-status-bar": "2.26.8",
+    "@opensumi/ide-storage": "2.26.8",
+    "@opensumi/ide-task": "2.26.8",
+    "@opensumi/ide-terminal-next": "2.26.8",
+    "@opensumi/ide-testing": "2.26.8",
+    "@opensumi/ide-theme": "2.26.8",
+    "@opensumi/ide-toolbar": "2.26.8",
+    "@opensumi/sumi": "2.26.8",
+    "@opensumi/ide-userstorage": "2.26.8",
+    "@opensumi/ide-utils": "2.26.8",
+    "@opensumi/ide-variable": "2.26.8",
+    "@opensumi/ide-webview": "2.26.8",
+    "@opensumi/ide-workspace": "2.26.8",
+    "@opensumi/ide-workspace-edit": "2.26.8"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/sumi",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "typings": "index.d.ts",
   "license": "MIT",
   "repository": {

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-userstorage",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-utils",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/variable/package.json
+++ b/packages/variable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-variable",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-webview",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/workspace-edit/package.json
+++ b/packages/workspace-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace-edit",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/ide-workspace",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "files": [
     "lib",
     "src"

--- a/tools/cli-engine/package.json
+++ b/tools/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/cli-engine",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "Integration engine runtime for opensumi-cli and opensumi extension",
   "license": "MIT",
   "files": [

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensumi/playwright",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "E2E test module for OpenSumi",
   "files": [
     "lib",


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d40162</samp>

*  Add a new event type `ResoucesOfActiveComponentChangedEvent` to indicate the resources of the active component change ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-4094653eb8c5e5971274e17d7a7d8a8837b1c4e2acd4804c1ef92a2b0b8178c6R480-R484))
*  Fire the `ResoucesOfActiveComponentChangedEvent` from the `EditorGroup` class when the resource is removed from the active components map ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8L1844-R1845), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8R1857-R1866), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-9db81a59800afc0949716126640fe241b64db6f5f5aebf7c29a00a4ae24577d8L1976-R1982))
*  Use the `useUpdateOnEventBusEvent` hook in the `EditorComponentWrapper` component to update the state when the `ResoucesOfActiveComponentChangedEvent` is fired ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-814e143ccdb3544451c42f672290a562abfcd27c7cdd469a7df79e31d7b64173L28-R28), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-814e143ccdb3544451c42f672290a562abfcd27c7cdd469a7df79e31d7b64173R48), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-814e143ccdb3544451c42f672290a562abfcd27c7cdd469a7df79e31d7b64173L492-R508))
*  Add a new state variable `viewStateRef` to the `ToolbarButton` component to avoid stale closures when using the `viewState` in callbacks ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998L31-R37))
*  Add type annotations and use the `viewStateRef` in the callback function that updates the view state and title of the `ToolbarButton` component ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998L77-R86))
*  Add a new method `getState` to the `ToolbarBtnDelegate` class and the `IToolbarActionBtnDelegate` interface to expose the current view state of the `ToolbarButton` component ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-f149b18ab4859702a01e8daac3133f60cf67c65b9a215d8981cd9f835287d998R311-R314), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-b9ffff8b7eca64c21c4f21e664738b65432b4ea0fe2025ed29899dbaa872e24aR228))
*  Avoid rendering breakpoints for lines that exceed the maximum line count of the editor model in the `DebugModel` class and update the corresponding test cases ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bR485-R488), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-a92f8d3d8e9e5077e368d120d4405b544ea65406e1dd6c0b5fc601a9791f726bL541-R546), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-84f0d8843f3731b82b2028c95e5c47d599504f5d76e60b686178ff36c1f3536fL162-R162), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-84f0d8843f3731b82b2028c95e5c47d599504f5d76e60b686178ff36c1f3536fL168-R168))
*  Avoid updating the description of the breakpoint node for lines that exceed the maximum line count of the editor model in the `DebugBreakpointsService` class ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-b495877d18ddd7d60798cb539367bce3e910600f7d426f9f7c965e5c5a1a6e70L226-R231))
*  Set the `uriScheme` property of the `env` object to the `Schemes.file` value in the `createWorkerHostEnvAPIFactory` function and add the property to the return type ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-aa83b997e857af59c15beb8b4f5741865213a9f30631f9d63049e8863bbb4723R4), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-aa83b997e857af59c15beb8b4f5741865213a9f30631f9d63049e8863bbb4723L10-R11), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-aa83b997e857af59c15beb8b4f5741865213a9f30631f9d63049e8863bbb4723R24))
*  Remove the redundant assignment of the `uriScheme` property to the `env` object in the `createAPIFactory` function and fix a typo in the `getSourceControl` method name ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562L4-R4), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562L176-R177), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-a8bcafe76fdf18ba6f70fc5772df7eb978d82e6805686c7860fd95443a0a6562L199-R196))
*  Update the active file decoration when the user selects a file or a folder in the file tree in the `FileTreeModelService` class ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1R774-R777), [link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L780-L783))
*  Sync the state of the `bottomExpanded` context key with the size of the bottom slot in the `LayoutService` class ([link](https://github.com/opensumi/core/pull/3058/files?diff=unified&w=0#diff-44758cd89b398dcea101472d9dc2de120b9c97709ed7a5de48d8a5317f1c1ccbL273-R279))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d40162</samp>

This pull request enhances various features and fixes some issues in the core, debug, editor, extension, file-tree-next, and main-layout packages. It improves the performance, type safety, usability, responsiveness, and consistency of the toolbar button, debug model, editor view, file tree, and layout service components. It also adds support for the `uriScheme` property of the `vscode.env` object and defines a new event type for the resources of the active component. It removes unused or redundant code and fixes a typo in the hosted extension API. It updates the corresponding test cases and types to match the new behavior and logic.
