### PR TITLE
style: improve preference checkbox style

### DIFF
--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -142,14 +142,8 @@
       .check {
         display: flex;
         align-items: center;
-        :global {
-          .kt-checkbox {
-            margin-right: 2px;
-            display: flex;
-            align-self: flex-start;
-          }
-        }
         & .desc {
+          margin-left: 2px;
           padding: 0;
         }
       }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b05a2f9</samp>

* Remove global style for `.kt-checkbox` and add margin-left to `.desc` to fix checkbox alignment in preferences panel ([link](https://github.com/opensumi/core/pull/3148/files?diff=unified&w=0#diff-fc7e3fea2f737893472d7d0fd250c2efc28c2cb70e525a1f1142de0f2a9fec86L145-R146))

<!-- Additional content -->
<!-- 补充额外内容 -->

问题样式：
<img width="265" alt="image" src="https://github.com/opensumi/core/assets/9823838/982229f6-b0e1-4b65-8d5d-27d783de8899">

这里移除了对于公共组件的强行覆盖，采用了局部样式进行控制

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b05a2f9</samp>

Removed a global style that affected checkboxes and adjusted the margin of labels in `preferences.module.less`. This improves the appearance of the preferences panel.
