### PR TITLE
chore: update component style

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.module.less
+++ b/packages/ai-native/src/browser/ai-chat.module.less
@@ -169,6 +169,7 @@
         }
 
         .chat_message_code {
+          margin-top: 32px;
           max-width: 100%;
         }
       }

--- a/packages/ai-native/src/browser/components/ChatInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatInput.tsx
@@ -268,6 +268,10 @@ export const ChatInput = (props: IChatInputProps) => {
 
     // 报错提示
     if (theme && !value.trim() && !selectCode) {
+      if (theme === InstructionEnum.aiSumiKey) {
+        message.info('很抱歉，您并未输入任何命令，可以试试这么问：/IDE 设置主题');
+        return;
+      }
       message.info('很抱歉，您并未选中或输入任何代码，请先选中或输入代码');
     }
   }, [onSend, value]);
@@ -345,12 +349,12 @@ export const ChatInput = (props: IChatInputProps) => {
   }, [isExpand]);
 
   const resetStatus = (clearExpand?: boolean) => {
-    setWrapperHeight(defaultHeight);
     if (clearExpand) {
       setShowExpand(false);
     }
     setIsExpand(false);
     setTheme('');
+    setWrapperHeight(defaultHeight);
   };
 
   return (

--- a/packages/ai-native/src/browser/components/components.module.less
+++ b/packages/ai-native/src/browser/components/components.module.less
@@ -1,14 +1,13 @@
 // 进度条
 .thinking_container {
   position: relative;
-
+  height: 100%;
   .stop {
     position: absolute;
-    bottom: -33px;
-    width: 100%;
+    bottom: -36px;
     padding-top: 12px;
     // TODO
-    left: -10px;
+    left: -7px;
     width: 105%;
 
     .block {
@@ -36,7 +35,7 @@
   align-items: center;
   flex-direction: row;
   position: absolute;
-  bottom: -39px;
+  bottom: -40px;
   width: 100%;
 
   .reset {
@@ -69,8 +68,8 @@
     align-items: center;
 
     .theme_block {
-      background-color: #34414b;
-      color: #40a6ff;
+      background-color: #6ca9ff1f;
+      color: #6ca9ff;
       border-radius: 6px;
       padding: 2px 8px;
       z-index: 1;
@@ -176,10 +175,7 @@
     :global {
       .kt-input-addon-after {
         align-items: flex-end;
-      }
-
-      .kt-input-addon-before {
-        margin-right: 0;
+        margin-right: 4px;
       }
     }
 
@@ -333,12 +329,12 @@
     }
 
     .tag {
-      color: #669ced;
       border-radius: 6px;
       padding: 2px 8px;
-      background-color: #243753;
       display: inline-block;
-      margin: 4px;
+      margin: 0 4px;
+      background-color: #6ca9ff1f;
+      color: #6ca9ff;
     }
   }
 }
@@ -430,6 +426,64 @@
       border-radius: 4px;
       background-color: #243753;
       margin: 0 2px;
+    }
+  }
+}
+
+.ai_loading {
+  .lds_ellipsis {
+    display: inline-block;
+    position: relative;
+    width: 80px;
+    height: 80px;
+  }
+  .lds_ellipsis div {
+    position: absolute;
+    top: 33px;
+    width: 13px;
+    height: 13px;
+    border-radius: 50%;
+    background: #fff;
+    animation-timing-function: cubic-bezier(0, 1, 1, 0);
+  }
+  .lds_ellipsis div:nth-child(1) {
+    left: 8px;
+    animation: lds-ellipsis1 0.6s infinite;
+  }
+  .lds_ellipsis div:nth-child(2) {
+    left: 8px;
+    animation: lds-ellipsis2 0.6s infinite;
+  }
+  .lds_ellipsis div:nth-child(3) {
+    left: 32px;
+    animation: lds-ellipsis2 0.6s infinite;
+  }
+  .lds_ellipsis div:nth-child(4) {
+    left: 56px;
+    animation: lds-ellipsis3 0.6s infinite;
+  }
+  @keyframes lds-ellipsis1 {
+    0% {
+      transform: scale(0);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  @keyframes lds-ellipsis3 {
+    0% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(0);
+    }
+  }
+  @keyframes lds-ellipsis2 {
+    0% {
+      transform: translate(0, 0);
+    }
+    100% {
+      transform: translate(24px, 0);
     }
   }
 }

--- a/packages/ai-native/src/browser/override/layout/layout.module.less
+++ b/packages/ai-native/src/browser/override/layout/layout.module.less
@@ -57,6 +57,9 @@
 
       div[class*='kt_editor_tab_current___'] {
         background-color: transparent !important;
+        div[class*='close_tab___'] {
+          display: block !important;
+        }
       }
     }
 
