### PR TITLE
ci: use nodejs 16.x

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -53,10 +53,10 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Get yarn cache directory path
         id: yarn_cache_dir_path
         run: echo "dir=$(yarn config get cacheFolder)" >> $Env:GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # os: [macos-latest, ubuntu-latest, windows-2019]
         os: [macos-latest, ubuntu-latest]
-        node-version: [14.x]
+        node-version: [16.x]
         ci-project: [node, jsdom]
 
     steps:
@@ -52,7 +52,7 @@ jobs:
         run: |
           yarn run ci --selectProjects ${{ matrix.ci-project }}
 
-      - if: ${{ matrix.node-version == '14.x' && matrix.os == 'ubuntu-latest' }}
+      - if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    name: ubuntu-latest, Node.js 14.x
+    name: ubuntu-latest, Node.js 16.x
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js "14.x"
+      - name: Use Node.js "16.x"
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get yarn cache directory path

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       # 判断用户是否有写权限

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     environment: latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       # 判断用户是否有管理员权限


### PR DESCRIPTION
### Types

- [x] 🏗️ Build System

### Background or solution

我们的 ci 还都是 nodejs 14，今天发现跑 lerna 会挂掉，升级到 16 解决

![image](https://github.com/opensumi/core/assets/13938334/008ee5c6-2e42-4242-b32e-487480cb3c00)


### Changelog

