### PR TITLE
Feat: registry command for open panel with command

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -588,7 +588,7 @@ const AIWithCommandReply = async (
                   opener.open(
                     URI.from({
                       scheme: 'command',
-                      path: QUICK_OPEN_COMMANDS.OPEN.id,
+                      path: QUICK_OPEN_COMMANDS.OPEN_WITH_COMMAND.id,
                       query: JSON.stringify([userInput]),
                     }),
                   )

--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -1023,6 +1023,9 @@ export namespace QUICK_OPEN_COMMANDS {
   export const OPEN_VIEW: Command = {
     id: 'editor.action.quickView',
   };
+  export const OPEN_WITH_COMMAND: Command = {
+    id: 'editor.action.quickCommand.withCommand',
+  };
 }
 
 export namespace SCM_COMMANDS {

--- a/packages/quick-open/src/browser/quick-open.contribution.ts
+++ b/packages/quick-open/src/browser/quick-open.contribution.ts
@@ -55,13 +55,16 @@ export class QuickOpenFeatureContribution
 
   registerCommands(commands: CommandRegistry): void {
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN, {
-      execute: (defaultInput?: string) => this.prefixQuickOpenService.open('>', defaultInput),
+      execute: () => this.prefixQuickOpenService.open('>'),
     });
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN_OUTLINE, {
-      execute: (defaultInput?: string) => this.prefixQuickOpenService.open('@', defaultInput),
+      execute: () => this.prefixQuickOpenService.open('@'),
     });
     commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN_VIEW, {
-      execute: (defaultInput?: string) => this.prefixQuickOpenService.open('view ', defaultInput),
+      execute: () => this.prefixQuickOpenService.open('view '),
+    });
+    commands.registerCommand(QUICK_OPEN_COMMANDS.OPEN_WITH_COMMAND, {
+      execute: (defaultValue?: string) => this.prefixQuickOpenService.open('>', defaultValue),
     });
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a401df3</samp>

*  Add a new command `OPEN_WITH_COMMAND` to execute a command with a given argument ([link](https://github.com/opensumi/core/pull/3203/files?diff=unified&w=0#diff-a688102e10b7d594a046a44531865122eaa41ed5f4b5bd53eeb7f1f9f499507cR1026-R1028))
*  Modify the `AIWithCommandReply` component to use the new command instead of the `OPEN` command ([link](https://github.com/opensumi/core/pull/3203/files?diff=unified&w=0#diff-afa0c70cc0a1850e60860ad2722243b3ef414e5c88f1c3f6b6804b43bfdd2d17L591-R591))
*  Simplify the other quick open commands by removing the `defaultInput` parameter ([link](https://github.com/opensumi/core/pull/3203/files?diff=unified&w=0#diff-4f73bd6a619ebbf6d7ad5c54cfc01de6d92215b920c3857502d940bd2f26c350L58-R68))
*  Register the new command and the simplified commands in the `quick-open.contribution.ts` file ([link](https://github.com/opensumi/core/pull/3203/files?diff=unified&w=0#diff-4f73bd6a619ebbf6d7ad5c54cfc01de6d92215b920c3857502d940bd2f26c350L58-R68))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a401df3</samp>

This pull request introduces a new `OPEN_WITH_COMMAND` command that allows the user to execute a command with a given input from the AI chat view. It also refactors the quick open commands to remove the `defaultInput` parameter and make them more consistent.
