### PR TITLE
feat: chat panel error message

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.service.ts
+++ b/packages/ai-native/src/browser/ai-chat.service.ts
@@ -157,8 +157,13 @@ export class AiChatService extends Disposable {
   public onMessage(message: string) {
     try {
       const msgObj = JSON.parse(message);
-      const { id, choices } = msgObj;
-      this.msgStreamManager.recordMessage(id, choices[0]);
+
+      if (msgObj.id && msgObj.choices) {
+        const { id, choices } = msgObj;
+        this.msgStreamManager.recordMessage(id, choices[0]);
+      } else {
+        this.msgStreamManager.sendError();
+      }
     } catch (error) {
       new Error(`onMessage error: ${error}`);
     }

--- a/packages/ai-native/src/browser/components/StreamMsg.tsx
+++ b/packages/ai-native/src/browser/components/StreamMsg.tsx
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { DisposableCollection, useInjectable } from '@opensumi/ide-core-browser';
 
@@ -13,6 +13,7 @@ export const StreamMsgWrapper = (props: { sessionId: string }) => {
   const { sessionId } = props;
   const [chunk, setChunk] = React.useState('');
   const [content, setContent] = React.useState<string>('');
+  const [isError, setIsError] = React.useState<boolean>(false);
   const [status, setStatus] = React.useState(EMsgStreamStatus.READY);
   const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
 
@@ -21,14 +22,20 @@ export const StreamMsgWrapper = (props: { sessionId: string }) => {
 
     disposableCollection.push(
       msgStreamManager.onMsgListChange(sessionId)((msg: IMsgStreamChoices) => {
-        const { delta } = msg;
-        setChunk(delta.content);
+        if (msg) {
+          const { delta } = msg;
+          setChunk(delta.content);
+        }
       }),
     );
 
     disposableCollection.push(
       msgStreamManager.onMsgStatus((status) => {
         setStatus(status);
+
+        if (msgStreamManager.currentSessionId === sessionId) {
+          setIsError(status === EMsgStreamStatus.ERROR);
+        }
       }),
     );
 
@@ -49,11 +56,15 @@ export const StreamMsgWrapper = (props: { sessionId: string }) => {
     () => (
       <div className={styles.ai_chat_code_wrapper}>
         <div className={styles.render_text}>
-          <CodeBlockWrapper text={content} />
+          {isError ? (
+            <span>当前与我互动的人太多，请稍后再试，感谢您的理解与支持</span>
+          ) : (
+            <CodeBlockWrapper text={content} />
+          )}
         </div>
       </div>
     ),
-    [content],
+    [content, isError],
   );
 
   return status === EMsgStreamStatus.THINKING && msgStreamManager.currentSessionId === sessionId ? (

--- a/packages/ai-native/src/browser/model/msg-stream-manager.ts
+++ b/packages/ai-native/src/browser/model/msg-stream-manager.ts
@@ -52,12 +52,20 @@ export class MsgStreamManager extends Disposable {
     return this.onDidMsgListChangeDispatcher.on(sessionId);
   }
 
+  public sendError(): void {
+    this.status = EMsgStreamStatus.ERROR;
+  }
+
   public recordMessage(answerId: string, msg: IMsgStreamChoices): void {
     if (!this._currentSessionId) {
       new Error('currentSessionId is null');
     }
 
     this.sessionIdToAnswerIdMap.set(this.currentSessionId, answerId);
+
+    if (!(answerId && msg)) {
+      new Error('answerId/msg is null');
+    }
 
     const answerList = this.answerIdToMsgStreamMap.get(answerId);
 
@@ -74,6 +82,7 @@ export class MsgStreamManager extends Disposable {
       this.status = EMsgStreamStatus.DONE;
     } else {
       this.status = EMsgStreamStatus.ERROR;
+      return;
     }
 
     this.onDidMsgListChangeDispatcher.dispatch(this._currentSessionId, msg);


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

chat 对话失败时显示默认提示消息

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d5a473</samp>

*  Add error handling and feedback logic for message streams ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L160-R166), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L2-R2), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R16), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L24-R28), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R35-R38), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L52-R67), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddR55-R58), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddR66-R69), [link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddR85))
  - Import `useMemo` hook in `StreamMsg.tsx` ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L2-R2)) and use it to memoize rendered content based on content and error state ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L52-R67))
  - Add `isError` state to `StreamMsgWrapper` component in `StreamMsg.tsx` ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R16)) and update it based on `onStatusChange` event ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R35-R38))
  - Display error message in `StreamMsgWrapper` component if `isError` is true, or `CodeBlockWrapper` component otherwise ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L52-R67))
  - Add `sendError` method to `MsgStreamManager` class in `msg-stream-manager.ts` ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddR55-R58)) and call it from `AiChatService` class in `ai-chat.service.ts` if message object is missing `id` or `choices` properties ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L160-R166))
  - Check for truthiness of `msg` argument in `StreamMsgWrapper` component ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L24-R28)) and `answerId` and `msg` arguments in `recordMessage` method of `MsgStreamManager` class ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddR66-R69)) and return early if falsy ([link](https://github.com/opensumi/core/pull/3169/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddR85))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d5a473</samp>

This pull request enhances the error handling and performance of the AI-native chat feature. It uses React hooks, state variables, and validation checks to avoid unnecessary re-rendering, display appropriate error messages, and prevent errors from malformed or missing data in the message stream. It affects the files `StreamMsg.tsx`, `msg-stream-manager.ts`, and `ai-chat.service.ts`.
