### PR TITLE
refactor: declare backservice type & remove old request method

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.contribution.ts
+++ b/packages/ai-native/src/browser/ai-chat.contribution.ts
@@ -9,7 +9,6 @@ import {
   Position,
   URI,
   getIcon,
-  IRange,
   SlotRendererContribution,
   SlotRendererRegistry,
   SlotLocation,
@@ -195,74 +194,6 @@ export class AiNativeCoreContribution
   }
 
   registerCommands(commands: CommandRegistry): void {
-    commands.registerCommand(
-      {
-        id: 'ai.suggest.documentation',
-      },
-      {
-        execute: async (range: IRange) => {
-          const currentEditor = this.editorService.currentEditor;
-          if (!currentEditor || !range) {
-            return;
-          }
-
-          const getContent = currentEditor.monacoEditor.getModel()!.getValueInRange(range);
-
-          if (getContent) {
-            const messageWithPrompt = `基于提供的代码，需要按照以下这种格式为这段代码添加 javadoc。
-格式要求是:
-/**
- * $\{关于这段代码的注释\}
- * 
- * 如果有参数，则添加 @param $\{参数信息\}。如果没有参数，则不需要添加 @param
- * @return $\{返回类型\}
- */
-
-代码内容是:
-${getContent}
-`;
-
-            const aiResult = await this.aiChatService.aiBackService.aiMFTCompletion(messageWithPrompt);
-            const resultContent = aiResult.data;
-
-            // 提取 markdown 里的代码
-            const regex = /```java\s*([\s\S]+?)\s*```/;
-            let code = regex.exec(resultContent)![1];
-
-            if (!code) {
-              return;
-            }
-
-            const monacoEditor = currentEditor.monacoEditor;
-
-            if (monacoEditor) {
-              const model = monacoEditor.getModel()!;
-
-              const indents = ' '.repeat(4);
-
-              const spcode = code.split('\n');
-              code = spcode.map((s, i) => (i === 0 ? s : indents + s)).join('\n');
-
-              model.pushStackElement();
-              model.pushEditOperations(
-                null,
-                [
-                  {
-                    range,
-                    text: code,
-                  },
-                ],
-                () => null,
-              );
-              model.pushStackElement();
-
-              monacoEditor.focus();
-            }
-          }
-        },
-      },
-    );
-
     commands.registerCommand(
       {
         id: 'ai.chat.createNewFile',

--- a/packages/ai-native/src/browser/ai-chat.service.ts
+++ b/packages/ai-native/src/browser/ai-chat.service.ts
@@ -9,8 +9,8 @@ import { AISerivceType, AiBackSerivcePath, IAiBackService, IAiBackServiceRespons
 import { MsgStreamManager } from './model/msg-stream-manager';
 
 export interface IAiSearchResponse extends IAiBackServiceResponse {
-  responseText: string;
-  urlMessage: string;
+  responseText?: string;
+  urlMessage?: string;
 }
 
 @Injectable()

--- a/packages/ai-native/src/browser/ai-chat.service.ts
+++ b/packages/ai-native/src/browser/ai-chat.service.ts
@@ -4,14 +4,19 @@ import { CancellationTokenSource, Disposable, Emitter, Event } from '@opensumi/i
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { WorkbenchEditorServiceImpl } from '@opensumi/ide-editor/lib/browser/workbench-editor.service';
 
-import { AISerivceType, AiBackSerivcePath, IAiBackService, IAiBackServiceOption, IChatMessageStructure, InstructionEnum } from '../common';
+import { AISerivceType, AiBackSerivcePath, IAiBackService, IAiBackServiceResponse, IAiBackServiceOption, IChatMessageStructure, InstructionEnum } from '../common';
 
 import { MsgStreamManager } from './model/msg-stream-manager';
+
+export interface IAiSearchResponse extends IAiBackServiceResponse {
+  responseText: string;
+  urlMessage: string;
+}
 
 @Injectable()
 export class AiChatService extends Disposable {
   @Autowired(AiBackSerivcePath)
-  public aiBackService: IAiBackService;
+  public aiBackService: IAiBackService<IAiSearchResponse>;
 
   @Autowired(PreferenceService)
   protected preferenceService: PreferenceService;
@@ -191,7 +196,7 @@ export class AiChatService extends Disposable {
   }
 
   public async search(input: string, options: IAiBackServiceOption = {}) {
-    return this.aiBackService.request<{ responseText: string; urlMessage: string; isCancel: boolean }, IAiBackServiceOption>(input, {
+    return this.aiBackService.request(input, {
       ...options,
       cancelToken: this.cancelIndicatorChatView.token,
     });

--- a/packages/ai-native/src/browser/ai-chat.service.ts
+++ b/packages/ai-native/src/browser/ai-chat.service.ts
@@ -172,17 +172,11 @@ export class AiChatService extends Disposable {
   public async messageWithStream(input: string, options: IAiBackServiceOption = {}, sessionId: string): Promise<void> {
     this.msgStreamManager.setCurrentSessionId(sessionId);
 
-    await this.aiBackService.requestStream(input, {
-      ...options,
-      cancelToken: this.cancelIndicatorChatView.token,
-    });
+    await this.aiBackService.requestStream(input, options, this.cancelIndicatorChatView.token);
   }
 
   public async message(input: string, options: IAiBackServiceOption = {}) {
-    const res = await this.aiBackService.request(input, {
-      ...options,
-      cancelToken: this.cancelIndicatorChatView.token,
-    });
+    const res = await this.aiBackService.request(input, options, this.cancelIndicatorChatView.token);
 
     if (res.isCancel) {
       return null;
@@ -196,10 +190,7 @@ export class AiChatService extends Disposable {
   }
 
   public async search(input: string, options: IAiBackServiceOption = {}) {
-    return this.aiBackService.request(input, {
-      ...options,
-      cancelToken: this.cancelIndicatorChatView.token,
-    });
+    return this.aiBackService.request(input, options, this.cancelIndicatorChatView.token);
   }
 
   public setLatestSessionId(id: string): void {

--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -324,7 +324,6 @@ const AISearch = async (input, aiChatService: AiChatService) => {
       input.message,
       {
         type: input.type,
-        cancelToken: aiChatService.cancelIndicatorChatView.token,
       }
     );
 

--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -167,11 +167,11 @@ export const AiChatView = observer(() => {
         } else if (userInput!.type === AISerivceType.Explain) {
           aiMessage = await AIStreamReply(userInput!.message!, aiChatService);
         } else if (userInput!.type === AISerivceType.Run) {
-          aiMessage = await aiChatService.aiBackService.aiAntGlm(
+          aiMessage = await aiRunService.requestBackService(
             userInput!.message!,
             aiChatService.cancelIndicatorChatView.token,
           );
-          aiMessage = await AIChatRunReply(aiMessage.data, aiRunService, aiChatService);
+          aiMessage = await AIChatRunReply(aiMessage, aiRunService, aiChatService);
         }
 
         if (aiMessage) {
@@ -320,10 +320,12 @@ const codeSearchMarkedRender = new (class extends DefaultMarkedRenderer {
 
 const AISearch = async (input, aiChatService: AiChatService) => {
   try {
-    const result = await aiChatService.aiBackService.aiSearchRequest(
+    const result = await aiChatService.search(
       input.message,
-      input.type === 'overall',
-      aiChatService.cancelIndicatorChatView.token,
+      {
+        type: input.type,
+        cancelToken: aiChatService.cancelIndicatorChatView.token,
+      }
     );
 
     const { responseText, urlMessage, isCancel } = result;

--- a/packages/ai-native/src/browser/ai-editor.contribution.ts
+++ b/packages/ai-native/src/browser/ai-editor.contribution.ts
@@ -221,7 +221,8 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
 
       const result = await this.aiBackService.request(
         prompt,
-        { cancelToken: this.aiChatService.cancelIndicator.token, enableGptCache },
+        { enableGptCache },
+        this.aiChatService.cancelIndicator.token
       );
 
       if (this.aiInlineChatDisposed.disposed || result.isCancel) {

--- a/packages/ai-native/src/browser/ai-editor.contribution.ts
+++ b/packages/ai-native/src/browser/ai-editor.contribution.ts
@@ -17,7 +17,7 @@ import { editor as MonacoEditor } from '@opensumi/monaco-editor-core';
 import { InlineCompletion, InlineCompletions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
-import { AiGPTBackSerivcePath, AiNativeSettingSectionsId, InstructionEnum } from '../common';
+import { AiBackSerivcePath, IAiBackService, AiNativeSettingSectionsId, InstructionEnum } from '../common';
 
 import { AiChatService } from './ai-chat.service';
 import { AiCodeWidget } from './code-widget/ai-code-widget';
@@ -33,8 +33,8 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
-  @Autowired(AiGPTBackSerivcePath)
-  private readonly aiGPTBackService: any;
+  @Autowired(AiBackSerivcePath)
+  private readonly aiBackService: IAiBackService;
 
   @Autowired(AiInlineChatService)
   private readonly aiInlineChatService: AiInlineChatService;
@@ -219,11 +219,9 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
 
       this.aiInlineChatService.launchChatStatus(EInlineChatStatus.THINKING);
 
-      const result = await this.aiGPTBackService.aiGPTcompletionRequest(
+      const result = await this.aiBackService.request(
         prompt,
-        {},
-        { enableGptCache },
-        this.aiChatService.cancelIndicator.token,
+        { cancelToken: this.aiChatService.cancelIndicator.token, enableGptCache },
       );
 
       if (this.aiInlineChatDisposed.disposed || result.isCancel) {
@@ -245,7 +243,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
 
       // 提取代码内容
       const regex = /```\w*([\s\S]+?)\s*```/;
-      const regExec = regex.exec(answer);
+      const regExec = regex.exec(answer!);
       answer = (regExec && regExec[1]) || answer;
 
       this.logger.log('aiGPTcompletionRequest:>>> refresh answer', answer);
@@ -274,7 +272,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
               [
                 {
                   range: crossSelection,
-                  text: answer,
+                  text: answer!,
                 },
               ],
               () => null,
@@ -445,7 +443,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
             reqStack.addReq({
               sendRequest: async () => {
                 isCancelFlag = false;
-                const completionResult = await this.aiGPTBackService.aiCompletionRequest({
+                const completionResult = await this.aiBackService.requestCompletion({
                   prompt,
                   suffix,
                   sessionId: uid,
@@ -453,11 +451,10 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
                   fileUrl: model.uri.toString().split('/').pop(),
                 });
 
-                const items = completionResult.data.codeModelList;
                 this.logger.log('onDidChangeModelContent:>>> ai 补全返回结果', completionResult);
                 return {
-                  items: items.map((data) => ({
-                    insertText: data.content,
+                  items: completionResult.map((data) => ({
+                    insertText: data,
                   })),
                 };
               },

--- a/packages/ai-native/src/browser/ai-project/generate.service.ts
+++ b/packages/ai-native/src/browser/ai-project/generate.service.ts
@@ -3,12 +3,12 @@ import { observable, computed } from 'mobx';
 import { Injectable, Autowired } from '@opensumi/di';
 import { ILogServiceClient, ILoggerManagerClient, SupportLogNamespace } from '@opensumi/ide-core-common';
 
-import { AiGPTBackSerivcePath } from '../../common';
+import { AiBackSerivcePath, IAiBackService } from '../../common';
 
 @Injectable()
 export class AiProjectGenerateService {
-  @Autowired(AiGPTBackSerivcePath)
-  aiBackService: any;
+  @Autowired(AiBackSerivcePath)
+  aiBackService: IAiBackService;
 
   @Autowired(ILoggerManagerClient)
   private readonly loggerManagerClient: ILoggerManagerClient;

--- a/packages/ai-native/src/browser/ai-sumi/sumi.service.ts
+++ b/packages/ai-native/src/browser/ai-sumi/sumi.service.ts
@@ -4,7 +4,7 @@ import { Injectable, Autowired } from '@opensumi/di';
 import { CommandService, CommandRegistry, Command, ILogServiceClient, ILoggerManagerClient, SupportLogNamespace } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 
-import { AiGPTBackSerivcePath } from '../../common';
+import { AiBackSerivcePath, IAiBackService } from '../../common';
 import { AiChatService } from '../ai-chat.service';
 import { SumiCommandPromptManager } from '../prompts/sumi.command';
 
@@ -27,8 +27,8 @@ export class AiSumiService {
   // for split command, too much will out of prompt tokens
   protected commandRequestStep = 50;
 
-  @Autowired(AiGPTBackSerivcePath)
-  aiBackService: any;
+  @Autowired(AiBackSerivcePath)
+  aiBackService: IAiBackService;
 
   @Autowired(CommandService)
   protected readonly commandService: CommandService;

--- a/packages/ai-native/src/browser/ai-sumi/sumi.service.ts
+++ b/packages/ai-native/src/browser/ai-sumi/sumi.service.ts
@@ -68,7 +68,9 @@ export class AiSumiService {
         unGroupCommands.slice(i * this.commandRequestStep, (i + 1) * this.commandRequestStep),
       );
 
-      await Promise.all(partCommands.map(async (commands) => this.requestForClassifyCommand(commands)));
+      for (const commands of partCommands) {
+        await this.requestForClassifyCommand(commands);
+      }
     }
   }
 

--- a/packages/ai-native/src/browser/components/ChatEditor.tsx
+++ b/packages/ai-native/src/browser/components/ChatEditor.tsx
@@ -163,7 +163,7 @@ const CodeEditorWithHighlight = ({ input, language }) => {
   );
 };
 
-const CodeBlock = ({ content }: { content: string }) => {
+const CodeBlock = ({ content = '' }: { content?: string }) => {
   const rgInlineCode = /`([^`]+)`/g;
   const rgBlockCode = /```([^]+?)```/g;
   const rgBlockCodeBefore = /```([^]+)?/g;
@@ -216,7 +216,7 @@ const CodeBlock = ({ content }: { content: string }) => {
   return <>{render}</>;
 };
 
-export const CodeBlockWrapper = ({ text }: { text: string }) => (
+export const CodeBlockWrapper = ({ text }: { text?: string }) => (
   <div className={styles.ai_chat_code_wrapper}>
     <div className={styles.render_text}>
       <CodeBlock content={text} />

--- a/packages/ai-native/src/browser/content-widget/ai-inline-chat.service.ts
+++ b/packages/ai-native/src/browser/content-widget/ai-inline-chat.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Autowired } from '@opensumi/di';
 import { PreferenceService } from '@opensumi/ide-core-browser';
 import { Emitter, Event, CommandService } from '@opensumi/ide-core-common';
 
-import { AiGPTBackSerivcePath } from '../../common/index';
+import { AiBackSerivcePath, IAiBackService } from '../../common/index';
 
 export const enum EChatStatus {
   READY,
@@ -13,8 +13,8 @@ export const enum EChatStatus {
 
 @Injectable({ multiple: false })
 export class AiInlineChatService {
-  @Autowired(AiGPTBackSerivcePath)
-  aiBackService: any;
+  @Autowired(AiBackSerivcePath)
+  aiBackService: IAiBackService;
 
   @Autowired(CommandService)
   protected readonly commandService: CommandService;

--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -8,8 +8,8 @@ import { Color, IThemeData, IThemeStore, registerColor, RGBA, ThemeContribution 
 import { ThemeStore } from '@opensumi/ide-theme/lib/browser/theme-store';
 
 import {
-  AiGPTBackSerivcePath,
-  AiGPTBackSerivceToken,
+  AiBackSerivcePath,
+  AiBackSerivceToken,
   AiNativeContribution,
   IAiChatService,
   IAiRunFeatureRegistry,
@@ -117,8 +117,8 @@ export class AiNativeModule extends BrowserModule {
 
   backServices = [
     {
-      servicePath: AiGPTBackSerivcePath,
-      token: AiGPTBackSerivceToken,
+      servicePath: AiBackSerivcePath,
+      token: AiBackSerivceToken,
       clientToken: IAiChatService,
     },
   ];

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-chat.service.ts
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-chat.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Autowired } from '@opensumi/di';
 import { PreferenceService } from '@opensumi/ide-core-browser';
 import { Emitter, Event, CommandService } from '@opensumi/ide-core-common';
 
-import { AiGPTBackSerivcePath } from '../../common/index';
+import { AiBackSerivcePath, IAiBackService } from '../../common/index';
 
 export const enum EInlineChatStatus {
   READY,
@@ -13,8 +13,8 @@ export const enum EInlineChatStatus {
 
 @Injectable({ multiple: false })
 export class AiInlineChatService {
-  @Autowired(AiGPTBackSerivcePath)
-  aiBackService: any;
+  @Autowired(AiBackSerivcePath)
+  aiBackService: IAiBackService;
 
   @Autowired(CommandService)
   protected readonly commandService: CommandService;

--- a/packages/ai-native/src/browser/run/run.feature.registry.ts
+++ b/packages/ai-native/src/browser/run/run.feature.registry.ts
@@ -17,6 +17,14 @@ export class AiRunFeatureRegistry implements IAiRunFeatureRegistry {
     this.answerComponent = component;
   }
 
+  registerRequest(request: IAiBackService['request']) {
+    this.request = request;
+  }
+
+  registerStreamRequest(streamRequest: IAiBackService['requestStream']) {
+    this.streamRequest = streamRequest;
+  }
+
   getRuns(): AiRunHandler[] {
     return this.runs;
   }

--- a/packages/ai-native/src/browser/run/run.feature.registry.ts
+++ b/packages/ai-native/src/browser/run/run.feature.registry.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@opensumi/di';
 
-import { AiRunHandler, IAiRunAnswerComponentProps, IAiRunFeatureRegistry } from '../../common';
+import { AiRunHandler, IAiRunAnswerComponentProps, IAiRunFeatureRegistry, IAiBackService } from '../../common';
 
 @Injectable()
 export class AiRunFeatureRegistry implements IAiRunFeatureRegistry {
   private runs: AiRunHandler[] = [];
   private answerComponent?: React.FC<IAiRunAnswerComponentProps>;
+  private request: IAiBackService['request'] | IAiBackService['requestStream'];
 
   registerRun(handler: AiRunHandler): void {
     this.runs.push(handler);
@@ -21,5 +22,9 @@ export class AiRunFeatureRegistry implements IAiRunFeatureRegistry {
 
   getAnswerComponent(): React.FC<IAiRunAnswerComponentProps> | undefined {
     return this.answerComponent;
+  }
+
+  getRequest(): IAiBackService['request'] | IAiBackService['requestStream'] {
+    return this.request;
   }
 }

--- a/packages/ai-native/src/browser/run/run.feature.registry.ts
+++ b/packages/ai-native/src/browser/run/run.feature.registry.ts
@@ -6,7 +6,8 @@ import { AiRunHandler, IAiRunAnswerComponentProps, IAiRunFeatureRegistry, IAiBac
 export class AiRunFeatureRegistry implements IAiRunFeatureRegistry {
   private runs: AiRunHandler[] = [];
   private answerComponent?: React.FC<IAiRunAnswerComponentProps>;
-  private request: IAiBackService['request'] | IAiBackService['requestStream'];
+  private request: IAiBackService['request'];
+  private streamRequest: IAiBackService['requestStream'];
 
   registerRun(handler: AiRunHandler): void {
     this.runs.push(handler);
@@ -24,7 +25,11 @@ export class AiRunFeatureRegistry implements IAiRunFeatureRegistry {
     return this.answerComponent;
   }
 
-  getRequest(): IAiBackService['request'] | IAiBackService['requestStream'] {
+  getRequest(): IAiBackService['request'] {
     return this.request;
+  }
+
+  getStreamRequest(): IAiBackService['requestStream'] {
+    return this.streamRequest;
   }
 }

--- a/packages/ai-native/src/browser/run/run.service.ts
+++ b/packages/ai-native/src/browser/run/run.service.ts
@@ -25,4 +25,9 @@ export class AiRunService {
     const request = this.aiRunFeatureRegistry.getRequest();
     return request(input, { cancelToken });
   }
+
+  public async requestStreamBackService(input: string, cancelToken: CancellationToken) {
+    const request = this.aiRunFeatureRegistry.getStreamRequest();
+    return request(input, { cancelToken });
+  }
 }

--- a/packages/ai-native/src/browser/run/run.service.ts
+++ b/packages/ai-native/src/browser/run/run.service.ts
@@ -23,11 +23,11 @@ export class AiRunService {
 
   public async requestBackService(input: string, cancelToken: CancellationToken) {
     const request = this.aiRunFeatureRegistry.getRequest();
-    return request(input, { cancelToken });
+    return request(input, {}, cancelToken);
   }
 
   public async requestStreamBackService(input: string, cancelToken: CancellationToken) {
     const request = this.aiRunFeatureRegistry.getStreamRequest();
-    return request(input, { cancelToken });
+    return request(input, {}, cancelToken);
   }
 }

--- a/packages/ai-native/src/browser/run/run.service.ts
+++ b/packages/ai-native/src/browser/run/run.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Autowired } from '@opensumi/di';
+import { CancellationToken } from '@opensumi/ide-core-common';
 
 import { IAiRunAnswerComponentProps, IAiRunFeatureRegistry } from '../../common';
 
@@ -18,5 +19,10 @@ export class AiRunService {
 
   public answerComponentRender(): React.FC<IAiRunAnswerComponentProps> | undefined {
     return this.aiRunFeatureRegistry.getAnswerComponent();
+  }
+
+  public async requestBackService(input: string, cancelToken: CancellationToken) {
+    const request = this.aiRunFeatureRegistry.getRequest();
+    return request(input, { cancelToken });
   }
 }

--- a/packages/ai-native/src/browser/run/run.service.ts
+++ b/packages/ai-native/src/browser/run/run.service.ts
@@ -23,11 +23,11 @@ export class AiRunService {
 
   public async requestBackService(input: string, cancelToken: CancellationToken) {
     const request = this.aiRunFeatureRegistry.getRequest();
-    return request(input, {}, cancelToken);
+    return request(input, { type: 'run' }, cancelToken);
   }
 
   public async requestStreamBackService(input: string, cancelToken: CancellationToken) {
     const request = this.aiRunFeatureRegistry.getStreamRequest();
-    return request(input, {}, cancelToken);
+    return request(input, { type: 'run' }, cancelToken);
   }
 }

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -1,7 +1,35 @@
-import { MaybePromise } from '@opensumi/ide-core-common';
+import { MaybePromise, CancellationToken } from '@opensumi/ide-core-common';
 
-export const AiGPTBackSerivceToken = Symbol('AiGPTBackSerivceToken');
-export const AiGPTBackSerivcePath = 'AiGPTBackSerivcePath';
+export const AiBackSerivceToken = Symbol('AiBackSerivceToken');
+export const AiBackSerivcePath = 'AiBackSerivcePath';
+
+export interface IAiBackServiceOption {
+  type?: string;
+  model?: string;
+  cancelToken?: CancellationToken;
+}
+
+export interface IAiCompletionOption {
+  prompt: string;
+  suffix?: string;
+  language?: string;
+  fileUrl?: string;
+}
+
+export interface IAiBackServiceResponse<T = string> {
+  errorCode?: number;
+  errorMsg?: string;
+  isCancel?: boolean;
+  data?: T;
+}
+
+export interface IAiBackService {
+  request<T extends IAiBackServiceResponse, O extends IAiBackServiceOption>(input: string, options?: O): Promise<T>;
+  requestStream<T extends IAiBackServiceResponse, O extends IAiBackServiceOption>(input: string, options?: O): Promise<T>;
+  requestCompletion<I extends IAiCompletionOption>(input: I): Promise<string[]>;
+}
+
+
 export const AiInlineChatContentWidget = 'Ai-inline-chat-content-widget';
 
 export const Ai_CHAT_CONTAINER_VIEW_ID = 'ai_chat';

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -25,10 +25,12 @@ export interface IAiBackServiceResponse<T = string> {
 
 export interface IAiBackService {
   request<T extends IAiBackServiceResponse, O extends IAiBackServiceOption>(input: string, options?: O): Promise<T>;
-  requestStream<T extends IAiBackServiceResponse, O extends IAiBackServiceOption>(input: string, options?: O): Promise<T>;
-  requestCompletion<I extends IAiCompletionOption>(input: I): Promise<string[]>;
+  requestStream<T extends NodeJS.ReadableStream, O extends IAiBackServiceOption>(
+    input: string,
+    options?: O,
+  ): Promise<T>;
+  requestCompletion<I extends IAiCompletionOption, T = string[]>(input: I): Promise<T>;
 }
-
 
 export const AiInlineChatContentWidget = 'Ai-inline-chat-content-widget';
 

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -24,8 +24,8 @@ export interface IAiBackServiceResponse<T = string> {
 }
 
 export interface IAiBackService<
-  BaseResponse extends IAiBackServiceResponse,
-  StreamResponse extends NodeJS.ReadableStream,
+  BaseResponse extends IAiBackServiceResponse = IAiBackServiceResponse,
+  StreamResponse extends NodeJS.ReadableStream = NodeJS.ReadableStream,
   CompletionResponse = string[]
 > {
   request<O extends IAiBackServiceOption>(input: string, options?: O): Promise<BaseResponse>;

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -112,7 +112,17 @@ export interface IAiRunFeatureRegistry {
    */
   registerAnswerComponent(component: React.FC<IAiRunAnswerComponentProps>): void;
 
+  registerRequest(request: IAiBackService['request']): void;
+
+  registerStreamRequest(streamRequest: IAiBackService['requestStream']): void;
+
   getRuns(): AiRunHandler[];
+
+  getAnswerComponent(): React.FC<IAiRunAnswerComponentProps> | undefined;
+
+  getRequest(): IAiBackService['request'];
+
+  getStreamRequest(): IAiBackService['requestStream'];
 }
 
 export const AiNativeContribution = Symbol('AiNativeContribution');

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -6,7 +6,7 @@ export const AiBackSerivcePath = 'AiBackSerivcePath';
 export interface IAiBackServiceOption {
   type?: string;
   model?: string;
-  cancelToken?: CancellationToken;
+  enableGptCache?: boolean;
 }
 
 export interface IAiCompletionOption {
@@ -28,11 +28,8 @@ export interface IAiBackService<
   StreamResponse extends NodeJS.ReadableStream = NodeJS.ReadableStream,
   CompletionResponse = string[]
 > {
-  request<O extends IAiBackServiceOption>(input: string, options?: O): Promise<BaseResponse>;
-  requestStream<O extends IAiBackServiceOption>(
-    input: string,
-    options?: O,
-  ): Promise<StreamResponse>;
+  request<O extends IAiBackServiceOption>(input: string, options: O, cancelToken?: CancellationToken): Promise<BaseResponse>;
+  requestStream<O extends IAiBackServiceOption>(input: string, options: O, cancelToken?: CancellationToken): Promise<StreamResponse>;
   requestCompletion<I extends IAiCompletionOption>(input: I): Promise<CompletionResponse>;
 }
 

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -23,13 +23,17 @@ export interface IAiBackServiceResponse<T = string> {
   data?: T;
 }
 
-export interface IAiBackService {
-  request<T extends IAiBackServiceResponse, O extends IAiBackServiceOption>(input: string, options?: O): Promise<T>;
-  requestStream<T extends NodeJS.ReadableStream, O extends IAiBackServiceOption>(
+export interface IAiBackService<
+  BaseResponse extends IAiBackServiceResponse,
+  StreamResponse extends NodeJS.ReadableStream,
+  CompletionResponse = string[]
+> {
+  request<O extends IAiBackServiceOption>(input: string, options?: O): Promise<BaseResponse>;
+  requestStream<O extends IAiBackServiceOption>(
     input: string,
     options?: O,
-  ): Promise<T>;
-  requestCompletion<I extends IAiCompletionOption, T = string[]>(input: I): Promise<T>;
+  ): Promise<StreamResponse>;
+  requestCompletion<I extends IAiCompletionOption>(input: I): Promise<CompletionResponse>;
 }
 
 export const AiInlineChatContentWidget = 'Ai-inline-chat-content-widget';

--- a/packages/ai-native/src/index.ts
+++ b/packages/ai-native/src/index.ts
@@ -1,1 +1,2 @@
 export * from './common';
+export { IAiSearchResponse } from './browser/ai-chat.service';

--- a/packages/ai-native/src/node/ai.service.ts
+++ b/packages/ai-native/src/node/ai.service.ts
@@ -11,7 +11,7 @@ export class AiBackService implements IAiBackService {
     return void 0 as T;
   }
 
-  async requestCompletion() {
-    return [];
+  async requestCompletion<T>() {
+    return void 0 as T;
   }
 }

--- a/packages/ai-native/src/node/ai.service.ts
+++ b/packages/ai-native/src/node/ai.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@opensumi/di';
+
+import { IAiBackService } from '../common';
+
+@Injectable()
+export class AiBackService implements IAiBackService {
+  async request<T>(): Promise<T> {
+    return void 0 as T;
+  }
+  async requestStream<T>(): Promise<T> {
+    return void 0 as T;
+  }
+
+  async requestCompletion() {
+    return [];
+  }
+}

--- a/packages/ai-native/src/node/index.ts
+++ b/packages/ai-native/src/node/index.ts
@@ -3,7 +3,8 @@ import { NodeModule } from '@opensumi/ide-core-node';
 
 import { AiBackSerivcePath, AiBackSerivceToken } from '../common';
 
-import { AiBackService } from './ai.service';
+// import { AiBackService } from './ai.service';
+import { AiBackService } from './ai-gpt.back.service';
 
 @Injectable()
 export class AiNativeModule extends NodeModule {

--- a/packages/ai-native/src/node/index.ts
+++ b/packages/ai-native/src/node/index.ts
@@ -1,24 +1,23 @@
 import { Provider, Injectable } from '@opensumi/di';
 import { NodeModule } from '@opensumi/ide-core-node';
 
-import { AiGPTBackSerivcePath, AiGPTBackSerivceToken, IAiChatService } from '../common';
+import { AiBackSerivcePath, AiBackSerivceToken } from '../common';
 
-// import { AiNativeBackService } from './ai-gpt.back.service';
+import { AiBackService } from './ai.service';
 
 @Injectable()
 export class AiNativeModule extends NodeModule {
   providers: Provider[] = [
     {
-      token: AiGPTBackSerivceToken,
-      // useClass: AiNativeBackService,
-      useClass: class {},
+      token: AiBackSerivceToken,
+      useClass: AiBackService,
     },
   ];
 
   backServices = [
     {
-      servicePath: AiGPTBackSerivcePath,
-      token: AiGPTBackSerivceToken,
+      servicePath: AiBackSerivcePath,
+      token: AiBackSerivceToken,
     },
   ];
 }

--- a/packages/ai-native/src/node/index.ts
+++ b/packages/ai-native/src/node/index.ts
@@ -3,8 +3,7 @@ import { NodeModule } from '@opensumi/ide-core-node';
 
 import { AiBackSerivcePath, AiBackSerivceToken } from '../common';
 
-// import { AiBackService } from './ai.service';
-import { AiBackService } from './ai-gpt.back.service';
+import { AiBackService } from './ai.service';
 
 @Injectable()
 export class AiNativeModule extends NodeModule {

--- a/packages/components/src/markdown/index.tsx
+++ b/packages/components/src/markdown/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { DATA_SET_COMMAND, IOpenerShape, RenderWrapper } from './render';
 
 interface IMarkdownProps {
-  value: string;
+  value?: string;
   renderer: marked.Renderer;
   opener?: IOpenerShape;
 }
@@ -21,10 +21,10 @@ export class DefaultMarkedRenderer extends Renderer {
 export function Markdown(props: IMarkdownProps) {
   const parseMarkdown = (text: string, renderer: any) => marked.parse(text, { renderer });
 
-  const [htmlContent, setHtmlContent] = React.useState(parseMarkdown(props.value, props.renderer));
+  const [htmlContent, setHtmlContent] = React.useState(parseMarkdown(props.value || '', props.renderer));
 
   React.useEffect(() => {
-    setHtmlContent(parseMarkdown(props.value, props.renderer));
+    setHtmlContent(parseMarkdown(props.value || '', props.renderer));
   }, [props.renderer, props.value]);
 
   return <RenderWrapper opener={props.opener} html={htmlContent}></RenderWrapper>;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🪚 Refactors
### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7d777b7</samp>

*  Simplify and standardize the AI back service API and types ( [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L11-R12), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L120-R121), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-6ecf6e19703eacc07117065aa73da7936083841ddcf45927d9f1ae44df2a309dL1-R32), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-73c71c112d2b16fdcaf13893453aaa4345daf7deeb21c858a2a59e1981227997R1-R17), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L4-R6), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L12-R13), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L20-R20))
  - Introduce `IAiBackService` interface and related types for generic and consistent requests and responses (, [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-6ecf6e19703eacc07117065aa73da7936083841ddcf45927d9f1ae44df2a309dL1-R32))
  - Implement `AiBackService` class as the backend logic for the AI back service ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-73c71c112d2b16fdcaf13893453aaa4345daf7deeb21c858a2a59e1981227997R1-R17))
  - Rename `AiGPTBackSerivcePath` to `AiBackSerivcePath` and export it from `./packages/ai-native/src/common/index.ts` ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L11-R12))
  - Remove `clientToken` property and `IAiChatService` interface from the `backServices` array in the `AiNativeModule` class ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L120-R121), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L4-R6))
  - Register `AiBackService` class as the provider of the `AiBackSerivceToken` in the `providers` array in the `AiNativeModule` class ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L12-R13))
  - Update the `backServices` array in the `AiNativeModule` class to use `AiBackSerivcePath` instead of `AiGPTBackSerivcePath` ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L20-R20))
* Refactor the AI chat service and view to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L7-R7), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L13-R14), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L167-R180), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R193-R199), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L170-R174), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L323-R328))
  - Update the imports, type annotations and method calls in `./packages/ai-native/src/browser/ai-chat.service.ts` to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L7-R7), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L13-R14), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L167-R180))
  - Add a new method `search` in `./packages/ai-native/src/browser/ai-chat.service.ts` that wraps the `request` method of the `aiBackService` with a specific type parameter and option parameter ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R193-R199))
  - Update the `AISearch` function in `./packages/ai-native/src/browser/ai-chat.view.tsx` to use the `search` method of the `aiChatService` instead of the `aiSearchRequest` method of the `aiBackService` ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L170-R174))
  - Update the `AISearch` function in `./packages/ai-native/src/browser/ai-chat.view.tsx` to pass the `type` option to the `search` method of the `aiChatService` instead of using a boolean parameter ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L323-R328))
* Refactor the AI editor contribution to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L20-R20), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L36-R37), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L222-R224), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L248-R246), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L277-R275), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L448-R446), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L456-R457))
  - Update the imports and type annotations in `./packages/ai-native/src/browser/ai-editor.contribution.ts` to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L20-R20), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L36-R37))
  - Update the `handleAiChat` method in `./packages/ai-native/src/browser/ai-editor.contribution.ts` to use the `request` method of the `aiBackService` instead of the `aiGPTcompletionRequest` method ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L222-R224))
  - Add non-null assertion operators to the `answer` variable in the `handleAiChat` method in `./packages/ai-native/src/browser/ai-editor.contribution.ts` to fix TypeScript errors caused by the change of the return type of the `request` method of the `aiBackService` ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L248-R246), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L277-R275))
  - Update the `sendRequest` function in the `registerCompletionItemProvider` method in `./packages/ai-native/src/browser/ai-editor.contribution.ts` to use the `requestCompletion` method of the `aiBackService` instead of the `aiCompletionRequest` method ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L448-R446))
  - Update the `sendRequest` function in the `registerCompletionItemProvider` method in `./packages/ai-native/src/browser/ai-editor.contribution.ts` to use the `completionResult` variable directly as an array of strings instead of accessing the `codeModelList` property of the `data` property ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L456-R457))
