### PR TITLE
fix: terminal shortcut kill process in windows

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -967,6 +967,12 @@ export namespace TERMINAL_COMMANDS {
     label: '%terminal.toggleTerminal%',
     category: CATEGORY,
   };
+
+  export const KILL_PROCESS = {
+    id: 'terminal.killProcess',
+    label: '%terminal.killProcess%',
+    category: CATEGORY,
+  };
 }
 
 export namespace LAYOUT_COMMANDS {

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1032,6 +1032,7 @@ export const localizationBundle = {
     'terminal.openFolder': 'Open folder in new window',
     'terminal.relaunch': 'Relaunch Terminal',
     'terminal.toggleTerminal': 'Toggle Terminal',
+    'terminal.killProcess': 'Kill Process',
 
     'terminal.focusNext.inTerminalGroup': 'Terminal: Focus Next Terminal in Terminal Group',
     'terminal.focusPrevious.inTerminalGroup': 'Terminal: Focus Previous Terminal in Terminal Group',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -705,6 +705,7 @@ export const localizationBundle = {
     'terminal.focusFolder': '聚焦资源管理器中的文件夹',
     'terminal.openFolder': '在新窗口中打开文件夹',
     'terminal.toggleTerminal': '切换终端面板',
+    'terminal.killProcess': '结束进程',
 
     'view.command.show': '打开 {0}',
 

--- a/packages/terminal-next/src/browser/contribution/terminal.command.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.command.ts
@@ -327,6 +327,23 @@ export class TerminalCommandContribution implements CommandContribution {
         client?.focus();
       },
     });
+
+    registry.registerCommand(TERMINAL_COMMANDS.KILL_PROCESS, {
+      execute: async () => {
+        const current = this.view.currentWidgetId;
+        const client = this.terminalController.findClientFromWidgetId(current);
+        if (client) {
+          const select = client.getSelection();
+          if (select && select.length > 0) {
+            // 有选择内容则复制到剪贴板
+            await this.clipboardService.writeText(client.getSelection());
+          } else {
+            // 没有选择内容则执行结束进程命令
+            await this.terminalApi.sendText(current, '\x03');
+          }
+        }
+      },
+    });
   }
 
   private getNextOrPrevTerminalClient(kind: 'next' | 'prev'): ITerminalClient | undefined {

--- a/packages/terminal-next/src/browser/contribution/terminal.keybinding.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.keybinding.ts
@@ -28,6 +28,11 @@ export class TerminalKeybindingContribution implements KeybindingContribution {
       when: RawContextKey.and(IsTerminalFocused.raw, 'locationProtocol != http'),
     });
     registry.registerKeybinding({
+      command: TERMINAL_COMMANDS.KILL_PROCESS.id,
+      keybinding: 'ctrlcmd+c',
+      when: RawContextKey.and(IsTerminalFocused.raw, 'locationProtocol != http'),
+    });
+    registry.registerKeybinding({
       command: TERMINAL_COMMANDS.PASTE.id,
       keybinding: isWindows ? 'ctrlcmd+shift+v' : 'ctrlcmd+v',
       // http 协议无法访问 navigator.clipboard，使用 xterm 原生快捷键

--- a/packages/terminal-next/src/browser/contribution/terminal.keybinding.ts
+++ b/packages/terminal-next/src/browser/contribution/terminal.keybinding.ts
@@ -30,7 +30,7 @@ export class TerminalKeybindingContribution implements KeybindingContribution {
     registry.registerKeybinding({
       command: TERMINAL_COMMANDS.KILL_PROCESS.id,
       keybinding: 'ctrlcmd+c',
-      when: RawContextKey.and(IsTerminalFocused.raw, 'locationProtocol != http'),
+      when: RawContextKey.and(IsTerminalFocused.raw, 'locationProtocol != http', 'isWindows'),
     });
     registry.registerKeybinding({
       command: TERMINAL_COMMANDS.PASTE.id,


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution

解决window操作系统终端中使用ctrl+c无法结束进程的问题

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 632596e</samp>

*  Add a new command `KILL_PROCESS` to kill the current process or copy the selection in the terminal widget ([link](https://github.com/opensumi/core/pull/3100/files?diff=unified&w=0#diff-a688102e10b7d594a046a44531865122eaa41ed5f4b5bd53eeb7f1f9f499507cR970-R975))
*  Implement the logic for executing the `KILL_PROCESS` command in `terminal.command.ts` ([link](https://github.com/opensumi/core/pull/3100/files?diff=unified&w=0#diff-dbc85461a9648b27059e455e6a0ef9a9b8a30755ef99eb5b2a4f35689f1485ebR330-R346))
*  Add a keybinding for the `KILL_PROCESS` command in `terminal.keybinding.ts` ([link](https://github.com/opensumi/core/pull/3100/files?diff=unified&w=0#diff-bb447ee805056eab81d217339880a591280451b2978789fc0ffadfa633bfe0e2R31-R35))
*  Add localization labels for the `KILL_PROCESS` command in `en-US.lang.ts` and `zh-CN.lang.ts` ([link](https://github.com/opensumi/core/pull/3100/files?diff=unified&w=0#diff-f66d683d6cd38ba54412c1c0a107842d6d65eb4312f6980a82ad912c4d51d9f4R1035), [link](https://github.com/opensumi/core/pull/3100/files?diff=unified&w=0#diff-a5b8f7c1565e0628de0e7e6586f3ec3457c5e82522354bbd3f58926ecd3cdeb7R708))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 632596e</samp>

This pull request adds a new `KILL_PROCESS` command to the terminal widget that can either kill the current process or copy the selected text to the clipboard. It also adds the corresponding localization and keybinding for the command.
