### PR TITLE
feat: open quickopen when not found command

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -15,7 +15,7 @@ import * as styles from './ai-chat.module.less';
 import { AiChatService } from './ai-chat.service';
 import { AiProjectGenerateService } from './ai-project/generate.service';
 import { AiSumiService } from './ai-sumi/sumi.service';
-import { NOTFOUND_COMMAND } from './common-reponse';
+import { NOTFOUND_COMMAND, ERROR_RESPONSE, NOTFOUND_COMMAND_TIP } from './common-reponse';
 import { CodeBlockWrapper, CodeBlockWrapperInput } from './components/ChatEditor';
 import { ChatInput } from './components/ChatInput';
 import { ChatMoreActions } from './components/ChatMoreActions';
@@ -26,6 +26,7 @@ import { Thinking } from './components/Thinking';
 import { MsgStreamManager, EMsgStreamStatus } from './model/msg-stream-manager';
 import { AiMenubarService } from './override/layout/menu-bar/menu-bar.service';
 import { AiRunService } from './run/run.service';
+
 interface MessageData extends Pick<ITextMessageProps, 'id' | 'position' | 'className' | 'title'> {
   role: 'user' | 'ai';
   relationId: string;
@@ -570,6 +571,7 @@ const AIWithCommandReply = async (
             failedText === NOTFOUND_COMMAND ? (
               <div>
                 <p>{failedText}</p>
+                <p>{NOTFOUND_COMMAND_TIP}</p>
                 <Button onClick={() => opener.open(URI.from({ scheme: 'command', path: QUICK_OPEN_COMMANDS.OPEN.id, query: JSON.stringify([userInput]) }))}>打开命令面板</Button>
               </div>
             ) : failedText

--- a/packages/ai-native/src/browser/common-reponse.ts
+++ b/packages/ai-native/src/browser/common-reponse.ts
@@ -3,4 +3,4 @@ export const ERROR_RESPONSE = '当前与我互动的人太多，请稍后再试�
 
 export const STOP_IMMEDIATELY = '我先不想了，有需要可以随时问我';
 
-export const NOTFOUND_COMMAND = '未找到合适的功能';
+export const NOTFOUND_COMMAND = '很抱歉，暂时未找到可立即执行的命令。你可以打开命令面板搜索相关操作或者重新提问。';

--- a/packages/ai-native/src/browser/common-reponse.ts
+++ b/packages/ai-native/src/browser/common-reponse.ts
@@ -3,4 +3,6 @@ export const ERROR_RESPONSE = '当前与我互动的人太多，请稍后再试�
 
 export const STOP_IMMEDIATELY = '我先不想了，有需要可以随时问我';
 
-export const NOTFOUND_COMMAND = '很抱歉，暂时未找到可立即执行的命令。你可以打开命令面板搜索相关操作或者重新提问。';
+export const NOTFOUND_COMMAND = '很抱歉，暂时未找到可立即执行的命令。';
+
+export const NOTFOUND_COMMAND_TIP = '你可以打开命令面板搜索相关操作或者重新提问。';

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-chat-controller.tsx
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-chat-controller.tsx
@@ -4,6 +4,7 @@ import { useInjectable } from '@opensumi/ide-core-browser';
 import { MenuNode } from '@opensumi/ide-core-browser/lib/menu/next/base';
 import { Emitter } from '@opensumi/ide-core-common';
 
+import { ERROR_RESPONSE } from '../common-reponse';
 import { AILogoAvatar, EnhanceIcon, EnhanceIconWithCtxMenu } from '../components/Icon';
 import { LineVertical } from '../components/lineVertical';
 import { Loading } from '../components/Loading';
@@ -179,7 +180,7 @@ export const AiInlineChatController = (props: IAiInlineChatControllerProps) => {
     if (isError) {
       return (
         <div className={styles.ai_inline_error_result_panel}>
-          <span>当前与我互动的人太多请稍后再试，感谢您的理解与支持</span>
+          <span>{ERROR_RESPONSE}</span>
         </div>
       );
     }

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -465,7 +465,7 @@ export interface QuickPickService {
 
 export const PrefixQuickOpenService = Symbol('PrefixQuickOpenService');
 export interface PrefixQuickOpenService {
-  open(prefix: string): void;
+  open(prefix: string, defaultInput?: string): void;
 }
 
 export const IQuickInputService = Symbol('IQuickInputService');

--- a/packages/quick-open/src/browser/prefix-quick-open.service.ts
+++ b/packages/quick-open/src/browser/prefix-quick-open.service.ts
@@ -161,11 +161,13 @@ export class PrefixQuickOpenServiceImpl implements PrefixQuickOpenService {
 
   private currentLookFor = '';
 
-  open(prefix: string): void {
+  open(prefix: string, defaultInput?: string): void {
     const handler = this.handlers.getHandlerOrDefault(prefix);
     // 恢复同一 tab 上次的输入，连续输入相同的快捷键也可以保留历史输入
     let shouldSelect = false;
-    if (
+    if (defaultInput) {
+      prefix += defaultInput;
+    } else if (
       this.corePreferences['workbench.quickOpen.preserveInput'] &&
       handler &&
       handler === this.currentHandler &&

--- a/packages/quick-open/src/browser/quick-open.contribution.ts
+++ b/packages/quick-open/src/browser/quick-open.contribution.ts
@@ -55,13 +55,13 @@ export class QuickOpenFeatureContribution
 
   registerCommands(commands: CommandRegistry): void {
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN, {
-      execute: () => this.prefixQuickOpenService.open('>'),
+      execute: (defaultInput?: string) => this.prefixQuickOpenService.open('>', defaultInput),
     });
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN_OUTLINE, {
-      execute: () => this.prefixQuickOpenService.open('@'),
+      execute: (defaultInput?: string) => this.prefixQuickOpenService.open('@', defaultInput),
     });
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN_VIEW, {
-      execute: () => this.prefixQuickOpenService.open('view '),
+      execute: (defaultInput?: string) => this.prefixQuickOpenService.open('view ', defaultInput),
     });
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b4af76e</samp>

*  Extend the `PrefixQuickOpenService` interface and the `PrefixQuickOpenServiceImpl` class to support opening the command palette with a default input ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-27adcfe43b78217fabf448b56fdd299f340097f3331147ef3307426ddcf3fa1fL468-R468), [link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-fd905f584c0e9a348395938c5ab99fe0ce623207c124b4d628d7b20fa5ebb28aL164-R170))
*  Register the `QUICK_OPEN_COMMANDS` with the optional `defaultInput` parameter and pass it to the `prefixQuickOpenService.open` method in the `QuickOpenFeatureContribution` class ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-4f73bd6a619ebbf6d7ad5c54cfc01de6d92215b920c3857502d940bd2f26c350L58-R64))
*  Import the `QUICK_OPEN_COMMANDS` constant from `@opensumi/ide-core-browser` and the `NOTFOUND_COMMAND_TIP` constant from `./common-reponse` in the `ai-chat.view.tsx` file ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L6-R6), [link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L18-R18))
*  Modify the `AIWithCommandReply` function call to pass the `userInput.message` as an additional argument and add the `userInput` parameter to the `AIChatRunReply` function signature in the `ai-chat.view.tsx` file ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L221-R222), [link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R550))
*  Conditionally render a different message and a button that opens the command palette with the default input when the `failedText` is equal to `NOTFOUND_COMMAND` in the `ai-chat.view.tsx` file ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L566-R580))
*  Modify the `NOTFOUND_COMMAND` constant to a more polite and informative message and add the `NOTFOUND_COMMAND_TIP` constant to provide guidance on how to use the command palette or rephrase the question in the `common-reponse.ts` file ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-dcbbf86d3b436023c02e3222be6a9eee297e9c3560d2081d2027f7c50dd1e60bL6-R8))
*  Replace the hard-coded error message with the `ERROR_RESPONSE` constant in the `inline-chat-controller.tsx` file ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL182-R183))
*  Add an empty line for code formatting and readability in the `ai-chat.view.tsx` file ([link](https://github.com/opensumi/core/pull/3190/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R29))

<!-- Additional content -->
<!-- 补充额外内容 -->

* 通过 command 打开命令面板增加默认值传递能力
* 找不到相关命令时，增加兜底方案，支持打开命令面板

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b4af76e</samp>

This pull request improves the AI chat feature by adding guidance on how to use the command palette or rephrase the question, displaying a generic error message when the service is unavailable, and enabling the user to open the command palette with a default input suggested by the AI chat. It modifies the `PrefixQuickOpenService` interface and its implementation, the `QuickOpenFeatureContribution` class, and some constants and components in the `ai-native` package.
