### PR TITLE
fix: support DirectDebugAdapter debug type

### DIFF
--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -891,6 +891,9 @@ export class DebugSession implements IDebugSession {
 
   public terminated = false;
   async terminate(restart?: boolean): Promise<void> {
+    // Some debug task may not support `initialized` request or failed to send `initialized` request
+    // State should not be DebugState.Initializing in this case
+    this.initialized = true;
     this.cancelAllRequests();
     if (this.lifecycleManagedByParent && this.parentSession) {
       await this.parentSession.terminate(restart);

--- a/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
+++ b/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
@@ -82,9 +82,9 @@ export function connectDebugAdapter(server: vscode.DebugAdapterServer): DebugStr
  */
 export function directDebugAdapter(id: string, da: vscode.DebugAdapter): DebugStreamConnection {
   const server = net
-    .createServer((socket: net.Socket) => {
+    .createServer(() => {
       const session = new DirectDebugAdapter(id, da);
-      session.start(socket as NodeJS.ReadableStream, socket);
+      session.start();
     })
     .listen(0);
   return connectDebugAdapter({ port: (server.address() as net.AddressInfo).port });


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dca5a22</samp>

*  Handle the case where debug tasks may not send the `initialized` request by setting the `initialized` property to `true` in the `DebugSession` class ([link](https://github.com/opensumi/core/pull/3216/files?diff=unified&w=0#diff-1b18fc6136c80057d620a2b903f2ee54151cb0db2846cfd22aea2aef4942c912R894-R896))
  - Import the `Emitter` class from the `@opensumi/ide-core-common` package to create events for the `DirectDebugAdapter` class ([link](https://github.com/opensumi/core/pull/3216/files?diff=unified&w=0#diff-b6b7d5427367c5fbfd89c2d49a7e70918f25c16cfcffbf04c1e97eb028314d3dL4-R4))
  - Implement the `DebugStreamConnection` interface in the `DirectDebugAdapter` class, which requires the `onClose`, `onMessageReceived`, `onError`, `start`, and `stop` properties and methods ([link](https://github.com/opensumi/core/pull/3216/files?diff=unified&w=0#diff-b6b7d5427367c5fbfd89c2d49a7e70918f25c16cfcffbf04c1e97eb028314d3dL18-R44))
  - Remove the unused parameters of the `start` method of the `DirectDebugAdapter` class, which are `channel` and `outStream` ([link](https://github.com/opensumi/core/pull/3216/files?diff=unified&w=0#diff-a229a2a198824dfcb3c29558a9d4074f5fb893df37b25bf788c96242e859bffdL85-R87))

<!-- Additional content -->
<!-- 补充额外内容 -->

close https://github.com/opensumi/core/issues/3158.
### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dca5a22</samp>

This pull request refactors the debug adapter communication and fixes a bug in the debug session initialization. It introduces the `DebugStreamConnection` interface to standardize the communication between the debug adapter and the debug session, and removes unused parameters from the `DirectDebugAdapter` class. It also adds a line of code and a comment to handle the case where the debug adapter does not send the `initialized` request. The affected files are `abstract-debug-adapter-session.ts`, `debug-session.ts`, and `extension-debug-adapter-starter.ts`.
