### PR TITLE
fix: error color

### DIFF
--- a/packages/core-common/src/log.ts
+++ b/packages/core-common/src/log.ts
@@ -231,7 +231,7 @@ export class DebugLog implements IDebugLog {
       black: '\x1b[30m',
       red: '\x1b[31m',
       green: '\x1b[32m',
-      yellow: '\x1b3[33m',
+      yellow: '\x1b[33m',
       blue: '\x1b[34m',
       magenta: '\x1b[35m',
       cyan: '\x1b[36m',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3eb1e74</samp>

* Fix the yellow color code in the `DebugLog` class ([link](https://github.com/opensumi/core/pull/3118/files?diff=unified&w=0#diff-a572c5492e0da3ee0c21cd57bb31be3ca408c5c3ee198b5932b3ee5a8baba9e3L234-R234))

<!-- Additional content -->


#3116 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eb1e74</samp>

Fixed a bug in the `DebugLog` class that caused the yellow color to be incorrect. This change affects the `log.ts` file in the `core-common` package.
