### PR TITLE
fix: clear tree node cache after the tree node is disposed

### DIFF
--- a/packages/components/__tests__/recycle-tree/tree/TreeNode.test.ts
+++ b/packages/components/__tests__/recycle-tree/tree/TreeNode.test.ts
@@ -265,19 +265,14 @@ describe('Tree', () => {
     tree.setPresetChildren([a, b]);
     await root.refresh();
 
-    expect(TreeNode.idToTreeNode).toEqual(
-      new Map([
-        [root.id, root],
-        [a.id, a],
-        [b.id, b],
-      ]),
-    );
-    expect(TreeNode.pathToTreeNode).toEqual(
-      new Map([
-        [root.path, root],
-        [a.path, a],
-        [b.path, b],
-      ]),
-    );
+    expect(TreeNode.idToTreeNode).toContainEqual([a.id, a]);
+    expect(TreeNode.idToTreeNode).toContainEqual([b.id, b]);
+    expect(TreeNode.pathToTreeNode).toContainEqual([a.path, a]);
+    expect(TreeNode.pathToTreeNode).toContainEqual([b.path, b]);
+
+    expect(TreeNode.idToTreeNode).not.toContainEqual([preA.id, preA]);
+    expect(TreeNode.idToTreeNode).not.toContainEqual([preB.id, preB]);
+    expect(TreeNode.pathToTreeNode).not.toContainEqual([preA.path, preA]);
+    expect(TreeNode.pathToTreeNode).not.toContainEqual([preB.path, preB]);
   });
 });

--- a/packages/components/__tests__/recycle-tree/tree/TreeNode.test.ts
+++ b/packages/components/__tests__/recycle-tree/tree/TreeNode.test.ts
@@ -233,4 +233,51 @@ describe('Tree', () => {
     root.addNode(d);
     expect(root.branchSize).toBe(2);
   });
+
+  test('should remove the node from TreeNode.idToTreeNode and TreeNode.pathToTreeNode after the node is disposed.', () => {
+    const tree = new TreeA();
+    const root = new Root(tree, undefined, undefined);
+    root.dispose();
+    expect(TreeNode.idToTreeNode.has(root.id)).not.toBeTruthy();
+    expect(TreeNode.pathToTreeNode.has(root.path)).not.toBeTruthy();
+  });
+
+  test('should remove the node from TreeNode.idToTreeNode and TreeNode.pathToTreeNode after the node is removed.', async () => {
+    const tree = new TreeA();
+    const root = new Root(tree, undefined, undefined);
+    const b = new File(tree, root, { name: 'b' });
+    tree.setPresetChildren([new Folder(tree, root, undefined, { name: 'a' }), b]);
+    await root.ensureLoaded();
+
+    root.unlinkItem(b);
+
+    expect(TreeNode.idToTreeNode.has(b.id)).not.toBeTruthy();
+    expect(TreeNode.pathToTreeNode.has(b.path)).not.toBeTruthy();
+  });
+
+  test('should refresh the node from TreeNode.idToTreeNode and TreeNode.pathToTreeNode after the node is refreshed.', async () => {
+    const preA = new Folder(tree, root, undefined, { name: 'a' });
+    const preB = new File(tree, root, { name: 'b' });
+    tree.setPresetChildren([preA, preB]);
+    await root.ensureLoaded();
+    const a = new Folder(tree, root, undefined, { name: 'a' });
+    const b = new File(tree, root, { name: 'b' });
+    tree.setPresetChildren([a, b]);
+    await root.refresh();
+
+    expect(TreeNode.idToTreeNode).toEqual(
+      new Map([
+        [root.id, root],
+        [a.id, a],
+        [b.id, b],
+      ]),
+    );
+    expect(TreeNode.pathToTreeNode).toEqual(
+      new Map([
+        [root.path, root],
+        [a.path, a],
+        [b.path, b],
+      ]),
+    );
+  });
 });