@@ -172,13 +175,13 @@
 
   // 搜索输入框样式
   :global {
-    div[class*='search_container___'] {
-      .kt-input-default {
-        background-color: #ffffff14;
-        border-radius: 8px;
-        color: #ffffff40;
-      }
+    // div[class*='search_container___'] {
+    .kt-input-default {
+      background-color: #ffffff14;
+      border-radius: 8px;
+      color: #ffffff40;
     }
+    // }
   }
 }
 
@@ -293,7 +296,7 @@
       display: flex;
       flex-direction: column;
       overflow: hidden;
-      padding-bottom: 40px;
+      padding-bottom: 32px;
     }
 
     .rce-ai-msg {
@@ -325,15 +328,10 @@
 
     .rce-container-mbox {
       overflow: initial;
-      margin: 8px 16px;
+      // margin: 8px 16px;
       min-width: initial;
     }
-    div[class*='chat_message_code'] {
-      margin-top: 30px;
-    }
-    div[class*='chat_message_code']:first-child {
-      margin-top: 8px;
-    }
+
     .rce-user-msg {
       .rce-mbox-right {
         border-radius: 12px 12px 2px 12px;
@@ -348,6 +346,16 @@
       background: var(--vscode-textBlockQuote-background);
       border-color: var(--vscode-textBlockQuote-border);
     }
+  }
+}
+
+:global {
+  .rce-container-mbox {
+    margin: 8px 16px;
+  }
+  // TODO
+  .rce-container-mbox:nth-child(2) {
+    margin-top: 8px !important;
   }
 }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6fb0d2c</samp>

*  Add a margin-top style to the chat message box ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-20edf3fe8e68df44c35112aaac2203a1fad690b093f8e6e77a5957a928b0ec22R172))
*  Import and render SystemMessage and Thinking components to show the AI's thinking status in the chat ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L3-R3), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R24), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R326-R336))
*  Add and update loading2 state variable to track the AI's thinking status separately from the loading status of the message stream ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R74-R75), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L80-R85))
*  Disable ChatInput component when loading or loading2 is true to prevent the user from sending messages while the AI is processing or thinking ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L354-R368))
*  Add loading2 and messageListData as dependencies to the useEffect hook that scrolls to the bottom of the message list ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L161-R164))
*  Set the width of the AIWithCommandReply component to 100% to fit the chat message box ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17R586))
*  Show a hint to the user when they try to send an empty command with the aiSumiKey theme ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154R271-R274))
*  Remove the setWrapperHeight call from the onOptionsClick function and add it to the onOptionsClose function to avoid resetting the height of the input wrapper when the options are toggled ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L348), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154R357))
*  Modify the styles of the thinking_container, stop, thinking_dots, theme_block, kt-input-addon-after, tag and ai_loading classes in the `components.module.less` file to adjust the position, size, appearance and animation of the elements in the chat ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L4-R10), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L39-R38), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L72-R72), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L179-R179), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L336-R337), [link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278R432-R489))
*  Make the close tab button visible in the chat tab ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeR60-R62))
*  Apply the background-color, border-radius and color styles to all the kt-input-default elements in the layout ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL175-R184))
*  Reduce the padding-bottom style of the chat_container class to reduce the space between the chat input and the bottom of the chat tab ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL296-R299))
*  Remove the margin styles from the chat_message_code class to avoid creating extra space between the code messages in the chat ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL328-R334))
*  Set the margin styles for the rce-container-mbox class and its second child to create consistent spacing between the chat messages ([link](https://github.com/opensumi/core/pull/3202/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeR352-R361))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6fb0d2c</samp>

This pull request enhances the chat interface and functionality for the `ai-native` package. It adds new components and animations to show the AI's thinking status and disable the input, fixes some layout and scrolling issues, and updates the styles of various chat elements. It mainly affects the `*.tsx` and `*.less` files in the `ai-native/src/browser` folder.
