### PR TITLE
fix:ai native style

### DIFF
--- a/packages/ai-native/src/browser/components/ChatInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatInput.tsx
@@ -21,7 +21,7 @@ const PLACEHOLDER = {
   CODE: '请输入或者粘贴代码',
 };
 
-const VALUE_START_WITH_THEME = /\/(\s?)(ide|explain|comments|test|searchdoc|run|optimize)\s/i;
+const VALUE_START_WITH_THEME = /^\/(\s?)(ide|explain|comments|test|searchdoc|run|optimize)\s/i;
 
 interface IBlockProps {
   icon?: string;
@@ -358,7 +358,7 @@ export const ChatInput = (props: IChatInputProps) => {
   };
 
   return (
-    <div className={styles.chat_input_container}>
+    <div className={cls(styles.chat_input_container, focus ? styles.active : null)}>
       {isShowOptions && (
         <div ref={instructionRef}>
           <InstructionOptions onClick={acquireOptionsCheck} bottom={optionsBottomPosition} />
@@ -401,10 +401,19 @@ export const ChatInput = (props: IChatInputProps) => {
               )}
             >
               <Popover id={`ai_chat_input_send_${uuid(4)}`} title={'Enter 发送'} disable={disabled}>
-                <Icon
-                  className={cls(disabled ? getIcon('more') : getIcon('send1'), styles.send_icon)}
-                  onClick={() => handleSend()}
-                />
+                {disabled ? (
+                  <div className={styles.ai_loading}>
+                    {' '}
+                    <div className={styles.lds_ellipsis}>
+                      <div></div>
+                      <div></div>
+                      <div></div>
+                      <div></div>
+                    </div>
+                  </div>
+                ) : (
+                  <Icon className={cls(getIcon('send1'), styles.send_icon)} onClick={() => handleSend()} />
+                )}
               </Popover>
             </div>
           </div>

--- a/packages/ai-native/src/browser/components/ChatInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatInput.tsx
@@ -251,7 +251,7 @@ export const ChatInput = (props: IChatInputProps) => {
     if (value.trim() && onSend) {
       setValue('');
       onSend(preText + value);
-      isExpand ? resetStatus() : resetStatus(true);
+      resetStatus();
       return;
     }
 
@@ -262,7 +262,7 @@ export const ChatInput = (props: IChatInputProps) => {
         return;
       }
       onSend(preText + ` \`\`\`\n ${selectCode} \n\`\`\``);
-      isExpand ? resetStatus() : resetStatus(true);
+      resetStatus();
       return;
     }
 
@@ -348,13 +348,13 @@ export const ChatInput = (props: IChatInputProps) => {
     }
   }, [isExpand]);
 
-  const resetStatus = (clearExpand?: boolean) => {
-    if (clearExpand) {
-      setShowExpand(false);
-    }
+  const resetStatus = () => {
     setIsExpand(false);
     setTheme('');
-    setWrapperHeight(defaultHeight);
+    setTimeout(() => {
+      setWrapperHeight(defaultHeight);
+      setShowExpand(false);
+    }, 0);
   };
 
   return (
@@ -378,7 +378,7 @@ export const ChatInput = (props: IChatInputProps) => {
         wrapperStyle={{ height: wrapperHeight + 'px' }}
         style={{
           // 2px 额外宽度 否则会有滚动条
-          height: wrapperHeight - 12 + 2 + 'px',
+          height: wrapperHeight - 12 + 'px',
           // maxHeight: wrapperHeight-16 + 'px',
           // minHeight: wrapperHeight-16 + 'px',
         }}

--- a/packages/ai-native/src/browser/components/components.module.less
+++ b/packages/ai-native/src/browser/components/components.module.less
@@ -61,7 +61,11 @@
   background-color: #272d32;
   position: relative;
   border-radius: 8px;
-
+  padding: 1px;
+  &.active {
+    border: 1px solid #363940;
+    padding: 0;
+  }
   .theme_container {
     padding: 8px 12px;
     display: flex;
@@ -171,7 +175,6 @@
     position: relative;
     background-color: #272d32;
     border: none;
-
     :global {
       .kt-input-addon-after {
         align-items: flex-end;
@@ -250,6 +253,7 @@
   position: relative;
   width: 100%;
   font-size: 14px;
+  line-height: 22px;
   .render_text {
     // white-space: pre-wrap;
 
@@ -274,6 +278,7 @@
           // overflow: hidden;
           font-size: 12px;
           padding: 30px 8px 8px 8px;
+          line-height: 18px;
         }
 
         .action_toolbar {
@@ -434,33 +439,33 @@
   .lds_ellipsis {
     display: inline-block;
     position: relative;
-    width: 80px;
-    height: 80px;
+    width: 20px;
+    height: 20px;
   }
   .lds_ellipsis div {
     position: absolute;
-    top: 33px;
-    width: 13px;
-    height: 13px;
+    top: 11px;
+    width: 5px;
+    height: 5px;
     border-radius: 50%;
-    background: #fff;
+    background: #315c99;
     animation-timing-function: cubic-bezier(0, 1, 1, 0);
   }
   .lds_ellipsis div:nth-child(1) {
-    left: 8px;
-    animation: lds-ellipsis1 0.6s infinite;
+    left: 0px;
+    animation: lds-ellipsis1 1s infinite;
   }
   .lds_ellipsis div:nth-child(2) {
-    left: 8px;
-    animation: lds-ellipsis2 0.6s infinite;
+    left: 0px;
+    animation: lds-ellipsis2 1s infinite;
   }
   .lds_ellipsis div:nth-child(3) {
-    left: 32px;
-    animation: lds-ellipsis2 0.6s infinite;
+    left: 8px;
+    animation: lds-ellipsis2 1s infinite;
   }
   .lds_ellipsis div:nth-child(4) {
-    left: 56px;
-    animation: lds-ellipsis3 0.6s infinite;
+    left: 16px;
+    animation: lds-ellipsis3 1s infinite;
   }
   @keyframes lds-ellipsis1 {
     0% {
@@ -483,7 +488,7 @@
       transform: translate(0, 0);
     }
     100% {
-      transform: translate(24px, 0);
+      transform: translate(8px, 0);
     }
   }
 }

--- a/packages/ai-native/src/browser/override/layout/layout.module.less
+++ b/packages/ai-native/src/browser/override/layout/layout.module.less
@@ -58,7 +58,12 @@
       div[class*='kt_editor_tab_current___'] {
         background-color: transparent !important;
         div[class*='close_tab___'] {
-          display: block !important;
+          display: block;
+        }
+      }
+      div[class*='kt_editor_tab_dirty___'] {
+        div[class*='close_tab___'] {
+          display: none;
         }
       }
     }

--- a/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.module.less
+++ b/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.module.less
@@ -97,7 +97,7 @@
           // filter: contrast(0.7);
         }
         &.closed {
-          filter: contrast(0.7);
+          // filter: contrast(0.7);
         }
       }
     }

--- a/packages/ai-native/src/browser/override/layout/override.less
+++ b/packages/ai-native/src/browser/override/layout/override.less
@@ -82,7 +82,7 @@ div[class*='box-panel___'] {
     border: 9px solid transparent;
     top: 100%;
     border-bottom-width: 0;
-    border-top-color: transparent;
+    border-top-color: var(--kt-popover-border);
   }
 }
 

--- a/packages/ai-native/src/browser/override/override.module.less
+++ b/packages/ai-native/src/browser/override/override.module.less
@@ -46,10 +46,6 @@
     background-color: var(--tab-activeBackground);
     color: var(--tab-activeForeground);
 
-    div[class*='close_tab___'] {
-      display: none !important;
-    }
-
     div:first-child {
       &::before {
         filter: grayscale(0);

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -319,6 +319,10 @@
           }
         }
       }
+      &.kt_editor_tab_dirty {
+        // TODO
+        display: flex;
+      }
       &.kt_on_drag_over {
         background-color: var(--editorGroup-dropBackground);
       }

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -373,6 +373,7 @@ export const Tabs = ({ group }: ITabsProps) => {
     <div className={styles.kt_editor_tabs_content} ref={contentRef as any}>
       {group.resources.map((resource, i) => {
         let ref: HTMLDivElement | null;
+        const decoration = resourceService.getResourceDecoration(resource.uri);
         return (
           <div
             draggable={true}
@@ -382,6 +383,7 @@ export const Tabs = ({ group }: ITabsProps) => {
               [styles.last_in_row]: tabMap.get(i),
               [styles.kt_editor_tab_current]: group.currentResource === resource,
               [styles.kt_editor_tab_preview]: group.previewURI && group.previewURI.isEqual(resource.uri),
+              [styles.kt_editor_tab_dirty]: decoration.dirty,
             })}
             style={
               wrapMode && i === group.resources.length - 1


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes


### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ed70db9</samp>

*  Modify the chat input component to improve the command recognition, visibility, and feedback ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L24-R24), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L361-R361), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L404-R416), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L64-R68), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L174), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278R256), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278R281), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L437-R468), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L486-R491))
  * Change the regular expression for matching commands to start with a slash at the beginning of the line ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L24-R24))
  * Add a border effect to the chat input container when it is focused, and align it with the editor tabs ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L361-R361), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L64-R68))
  * Replace the send icon with a loading animation when the chat input is disabled, and adjust the animation style to match the color scheme and size ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f556fbc944b8aa4b7c9802c16f932d05424c52772de818c603ea96910a41b154L404-R416), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L437-R468), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L486-R491))
  * Add padding and line-height properties to the chat input and placeholder elements, to make the text more readable and consistent ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278L174), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278R256), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-5a2dda8e155228f1a3e35dbca86da2f362955b1b23d40e3f1499f5f4f4c73278R281))