* Refactor the AI project generate service, AI sumi service, AI inline chat service and AI inline chat widget service to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL6-R11), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-6e4e8e9328da05c3c420297407403bb215c83bcb1c7087bad884c54d6cddeeecL7-R7), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-6e4e8e9328da05c3c420297407403bb215c83bcb1c7087bad884c54d6cddeeecL30-R31), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-babfafe49680e95a904a8010238d3c805747e57fde0df25a2d003c54fe2a027aL5-R5), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-babfafe49680e95a904a8010238d3c805747e57fde0df25a2d003c54fe2a027aL16-R17), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-48cc75c4dd0c34c4fee759e9f60fe8dc6a57e567d94a6ecf12978ee7c5c03f71L5-R5), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-48cc75c4dd0c34c4fee759e9f60fe8dc6a57e567d94a6ecf12978ee7c5c03f71L16-R17))
  - Update the imports and type annotations in `./packages/ai-native/src/browser/ai-project/generate.service.ts`, `./packages/ai-native/src/browser/ai-sumi/sumi.service.ts`, `./packages/ai-native/src/browser/content-widget/ai-inline-chat.service.ts` and `./packages/ai-native/src/browser/inline-chat-widget/inline-chat.service.ts` to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL6-R11), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-6e4e8e9328da05c3c420297407403bb215c83bcb1c7087bad884c54d6cddeeecL7-R7), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-6e4e8e9328da05c3c420297407403bb215c83bcb1c7087bad884c54d6cddeeecL30-R31), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-babfafe49680e95a904a8010238d3c805747e57fde0df25a2d003c54fe2a027aL5-R5), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-babfafe49680e95a904a8010238d3c805747e57fde0df25a2d003c54fe2a027aL16-R17), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-48cc75c4dd0c34c4fee759e9f60fe8dc6a57e567d94a6ecf12978ee7c5c03f71L5-R5), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-48cc75c4dd0c34c4fee759e9f60fe8dc6a57e567d94a6ecf12978ee7c5c03f71L16-R17))