--- a/packages/components/src/recycle-tree/basic/tree-service.ts
+++ b/packages/components/src/recycle-tree/basic/tree-service.ts
@@ -202,6 +202,7 @@ export class BasicTreeService extends Tree {
   };
 
   dispose() {
+    super.dispose();
     this.disposableCollection.dispose();
     this.decorationDisposableCollection.dispose();
   }

--- a/packages/components/src/recycle-tree/tree/Tree.ts
+++ b/packages/components/src/recycle-tree/tree/Tree.ts
@@ -15,6 +15,7 @@ export abstract class Tree implements ITree {
 
   dispose(): void {
     this.toDispose.dispose();
+    this._root?.dispose();
   }
 
   get root(): CompositeTreeNode | undefined {
@@ -22,6 +23,11 @@ export abstract class Tree implements ITree {
   }
 
   set root(root: CompositeTreeNode | undefined) {
+    if (root === this._root) {
+      return;
+    }
+
+    this._root?.dispose();
     this._root = root;
   }
 

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -331,6 +331,8 @@ export class TreeNode implements ITreeNode {
     if (this._disposed) {
       return;
     }
+
+    TreeNode.removeTreeNode(this.id, this.path);
     this._disposed = true;
     this._watcher.notifyDidDispose(this);
   }
@@ -870,6 +872,7 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
             // 如果存在上一次缓存的节点，则使用缓存节点的 ID
             (child as TreeNode).id = TreeNode.getIdByPath(child.path) || (child as TreeNode).id;
             this._children[i] = child;
+            TreeNode.setIdByPath(child.path, child.id);
             if (CompositeTreeNode.is(child) && child.expanded) {
               expandedChilds.push(child as CompositeTreeNode);
             }

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -178,7 +178,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
           roots[0],
           this.fileTreeAPI.getReadableTooltip(newRootUri),
         );
-        this._root = newRoot;
+        this.root = newRoot;
         this.onWorkspaceChangeEmitter.fire(newRoot);
         this.refresh();
       }),
@@ -192,6 +192,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
 
     this.toDispose.push(
       Disposable.create(() => {
+        this._root?.dispose();
         this._roots = null;
       }),
     );


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6349cdb</samp>

*  Dispose the root node of the tree when the tree or the tree service is disposed ([link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-f29ee99a9c13c2068cbbd3db54b2b534e175f5ba6e84ae0cdadadee2a5ecd80bR18), [link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bL181-R181), [link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-2435fb9fb663600404d30dfdfbcce6633ef04d1e96544bc99770ea8ca6c1cb2bR195))
*  Add a super.dispose() call to the BasicTreeService class to dispose the parent class resources ([link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-1f7540db9587a83872a41a538717851bbe3384156bfd544711ee7b700fcf1b12R205))
*  Remove the node from the static maps of idToTreeNode and pathToTreeNode when the node is disposed, removed, or refreshed ([link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-e06f6e62a0aec13e178cf8da9849199b77cb52168b1f794591f7ced4a2e1d109R334-R335), [link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-2f6de085e6ee0e6f5b5f1ccbc5d14d23d4cf2183c3540b14eb55e54e9b335c4bR236-R282))
*  Add a condition to the Tree class to avoid unnecessary disposal of the root node when it is not changed ([link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-f29ee99a9c13c2068cbbd3db54b2b534e175f5ba6e84ae0cdadadee2a5ecd80bR26-R30))
*  Add the child node to the static map of pathToTreeNode when the child node is created in the CompositeTreeNode class ([link](https://github.com/opensumi/core/pull/3109/files?diff=unified&w=0#diff-e06f6e62a0aec13e178cf8da9849199b77cb52168b1f794591f7ced4a2e1d109R875))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6349cdb</samp>

This pull request enhances the memory management and error handling of the tree components and services by disposing the root nodes and updating the static maps when the tree structure changes. It also adds new test cases to verify the TreeNode logic and ensure the code coverage.