* Modify the editor tabs component to show a dirty indicator icon for unsaved files, and hide the close tab button for dirty tabs ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL61-R68), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-2300011e8ef6e7b26b763730af485180eb7f20dcb55baa02f2f893a777ceb9d9L49-L52), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-a92d3c79f3be1ec7533bcb9d276d6cacbd8a6a9df61391c4cfd7fcf805025ce1R322-R325), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-9d7157b3395e32c345a35d95b48014f7244d32eaa8384ea584bcf15955f99078R376), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-9d7157b3395e32c345a35d95b48014f7244d32eaa8384ea584bcf15955f99078R386))
  * Remove the important flag and add a conditional rule to hide the close tab button based on the tab state ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL61-R68), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-2300011e8ef6e7b26b763730af485180eb7f20dcb55baa02f2f893a777ceb9d9L49-L52))
  * Add a display property of flex to the editor tabs that have the dirty state, and show a dirty indicator icon next to the file name ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-a92d3c79f3be1ec7533bcb9d276d6cacbd8a6a9df61391c4cfd7fcf805025ce1R322-R325), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-9d7157b3395e32c345a35d95b48014f7244d32eaa8384ea584bcf15955f99078R386))
  * Get the resource decoration for the tab resource, which contains information about the resource state ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-9d7157b3395e32c345a35d95b48014f7244d32eaa8384ea584bcf15955f99078R376))
* Modify the menu bar and popover components to use variables for the border colors, and remove the contrast effect for the closed menu items ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f152821f0c3df47f04a2033d87eb55c99f206ad2db20995455075fb99302ad9cL100-R100), [link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-a2cdc17c85e603fe7937670d916b135be9269fb6cac302002333f12da511c632L85-R85))
  * Comment out the filter property for the closed menu items, which makes them look grayed out ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-f152821f0c3df47f04a2033d87eb55c99f206ad2db20995455075fb99302ad9cL100-R100))
  * Change the border-top-color property for the popover component to use a variable instead of a hard-coded value ([link](https://github.com/opensumi/core/pull/3206/files?diff=unified&w=0#diff-a2cdc17c85e603fe7937670d916b135be9269fb6cac302002333f12da511c632L85-R85))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ed70db9</samp>

This pull request improves the chat input component and the tab view component in the `ai-native` and `editor` packages. It fixes some issues with the command recognition and the loading indicator in the chat input, and adds a dirty indicator icon for the tabs that have unsaved changes. It also modifies some style rules to make the components more consistent with the application theme and design.
