### PR TITLE
style: open editor displays the delete button in its selected state

### DIFF
--- a/packages/opened-editor/src/browser/opened-editor-node.module.less
+++ b/packages/opened-editor/src/browser/opened-editor-node.module.less
@@ -20,6 +20,9 @@
   &.mod_selected {
     color: var(--kt-tree-inactiveSelectionForeground) !important;
     background: var(--kt-tree-inactiveSelectionBackground);
+    .opened_editor_action_bar {
+      display: block;
+    }
   }
 
   &.mod_focused {


### PR DESCRIPTION
### Types

- [X] 🎉 New Features

fix: https://github.com/opensumi/core/issues/3102

### Background or solution
![image](https://github.com/opensumi/core/assets/1762334/33a4795c-6bea-4e1e-85be-16bef63f05f9)
### Changelog
feat: 打开的编辑器的文件树选中状态下展示删除操作

