### PR TITLE
feat: support chat thumb action

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -517,7 +517,7 @@ const AIWithCommandReply = async (commandRes: IAiBackServiceResponse<Command>, o
     return createMessageByAI({
       id: uuid(6),
       relationId,
-      text: failedText,
+      text: (<ChatMoreActions sessionId={relationId}>{failedText}</ChatMoreActions>),
     });
   }
 

--- a/packages/ai-native/src/browser/ai-editor.contribution.ts
+++ b/packages/ai-native/src/browser/ai-editor.contribution.ts
@@ -262,7 +262,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
         });
         this.aiInlineContentWidget?.layoutContentWidget();
 
-        this.aiInlineChatOperationDisposed.addDispose(
+        this.aiInlineChatOperationDisposed.addDispose([
           this.aiInlineChatService.onAccept(() => {
             this.aiReporter.end(relationId, { message: 'accept', success: true, isReceive: true });
             monacoEditor.getModel()?.pushEditOperations(
@@ -279,7 +279,10 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
               this.disposeAllWidget();
             }, 110);
           }),
-        );
+          this.aiInlineChatService.onThumbs((isLike: boolean) => {
+            this.aiReporter.end(relationId, { isLike });
+          }),
+        ]);
       }
 
       return answer;

--- a/packages/ai-native/src/browser/components/ChatMoreActions.tsx
+++ b/packages/ai-native/src/browser/components/ChatMoreActions.tsx
@@ -1,38 +1,56 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 
-import { getExternalIcon, useInjectable } from '@opensumi/ide-core-browser';
+import { useInjectable } from '@opensumi/ide-core-browser';
 
-import { MsgStreamManager } from '../model/msg-stream-manager';
+import { IAIReporter } from '../../common';
+import { AiChatService } from '../ai-chat.service';
 
 import * as styles from './components.module.less';
 import { EnhanceIcon } from './Icon';
+import { Thumbs } from './Thumbs';
 
 export interface IChatMoreActionsProps {
   children: React.ReactNode;
   sessionId: string;
+  onRetry?: () => void;
 }
 
 export const ChatMoreActions = (props: IChatMoreActionsProps) => {
-  const { children, sessionId } = props;
-  const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
+  const { children, sessionId, onRetry } = props;
+  const aiChatService = useInjectable<AiChatService>(AiChatService);
+  const aiReporter = useInjectable<IAIReporter>(IAIReporter);
 
-  const canRetry = useMemo(() => sessionId === msgStreamManager.currentSessionId, [sessionId]);
+  const [latestSessionId, setLatestSessionId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const dispose = aiChatService.onChangeSessionId((sid) => {
+      setLatestSessionId(sid);
+    });
+
+    return () => dispose.dispose();
+  }, [aiChatService]);
+
+  const showOperate = useMemo(() => sessionId === aiChatService.latestSessionId, [sessionId, latestSessionId]);
 
   return (
     <div className={styles.ai_chat_more_actions_container}>
       <div className={styles.ai_chat_message}>{children}</div>
-      <div className={styles.chat_msg_more_actions}>
-        <div className={styles.left_side}>
-          {canRetry && (
-            <div className={styles.side}>
-              <EnhanceIcon className={getExternalIcon('refresh')}>
-                <span style={{ marginLeft: 5, fontSize: 12 }}>重新生成</span>
-              </EnhanceIcon>
+      {
+        showOperate ? (
+          <div className={styles.bottom_container}>
+            <div className={styles.reset}>
+              {
+                onRetry && (
+                  <EnhanceIcon icon={'refresh'} className={styles.transform}>
+                    <span>重新生成</span>
+                  </EnhanceIcon>
+                )
+              }
             </div>
-          )}
-        </div>
-        {/* <div className={styles.side}><Thumbs /></div> */}
-      </div>
+            <div className={styles.thumbs}><Thumbs relationId={sessionId} aiReporterService={aiReporter} /></div>
+          </div>
+        ) : null
+      }
     </div>
   );
 };

--- a/packages/ai-native/src/browser/components/Thinking.tsx
+++ b/packages/ai-native/src/browser/components/Thinking.tsx
@@ -10,6 +10,7 @@ import { MsgStreamManager, EMsgStreamStatus } from '../model/msg-stream-manager'
 
 import * as styles from './components.module.less';
 import { EnhanceIcon } from './Icon';
