### PR TITLE
feat: support right panel header render

### DIFF
--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -1,8 +1,10 @@
 import { Injectable, Injector, Provider } from '@opensumi/di';
-import { BrowserModule, URI } from '@opensumi/ide-core-browser';
+import { BrowserModule, URI, View, ViewContainerOptions } from '@opensumi/ide-core-browser';
 import { LAYOUT_VIEW_SIZE } from '@opensumi/ide-core-browser/lib/layout/constants';
 import { IBrowserCtxMenu } from '@opensumi/ide-core-browser/lib/menu/next/renderer/ctxmenu/browser';
 import { IEditorTabService } from '@opensumi/ide-editor/lib/browser';
+import { IMainLayoutService } from '@opensumi/ide-main-layout';
+import { LayoutService } from '@opensumi/ide-main-layout/lib/browser/layout.service';
 import { IMarkerService } from '@opensumi/ide-markers';
 import { Color, IThemeData, IThemeStore, registerColor, RGBA, ThemeContribution } from '@opensumi/ide-theme';
 import { ThemeStore } from '@opensumi/ide-theme/lib/browser/theme-store';
@@ -107,6 +109,21 @@ export class AiNativeModule extends BrowserModule {
       {
         token: IBrowserCtxMenu,
         useClass: AiBrowserCtxMenuService,
+      },
+      {
+        token: IMainLayoutService,
+        useClass: class extends LayoutService {
+          override collectTabbarComponent(
+            views: View[],
+            options: ViewContainerOptions,
+            side: string,
+            Fc?: any,
+          ): string {
+            // AI Native IDE 模式下禁用该功能
+            options.noResize = false;
+            return super.collectTabbarComponent(views, options, side, Fc);
+          }
+        },
       },
     );
 

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-chat.module.less
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-chat.module.less
@@ -41,7 +41,7 @@
   }
 
   .operate_container {
-    > div:nth-child(2) > span {
+    span {
       line-height: 14px;
     }
 

--- a/packages/ai-native/src/browser/override/layout/layout.module.less
+++ b/packages/ai-native/src/browser/override/layout/layout.module.less
@@ -57,10 +57,12 @@
 
       div[class*='kt_editor_tab_current___'] {
         background-color: transparent !important;
+
         div[class*='close_tab___'] {
           display: block;
         }
       }
+
       div[class*='kt_editor_tab_dirty___'] {
         div[class*='close_tab___'] {
           display: none;
@@ -86,6 +88,7 @@
   div[class*='file_tree_node___'] {
     border-radius: 4px;
   }
+
   div[class*='opened_editor_node___'] {
     border-radius: 4px;
   }
@@ -186,6 +189,7 @@
       border-radius: 8px;
       color: #ffffff40;
     }
+
     // }
   }
 }
@@ -213,25 +217,32 @@
     width: 100%;
     height: 32px;
   }
+
   /* 过度方案 */
   div[class*='tab_bar___'] {
     background-color: rgba(255, 255, 255, 0.04);
   }
+
   li[class*='bottom_tab___'] {
     background-color: transparent;
   }
+
   div[class*='panel_title_bar___'] {
     background-color: rgba(255, 255, 255, 0.04);
   }
+
   div[class*='panel_title_bar___']::before {
     content: none;
   }
+
   div[class*='bottom_bar_container___'] {
     border-top: none;
   }
+
   div[class*='item_selected___'] {
     background-color: rgba(21, 27, 33, 1);
   }
+
   div[class*='tab_contents___'] {
     height: 35px;
   }
@@ -242,6 +253,7 @@
 */
 #ai_chat_panel {
   height: 100%;
