### PR TITLE
fix: filetree rename file correctly

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -446,7 +446,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
     }
   }
 
-  // 软链接目录下，文件节点路径不能通过uri去获取，存在偏差
+  // 软链接目录下，文件节点路径不能通过 uri 去获取，存在偏差
   public async moveNodeByPath(
     from: Directory,
     to: Directory,
@@ -459,8 +459,8 @@ export class FileTreeService extends Tree implements IFileTreeService {
     if (oldPath && newPath && newPath !== oldPath) {
       const movedNode = from.moveNode(oldPath, newPath);
       // 更新节点除了 name 以外的其他属性，如 fileStat，tooltip 等，否则节点数据可能会异常
-      if (movedNode) {
-        (movedNode as File).updateMetaData({
+      if (movedNode && File.is(movedNode)) {
+        movedNode.updateMetaData({
           uri: to.uri.resolve(newName),
           fileStat: {
             ...to.filestat,
@@ -469,8 +469,35 @@ export class FileTreeService extends Tree implements IFileTreeService {
           },
           tooltip: this.fileTreeAPI.getReadableTooltip(to.uri.resolve(newName)),
         });
+        if (Directory.is(movedNode)) {
+          this.updateChildren(movedNode);
+        }
       }
       return movedNode;
+    }
+  }
+
+  private async updateChildren(parent: Directory) {
+    const children = parent.children;
+    if (!children || children.length === 0) {
+      return;
+    }
+    for (const child of children) {
+      if (File.is(child)) {
+        const newUri = parent.uri.resolve(child.uri.displayName);
+        child.updateMetaData({
+          uri: newUri,
+          fileStat: {
+            ...child.filestat,
+            uri: newUri.toString(),
+            isDirectory: Directory.is(child) ? true : false,
+          },
+          tooltip: this.fileTreeAPI.getReadableTooltip(newUri),
+        });
+        if (Directory.is(child)) {
+          this.updateChildren(child);
+        }
+      }
     }
   }
 
@@ -527,8 +554,8 @@ export class FileTreeService extends Tree implements IFileTreeService {
     const nodes: File[] = [];
     for (const uri of uris) {
       const node = this.getNodeByPathOrUri(uri);
-      if (node) {
-        nodes.push(node as File);
+      if (node && File.is(node)) {
+        nodes.push(node);
       }
     }
     for (const node of nodes) {
@@ -660,12 +687,14 @@ export class FileTreeService extends Tree implements IFileTreeService {
   /**
    * 刷新指定下的所有子节点
    */
-  async refresh(node: Directory = this.root as Directory) {
+  async refresh(node: Directory | File = this.root as Directory) {
     if (!node) {
       return;
     }
-    if (!Directory.is(node) && node.parent) {
-      node = node.parent as Directory;
+    if (!Directory.is(node)) {
+      if (File.is(node) && node.parent) {
+        node = node.parent as Directory;
+      }
     }
 
     // 队列化刷新动作减少更新成本

--- a/packages/file-tree-next/src/common/file-tree-node.define.ts
+++ b/packages/file-tree-next/src/common/file-tree-node.define.ts
@@ -3,6 +3,10 @@ import { URI } from '@opensumi/ide-core-browser';
 import { FileStat } from '@opensumi/ide-file-service';
 
 export class Directory extends CompositeTreeNode {
+  public static is(node: any): node is Directory {
+    return CompositeTreeNode.is(node);
+  }
+
   constructor(
     tree: ITree,
     parent: ICompositeTreeNode | undefined,
@@ -50,6 +54,10 @@ export class Directory extends CompositeTreeNode {
 }
 
 export class File extends TreeNode {
+  public static is(node: any): node is File {
+    return TreeNode.is(node);
+  }
+
   constructor(
     tree: ITree,
     parent: CompositeTreeNode | undefined,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1b9c17</samp>

*  Prevent renaming of compact nodes that do not match the active uri to avoid confusion or inconsistency in the file tree ([link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L1175-R1191))
*  Add type guards to check if the nodes are `File` or `Directory` instances before calling methods or accessing properties that are specific to those types, such as `updateMetaData`, `updateChildren`, `fileStat`, or `children` ([link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bL462-R463), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bR472-R474), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bL530-R558), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L1185-R1202), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L1215-R1232), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L1230-R1254), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-1912008d7c27f4b973a7bf484968a2056a09bf8cbb9329a5d8201a67e9a65fe3R6-R9), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-1912008d7c27f4b973a7bf484968a2056a09bf8cbb9329a5d8201a67e9a65fe3R57-R60))
*  Add a space between the Chinese words and the English word `uri` in a comment in `file-tree.service.ts` to follow the code style convention ([link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bL449-R449))
*  Add a method `updateChildren` to the `FileTreeService` class in `file-tree.service.ts` that recursively updates the metadata of the children nodes of a moved directory node ([link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bR480-R503))
*  Modify the parameter type and the conditional logic of the `refresh` method in the `FileTreeService` class in `file-tree.service.ts` to accept either a directory or a file node as an argument and refresh the parent directory of a file node or the directory node itself ([link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bL663-R697))
*  Modify the logic of the `rename` method in the `FileTreeModelService` class in `file-tree-model.service.ts` to set or unset the `updateRefreshable` flag before and after certain file operations, such as moving, validating, or deselecting nodes, to indicate whether the file tree service should refresh the file tree data ([link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L1199-R1214), [link](https://github.com/opensumi/core/pull/3108/files?diff=unified&w=0#diff-2bcf08e7f72df7d876cb302aa9809761195c7f26081d7de28acebc5b4494b6d1L1215-R1232))

<!-- Additional content -->
<!-- 补充额外内容 -->
close #3090

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1b9c17</samp>

This pull request enhances the file tree service and model by adding or improving type guards, metadata, and refresh logic. These changes improve the type safety, consistency, and usability of the file tree data and operations. The files affected are `file-tree.service.ts`, `file-tree-model.service.ts`, and `file-tree-node.define.ts`.