* Refactor the AI run feature registry and run service to use the new AI back service API and types ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-4329428a82868870b17af4b014a132c24f365de4cdbf3389cb8c4d3ead0a0efbL3-R3), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-4329428a82868870b17af4b014a132c24f365de4cdbf3389cb8c4d3ead0a0efbR9), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-4329428a82868870b17af4b014a132c24f365de4cdbf3389cb8c4d3ead0a0efbR26-R29), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0R2), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0R23-R27))
  - Add an import of `IAiBackService` interface to `./packages/ai-native/src/browser/run/run.feature.registry.ts` and a private property `request` that stores a reference to the `request` or `requestStream` method of the `aiBackService` depending on the feature type ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-4329428a82868870b17af4b014a132c24f365de4cdbf3389cb8c4d3ead0a0efbL3-R3), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-4329428a82868870b17af4b014a132c24f365de4cdbf3389cb8c4d3ead0a0efbR9))
  - Add a public method `getRequest` that returns the `request` property of the `AiRunFeatureRegistry` class in `./packages/ai-native/src/browser/run/run.feature.registry.ts` ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-4329428a82868870b17af4b014a132c24f365de4cdbf3389cb8c4d3ead0a0efbR26-R29))
  - Add an import of `CancellationToken` to `./packages/ai-native/src/browser/run/run.service.ts` and a public method `requestBackService` that takes an input string and a cancel token and returns a promise of the result of calling the `request` or `requestStream` method of the `aiBackService` depending on the feature type ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0R2), [link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0R23-R27))
* Remove an unused import of `IRange` from `./packages/ai-native/src/browser/ai-chat.contribution.ts` ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794L12))
* Remove a large block of code from the `AiNativeCoreContribution` class that implements a command for generating javadoc comments based on the selected code ([link](https://github.com/opensumi/core/pull/3164/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794L200-L267))

<!-- Additional content -->
<!-- 补充额外内容 -->

* 重构后端服务类型
* 移除旧调用方式

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d777b7</samp>

This pull request refactors the code related to the AI back service in the `ai-native` package. It introduces a common interface `IAiBackService` for the service and its options, requests, and responses. It updates the imports, type annotations, and method calls in various modules to use this interface. It also removes some unused and unnecessary code and renames some identifiers for clarity and consistency. This improves the code quality, readability, and modularity of the AI back service.
