### PR TITLE
fix: show first level child when folder tree node is filtered

### DIFF
--- a/packages/components/src/recycle-tree/RecycleTree.tsx
+++ b/packages/components/src/recycle-tree/RecycleTree.tsx
@@ -802,7 +802,13 @@ export class RecycleTree extends React.Component<IRecycleTreeProps> {
             dangerouslySetInnerHTML={{ __html: item.string || '' }}
           ></div>
         ));
-        // 不应包含根节点
+        if (CompositeTreeNode.is(node)) {
+          for (const child of node.children || []) {
+            // 让筛选到的节点目录也展示其首层子节点
+            idSets.add(child.id);
+          }
+        }
+        // 当子节点被筛选时，向上的所有父节点均应该被展示
         while (parent && !CompositeTreeNode.isRoot(parent)) {
           idSets.add(parent.id);
           parent = parent.parent;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

copilot:walkthrough

<!-- Additional content -->
<!-- 补充额外内容 -->

fix #3082 

![Kapture 2023-09-26 at 09 52 11](https://github.com/opensumi/core/assets/9823838/f1428375-4218-4a1e-b563-0be53572c14d)

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

copilot:summary
