### PR TITLE
feat: notification support button

### DIFF
--- a/packages/core-browser/src/progress/progress.service.tsx
+++ b/packages/core-browser/src/progress/progress.service.tsx
@@ -27,6 +27,7 @@ import {
   parseLinkedText,
   IDisposable,
   timeout,
+  IAction,
 } from '@opensumi/ide-core-common';
 
 import { open } from '../components';
@@ -305,14 +306,15 @@ export class ProgressService implements IProgressService {
     let isInfinite = false;
 
     const createNotification = (message: string, silent: boolean, increment?: number): string => {
-      const buttons: string[] = [];
+      const buttons: Array<string | IAction> = [];
       const closeable = options.closeable ?? true;
-      if (options.buttons) {
-        // TODO: with progress Notification暂不支持自定义按钮
-      }
 
       if (options.cancellable) {
         buttons.push(localize('ButtonCancel'));
+      }
+
+      if (options.buttons) {
+        buttons.push(...options.buttons);
       }
 
       const notificationKey = Math.random().toString(18).slice(2, 5);

--- a/packages/utils/src/progress.ts
+++ b/packages/utils/src/progress.ts
@@ -12,10 +12,11 @@ export enum ProgressLocation {
 export interface IAction extends IDisposable {
   readonly id: string;
   label: string;
-  tooltip: string;
-  class: string | undefined;
-  enabled: boolean;
-  checked: boolean;
+  tooltip?: string;
+  class?: string;
+  enabled?: boolean;
+  checked?: boolean;
+  primary?: boolean;
   run(event?: any): Promise<any>;
 }
 
@@ -26,8 +27,7 @@ export interface IProgressOptions {
   readonly total?: number;
   readonly cancellable?: boolean;
   readonly closeable?: boolean;
-  // 暂不支持
-  readonly buttons?: string[];
+  readonly buttons?: Array<string | IAction>;
 }
 
 export interface IProgressNotificationOptions extends IProgressOptions {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4420f09</samp>

*  Added support for custom notification buttons using the `IAction` interface ([link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-9ceeaea01918c3e405fc705fdff21a303904cc984b7918a3f31fdce5a8d84259R4), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-9ceeaea01918c3e405fc705fdff21a303904cc984b7918a3f31fdce5a8d84259L31-R32), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-9ceeaea01918c3e405fc705fdff21a303904cc984b7918a3f31fdce5a8d84259L51-R72), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-d8040ae7d93cc1185f86da6da86c05a9cc9ea1f655c20326a297d386646bb8e9R30), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-d8040ae7d93cc1185f86da6da86c05a9cc9ea1f655c20326a297d386646bb8e9L308-R310), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-d8040ae7d93cc1185f86da6da86c05a9cc9ea1f655c20326a297d386646bb8e9R316-R319), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-996c2c0bacf95b66ba78332934174c3a02efb6146d870f2c46747878a2d94db2L15-R19), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-996c2c0bacf95b66ba78332934174c3a02efb6146d870f2c46747878a2d94db2L29-R30))
  - Imported the `IAction` interface from `@opensumi/ide-core-common` in `notification` component and `progress` service ([link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-9ceeaea01918c3e405fc705fdff21a303904cc984b7918a3f31fdce5a8d84259R4), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-d8040ae7d93cc1185f86da6da86c05a9cc9ea1f655c20326a297d386646bb8e9R30))
  - Changed the `buttons` parameter of the `open` function in `notification` component and the `buttons` option of the `IProgressOptions` interface in `progress` service and utility to accept an array of strings or `IAction` objects ([link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-9ceeaea01918c3e405fc705fdff21a303904cc984b7918a3f31fdce5a8d84259L31-R32), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-d8040ae7d93cc1185f86da6da86c05a9cc9ea1f655c20326a297d386646bb8e9L308-R310), [link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-996c2c0bacf95b66ba78332934174c3a02efb6146d870f2c46747878a2d94db2L29-R30))
  - Modified the logic for rendering the notification buttons in the `open` function to handle both string and `IAction` types and to apply the corresponding props and actions for each button ([link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-9ceeaea01918c3e405fc705fdff21a303904cc984b7918a3f31fdce5a8d84259L51-R72))
  - Passed the `buttons` option from the `progress` service to the `notification` component in the `createNotification` method ([link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-d8040ae7d93cc1185f86da6da86c05a9cc9ea1f655c20326a297d386646bb8e9R316-R319))
  - Updated the `IAction` interface in the `progress` utility to make some properties optional and to add a `primary` property ([link](https://github.com/opensumi/core/pull/3073/files?diff=unified&w=0#diff-996c2c0bacf95b66ba78332934174c3a02efb6146d870f2c46747878a2d94db2L15-R19))

<!-- Additional content -->
<!-- 补充额外内容 -->

* notification 支持按钮
  * 新效果
![刷新](https://github.com/opensumi/core/assets/9477255/32cca04a-96d2-497b-adea-b4e7044b66d9)
  * 兼容原有取消按钮
![刷新+cancle](https://github.com/opensumi/core/assets/9477255/d559c200-847a-407a-ad4e-5d45c28b2b59)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4420f09</samp>

Enhanced the `notification` component and related services and utilities to allow custom actions and props for the notification buttons. This enables more flexibility and interactivity for displaying progress and feedback to the user. Used the `IAction` interface from `@opensumi/ide-core-common` to define the button options.