+
   div[class*='tab_panel___'] {
     &::before {
       content: none;
@@ -358,6 +370,7 @@
   .rce-container-mbox {
     margin: 8px 16px;
   }
+
   // TODO
   .rce-container-mbox:nth-child(2) {
     margin-top: 8px !important;
@@ -368,8 +381,34 @@
 * -------------------------------------------- 原默认右侧视图面板样式 --------------------------------------------
 */
 .ai_right_slot {
+  div[class*='tab_panel___'] {
+    &::before {
+      content: none;
+    }
+  }
+
   background-color: var(--panel-background);
   border: 1px solid var(--sideBar-border);
   border-radius: 12px;
   overflow: hidden;
+  height: 100%;
+
+  .right_slot_container_wrap {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .header {
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-bottom: 1px solid var(--sideBar-border);
+      padding: 0 10px;
+    }
+
+    .container {
+      flex: 1;
+    }
+  }
 }

--- a/packages/extension/src/browser/sumi/contributes/browser-views.ts
+++ b/packages/extension/src/browser/sumi/contributes/browser-views.ts
@@ -134,11 +134,7 @@ export class BrowserViewContributionPoint extends VSCodeContributePoint<KtViewsC
                   priority,
                   expanded,
                   containerId,
-                  /**
-                   * AI Native IDE 模式下禁用该功能
-                   */
-                  noResize: false,
-                  // noResize,
+                  noResize,
                   fromExtension: true,
                   hideTab,
                 },

--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -1,6 +1,6 @@
 import clsx from 'classnames';
 import { observer } from 'mobx-react-lite';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { INJECTOR_TOKEN, Injector } from '@opensumi/di';
 import {
@@ -96,7 +96,10 @@ export const ContainerView: React.FC<{
   component: ComponentRegistryInfo;
   side: string;
   titleMenu: IMenu;
-}> = observer(({ component, titleMenu, side }) => {
+  renderContainerWrap?: React.FC<{
+    children: React.ReactNode;
+  }>;
+}> = observer(({ component, titleMenu, side, renderContainerWrap }) => {
   const ref = React.useRef<HTMLElement | null>();
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const appConfig = useInjectable<AppConfig>(AppConfig);
@@ -121,6 +124,17 @@ export const ContainerView: React.FC<{
     [appConfig],
   );
 
+  const renderContainerWrapFn = useCallback(
+    (node: React.ReactNode) => {
+      if (renderContainerWrap) {
+        return renderContainerWrap({ children: node });
+      }
+
+      return node;
+    },
+    [renderContainerWrap],
+  );
+
   return (
     <div ref={containerRef} className={styles.view_container}>
       {!CustomComponent && (
@@ -139,19 +153,21 @@ export const ContainerView: React.FC<{
       )}
       <div className={styles.container_wrap} ref={(ele) => (ref.current = ele)}>
         <ProgressBar progressModel={indicator.progressModel} />
-        {CustomComponent ? (
-          <ConfigProvider value={appConfig}>
-            <ComponentRenderer
-              initialProps={{ viewState, ...component.options?.initialProps }}
-              Component={CustomComponent}
+        {renderContainerWrapFn(
+          CustomComponent ? (
+            <ConfigProvider value={appConfig}>
+              <ComponentRenderer
+                initialProps={{ viewState, ...component.options?.initialProps }}
+                Component={CustomComponent}
+              />
+            </ConfigProvider>
+          ) : (
+            <AccordionContainer
+              views={component.views}
+              minSize={component.options!.miniSize}
+              containerId={component.options!.containerId}
             />
-          </ConfigProvider>
-        ) : (
-          <AccordionContainer
-            views={component.views}
-            minSize={component.options!.miniSize}
-            containerId={component.options!.containerId}
-          />
+          ),
         )}
       </div>
     </div>

--- a/packages/output/src/browser/output.service.ts
+++ b/packages/output/src/browser/output.service.ts
@@ -112,6 +112,11 @@ export class OutputService extends WithEventBus {
   }
 
   public async initOutputMonacoInstance(container: HTMLDivElement) {
+    // 防止重复初始化
+    if (this.outputEditor) {
+      return;
+    }
+
     this.outputEditor = this.editorCollectionService.createCodeEditor(container, {
       ...getSimpleEditorOptions(),
       lineDecorationsWidth: 20,


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

ai native 模式下 right 面板支持顶部标题渲染，方便用户关闭窗口


<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fea9ad7</samp>

*  Disable the resizing feature of the tabbar components in the AI Native IDE mode by overriding the `collectTabbarComponent` method of the `LayoutService` class and setting the `noResize` option to false ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L2-R7),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746R113-R127))
*  Implement the new design and functionality of the right slot container in the AI Native IDE mode, which includes a header with a title and a close button, and a flexible container for the component views, by replacing the `RightTabRenderer` component with a custom implementation based on the `TabRendererBase` and `BaseTabPanelView` components in the `AiRightTabRenderer` component ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-90469e26eb0516285e24b38ce04e0f323e55c6e072d04a08f5060fe9548b540aL2-R7),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-90469e26eb0516285e24b38ce04e0f323e55c6e072d04a08f5060fe9548b540aL12),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-90469e26eb0516285e24b38ce04e0f323e55c6e072d04a08f5060fe9548b540aL118-R130),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L3-R3),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L99-R102),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548R127-R137),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-d652ee3879080450ea331b5fcba0d0c5d8f2e061b5d65b0dbf207612cb6a8548L142-R170))
*  Improve the user experience and code quality of the left tabbar component in the AI Native IDE mode by replacing the `RenderExtraMenus` component with the `EnhanceIconWithCtxMenu` component, which provides a more consistent and convenient way to render the extra menus for the left tabbar components ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-90469e26eb0516285e24b38ce04e0f323e55c6e072d04a08f5060fe9548b540aL2-R7),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-90469e26eb0516285e24b38ce04e0f323e55c6e072d04a08f5060fe9548b540aL18-R25),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-90469e26eb0516285e24b38ce04e0f323e55c6e072d04a08f5060fe9548b540aL91-R61))
*  Fix a bug or a regression that disabled the resizing feature for the view containers in the normal IDE mode, by restoring the original value of the `noResize` option for the browser view contribution point in the `packages/extension/src/browser/sumi/contributes/browser-views.ts` file ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-ea16e5b7be5101d2c61f17947018b518b6ae28174bfee6ca473ea6bca0d13dc2L137-R137))
*  Prevent the repeated initialization of the `outputEditor` property in the `OutputService` class, which could cause some errors or performance issues, by adding a condition to check if the property is already initialized and returning early if so ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-dd65117b16395985e119e35d3ee2cf418483d799eddc786771156dc56010805bR115-R119))
*  Improve the code style and readability of the CSS code in the `packages/ai-native/src/browser/override/layout/layout.module.less` file, by adding or removing blank lines between different logical blocks of rules ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL60-R65),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeR91),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeR192),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL216-R245),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeR256),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeR373),[link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-1875c4d7be0a81b24cc67dac1fc38b217f34bf500f6fe5c7a0877392ab21f5eeL371-R413))
*  Simplify the CSS selector for the `line-height` property of the span element inside the `.operate_container` class in the `packages/ai-native/src/browser/inline-chat-widget/inline-chat.module.less` file, by removing the unnecessary `> div:nth-child(2)` part ([link](https://github.com/opensumi/core/pull/3208/files?diff=unified&w=0#diff-5d526ac61e5f1f722c03f96f9d38292190a316e85fc738acb2d7761629538191L44-R44))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fea9ad7</samp>

This pull request implements the AI Native IDE mode for the OpenSumi project, which is a special mode that provides a customized layout and functionality for the AI Native extension. It modifies several files in the `packages/ai-native` and `packages/main-layout` directories, and imports some modules and components from `@opensumi/ide-core-browser`. It also fixes a bug in the `packages/extension` directory that affected the resizing feature of the browser view containers, and improves the code style and performance of some CSS and TypeScript files.
