### PR TITLE
feat: implement workspaceEdit needConfirmation

### DIFF
--- a/packages/extension/__tests__/browser/main.thread.workspace.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.workspace.test.ts
@@ -87,7 +87,8 @@ import MonacoServiceImpl from '@opensumi/ide-monaco/lib/browser/monaco.service';
 import { IWebviewService } from '@opensumi/ide-webview';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { MockWorkspaceService } from '@opensumi/ide-workspace/lib/common/mocks';
-import { IWorkspaceEditService, IWorkspaceFileService } from '@opensumi/ide-workspace-edit';
+import { IBulkEditServiceShape, IWorkspaceEditService, IWorkspaceFileService } from '@opensumi/ide-workspace-edit';
+import { MonacoBulkEditService } from '@opensumi/ide-workspace-edit/lib/browser/bulk-edit.service';
 import { WorkspaceEditServiceImpl } from '@opensumi/ide-workspace-edit/lib/browser/workspace-edit.service';
 import { WorkspaceFileService } from '@opensumi/ide-workspace-edit/lib/browser/workspace-file.service';
 
@@ -146,6 +147,10 @@ describe('MainThreadWorkspace API Test Suite', () => {
     {
       token: IWorkspaceService,
       useClass: MockWorkspaceService,
+    },
+    {
+      token: IBulkEditServiceShape,
+      useClass: MonacoBulkEditService,
     },
     {
       token: IWorkspaceEditService,

--- a/packages/monaco/src/browser/monaco-api/index.ts
+++ b/packages/monaco/src/browser/monaco-api/index.ts
@@ -7,4 +7,7 @@ export const monaco = Object.freeze({
 });
 
 export { URI } from '@opensumi/monaco-editor-core/esm/vs/base/common/uri';
-export { ResourceEdit } from '@opensumi/monaco-editor-core/esm/vs/editor/browser/services/bulkEditService';
+export {
+  ResourceEdit,
+  IBulkEditResult,
+} from '@opensumi/monaco-editor-core/esm/vs/editor/browser/services/bulkEditService';

--- a/packages/workspace-edit/__tests__/browser/index.test.ts
+++ b/packages/workspace-edit/__tests__/browser/index.test.ts
@@ -338,4 +338,38 @@ describe('workspace edit tests', () => {
 
     expect(mockedPreviewFn).toBeCalled();
   });
+
+  it('monaco bulk edit metadata needsConfirmation test', async () => {
+    const mockedPreviewFn = jest.fn(
+      (edits: ResourceEdit[], options?: IBulkEditOptions): Promise<ResourceEdit[]> => Promise.resolve(edits),
+    );
+    const monacoBulkEditService: MonacoBulkEditService = injector.get(MonacoBulkEditService);
+    monacoBulkEditService.setPreviewHandler(mockedPreviewFn);
+
+    await monacoBulkEditService.apply([
+      {
+        resource: Uri.parse('file:///monaco-test-3.ts'),
+        textEdit: {
+          range: {
+            startColumn: 1,
+            endColumn: 1,
+            startLineNumber: 1,
+            endLineNumber: 1,
+          },
+          text: 'test1',
+        },
+        metadata: {
+          needsConfirmation: true,
+        },
+      },
+    ] as unknown as ResourceEdit[]);
+
+    const model = monaco.editor.getModel(Uri.parse('file:///monaco-test-3.ts'))!;
+    expect(model.pushEditOperations).toBeCalled();
+    expect(model.pushStackElement).toBeCalled();
+
+    expect(injector.get(WorkbenchEditorService).open).toBeCalled();
+
+    expect(mockedPreviewFn).toBeCalled();
+  });
 });

--- a/packages/workspace-edit/src/browser/bulk-edit.service.ts
+++ b/packages/workspace-edit/src/browser/bulk-edit.service.ts
@@ -65,7 +65,7 @@ export class MonacoBulkEditService implements IBulkEditService {
   ): Promise<IBulkEditResult & { success: boolean }> {
     let edits = reviveWorkspaceEditDto2(resourceEdits);
 
-    if (options?.showPreview && this._previewHandler) {
+    if ((options?.showPreview || edits.some((edit) => edit.metadata?.needsConfirmation)) && this._previewHandler) {
       try {
         edits = await this._previewHandler(edits, options);
       } catch (err) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

fix #3121

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19b5158</samp>

*  Refactored the workspace edit API to use the monaco bulk edit service and align with the VS Code API ([link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-d058abd202a9b4bd1dbb712c71ba170e0fb4f10a43277b5264a12feca8f5190bL8-R12), [link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-d058abd202a9b4bd1dbb712c71ba170e0fb4f10a43277b5264a12feca8f5190bL37-R33), [link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-d058abd202a9b4bd1dbb712c71ba170e0fb4f10a43277b5264a12feca8f5190bL120-R118), [link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-112d790fce12b03f504cb1389983552c3e8219153ab66260e52ab2b2e945d61bL10-R13), [link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-249e6fa5702ecd58624f0c61d63e9409db1825b66d6d28f12f666b69ad42443eL68-R68))
  - Updated the imports in `main.thread.workspace.ts` to use the new types from `@opensumi/ide-monaco` ([link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-d058abd202a9b4bd1dbb712c71ba170e0fb4f10a43277b5264a12feca8f5190bL8-R12))
  - Replaced the `workspaceEditService` property with the `bulkEditService` property in `main.thread.workspace.ts` ([link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-d058abd202a9b4bd1dbb712c71ba170e0fb4f10a43277b5264a12feca8f5190bL37-R33))
  - Changed the `$tryApplyWorkspaceEdit` method in `main.thread.workspace.ts` to use the `ResourceEdit.convert` and `bulkEditService.apply` methods and return the `success` property of the bulk edit result ([link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-d058abd202a9b4bd1dbb712c71ba170e0fb4f10a43277b5264a12feca8f5190bL120-R118))
  - Exported the `IBulkEditResult` type from `monaco-api/index.ts` along with the `ResourceEdit` type ([link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-112d790fce12b03f504cb1389983552c3e8219153ab66260e52ab2b2e945d61bL10-R13))
  - Changed the condition for showing the preview of the edits in `bulk-edit.service.ts` to also check the `needsConfirmation` metadata flag ([link](https://github.com/opensumi/core/pull/3122/files?diff=unified&w=0#diff-249e6fa5702ecd58624f0c61d63e9409db1825b66d6d28f12f666b69ad42443eL68-R68))

<!-- Additional content -->
<!-- 补充额外内容 -->

![image](https://github.com/opensumi/core/assets/6399899/55bfcda3-46ec-4a67-9455-6d111664e110)


### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19b5158</samp>

Refactored the VS Code workspace edit API to use the monaco bulk edit service and aligned the preview behavior with the VS Code API. Exported some types from the `@opensumi/ide-monaco` package for reuse.
