### PR TITLE
fix: 新建文件时，展示的文件层级异常

### DIFF
--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -1429,7 +1429,9 @@ export class FileTreeModelService {
       }
       // 移除目录下的子节点
       if ((targetNode as Directory).children) {
-        for (const node of (targetNode as Directory).children!) {
+        // deleteAffectedNodeByPath 有副作用，会直接操作 children 数组，因此这里需要用一个新数组轮询
+        const cacheChildren = [...(targetNode as Directory).children!];
+        for (const node of cacheChildren) {
           this.fileTreeService.deleteAffectedNodeByPath(node.path, true);
         }
       }


### PR DESCRIPTION
### Types



- [x] 🐛 Bug Fixes

此 https://github.com/opensumi/core/issues/3045 issue 发现的新的边界case

### Background or solution
数组被循环体中方法设置，导致遍历未完成。




