### PR TITLE
refactor: diff editor widget

### DIFF
--- a/packages/ai-native/src/browser/ai-editor.contribution.ts
+++ b/packages/ai-native/src/browser/ai-editor.contribution.ts
@@ -294,7 +294,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
 
         this.aiInlineContentWidget?.setOptions({
           position: {
-            lineNumber: crossSelection.endLineNumber + 1,
+            lineNumber: crossSelection.startLineNumber - 1,
             column: 1,
           },
         });
@@ -319,6 +319,12 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
           }),
           this.aiInlineChatService.onThumbs((isLike: boolean) => {
             this.aiReporter.end(relationId, { isLike });
+          }),
+          this.aiDiffWidget.onMaxLincCount((count) => {
+            requestAnimationFrame(() => {
+              const lineHeight = editor.monacoEditor.getOption(monaco.editor.EditorOption.lineHeight);
+              this.aiInlineContentWidget.offsetTop(lineHeight * count + 12);
+            });
           }),
         ]);
       }

--- a/packages/ai-native/src/browser/ai-editor.contribution.ts
+++ b/packages/ai-native/src/browser/ai-editor.contribution.ts
@@ -285,7 +285,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
 
         editor.monacoEditor.setHiddenAreas([crossSelection], AiDiffWidget._hideId);
 
-        this.aiDiffWidget = this.injector.get(AiDiffWidget, [monacoEditor!, crossCode, answer, model.getLanguageId()]);
+        this.aiDiffWidget = this.injector.get(AiDiffWidget, [monacoEditor!, crossSelection, answer]);
         this.aiDiffWidget.create();
         this.aiDiffWidget.showByLine(
           crossSelection.startLineNumber - 1,
@@ -294,7 +294,7 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
 
         this.aiInlineContentWidget?.setOptions({
           position: {
-            lineNumber: crossSelection.startLineNumber - 1,
+            lineNumber: crossSelection.endLineNumber + 1,
             column: 1,
           },
         });
@@ -322,8 +322,10 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
           }),
           this.aiDiffWidget.onMaxLincCount((count) => {
             requestAnimationFrame(() => {
-              const lineHeight = editor.monacoEditor.getOption(monaco.editor.EditorOption.lineHeight);
-              this.aiInlineContentWidget.offsetTop(lineHeight * count + 12);
+              if (crossSelection.endLineNumber === model.getLineCount()) {
+                const lineHeight = editor.monacoEditor.getOption(monaco.editor.EditorOption.lineHeight);
+                this.aiInlineContentWidget.offsetTop(lineHeight * count + 12);
+              }
             });
           }),
         ]);

--- a/packages/ai-native/src/browser/diff-widget/diff-widget.module.less
+++ b/packages/ai-native/src/browser/diff-widget/diff-widget.module.less
@@ -1,0 +1,15 @@
+.ai_diff_editor_container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  position: relative;
+  overflow: hidden;
+
+  .diff_editor_widget {
+    position: absolute;
+    height: inherit;
+    width: 100%;
+  }
+}

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-content-widget.tsx
@@ -43,6 +43,9 @@ export class AiInlineContentWidget extends Disposable implements IInlineContentW
   private domNode: HTMLElement;
   protected options: ShowAiContentOptions | undefined;
 
+  // 记录最开始时的 top 值
+  private originTop = 0;
+
   private readonly _onClickOperation = new Emitter<EInlineOperation>();
   public readonly onClickOperation: Event<EInlineOperation> = this._onClickOperation.event;
 
@@ -112,7 +115,16 @@ export class AiInlineContentWidget extends Disposable implements IInlineContentW
   hide: (options?: ShowAiContentOptions | undefined) => void = () => {
     this.options = undefined;
     this.editor.removeContentWidget(this);
+    ReactDOM.unmountComponentAtNode(this.getDomNode());
   };
+
+  offsetTop(top: number): void {
+    if (this.originTop === 0) {
+      this.originTop = this.domNode.style.top ? parseInt(this.domNode.style.top, 10) : 0;
+    }
+
+    this.domNode.style.top = `${this.originTop + top}px`;
+  }
 
   getId(): string {
     return AiInlineChatContentWidget;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
- [x] 修复偶现的 inline chat popover 不消失的问题
- [x] 修复当 diff editor widget 显示在编辑器最后一行的时候，inline chat 操作面板被遮挡的问题
- [x] 重构 inline diff widget

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 96e7554</samp>

*  Refactor the diff editor logic to use the monaco service, the standalone model service, the selection range, and the modified value as the input, and to emit the maximum line count as an event ([link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L5-R17), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L23-R27), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L40-R49), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L47-R56), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L56-R104), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L116-R112), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L132-R125), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L169-R152), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L175-R162), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L189-L192), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L215-R197), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L230-R208), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L288-R288))
* Add a new CSS module file to style the diff editor and its container element ([link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-eb6ce0618227e91a590e775d416fd3df8de7ac1d95faded003aec736d7bfe463R1-R15))
* Add a new event listener to the `AiEditorContribution` class to adjust the offset top of the `aiInlineContentWidget` instance when the diff editor has a large height ([link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818R323-R330))
* Add a new property to the `AiInlineContentWidget` class to record the original top value of the widget ([link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8R46-R48))
* Add a new logic of unmounting the React component from the DOM node of the widget in the `AiDiffWidget` class and the `AiInlineContentWidget` class to clean up the DOM and avoid memory leaks ([link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-f5cd68ba72a62a3217e8a63541dc8cb11fc4850826b7168da2617985a2369b09L215-R197), [link](https://github.com/opensumi/core/pull/3212/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L115-R128))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 96e7554</samp>

This pull request enhances the AI editor feature by refactoring the `AiDiffWidget` class to use a simpler input format and a more efficient diff editor creation logic, improving the positioning and memory management of the inline chat and diff widgets, and adding new styles for the diff editor. These changes affect the files `ai-editor.contribution.ts`, `ai-diff-widget.tsx`, `inline-content-widget.tsx`, and `diff-widget.module.less` in the `packages/ai-native/src/browser` folder.
