### PR TITLE
feat: add retry for command

### DIFF
--- a/packages/ai-native/src/browser/ai-reporter.ts
+++ b/packages/ai-native/src/browser/ai-reporter.ts
@@ -55,6 +55,6 @@ export class AIReporter implements IAIReporter {
     };
 
     this.reportInfoCache.set(relationId, reportInfo);
-    this.reporter.point(AI_REPORTER_NAME, data.msgType, reportInfo);
+    this.reporter.point(AI_REPORTER_NAME, data.msgType || reportInfo.msgType, reportInfo);
   }
 }

--- a/packages/ai-native/src/browser/components/ChatMoreActions.tsx
+++ b/packages/ai-native/src/browser/components/ChatMoreActions.tsx
@@ -41,7 +41,7 @@ export const ChatMoreActions = (props: IChatMoreActionsProps) => {
             <div className={styles.reset}>
               {
                 onRetry && (
-                  <EnhanceIcon icon={'refresh'} className={styles.transform}>
+                  <EnhanceIcon icon={'refresh'} className={styles.transform} onClick={onRetry}>
                     <span>重新生成</span>
                   </EnhanceIcon>
                 )


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4942756</samp>

*  Extract user input and AI reply logic into `handleReply` function and memoize it with `React.useCallback` hook ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R197-R205))
* Add `onRetry` parameter to `AIWithCommandReply` function and pass it to `ChatMoreActions` component to enable user to retry generating AI reply ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L212-R220), [link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L536-R555), [link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L549-R566), [link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L577-R594))
* Add `handleCommonRetry` function to handle common retry logic and pass it to `AIWithCommandReply` function as `onRetry` parameter ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L236-R253))
* Move session id update to the beginning of `AIWithCommandReply` function and pass it to `ChatMoreActions` component as `sessionId` prop ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L536-R555), [link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L549-R566), [link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L591))
* Add `onClick` handler to `EnhanceIcon` component in `ChatMoreActions` component to trigger `onRetry` callback ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-59cb9dbd1d7211f39f3821d16d500b5d99d3a674411c11f0fef37c8c532ec7e7L44-R44))
* Modify `messageListData` state update to avoid direct mutation and use spread operator ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L227-R236))
* Add fallback value for `data.msgType` parameter in `AIReporter` class ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-0a5b5a2af6775b809b915bdf1a961b1f6edc479ec129cee1c69c8f0568bc6b16L58-R58))
* Remove unused variable `aiMessage` from `AiChatView` component ([link](https://github.com/opensumi/core/pull/3184/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L175))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4942756</samp>

This pull request enhances the AI chat feature by adding a retry option, refactoring the chat view component, and fixing the message type reporting. It affects the files `ai-chat.view.tsx`, `ai-reporter.ts`, and `ChatMoreActions.tsx` in the `packages/ai-native` folder.
