### PR TITLE
fix: add progress loading for common input

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -23,7 +23,7 @@ import { AILogoAvatar, EnhanceIcon } from './components/Icon';
 import { LineVertical } from './components/lineVertical';
 import { StreamMsgWrapper } from './components/StreamMsg';
 import { Thinking } from './components/Thinking';
-import { MsgStreamManager } from './model/msg-stream-manager';
+import { MsgStreamManager, EMsgStreamStatus } from './model/msg-stream-manager';
 import { AiMenubarService } from './override/layout/menu-bar/menu-bar.service';
 import { AiRunService } from './run/run.service';
 interface MessageData extends Pick<ITextMessageProps, 'id' | 'position' | 'className' | 'title'> {
@@ -282,7 +282,7 @@ export const AiChatView = observer(() => {
                   title={AI_NAME}
                   className={styles.smsg}
                   // @ts-ignore
-                  text={<Thinking />}
+                  text={<Thinking status={EMsgStreamStatus.THINKING} />}
                 ></SystemMessage>
               </div>
             )}

--- a/packages/ai-native/src/browser/components/Thinking.tsx
+++ b/packages/ai-native/src/browser/components/Thinking.tsx
@@ -47,7 +47,7 @@ export const Thinking = ({ children, status, message, onStop }: ITinkingProps) =
       <div className={styles.stop}>
         <span className={styles.progress_bar}>
           {/* 保持动画效果一致 */}
-          {status && (
+          {!!status && (
             <Progress
               loading={true}
               wrapperClassName={`ai-native-progress-wrapper ${


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 38a0351</samp>

* Import `EMsgStreamStatus` enum to use as a prop for `Thinking` component ([link](https://github.com/opensumi/core/pull/3181/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L26-R26))
* Pass `EMsgStreamStatus.THINKING` as `status` prop to `Thinking` component in `ai-chat.view.tsx` to indicate AI processing ([link](https://github.com/opensumi/core/pull/3181/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L285-R285))
* Coerce `status` prop to boolean in `Thinking` component in `components/Thinking.tsx` to avoid rendering `Progress` component when idle ([link](https://github.com/opensumi/core/pull/3181/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6L50-R50))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 38a0351</samp>

Added a `status` prop to the `Thinking` component to show the AI's progress in the chat view. Fixed a bug where the `Progress` component would render when the AI was idle.
