### PR TITLE
fix: chat stream message pause

### DIFF
--- a/packages/ai-native/src/browser/components/Popover.tsx
+++ b/packages/ai-native/src/browser/components/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { IPopoverProps, Popover } from '@opensumi/ide-components';
 import { uuid } from '@opensumi/ide-core-common';
@@ -19,8 +19,12 @@ export const EnhancePopover = (props: IPopoverProps) => {
     [onClick],
   );
 
+  const onDisplayChange = useCallback((d: boolean) => {
+    setDisplay(d);
+  }, []);
+
   return (
-    <Popover id={uid} title={title} onClick={handleClick} display={display}>
+    <Popover id={uid} title={title} onClick={handleClick} display={display} onDisplayChange={onDisplayChange}>
       {children}
     </Popover>
   );

--- a/packages/ai-native/src/browser/components/StreamMsg.tsx
+++ b/packages/ai-native/src/browser/components/StreamMsg.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { DisposableCollection, useInjectable } from '@opensumi/ide-core-browser';
 
+import { AiChatService } from '../ai-chat.service';
 import { EMsgStreamStatus, IMsgStreamChoices, MsgStreamManager } from '../model/msg-stream-manager';
 
 import { CodeBlockWrapper } from './ChatEditor';
@@ -16,6 +17,7 @@ export const StreamMsgWrapper = (props: { sessionId: string }) => {
   const [isError, setIsError] = React.useState<boolean>(false);
   const [status, setStatus] = React.useState(EMsgStreamStatus.READY);
   const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
+  const aiChatService = useInjectable<AiChatService>(AiChatService);
 
   useEffect(() => {
     const disposableCollection = new DisposableCollection();
@@ -67,10 +69,13 @@ export const StreamMsgWrapper = (props: { sessionId: string }) => {
     [content, isError],
   );
 
-  // return  <Thinking>{renderMsgList()}</Thinking>;
+  const handlePause = useCallback(async () => {
+    await aiChatService.destroyStreamRequest(sessionId);
+    msgStreamManager.sendDoneStatue();
+  }, [sessionId]);
 
   return status === EMsgStreamStatus.THINKING && msgStreamManager.currentSessionId === sessionId ? (
-    <Thinking>{renderMsgList()}</Thinking>
+    <Thinking onPause={handlePause}>{renderMsgList()}</Thinking>
   ) : (
     renderMsgList()
   );

--- a/packages/ai-native/src/browser/components/Thinking.tsx
+++ b/packages/ai-native/src/browser/components/Thinking.tsx
@@ -8,11 +8,19 @@ import { AiChatService } from '../ai-chat.service';
 
 import * as styles from './components.module.less';
 
-export const Thinking = ({ children }: { children?: React.ReactNode }) => {
+interface ITinkingProps {
+  children?: React.ReactNode;
+  onPause?: () => void;
+}
+
+export const Thinking = ({ children, onPause }: ITinkingProps) => {
   const aiChatService = useInjectable<AiChatService>(AiChatService);
 
   const handlePause = useCallback(() => {
     aiChatService.cancelChatViewToken();
+    if (onPause) {
+      onPause();
+    }
   }, []);
 
   return (

--- a/packages/ai-native/src/browser/model/msg-stream-manager.ts
+++ b/packages/ai-native/src/browser/model/msg-stream-manager.ts
@@ -52,8 +52,16 @@ export class MsgStreamManager extends Disposable {
     return this.onDidMsgListChangeDispatcher.on(sessionId);
   }
 
-  public sendError(): void {
+  public sendErrorStatue(): void {
     this.status = EMsgStreamStatus.ERROR;
+  }
+
+  public sendDoneStatue(): void {
+    this.status = EMsgStreamStatus.DONE;
+  }
+
+  public sendThinkingStatue(): void {
+    this.status = EMsgStreamStatus.THINKING;
   }
 
   public recordMessage(answerId: string, msg: IMsgStreamChoices): void {
@@ -77,11 +85,11 @@ export class MsgStreamManager extends Disposable {
 
     const { finish_reason } = msg;
     if (!finish_reason) {
-      this.status = EMsgStreamStatus.THINKING;
+      this.sendThinkingStatue();
     } else if (finish_reason === 'stop') {
-      this.status = EMsgStreamStatus.DONE;
+      this.sendDoneStatue();
     } else {
-      this.status = EMsgStreamStatus.ERROR;
+      this.sendErrorStatue();
       return;
     }
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -1,5 +1,5 @@
 import clx from 'classnames';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import './styles.less';
 import { Button } from '../button';
@@ -37,6 +37,7 @@ export interface IPopoverProps {
   action?: string;
   disable?: boolean;
   onClickAction?: (args: any) => void;
+  onDisplayChange?: (display: boolean) => void;
 }
 
 export const Popover: React.FC<IPopoverProps> = ({
@@ -53,6 +54,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   titleClassName,
   action,
   onClickAction,
+  onDisplayChange,
   disable,
   ...restProps
 }) => {
@@ -126,6 +128,9 @@ export const Popover: React.FC<IPopoverProps> = ({
     }
     clearTimeout(hideContentTimer);
     contentEl.current.style.display = 'block';
+    if (onDisplayChange) {
+      onDisplayChange(true);
+    }
     window.requestAnimationFrame(() => {
       if (!childEl.current || !contentEl.current) {
         return;
@@ -150,6 +155,9 @@ export const Popover: React.FC<IPopoverProps> = ({
       }
       contentEl.current.style.display = 'none';
       contentEl.current.style.visibility = 'hidden';
+      if (onDisplayChange) {
+        onDisplayChange(false);
+      }
     }, delay);
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution
修复流式渲染时点击停止按钮不生效的问题

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4167449</samp>

*  Add `onDisplayChange` prop to `Popover` and `EnhancePopover` components to notify parent component of display change ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-157c2516da6dacc12ad0827eb19191997eb1adca34bd418c01caf13c25fe8ecaL22-R27), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6L11-R23), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-17616836f71aea95243b3f7b4846281ac2502d0bc9d09e13c555fac6d9c1441dR40), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-17616836f71aea95243b3f7b4846281ac2502d0bc9d09e13c555fac6d9c1441dR57), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-17616836f71aea95243b3f7b4846281ac2502d0bc9d09e13c555fac6d9c1441dR131-R133), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-17616836f71aea95243b3f7b4846281ac2502d0bc9d09e13c555fac6d9c1441dR158-R160))
*  Add `useEffect` hook to `Popover.tsx` and `index.tsx` to hide popover on clicks outside the component ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-157c2516da6dacc12ad0827eb19191997eb1adca34bd418c01caf13c25fe8ecaL1-R1), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-17616836f71aea95243b3f7b4846281ac2502d0bc9d09e13c555fac6d9c1441dL2-R2))
*  Add `IAiStreamMessageService` interface to extend `IAiBackService` with `destroyStreamRequest` method and use it in `AiChatService` ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L24-R31), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R81-R86))
*  Add `destroyStreamRequest` method to `AiChatService` to cancel stream request from backend service ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R81-R86))
*  Add `sendDoneStatue`, `sendThinkingStatue`, and `sendErrorStatue` methods to `MsgStreamManager` to update stream status ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddL55-R66), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-2b71d2d9b2ad98904e56415b36ea88503c3a33647145d0fc4cd1ca61a3cb39ddL80-R92))
*  Call `requestStream` method with `sessionId` option in `AiChatService` to identify stream request ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L188-R205))
*  Rename `sendError` method to `sendErrorStatue` in `MsgStreamManager` to avoid confusion ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1L178-R188))
*  Use `useInjectable` hook to get `aiChatService` instance in `StreamMsgWrapper` component ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R20))
*  Add `handlePause` function to `StreamMsgWrapper` component to call `destroyStreamRequest` and `sendDoneStatue` methods ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L70-R78))
*  Add `onPause` prop and pause button to `Thinking` component to trigger `handlePause` function ([link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L70-R78), [link](https://github.com/opensumi/core/pull/3173/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6L11-R23))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4167449</samp>

This pull request adds a feature to pause the chat stream request and send a done status to the server in the `ai-native` package. It also improves the functionality and usability of the `Popover` component in the `components` and `ai-native` packages. The changes involve modifying the `AiChatService`, `MsgStreamManager`, `StreamMsg`, `Thinking`, and `Popover` classes and components, as well as adding some props and hooks.
