### PR TITLE
fix: editor selection hide status bar

### DIFF
--- a/packages/ai-native/src/browser/inline-completions/completeProvider.ts
+++ b/packages/ai-native/src/browser/inline-completions/completeProvider.ts
@@ -266,6 +266,7 @@ export class TypeScriptCompletionsProvider extends WithEventBus implements Provi
         return;
       }
       // clearPromptMessage();
+      this.aiCompletionsService.hideStatusBarItem();
       const selection = editor.monacoEditor.getSelection()!;
       // 判断是否选中区域
       if (selection.startLineNumber !== selection.endLineNumber || selection.startColumn !== selection.endColumn) {

--- a/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.module.less
+++ b/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.module.less
@@ -10,6 +10,7 @@
     width: inherit;
     align-items: center;
     padding: 0 16px;
+    padding-left: 12px;
 
     .left {
       display: flex;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

调整左上角图标样式 & 移动光标时隐藏 inline completion 的 statusbar 状态