### PR TITLE
feat: use extensionLogger when extension log

### DIFF
--- a/packages/core-common/src/log.ts
+++ b/packages/core-common/src/log.ts
@@ -22,6 +22,8 @@ export enum SupportLogNamespace {
   Browser = 'browser',
   // 插件进程
   ExtensionHost = 'extHost',
+  // 插件
+  Extension = 'extension',
   // 应用层
   App = 'app',
   // 其他未分类

--- a/packages/extension/src/hosted/extension-log2.ts
+++ b/packages/extension/src/hosted/extension-log2.ts
@@ -15,13 +15,13 @@ export class ExtensionLogger2 implements IExtensionLogger {
   private logger: ILogService;
   private config: AppConfig;
 
-  constructor(injector: Injector) {
+  constructor(injector: Injector, namespace?: SupportLogNamespace) {
     this.injector = injector;
     this.config = this.injector.get(AppConfig);
     this.injectLogService();
 
     this.loggerManager = this.injector.get(LogServiceManager);
-    this.logger = this.loggerManager.getLogger(SupportLogNamespace.ExtensionHost, this.config);
+    this.logger = this.loggerManager.getLogger(namespace ?? SupportLogNamespace.ExtensionHost, this.config);
   }
 
   injectLogService() {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ace0b73</samp>

*  Add a new log source and category for extensions ([link](https://github.com/opensumi/core/pull/3091/files?diff=unified&w=0#diff-a572c5492e0da3ee0c21cd57bb31be3ca408c5c3ee198b5932b3ee5a8baba9e3R25-R26))
*  Import and use the `DebugLog` decorator and the `SupportLogNamespace` enum from `log.ts` in `ext.process-base.ts` to mark and identify loggable methods ([link](https://github.com/opensumi/core/pull/3091/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30R17-R18))
*  Move and modify the `patchConsole` function from `ext.process-base.ts` to `log.ts` to use a custom logger for console output from extensions ([link](https://github.com/opensumi/core/pull/3091/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L126-R147))
*  Initialize the extension process and the RPC protocol with the patched console and store the original console object in a global variable in `ext.process-base.ts` ([link](https://github.com/opensumi/core/pull/3091/files?diff=unified&w=0#diff-c7d2dcfbc69eca7fdb8b6a13352db78e0cd7c3f8ab2d719412bb0541d6577a30L165-R171))
*  Add an optional parameter `namespace` to the `ExtensionLogger2` constructor in `log.ts` to pass the log source and category to the logger manager ([link](https://github.com/opensumi/core/pull/3091/files?diff=unified&w=0#diff-30dc8452a45aa265d2c60c3f65aa461efe8d0fcd51d5001083cd81838f4e8e38L18-R18))
*  Use the `namespace` parameter to get the logger from the logger manager in the `ExtensionLogger2` class in `log.ts` ([link](https://github.com/opensumi/core/pull/3091/files?diff=unified&w=0#diff-30dc8452a45aa265d2c60c3f65aa461efe8d0fcd51d5001083cd81838f4e8e38L24-R24))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ace0b73</samp>

This pull request improves the logging functionality for extensions by using a custom logger and a decorator, and by allowing extensions to specify their own log sources and categories. It also refactors some code to separate concerns and avoid duplication. The main files affected are `ext.process-base.ts`, `extension-log2.ts`, and `log.ts`.
