### PR TITLE
fix: add isStart at report

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -508,7 +508,7 @@ const AIWithCommandReply = async (command: Command, opener: CommandOpener, param
     replytime: +new Date() - startTime,
     success: true,
     msgType: AISerivceType.Sumi,
-    message: command.id,
+    message: command?.id,
   });
 
   if (!command) {

--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -185,6 +185,7 @@ export const AiChatView = observer(() => {
 
       preMessagelist.push(codeSendMessage);
       setMessageListData(preMessagelist);
+      updateState({});
 
       const replayCommandProps = {
         aiChatService,

--- a/packages/ai-native/src/browser/ai-reporter.ts
+++ b/packages/ai-native/src/browser/ai-reporter.ts
@@ -24,7 +24,7 @@ export class AIReporter implements IAIReporter {
   start(msg: AISerivceType, data: ReportInfo): string {
     const relationId = this.getRelationId();
 
-    this.report(relationId, { ...data, msgType: msg });
+    this.report(relationId, { ...data, msgType: msg, isStart: true });
 
     // 这里做个兜底，如果 60s 模型还没有返回结果，上报失败
     const cancleHanddler = setTimeout(() => {
@@ -41,7 +41,7 @@ export class AIReporter implements IAIReporter {
       clearTimeout(cancleHanddler);
     }
 
-    this.report(relationId, { ...data, success: true });
+    this.report(relationId, { ...data, success: true, isStart: false });
   }
 
   private report(relationId: string, data: ReportInfo) {

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -7,6 +7,7 @@ export interface CommonLogInfo {
   success: boolean;
   msgType: AISerivceType;
   message: string;
+  isStart: boolean;
 }
 
 export interface QuestionInfo extends Partial<CommonLogInfo> {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b978340</samp>

*  Add `isStart` property to report data to indicate start or end of command execution ([link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-0a5b5a2af6775b809b915bdf1a961b1f6edc479ec129cee1c69c8f0568bc6b16L27-R27), [link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-0a5b5a2af6775b809b915bdf1a961b1f6edc479ec129cee1c69c8f0568bc6b16L44-R44), [link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-d0fd7520ce5cd047ba1beac6d5f5594a0b3d164234bf7191af3c7c6c49a811f7R10))
  * Update `CommonLogInfo` interface in `reporter.ts` to include `isStart` ([link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-d0fd7520ce5cd047ba1beac6d5f5594a0b3d164234bf7191af3c7c6c49a811f7R10))
  * Pass `isStart` as true or false to `report` method in `ai-reporter.ts` depending on command status ([link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-0a5b5a2af6775b809b915bdf1a961b1f6edc479ec129cee1c69c8f0568bc6b16L27-R27), [link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-0a5b5a2af6775b809b915bdf1a961b1f6edc479ec129cee1c69c8f0568bc6b16L44-R44))
*  Use null-safe operator for `command?.id` in `ai-chat.view.tsx` to prevent possible errors ([link](https://github.com/opensumi/core/pull/3179/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L511-R511))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b978340</samp>

This pull request adds a new `isStart` property to the report data for AI commands, to enable better monitoring and analysis of the AI service. It also fixes a potential null pointer error in the `ai-chat.view.tsx` file.
