### PR TITLE
feat: add data repoter

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.service.ts
+++ b/packages/ai-native/src/browser/ai-chat.service.ts
@@ -12,6 +12,7 @@ import {
   IAiBackServiceOption,
   IChatMessageStructure,
   InstructionEnum,
+  IAIReporter,
 } from '../common';
 
 import { MsgStreamManager } from './model/msg-stream-manager';
@@ -38,6 +39,9 @@ export class AiChatService extends Disposable {
 
   @Autowired(MsgStreamManager)
   private readonly msgStreamManager: MsgStreamManager;
+
+  @Autowired(IAIReporter)
+  private readonly aiReporter: IAIReporter;
 
   private readonly _onChatMessageLaunch = new Emitter<IChatMessageStructure>();
   public readonly onChatMessageLaunch: Event<IChatMessageStructure> = this._onChatMessageLaunch.event;

--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable import/order */
 import { observer } from 'mobx-react-lite';
 import * as React from 'react';
-// @ts-ignore
-import { Avatar, MessageList, SystemMessage } from 'react-chat-elements';
+import { MessageList, SystemMessage, ITextMessageProps } from 'react-chat-elements';
 
 import { DefaultMarkedRenderer, Markdown } from '@opensumi/ide-components/lib/markdown/index';
 import { getIcon, useInjectable } from '@opensumi/ide-core-browser';
@@ -11,7 +9,7 @@ import { CommandOpener } from '@opensumi/ide-core-browser/lib/opener/command-ope
 import { Command, isMacintosh, URI, uuid } from '@opensumi/ide-core-common';
 import 'react-chat-elements/dist/main.css';
 
-import { AISerivceType, IChatMessageStructure, InstructionEnum } from '../common';
+import { AISerivceType, IChatMessageStructure, InstructionEnum, IAIReporter } from '../common';
 
 import * as styles from './ai-chat.module.less';
 import { AiChatService } from './ai-chat.service';
@@ -27,18 +25,32 @@ import { Thinking } from './components/Thinking';
 import { MsgStreamManager } from './model/msg-stream-manager';
 import { AiMenubarService } from './override/layout/menu-bar/menu-bar.service';
 import { AiRunService } from './run/run.service';
-import cls from 'classnames';
 
-const createMessage = (position: string, title: string, text: string | React.ReactNode, className?: string) => ({
-  position,
+interface MessageData extends Pick<ITextMessageProps, 'id' | 'position' | 'className' | 'title'> {
+  role: 'user' | 'ai';
+  relationId: string;
+  className?: string;
+  text: string | React.ReactNode;
+}
+
+type AIMessageData = Omit<MessageData, 'role' | 'position' | 'title'>;
+
+interface ReplayComponentParam {
+  aiChatService: AiChatService;
+  aiRunService: AiRunService;
+  aiReporter: IAIReporter;
+  relationId: string;
+  startTime: number;
+}
+
+const createMessage = (message: MessageData) => ({
+  ...message,
   type: 'text',
-  title,
-  text,
-  className: `${position === 'left' ? 'rce-ai-msg' : 'rce-user-msg'} ${className ? className : ''}`,
+  className: `${message.position === 'left' ? 'rce-ai-msg' : 'rce-user-msg'} ${message.className ? message.className : ''}`,
 });
 
-const createMessageByAI = (text: string | React.ReactNode, className?: string) =>
-  createMessage('left', '', text, className);
+const createMessageByAI = (message: AIMessageData, className?: string) =>
+  createMessage({ ...message, position: 'left', title: '', className, role: 'ai' });
 
 const AI_NAME = 'AI 研发助手';
 const ME_NAME = '';
@@ -49,11 +61,12 @@ export const AiChatView = observer(() => {
   const aiSumiService = useInjectable<AiSumiService>(AiSumiService);
   const aiRunService = useInjectable<AiRunService>(AiRunService);
   const aiMenubarService = useInjectable<AiMenubarService>(AiMenubarService);
+  const aiReporter = useInjectable<IAIReporter>(IAIReporter);
   const opener = useInjectable<CommandOpener>(CommandOpener);
   const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
-  const [messageListData, setMessageListData] = React.useState<any[]>([]);
+  const [messageListData, setMessageListData] = React.useState<MessageData[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [theme, setTheme] = React.useState<string | null>(null);
 
@@ -61,11 +74,11 @@ export const AiChatView = observer(() => {
   // 项目生成
   const generateProject = React.useCallback(async () => {
     aiProjectGenerateService.start((messageList) => {
-      const aiMessageList = messageList.map(({ message, immediately, type = 'message' }) =>
+      const aiMessageList = messageList.map(({ message, immediately, type = 'message', relationId }) =>
         type === 'message'
-          ? createMessageByAI(<AiReply text={message} immediately={immediately} />)
-          : AICodeReply(message, aiChatService),
-      );
+          ? createMessageByAI({ text: <AiReply text={message} immediately={immediately} />, id: uuid(6), relationId })
+          : AICodeReply(message, aiChatService, relationId),
+      ).filter((m) => !!m) as MessageData[];
       setMessageListData([...aiMessageList]);
     });
   }, []);
@@ -106,7 +119,11 @@ export const AiChatView = observer(() => {
     );
   };
 
-  const firstMsg = React.useMemo(() => createMessageByAI(<InitMsgComponent />), [InitMsgComponent]);
+  const firstMsg = React.useMemo(() => createMessageByAI({
+    id: uuid(6),
+    relationId: '',
+    text: <InitMsgComponent />,
+  }), [InitMsgComponent]);
   const scrollToBottom = React.useCallback(() => {
     if (containerRef && containerRef.current) {
       containerRef.current.scrollTop = Number.MAX_SAFE_INTEGER;
@@ -144,55 +161,67 @@ export const AiChatView = observer(() => {
     async (value: IChatMessageStructure) => {
       const { message, prompt } = value;
       const preMessagelist = messageListData;
-      const preInputValue = message;
 
       setLoading(true);
-      const codeSendMessage = createMessage(
-        'right',
-        ME_NAME,
-        <CodeBlockWrapperInput text={preInputValue as string} />,
-        styles.chat_message_code,
-      );
+
+      let aiMessage;
+      const userInput = await aiChatService.switchAIService(message as string, prompt);
+
+      const startTime = +new Date();
+      const relationId = aiReporter.start(userInput.type, {
+        msgType: userInput.type,
+        message: userInput.message,
+      });
+
+      const codeSendMessage = createMessage({
+        id: uuid(6),
+        relationId,
+        position: 'right',
+        title: ME_NAME,
+        text: <CodeBlockWrapperInput text={message} />,
+        className:styles.chat_message_code,
+        role: 'user',
+      });
 
       preMessagelist.push(codeSendMessage);
       setMessageListData(preMessagelist);
 
-      // 检查前缀 aiSearchKey
-      if (typeof preInputValue === 'string') {
-        let aiMessage;
+      const replayCommandProps = {
+        aiChatService,
+        aiReporter,
+        aiRunService,
+        relationId,
+        startTime,
+      };
 
-        const userInput = await aiChatService.switchAIService(preInputValue, prompt);
-
-        if (userInput!.type === AISerivceType.Search) {
-          aiMessage = await AISearch(userInput, aiChatService);
-        } else if (userInput!.type === AISerivceType.Sumi) {
-          aiMessage = await aiSumiService.searchCommand(userInput!.message!);
-          aiMessage = await AIWithCommandReply(aiMessage, opener, aiChatService);
-        } else if (userInput!.type === AISerivceType.GPT) {
-          const withPrompt = aiChatService.opensumiRolePrompt(userInput!.message!);
-          aiMessage = await AIStreamReply(withPrompt, aiChatService);
-        } else if (userInput!.type === AISerivceType.Explain) {
-          aiMessage = await AIStreamReply(userInput!.message!, aiChatService);
-        } else if (userInput!.type === AISerivceType.Run) {
-          aiMessage = await aiRunService.requestBackService(
-            userInput!.message!,
-            aiChatService.cancelIndicatorChatView.token,
-          );
-          aiMessage = await AIChatRunReply(aiMessage, aiRunService, aiChatService);
-        }
-
-        if (aiMessage) {
-          preMessagelist.push(aiMessage);
-          setMessageListData(preMessagelist);
-          updateState({});
-          if (containerRef && containerRef.current) {
-            containerRef.current.scrollTop = Number.MAX_SAFE_INTEGER;
-          }
-        }
-
-        setLoading(false);
-        return;
+      if (userInput.type === AISerivceType.Search) {
+        aiMessage = await AISearch(userInput, replayCommandProps);
+      } else if (userInput.type === AISerivceType.Sumi) {
+        aiMessage = await aiSumiService.searchCommand(userInput.message!);
+        aiMessage = await AIWithCommandReply(aiMessage, opener, replayCommandProps);
+      } else if (userInput.type === AISerivceType.GPT) {
+        const withPrompt = aiChatService.opensumiRolePrompt(userInput.message!);
+        aiMessage = await AIStreamReply(withPrompt, replayCommandProps);
+      } else if (userInput.type === AISerivceType.Explain) {
+        aiMessage = await AIStreamReply(userInput.message, replayCommandProps);
+      } else if (userInput.type === AISerivceType.Run) {
+        aiMessage = await aiRunService.requestBackService(
+          userInput.message!,
+          aiChatService.cancelIndicatorChatView.token,
+        );
+        aiMessage = await AIChatRunReply(aiMessage, replayCommandProps);
       }
+
+      if (aiMessage) {
+        preMessagelist.push(aiMessage);
+        setMessageListData(preMessagelist);
+        updateState({});
+        if (containerRef && containerRef.current) {
+          containerRef.current.scrollTop = Number.MAX_SAFE_INTEGER;
+        }
+      }
+
+      setLoading(false);
     },
     [messageListData, containerRef, loading],
   );
@@ -354,13 +383,23 @@ const codeSearchMarkedRender = new (class extends DefaultMarkedRenderer {
   }
 })();
 
-const AISearch = async (input, aiChatService: AiChatService) => {
+const AISearch = async (input, params: ReplayComponentParam) => {
   try {
+    const { aiChatService, aiReporter, relationId, startTime } = params;
     const result = await aiChatService.search(input.message, {
       type: input.type,
     });
 
     const { responseText, urlMessage, isCancel } = result;
+
+    aiReporter.end(relationId, {
+      message: `${responseText}\\n${urlMessage}`,
+      replytime: +new Date() - startTime,
+      success: !result.errorCode,
+      isStop: isCancel,
+      msgType: AISerivceType.Search,
+      relationId,
+    });
 
     if (isCancel) {
       return null;
@@ -368,20 +407,24 @@ const AISearch = async (input, aiChatService: AiChatService) => {
 
     const uid = uuid(6);
 
-    const aiMessage = createMessageByAI(
-      <ChatMoreActions sessionId={uid}>
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <div>
-            <CodeBlockWrapper text={responseText} />
+    const aiMessage = createMessageByAI({
+      id: uid,
+      relationId,
+      text: (
+        <ChatMoreActions sessionId={uid}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div>
+              <CodeBlockWrapper text={responseText} />
+            </div>
+            <div style={{ whiteSpace: 'pre-wrap' }}>
+              <Markdown value={urlMessage} renderer={codeSearchMarkedRender}></Markdown>
+              {/* {AICodeReply(urlMessage)} */}
+            </div>
           </div>
-          <div style={{ whiteSpace: 'pre-wrap' }}>
-            <Markdown value={urlMessage} renderer={codeSearchMarkedRender}></Markdown>
-            {/* {AICodeReply(urlMessage)} */}
-          </div>
-        </div>
-      </ChatMoreActions>,
-      styles.chat_with_more_actions,
-    );
+        </ChatMoreActions>
+      ),
+      className: styles.chat_with_more_actions,
+    });
 
     aiChatService.setLatestSessionId(uid);
     return aiMessage;
@@ -389,68 +432,111 @@ const AISearch = async (input, aiChatService: AiChatService) => {
 };
 
 // 流式输出渲染组件
-const AIStreamReply = async (prompt: string, aiChatService: AiChatService) => {
+const AIStreamReply = async (prompt: string, params: ReplayComponentParam) => {
   try {
-    const uid = uuid(6);
-    aiChatService.messageWithStream(prompt, {}, uid);
+    const { aiChatService, relationId } = params;
+    await aiChatService.messageWithStream(prompt, {}, relationId);
 
-    const aiMessage = createMessageByAI(
-      <StreamMsgWrapper sessionId={uid} prompt={prompt}></StreamMsgWrapper>,
-      styles.chat_with_more_actions,
-    );
+    const aiMessage = createMessageByAI({
+      id: uuid(6),
+      relationId,
+      text: <StreamMsgWrapper sessionId={relationId} />,
+      className: styles.chat_with_more_actions,
+    });
 
-    aiChatService.setLatestSessionId(uid);
+    aiChatService.setLatestSessionId(relationId);
     return aiMessage;
   } catch (error) {}
 };
 
 // 带有代码的 AI 回复组件
-const AICodeReply = (input, aiChatService: AiChatService) => {
+const AICodeReply = (input, aiChatService: AiChatService, relationId: string) => {
   try {
-    const uid = uuid(6);
+    const aiMessage = createMessageByAI({
+      id: uuid(6),
+      relationId,
+      text: (
+        <ChatMoreActions sessionId={relationId}>
+          <CodeBlockWrapper text={input} />
+        </ChatMoreActions>
+      ),
+      className: styles.chat_with_more_actions,
+    });
 
-    const aiMessage = createMessageByAI(
-      <ChatMoreActions sessionId={uid}>
-        <CodeBlockWrapper text={input} />
-      </ChatMoreActions>,
-      styles.chat_with_more_actions,
-    );
-
-    aiChatService.setLatestSessionId(uid);
+    aiChatService.setLatestSessionId(relationId);
     return aiMessage;
   } catch (error) {}
 };
 
 // run 的 AI 回复组件
-const AIChatRunReply = async (input, aiRunService: AiRunService, aiChatService: AiChatService) => {
+const AIChatRunReply = async (input, params: ReplayComponentParam) => {
   try {
-    const uid = uuid(6);
+    const { aiRunService, relationId, aiChatService } = params;
 
     const RenderAnswer = aiRunService.answerComponentRender();
 
-    const aiMessage = createMessageByAI(
-      <ChatMoreActions sessionId={uid}>
-        {RenderAnswer ? <RenderAnswer input={input} /> : <CodeBlockWrapper text={input} />}
-      </ChatMoreActions>,
-      styles.chat_with_more_actions,
-    );
+    const aiMessage = createMessageByAI({
+      id: uuid(6),
+      relationId,
+      text: (
+        <ChatMoreActions sessionId={relationId}>
+          {RenderAnswer ? <RenderAnswer input={input} /> : <CodeBlockWrapper text={input} />}
+        </ChatMoreActions>
+      ),
+      className: styles.chat_with_more_actions,
+    });
 
-    aiChatService.setLatestSessionId(uid);
+    aiChatService.setLatestSessionId(relationId);
     return aiMessage;
   } catch (error) {}
 };
 
 // 带有命令按钮的 AI 回复
-const AIWithCommandReply = async (command: Command, opener, aiChatService: AiChatService) => {
-  try {
-    if (!command) {
-      return createMessageByAI('未找到合适的功能');
+const AIWithCommandReply = async (command: Command, opener: CommandOpener, params: ReplayComponentParam) => {
+  const { aiChatService, aiReporter, relationId, startTime } = params;
+
+  aiReporter.end(relationId, {
+    replytime: +new Date() - startTime,
+    success: true,
+    msgType: AISerivceType.Sumi,
+    message: command.id,
+    relationId,
+  });
+
+  if (!command) {
+    return createMessageByAI({
+      id: uuid(6),
+      relationId,
+      text: '未找到合适的功能',
+    });
+  }
+
+  const { labelLocalized, label, delegate, id } = command;
+  const uid = uuid(6);
+
+  function excuteCommand() {
+    let success = true;
+    try {
+      opener.open(URI.parse(`command:${delegate || id}`));
+    } catch {
+      success = false;
     }
 
-    const { labelLocalized, label, delegate, id } = command;
-    const uid = uuid(6);
+    aiReporter.end(relationId, {
+      replytime: +new Date() - startTime,
+      success: true,
+      msgType: AISerivceType.Sumi,
+      message: command.id,
+      relationId,
+      useCommand: true,
+      useCommandSuccess: success,
+    });
+  }
 
-    const aiMessage = createMessageByAI(
+  const aiMessage = createMessageByAI({
+    id: uid,
+    relationId,
+    text: (
       <ChatMoreActions sessionId={uid}>
         <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
           <div>已在系统内找到适合功能: {labelLocalized?.localized || label}，可以按以下步骤尝试：</div>
@@ -458,13 +544,13 @@ const AIWithCommandReply = async (command: Command, opener, aiChatService: AiCha
             <li style={{ listStyle: 'inherit' }}>打开命令面板：({isMacintosh ? 'cmd' : 'ctrl'} + shift + p)</li>
             <li style={{ listStyle: 'inherit' }}>输入：{labelLocalized?.localized || label}</li>
           </ol>
-          <Button onClick={() => opener.open(URI.parse(`command:${delegate || id}`))}>点击执行命令</Button>
+          <Button onClick={excuteCommand}>点击执行命令</Button>
         </div>
-      </ChatMoreActions>,
-      styles.chat_with_more_actions,
-    );
+      </ChatMoreActions>
+    ),
+    className: styles.chat_with_more_actions,
+  });
 
-    aiChatService.setLatestSessionId(uid);
-    return aiMessage;
-  } catch (error) {}
+  aiChatService.setLatestSessionId(uid);
+  return aiMessage;
 };

--- a/packages/ai-native/src/browser/ai-project/generate.service.ts
+++ b/packages/ai-native/src/browser/ai-project/generate.service.ts
@@ -40,7 +40,7 @@ export class AiProjectGenerateService {
   }
 
   public async start(
-    callback: (messageList: Array<{ message: string; immediately?: boolean; type?: string }>) => void,
+    callback: (messageList: Array<{ message: string; relationId: string; immediately?: boolean; type?: string }>) => void,
   ) {
     callback([]);
   }

--- a/packages/ai-native/src/browser/ai-project/generate.service.ts
+++ b/packages/ai-native/src/browser/ai-project/generate.service.ts
@@ -3,7 +3,7 @@ import { observable, computed } from 'mobx';
 import { Injectable, Autowired } from '@opensumi/di';
 import { ILogServiceClient, ILoggerManagerClient, SupportLogNamespace } from '@opensumi/ide-core-common';
 
-import { AiBackSerivcePath, IAiBackService } from '../../common';
+import { AiBackSerivcePath, IAiBackService, IAIReporter } from '../../common';
 
 @Injectable()
 export class AiProjectGenerateService {
@@ -13,9 +13,14 @@ export class AiProjectGenerateService {
   @Autowired(ILoggerManagerClient)
   private readonly loggerManagerClient: ILoggerManagerClient;
 
+  @Autowired(IAIReporter)
+  readonly reporter: IAIReporter;
+
   protected logger: ILogServiceClient;
 
   protected codeStructure: string;
+
+  private releationId?: string; // 用于数据埋点，可空
 
   @observable
   protected _requirements?: Record<string, any>;
@@ -24,8 +29,9 @@ export class AiProjectGenerateService {
     this.logger = this.loggerManagerClient.getLogger(SupportLogNamespace.Browser);
   }
 
-  public initRequirements(requirements?: Record<string, any>) {
+  public initRequirements(requirements?: Record<string, any>, relationId?: string) {
     this._requirements = requirements;
+    this.releationId = relationId;
   }
 
   @computed

--- a/packages/ai-native/src/browser/ai-reporter.ts
+++ b/packages/ai-native/src/browser/ai-reporter.ts
@@ -1,0 +1,59 @@
+import { Injectable, Autowired } from '@opensumi/di';
+import { IReporterService, uuid } from '@opensumi/ide-core-common';
+
+import { ReportInfo, IAIReporter, AI_REPORTER_NAME } from '../common';
+
+@Injectable()
+export class AIReporter implements IAIReporter {
+  @Autowired(IReporterService)
+  readonly reporter: IReporterService;
+
+  private reportInfoCache: Map<string, ReportInfo>;
+
+  private reporterCancelHandler: Map<string, ReturnType<typeof setTimeout>>;
+
+  private getRelationId() {
+    return uuid();
+  }
+  // 集成方自定义上报内容
+  getCommonReportInfo() {
+    return {};
+  }
+
+  // 返回关联 ID
+  start(data: ReportInfo): string {
+    const relationId = this.getRelationId();
+
+    this.report(relationId, { ...data, relationId });
+
+    // 这里做个兜底，如果 60s 模型还没有返回结果，上报失败
+    const cancleHanddler = setTimeout(() => {
+      this.report(relationId, { ...data, success: false });
+    }, 60 * 1000);
+
+    this.reporterCancelHandler.set(relationId, cancleHanddler);
+
+    return relationId;
+  }
+  end(relationId: string, data: ReportInfo) {
+    const cancleHanddler = this.reporterCancelHandler.get(relationId);
+    if (cancleHanddler) {
+      clearTimeout(cancleHanddler);
+    }
+
+    this.report(relationId, { ...data, success: true });
+  }
+
+  private report(relationId: string, data: ReportInfo) {
+    const reportInfoCache = this.reportInfoCache.get(relationId) || {};
+
+    const reportInfo = {
+      ...this.getCommonReportInfo(),
+      ...reportInfoCache,
+      ...data,
+    };
+
+    this.reportInfoCache.set(relationId, reportInfo);
+    this.reporter.point(AI_REPORTER_NAME, data.msg, reportInfo);
+  }
+}

--- a/packages/ai-native/src/browser/ai-reporter.ts
+++ b/packages/ai-native/src/browser/ai-reporter.ts
@@ -1,7 +1,7 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import { IReporterService, uuid } from '@opensumi/ide-core-common';
 
-import { ReportInfo, IAIReporter, AI_REPORTER_NAME } from '../common';
+import { ReportInfo, IAIReporter, AI_REPORTER_NAME, AIReporterMsg } from '../common';
 
 @Injectable()
 export class AIReporter implements IAIReporter {
@@ -21,10 +21,10 @@ export class AIReporter implements IAIReporter {
   }
 
   // 返回关联 ID
-  start(data: ReportInfo): string {
+  start(msg: AIReporterMsg, data: ReportInfo): string {
     const relationId = this.getRelationId();
 
-    this.report(relationId, { ...data, relationId });
+    this.report(relationId, { ...data, msg, relationId });
 
     // 这里做个兜底，如果 60s 模型还没有返回结果，上报失败
     const cancleHanddler = setTimeout(() => {

--- a/packages/ai-native/src/browser/ai-reporter.ts
+++ b/packages/ai-native/src/browser/ai-reporter.ts
@@ -24,7 +24,7 @@ export class AIReporter implements IAIReporter {
   start(msg: AISerivceType, data: ReportInfo): string {
     const relationId = this.getRelationId();
 
-    this.report(relationId, { ...data, msgType: msg, relationId });
+    this.report(relationId, { ...data, msgType: msg });
 
     // 这里做个兜底，如果 60s 模型还没有返回结果，上报失败
     const cancleHanddler = setTimeout(() => {
@@ -34,13 +34,14 @@ export class AIReporter implements IAIReporter {
     this.reporterCancelHandler.set(relationId, cancleHanddler);
     return relationId;
   }
+
   end(relationId: string, data: ReportInfo) {
     const cancleHanddler = this.reporterCancelHandler.get(relationId);
     if (cancleHanddler) {
       clearTimeout(cancleHanddler);
     }
 
-    this.report(relationId, { ...data, relationId, success: true });
+    this.report(relationId, { ...data, success: true });
   }
 
   private report(relationId: string, data: ReportInfo) {
@@ -50,6 +51,7 @@ export class AIReporter implements IAIReporter {
       ...this.getCommonReportInfo(),
       ...reportInfoCache,
       ...data,
+      relationId,
     };
 
     this.reportInfoCache.set(relationId, reportInfo);

--- a/packages/ai-native/src/browser/components/StreamMsg.tsx
+++ b/packages/ai-native/src/browser/components/StreamMsg.tsx
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import { DisposableCollection, useInjectable } from '@opensumi/ide-core-browser';
 

--- a/packages/ai-native/src/browser/components/StreamMsg.tsx
+++ b/packages/ai-native/src/browser/components/StreamMsg.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect } from 'react';
 
 import { DisposableCollection, useInjectable } from '@opensumi/ide-core-browser';
 
+import { IAIReporter } from '../../common';
 import { AiChatService } from '../ai-chat.service';
 import { EMsgStreamStatus, IMsgStreamChoices, MsgStreamManager } from '../model/msg-stream-manager';
 
@@ -13,10 +14,11 @@ import { Thinking, ThinkingResult } from './Thinking';
 interface IStreamMsgWrapperProps {
   sessionId: string;
   prompt: string;
+  startTime?: number;
 }
 
 export const StreamMsgWrapper = (props: IStreamMsgWrapperProps) => {
-  const { sessionId, prompt } = props;
+  const { sessionId, prompt, startTime = 0 } = props;
   const [chunk, setChunk] = React.useState('');
   const [content, setContent] = React.useState<string>('');
   const [isError, setIsError] = React.useState<boolean>(false);
@@ -24,6 +26,7 @@ export const StreamMsgWrapper = (props: IStreamMsgWrapperProps) => {
   const [status, setStatus] = React.useState(EMsgStreamStatus.THINKING);
   const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
   const aiChatService = useInjectable<AiChatService>(AiChatService);
+  const aiReporter = useInjectable<IAIReporter>(IAIReporter);
 
   useEffect(() => {
     const disposableCollection = new DisposableCollection();
@@ -68,6 +71,21 @@ export const StreamMsgWrapper = (props: IStreamMsgWrapperProps) => {
     setContent(content + chunk);
   }, [chunk]);
 
+  const report = useCallback((success: boolean, stop: boolean) => {
+    aiReporter.end(sessionId, {
+      message: content,
+      replytime: +new Date() - startTime,
+      success,
+      isStop: stop,
+    });
+  }, [content]);
+
+  useEffect(() => {
+    if (status === EMsgStreamStatus.DONE) {
+      report(true, false);
+    }
+  }, [status]);
+
   const handleRegenerate = useCallback(() => {
     reset();
     aiChatService.messageWithStream(prompt, {}, sessionId);
@@ -88,8 +106,12 @@ export const StreamMsgWrapper = (props: IStreamMsgWrapperProps) => {
     [content, isError, isDone, status, sessionId],
   );
 
+  const onStop = () => {
+    report(false, true);
+  };
+
   return status === EMsgStreamStatus.THINKING && msgStreamManager.currentSessionId === sessionId ? (
-    <Thinking status={status} message={content}>
+    <Thinking status={status} message={content} onStop={onStop}>
       {renderMsgList()}
     </Thinking>
   ) : (

--- a/packages/ai-native/src/browser/components/Thinking.tsx
+++ b/packages/ai-native/src/browser/components/Thinking.tsx
@@ -9,7 +9,6 @@ import { MsgStreamManager, EMsgStreamStatus } from '../model/msg-stream-manager'
 
 import * as styles from './components.module.less';
 import { EnhanceIcon } from './Icon';
-import { Thumbs } from './Thumbs';
 
 interface ITinkingProps {
   children?: React.ReactNode;
@@ -17,9 +16,10 @@ interface ITinkingProps {
   message?: string;
   onRegenerate?: () => void;
   sessionId?: string;
+  onStop?: () => void;
 }
 
-export const Thinking = ({ children, status, message }: ITinkingProps) => {
+export const Thinking = ({ children, status, message, onStop }: ITinkingProps) => {
   const aiChatService = useInjectable<AiChatService>(AiChatService);
   const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
 
@@ -29,6 +29,7 @@ export const Thinking = ({ children, status, message }: ITinkingProps) => {
     if (currentSessionId) {
       await aiChatService.destroyStreamRequest(currentSessionId);
     }
+    onStop && onStop();
   }, [msgStreamManager]);
 
   const renderContent = useCallback(() => {

--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -16,6 +16,7 @@ import {
 } from '../common';
 
 import { AiNativeCoreContribution } from './ai-chat.contribution';
+import { AIReporter } from './ai-reporter';
 import { AiChatService } from './ai-chat.service';
 import { AiEditorTabService } from './override/ai-editor-tab.service';
 import { AiMarkerService } from './override/ai-marker.service';
@@ -37,6 +38,10 @@ export class AiNativeModule extends BrowserModule {
     {
       token: IAiChatService,
       useClass: AiChatService,
+    },
+    {
+      token: IAIReporter,
+      useClass: AIReporter,
     },
   ];
 

--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -13,11 +13,12 @@ import {
   AiNativeContribution,
   IAiChatService,
   IAiRunFeatureRegistry,
+  IAIReporter,
 } from '../common';
 
 import { AiNativeCoreContribution } from './ai-chat.contribution';
-import { AIReporter } from './ai-reporter';
 import { AiChatService } from './ai-chat.service';
+import { AIReporter } from './ai-reporter';
 import { AiEditorTabService } from './override/ai-editor-tab.service';
 import { AiMarkerService } from './override/ai-marker.service';
 import { AiBrowserCtxMenuService } from './override/ai-menu.service';

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -50,7 +50,7 @@ export interface IChatMessageStructure {
   /**
    * 用于 chat 面板展示
    */
-  message: string | React.ReactNode;
+  message: string;
   /**
    * 实际调用的 prompt
    */
@@ -97,13 +97,14 @@ export interface ChatCompletionRequestMessage {
 }
 
 export enum AISerivceType {
-  Search,
-  Sumi,
-  GPT,
-  Explain,
-  Run,
-  Test,
-  Optimize,
+  Search = 'search',
+  Sumi = 'sumi',
+  GPT = 'chat',
+  Explain = 'explain',
+  Run = 'run',
+  Test = 'test',
+  Optimize = 'optimize',
+  Generate = 'generate'
 }
 
 export type AiRunHandler = () => MaybePromise<void>;

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -1,5 +1,6 @@
 import { MaybePromise, CancellationToken } from '@opensumi/ide-core-common';
 
+export * from './reporter';
 export const AiBackSerivceToken = Symbol('AiBackSerivceToken');
 export const AiBackSerivcePath = 'AiBackSerivcePath';
 

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -1,15 +1,16 @@
 export const AI_REPORTER_NAME = 'AI';
 
-export enum AI_REPORTER_MSG {
-  CHAT_QUESTION = 'chat_question',
-  CHAT_ANSWER = 'chat_answer'
+export enum AIReporterMsg {
+  generateProject = 'generateProject',
+  chatQuestion = 'chatQuestion',
+  chatAnswer = 'chatAnswer'
 };
 
 export interface CommonLogInfo {
   replytime: number;
   success: boolean;
   scenarioName: string;
-  msg: AI_REPORTER_MSG;
+  msg: AIReporterMsg;
   model: string;
   prompt: string;
   answer: string;
@@ -49,6 +50,6 @@ export const IAIReporter = Symbol('IAIReporter');
 export interface IAIReporter {
   getCommonReportInfo(): Record<string, unknown>;
   // 返回关联 ID
-  start(data: ReportInfo): string;
+  start(msg: AIReporterMsg, data: ReportInfo): string;
   end(relationId: string, data: ReportInfo);
 }

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -1,55 +1,56 @@
-export const AI_REPORTER_NAME = 'AI';
+import { AISerivceType } from '../index';
 
-export enum AIReporterMsg {
-  generateProject = 'generateProject',
-  chatQuestion = 'chatQuestion',
-  chatAnswer = 'chatAnswer'
-};
+export const AI_REPORTER_NAME = 'AI';
 
 export interface CommonLogInfo {
   replytime: number;
   success: boolean;
-  scenarioName: string;
-  msg: AIReporterMsg;
-  model: string;
-  prompt: string;
-  answer: string;
+  msgType: AISerivceType;
+  message: string;
   relationId: string;
 }
 
-export interface QuestionInfo extends CommonLogInfo {
+export interface QuestionInfo extends Partial<CommonLogInfo> {
   isLike: boolean;
   isRetry: boolean;
   isStop: boolean;
 }
 
-export interface CodeInfo extends CommonLogInfo {
+export interface CodeInfo extends Partial<CommonLogInfo> {
   isReceive: boolean;
   isDrop: boolean;
 }
 
-export interface GenerateInfo extends CommonLogInfo {
+export interface GenerateInfo extends Partial<CommonLogInfo> {
   fileCount: number;
   requirment: string;
 }
 
-export interface CommandInfo extends CommonLogInfo {
+export interface CommandInfo extends Partial<CommonLogInfo> {
   useCommand: boolean;
   useCommandSuccess: boolean;
 }
 
-export interface RunInfo extends CommonLogInfo {
+export interface RunInfo extends Partial<CommonLogInfo> {
   generateFile: boolean;
   runSuccess: boolean;
 }
 
-export type ReportInfo = Partial<QuestionInfo> | Partial<CodeInfo> | Partial<GenerateInfo> | Partial<CommandInfo> | Partial<RunInfo>;
+export type ReportInfo = Partial<CommonLogInfo>
+  | ({ type: AISerivceType.GPT } & QuestionInfo)
+  | ({ type: AISerivceType.Explain } & QuestionInfo)
+  | ({ type: AISerivceType.Search } & QuestionInfo)
+  | ({ type: AISerivceType.Test } & QuestionInfo)
+  | ({ type: AISerivceType.Optimize } & CodeInfo)
+  | ({ type: AISerivceType.Generate } & GenerateInfo)
+  | ({ type: AISerivceType.Sumi } & CommandInfo)
+  | ({ type: AISerivceType.Run } & RunInfo);
 
 export const IAIReporter = Symbol('IAIReporter');
 
 export interface IAIReporter {
   getCommonReportInfo(): Record<string, unknown>;
   // 返回关联 ID
-  start(msg: AIReporterMsg, data: ReportInfo): string;
+  start(msg: AISerivceType, data: ReportInfo): string;
   end(relationId: string, data: ReportInfo);
 }

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -1,0 +1,54 @@
+export const AI_REPORTER_NAME = 'AI';
+
+export enum AI_REPORTER_MSG {
+  CHAT_QUESTION = 'chat_question',
+  CHAT_ANSWER = 'chat_answer'
+};
+
+export interface CommonLogInfo {
+  replytime: number;
+  success: boolean;
+  scenarioName: string;
+  msg: AI_REPORTER_MSG;
+  model: string;
+  prompt: string;
+  answer: string;
+  relationId: string;
+}
+
+export interface QuestionInfo extends CommonLogInfo {
+  isLike: boolean;
+  isRetry: boolean;
+  isStop: boolean;
+}
+
+export interface CodeInfo extends CommonLogInfo {
+  isReceive: boolean;
+  isDrop: boolean;
+}
+
+export interface GenerateInfo extends CommonLogInfo {
+  fileCount: number;
+  requirment: string;
+}
+
+export interface CommandInfo extends CommonLogInfo {
+  useCommand: boolean;
+  useCommandSuccess: boolean;
+}
+
+export interface RunInfo extends CommonLogInfo {
+  generateFile: boolean;
+  runSuccess: boolean;
+}
+
+export type ReportInfo = Partial<QuestionInfo> | Partial<CodeInfo> | Partial<GenerateInfo> | Partial<CommandInfo> | Partial<RunInfo>;
+
+export const IAIReporter = Symbol('IAIReporter');
+
+export interface IAIReporter {
+  getCommonReportInfo(): Record<string, unknown>;
+  // 返回关联 ID
+  start(data: ReportInfo): string;
+  end(relationId: string, data: ReportInfo);
+}

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -7,7 +7,6 @@ export interface CommonLogInfo {
   success: boolean;
   msgType: AISerivceType;
   message: string;
-  relationId: string;
 }
 
 export interface QuestionInfo extends Partial<CommonLogInfo> {
@@ -32,7 +31,6 @@ export interface CommandInfo extends Partial<CommonLogInfo> {
 }
 
 export interface RunInfo extends Partial<CommonLogInfo> {
-  generateFile: boolean;
   runSuccess: boolean;
 }
 

--- a/packages/ai-native/src/node/index.ts
+++ b/packages/ai-native/src/node/index.ts
@@ -3,8 +3,8 @@ import { NodeModule } from '@opensumi/ide-core-node';
 
 import { AiBackSerivcePath, AiBackSerivceToken } from '../common';
 
-import { AiBackService } from './ai.service';
-// import { AiBackService } from './ai-gpt.back.service';
+// import { AiBackService } from './ai.service';
+import { AiBackService } from './ai-gpt.back.service';
 
 @Injectable()
 export class AiNativeModule extends NodeModule {

--- a/packages/ai-native/src/node/index.ts
+++ b/packages/ai-native/src/node/index.ts
@@ -3,8 +3,8 @@ import { NodeModule } from '@opensumi/ide-core-node';
 
 import { AiBackSerivcePath, AiBackSerivceToken } from '../common';
 
-// import { AiBackService } from './ai.service';
-import { AiBackService } from './ai-gpt.back.service';
+import { AiBackService } from './ai.service';
+// import { AiBackService } from './ai-gpt.back.service';
 
 @Injectable()
 export class AiNativeModule extends NodeModule {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef7bbaf</samp>

*  Add the `IAIReporter` service and the `AIReporter` class to send data points to the backend for analysis and monitoring of the AI chat feature ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-0a5b5a2af6775b809b915bdf1a961b1f6edc479ec129cee1c69c8f0568bc6b16R1-R60), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-d0fd7520ce5cd047ba1beac6d5f5594a0b3d164234bf7191af3c7c6c49a811f7R1-R54), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L16-R21), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746R43-R46))
*  Inject the `IAIReporter` service in the `AiChatService`, `AiProjectGenerateService`, `AiRunService`, and the React components that handle the AI chat interactions ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R15), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R43-R45), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L1-R3), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L30-R53), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL6-R6), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL16-R24), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L2-R6), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L16-R21), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R29), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0L4-R4), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0L13-R33))
*  Add the `relationId` field to the chat message data and the project generation message data, and use the `uuid` function to generate unique identifiers for the messages ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L1-R3), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L14-R12), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L30-R53), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L52-R69), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L109-R126), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL27-R34), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL37-R43))
*  Add the `startTime` variable to the React components that handle the AI chat interactions, and use it to measure the response time of the AI chat service ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L30-R53), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L64-R81), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L147-R224), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L16-R21), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R74-R88))
*  Call the `start` and `end` methods of the `IAIReporter` service in the `AiChatService`, `AiProjectGenerateService`, `AiRunService`, and the React components that handle the AI chat interactions, and pass the relevant data points based on the type of the AI chat service ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R43-R45), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L64-R81), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L147-R224), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L357-R388), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R395-R402), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L392-R446), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L408-R465), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L425-R546), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L461-R562), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL16-R24), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-692f0eda5e694e302b73f85d7a10cfb9d464746e87f8cd9be8fac59d70ebc52eL37-R43), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R29), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R74-R88), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L91-R114), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-889ca9a5c6a54806fa808701a3191d65f328a1e52b8e5f88a7244fdfa35e3da0L13-R33))
*  Update the `switchAIService` method of the `AiChatService` to return the appropriate AI service type and message based on the user's input and prompt ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R43-R45), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L64-R81), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L147-R224))
*  Update the `onSubmit` function in the `AiChatView` component to remove the unnecessary check for the `preInputValue` type, and to use the `switchAIService` method of the `AiChatService` ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L147-R224))
*  Update the `generateProject` function in the `AiChatView` component to filter out any undefined messages from the message list, and to cast the result as `MessageData[]` ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L52-R69))
*  Update the `AISearch`, `AIStreamReply`, `AICodeReply`, `AIChatRunReply`, and `AIWithCommandReply` functions in the `ai-chat.view.tsx` module to accept a `ReplayComponentParam` object instead of individual parameters, and to use the `relationId` and `startTime` fields ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L30-R53), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L357-R388), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L371-R426), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L392-R446), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L408-R465), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L425-R546), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L461-R562))
*  Update the `AISearch` function in the `ai-chat.view.tsx` module to add the `isCancel` variable, which indicates whether the AI search session was canceled by the user, and to add the `isStop` field to the data reported by the `IAIReporter` service ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R395-R402))
*  Update the `AIWithCommandReply` function in the `ai-chat.view.tsx` module to add the `excuteCommand` function, which handles the logic for executing the suggested command and reporting the result to the `IAIReporter` service, and to use it instead of the `open` method of the `opener` instance ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L461-R562))
*  Update the `Thinking` component in the `components/Thinking.tsx` module to add the `onStop` prop, which is a function that is called when the user clicks the stop button to cancel the stream message, and to use it in the `onClick` prop of the `Button` component ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6L20-R22), [link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6R32))
*  Update the `StreamMsgWrapper` component in the `components/StreamMsg.tsx` module to add the `report` function, which is used to report the end of the stream message session with the relevant data, and to use the `useEffect` hook to call it when the status of the stream message is done ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46R74-R88))
*  Update the `StreamMsgWrapper` component in the `components/StreamMsg.tsx` module to add the `onStop` function, which is used to report the end of the stream message session with a failure and a stop flag, and to use it in the `onStop` prop of the `Thinking` component ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-2997e9107bc77e1e829aa5fed41d20b2a711101e8c7af3022e2e2fcc59c78c46L91-R114))
*  Update the `AISerivceType` enum in the `index.ts` module to use strings instead of numbers as the values, and to add the `Generate` value ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-6ecf6e19703eacc07117065aa73da7936083841ddcf45927d9f1ae44df2a309dL99-R107))
*  Update the `IChatMessageStructure` interface in the `index.ts` module to use `string` instead of `string | React.ReactNode` as the type of the `message` field ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-6ecf6e19703eacc07117065aa73da7936083841ddcf45927d9f1ae44df2a309dL52-R53))
*  Update the `node/index.ts` module to switch the implementation of the AI back service from the mock service to the GPT service ([link](https://github.com/opensumi/core/pull/3176/files?diff=unified&w=0#diff-bcea31e51c5ceb280434aa05bdeb1db188052e78e8410bbfc43500d28b8b0f98L6-R7))

<!-- Additional content -->
<!-- 补充额外内容 -->

* 增加数据采集能力

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef7bbaf</samp>

This pull request adds the AI reporter feature to the AI chat service, which allows sending data points to the backend for analysis and monitoring. It defines the `IAIReporter` interface and the `AIReporter` class, which implement the logic for reporting the data points based on the type and outcome of the AI chat session. It also injects the `IAIReporter` service to the various AI chat components and services, such as `AiChatService`, `AiRunService`, `GenerateService`, and `StreamMsg`. It also updates the UI components, such as `AiChatView` and `Thinking`, to use the `relationId` field and the stop button for tracking and canceling the sessions. It also switches the AI back service implementation from the mock service to the GPT service.
