### PR TITLE
fix: fix electron ide build error

### DIFF
--- a/packages/extension/src/common/vscode/localization.ts
+++ b/packages/extension/src/common/vscode/localization.ts
@@ -1,6 +1,6 @@
 import type { Uri } from '@opensumi/ide-core-common';
 
-import type { IExtensionDescription } from '../../../src/common/vscode';
+import type { IExtensionDescription } from '../../common/vscode';
 
 import { UriComponents } from './ext-types';
 


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution
下面的路径写法会导致electron版本build的时候报错，调整了一下
<img width="696" alt="image" src="https://github.com/opensumi/core/assets/3340210/76b9eced-6f70-4ad4-abb2-18e6e6444aaa">
<img width="1430" alt="image" src="https://github.com/opensumi/core/assets/3340210/85a8a3c6-e09b-452c-b16a-42ad870c5845">


<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cbe9fbc</samp>

*  Update import path for `IExtensionDescription` to match new location of `common/vscode` folder ([link](https://github.com/opensumi/core/pull/3113/files?diff=unified&w=0#diff-c51007febd76e039e6596c36411341af307712ae2babc252816378dfd6c2161eL3-R3))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cbe9fbc</samp>

Refactored the code structure and updated the import path for `IExtensionDescription` in `localization.ts`. This improves the code organization and avoids duplication.
