### PR TITLE
fix: toolbar width should change when props change

### DIFF
--- a/packages/core-browser/src/toolbar/toolbar.tsx
+++ b/packages/core-browser/src/toolbar/toolbar.tsx
@@ -148,7 +148,7 @@ export const ToolbarLocation = (props: IToolbarLocationProps & React.HTMLAttribu
       }
       return () => disposer.dispose();
     }
-  }, []);
+  }, [preferences.noDropDown]);
 
   return (
     <div


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

toolbar 有个功能是当距离不够时自动变成 DropDown，但是它没有响应 props 的改变



### Changelog

toolbar width should change when props change
