### PR TITLE
feat: support anchor extra ctx menu

### DIFF
--- a/packages/ai-native/src/browser/components/Icon.tsx
+++ b/packages/ai-native/src/browser/components/Icon.tsx
@@ -7,11 +7,17 @@ import * as styles from './components.module.less';
 
 interface IEnhanceIconProps extends IconProps {
   wrapperStyle?: React.CSSProperties;
+  wrapperClassName?: string;
 }
 
 export const EnhanceIcon = React.forwardRef<HTMLDivElement | null, IEnhanceIconProps>(
   (props: IEnhanceIconProps, ref?) => (
-    <div className={styles.ai_enhance_icon} style={props.wrapperStyle} onClick={props.onClick} ref={ref}>
+    <div
+      className={cls(props.wrapperClassName, styles.ai_enhance_icon)}
+      style={props.wrapperStyle}
+      onClick={props.onClick}
+      ref={ref}
+    >
       <Icon {...props} className={cls(props.className, styles.icon)} children={null} onClick={() => null} />
       {props.children && <span className={styles.children_wrap}>{props.children}</span>}
     </div>

--- a/packages/ai-native/src/browser/override/layout/layout.module.less
+++ b/packages/ai-native/src/browser/override/layout/layout.module.less
@@ -147,12 +147,19 @@
   }
 
   // 底部菜单样式
-  div[class*='titleActions___'] {
-    span[class*='iconAction___'] {
+  .extra_bottom_icon {
+    &:hover {
+      background-color: transparent !important;
+    }
+
+    span {
       width: 32px;
       height: 32px;
       font-size: 16px;
       border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       &:hover {
         background-color: var(--activityBar-activeBorder);

--- a/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.view.tsx
+++ b/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.view.tsx
@@ -41,8 +41,6 @@ const AiMenuBarRender = () => {
     [contextmenuService],
   );
 
-  const [navMenu, moreMenu] = useContextMenus(extraTopMenus);
-
   const handleClick = React.useCallback(() => {
     if (!anchor) {
       return;

--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -273,7 +273,8 @@ export const LeftTabbarRenderer: React.FC<{
     ) => React.JSX.Element | null;
   }>;
   isRenderExtraTopMenus?: boolean;
-}> = ({ renderOtherVisibleContainers, isRenderExtraTopMenus = true }) => {
+  renderExtraMenus?: React.ReactNode;
+}> = ({ renderOtherVisibleContainers, isRenderExtraTopMenus = true, renderExtraMenus }) => {
   const { side } = React.useContext(TabbarConfig);
   const layoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
   const tabbarService: TabbarService = useInjectable(TabbarServiceFactory)(side);
@@ -301,7 +302,7 @@ export const LeftTabbarRenderer: React.FC<{
         panelBorderSize={1}
         renderOtherVisibleContainers={renderOtherVisibleContainers}
       />
-      <InlineMenuBar className={styles.vertical_icons} menus={extraMenus} />
+      {renderExtraMenus || <InlineMenuBar className={styles.vertical_icons} menus={extraMenus} />}
     </div>
   );
 };


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

左侧底部菜单支持自定义组件渲染，并固定弹出菜单的位置，不再跟随鼠标位置

![image](https://github.com/opensumi/core/assets/20262815/417fc11c-cbef-49c9-b1f4-0d07a3d74672)
