### PR TITLE
chore: 下载插件也加入 retry 机制

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -150,12 +150,12 @@ const installExtension = async (namespace, name, version) => {
   }
 
   if (downloadUrl) {
-    const { targetDirName, tmpZipFile } = await downloadExtension(downloadUrl, namespace, name);
-
-    // 解压插件，使用 opentrs 插件时解压缩容易出错，因此这里加一个重试逻辑
-    await retry(() => unzipFile(targetDir, targetDirName, tmpZipFile), { retries: 5 });
-
-    rimraf.sync(tmpZipFile);
+    // 下载解压插件容易出错，因此这里加一个重试逻辑
+    await retry(async () => {
+      const { targetDirName, tmpZipFile } = await downloadExtension(downloadUrl, namespace, name);
+      await unzipFile(targetDir, targetDirName, tmpZipFile);
+      rimraf.sync(tmpZipFile);
+    }, { retries: 5 });
   }
 };
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🏗️ Build System

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6f66c7c</samp>

* Move the retry logic to wrap the whole download and unzip process ([link](https://github.com/opensumi/core/pull/3117/files?diff=unified&w=0#diff-275a1a02d5728cab84d6b7293750aa0656f3f7e082baef38c3f124db45631e2fL153-R158))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f66c7c</samp>

Improved the reliability and readability of the extension download script by applying retry logic to the whole download and unzip process.