+import { Thumbs } from './Thumbs';
 
 interface ITinkingProps {
   children?: React.ReactNode;
@@ -105,7 +106,7 @@ export const ThinkingResult = ({ children, message, status, onRegenerate, sessio
               <span>重新生成</span>
             </EnhanceIcon>
           </div>
-          <div className={styles.thumbs}>{/* <Thumbs /> */}</div>
+          <div className={styles.thumbs}><Thumbs /></div>
         </div>
       ) : null}
     </div>

--- a/packages/ai-native/src/browser/components/Thinking.tsx
+++ b/packages/ai-native/src/browser/components/Thinking.tsx
@@ -4,6 +4,7 @@ import { useInjectable } from '@opensumi/ide-core-browser';
 import { Icon, getIcon } from '@opensumi/ide-core-browser/lib/components';
 import { Progress } from '@opensumi/ide-core-browser/lib/progress/progress-bar';
 
+import { IAIReporter } from '../../common';
 import { AiChatService } from '../ai-chat.service';
 import { STOP_IMMEDIATELY } from '../common-reponse';
 import { MsgStreamManager, EMsgStreamStatus } from '../model/msg-stream-manager';
@@ -70,6 +71,7 @@ export const Thinking = ({ children, status, message, onStop }: ITinkingProps) =
 
 export const ThinkingResult = ({ children, message, status, onRegenerate, sessionId }: ITinkingProps) => {
   const aiChatService = useInjectable<AiChatService>(AiChatService);
+  const aiReporter = useInjectable<IAIReporter>(IAIReporter);
   const [latestSessionId, setLatestSessionId] = useState<string | undefined>(undefined);
 
   useEffect(() => {
@@ -106,7 +108,7 @@ export const ThinkingResult = ({ children, message, status, onRegenerate, sessio
               <span>重新生成</span>
             </EnhanceIcon>
           </div>
-          <div className={styles.thumbs}><Thumbs /></div>
+          <div className={styles.thumbs}><Thumbs relationId={sessionId} aiReporterService={aiReporter} /></div>
         </div>
       ) : null}
     </div>

--- a/packages/ai-native/src/browser/components/Thumbs.tsx
+++ b/packages/ai-native/src/browser/components/Thumbs.tsx
@@ -10,10 +10,11 @@ import { EnhanceIcon } from './Icon';
 interface ThumbsProps {
   relationId?: string;
   aiReporterService?: IAIReporter;
+  onClick?: (isLike?: boolean) => void;
 }
 
 export const Thumbs = (props: ThumbsProps) => {
-  const { relationId, aiReporterService } = props;
+  const { relationId, aiReporterService, onClick } = props;
 
   const [thumbsupIcon, setThumbsupIcon] = useState('thumbs');
   const [thumbsdownIcon, setThumbsdownIcon] = useState('thumbsdown');
@@ -21,6 +22,9 @@ export const Thumbs = (props: ThumbsProps) => {
   const report = useCallback((isLike: boolean) => {
     if (relationId && aiReporterService) {
       aiReporterService.end(relationId, { isLike });
+    }
+    if (onClick) {
+      onClick(isLike);
     }
   }, [relationId, aiReporterService]);
 

--- a/packages/ai-native/src/browser/components/Thumbs.tsx
+++ b/packages/ai-native/src/browser/components/Thumbs.tsx
@@ -1,21 +1,51 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback, useState } from 'react';
 
-import { getExternalIcon, uuid } from '@opensumi/ide-core-browser';
-import { Icon, Popover } from '@opensumi/ide-core-browser/lib/components';
+import { getExternalIcon, uuid, KTICON_OWNER } from '@opensumi/ide-core-browser';
+import { Popover } from '@opensumi/ide-core-browser/lib/components';
+
+import { IAIReporter } from '../../common';
 
 import { EnhanceIcon } from './Icon';
-import { LineVertical } from './lineVertical';
 
-export const Thumbs = () => {
-  const useUUID = useMemo(() => uuid(12), []);
+interface ThumbsProps {
+  relationId?: string;
+  aiReporterService?: IAIReporter;
+}
+
+export const Thumbs = (props: ThumbsProps) => {
+  const { relationId, aiReporterService } = props;
+
+  const [thumbsupIcon, setThumbsupIcon] = useState('thumbs');
+  const [thumbsdownIcon, setThumbsdownIcon] = useState('thumbsdown');
+
+  const report = useCallback((isLike: boolean) => {
+    if (relationId && aiReporterService) {
+      aiReporterService.end(relationId, { isLike });
+    }
+  }, [relationId, aiReporterService]);
+
+  const handleClick = useCallback((type: 'up' | 'down') => {
+    // only click once
+    if (type === 'up' && thumbsupIcon === 'thumbs') {
+      setThumbsupIcon('thumbs-fill');
+      report(true);
+    }
+
+    if (type === 'down' && thumbsdownIcon === 'thumbsdown') {
+      setThumbsdownIcon('thumbsdown-fill');
+      report(false);
+    }
+  }, [ thumbsupIcon, thumbsdownIcon]);
+
+  const useUUID = useMemo(() => uuid(6), []);
 
   return (
     <>
       <Popover id={`ai-chat-thumbsup-${useUUID}`} title='赞'>
-        <EnhanceIcon className={getExternalIcon('thumbsup')} />
+        <EnhanceIcon onClick={() => handleClick('up')} className={getExternalIcon(thumbsupIcon, KTICON_OWNER)} />
       </Popover>
       <Popover id={`ai-chat-thumbsdown-${useUUID}`} title='踩'>
-        <EnhanceIcon className={getExternalIcon('thumbsdown')} />
+        <EnhanceIcon onClick={() => handleClick('down')} className={getExternalIcon(thumbsdownIcon, KTICON_OWNER)} />
       </Popover>
     </>
   );

--- a/packages/ai-native/src/browser/components/components.module.less
+++ b/packages/ai-native/src/browser/components/components.module.less
@@ -26,30 +26,31 @@
       }
     }
   }
-  .bottom_container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: row;
-    position: absolute;
-    bottom: -39px;
-    width: 100%;
+}
 
-    .reset {
-      flex: 1 1 auto;
-      align-items: center;
-      display: flex;
-      justify-content: left;
-      .transform {
-        transform: rotate(90deg);
-        margin-right: 6px;
-        cursor: pointer;
-      }
+.bottom_container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
+  position: absolute;
+  bottom: -39px;
+  width: 100%;
+
+  .reset {
+    flex: 1 1 auto;
+    align-items: center;
+    display: flex;
+    justify-content: left;
+    .transform {
+      transform: rotate(90deg);
+      margin-right: 6px;
+      cursor: pointer;
     }
-    .thumbs {
-      display: flex;
-      flex: 0 0 auto;
-    }
+  }
+  .thumbs {
+    display: flex;
+    flex: 0 0 auto;
   }
 }
 
@@ -331,33 +332,6 @@
 
 .ai_chat_more_actions_container {
   position: relative;
-
-  .chat_msg_more_actions {
-    position: absolute;
-    z-index: 1000;
-    bottom: -36px;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    height: 16px;
-    padding: 0 4px;
-    display: none;
-
-    &::after {
-      content: initial !important;
-    }
-
-    .side {
-      display: flex;
-      align-items: center;
-      justify-items: right;
-      height: inherit;
-
-      .ai_enhance_icon {
-        cursor: pointer;
-      }
-    }
-  }
 }
 
 .ai_native_input_container {

--- a/packages/ai-native/src/browser/components/components.module.less
+++ b/packages/ai-native/src/browser/components/components.module.less
@@ -40,10 +40,10 @@
       align-items: center;
       display: flex;
       justify-content: left;
-      cursor: pointer;
       .transform {
         transform: rotate(90deg);
         margin-right: 6px;
+        cursor: pointer;
       }
     }
     .thumbs {

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-chat-controller.tsx
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-chat-controller.tsx
@@ -8,6 +8,7 @@ import { AILogoAvatar, EnhanceIcon, EnhanceIconWithCtxMenu } from '../components
 import { LineVertical } from '../components/lineVertical';
 import { Loading } from '../components/Loading';
 import { EnhancePopover } from '../components/Popover';
+import { Thumbs } from '../components/Thumbs';
 
 import * as styles from './inline-chat.module.less';
 import { AiInlineChatService, EInlineChatStatus } from './inline-chat.service';
@@ -110,6 +111,10 @@ const AiInlineResult = () => {
     aiInlineChatService._onRegenerate.fire();
   }, []);
 
+  const handleThumbs = useCallback((islike: boolean) => {
+    aiInlineChatService._onThumbs.fire(islike);
+  }, []);
+
   return (
     <div className={styles.ai_inline_result_panel}>
       <div className={styles.side} style={{ marginRight: 128 }}>
@@ -123,9 +128,9 @@ const AiInlineResult = () => {
           <span>重新生成</span>
         </EnhanceIcon>
       </div>
-      {/* <div className={styles.side}>
-        <Thumbs />
-      </div> */}
+      <div className={styles.side}>
+        <Thumbs onClick={handleThumbs} />
+      </div>
     </div>
   );
 };

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-chat.service.ts
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-chat.service.ts
@@ -43,6 +43,10 @@ export class AiInlineChatService {
   public readonly _onRegenerate = new Emitter<void>();
   public readonly onRegenerate: Event<void> = this._onRegenerate.event;
 
+  // 点赞点踩
+  public readonly _onThumbs = new Emitter<boolean>();
+  public readonly onThumbs: Event<boolean> = this._onThumbs.event;
+
   public isLoading(): boolean {
     return this._status === EInlineChatStatus.THINKING;
   }

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -8,10 +8,10 @@ export interface CommonLogInfo {
   msgType: AISerivceType;
   message: string;
   isStart: boolean;
+  isLike: boolean;
 }
 
 export interface QuestionInfo extends Partial<CommonLogInfo> {
-  isLike: boolean;
   isRetry: boolean;
   isStop: boolean;
 }

--- a/packages/core-browser/src/style/icon/icon.ts
+++ b/packages/core-browser/src/style/icon/icon.ts
@@ -360,6 +360,7 @@ const codIconId = [
   'three-bars',
   'thumbsdown',
   'thumbsup',
+  'thumbs',
   'tools',
   'triangle-down',
   'triangle-left',

--- a/packages/core-browser/src/style/icon/ide-iconfont.ts
+++ b/packages/core-browser/src/style/icon/ide-iconfont.ts
@@ -1,4 +1,4 @@
-export const IDE_ICONFONT_CN_CSS = '//at.alicdn.com/t/a/font_1432262_twenb9gmgb.css';
+export const IDE_ICONFONT_CN_CSS = '//at.alicdn.com/t/a/font_1432262_bmhbfzjk97g.css';
 
 export const IDE_ICONFONT_CN_JS = IDE_ICONFONT_CN_CSS.replace(/\.css$/, '.js');
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7d5f45</samp>

*  Add a custom component `ChatMoreActions` to allow the user to retry or give feedback on the failed AI messages ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L520-R520))
*  Use the `AiChatService` and the `IAIReporter` services in the `ChatMoreActions` component to get the session id and report the feedback ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-59cb9dbd1d7211f39f3821d16d500b5d99d3a674411c11f0fef37c8c532ec7e7L1-R53))
*  Import the `IAIReporter` interface and the `Thumbs` component in the `Thinking` component to enable the feedback functionality ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6R7), [link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6R14))
*  Pass the `relationId` and the `aiReporter` props to the `Thumbs` component in the `ThinkingResult` component ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6L108-R111))
*  Use the `useInjectable` hook to get the `IAIReporter` service instance in the `ThinkingResult` component ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-ea2d6fe7d1c952022a317b9b61c3b3f9eaa950ea59b6c031e965fc9e70844bb6R74))
*  Modify the `Thumbs` component to use the `relationId` and the `aiReporterService` props to report the feedback and handle the icon changes and the click events ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-c574fbd75361667f708b2506ce2d025d66c0179e5e282b3f8114a73e9c241044L1-R48))
*  Add the `isLike` property to the `CommonLogInfo` interface to simplify the reporting logic ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-d0fd7520ce5cd047ba1beac6d5f5594a0b3d164234bf7191af3c7c6c49a811f7L11-R14))
*  Move the `.bottom_container` style rule out of the `.ai_chat_more_actions_container` rule to make it a global style for the chat components ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L29-R54))
*  Remove the unused `.chat_msg_more_actions` style rule ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L334-L360))
*  Update the icon font constants to include the new icons ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-0df04efccf01ae2b78b5862b4b8a6cab7c871078cd2f9e62e693797625b670deL1-R1))
*  Register the `thumbs` icon name as a valid icon for the `EnhanceIcon` component ([link](https://github.com/opensumi/core/pull/3183/files?diff=unified&w=0#diff-c0bf115d2f5cbdf886c511b93250029cf4f75a6d3985d1ab3c01db199f2b6738R363))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7d5f45</samp>

This pull request adds a feedback feature to the `Thinking` and `ChatMoreActions` components in the AI chat view, allowing the user to report their satisfaction with the AI response using the `Thumbs` component and the `IAIReporter` service. It also refactors some style rules and updates the icon font to include the new icons.
