### PR TITLE
fix: scm module support chinese title #2977

### DIFF
--- a/packages/scm/src/browser/scm-util.ts
+++ b/packages/scm/src/browser/scm-util.ts
@@ -21,7 +21,7 @@ export function getSCMResourceGroupContextValue(resource: ISCMResourceGroup | IS
 
 export function getSCMRepositoryDesc(repository: ISCMRepository) {
   const hasRootUri = repository.provider.rootUri;
-  const title = hasRootUri ? basename(repository.provider.rootUri!.toString()) : repository.provider.label;
+  const title = hasRootUri ? basename(repository.provider.rootUri.path) : repository.provider.label;
 
   const type = hasRootUri ? repository.provider.label : '';
 


### PR DESCRIPTION
### Types
- [ ] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f30e69d</samp>

* Fix bug where SCM repository title shows full URI instead of basename ([link](https://github.com/opensumi/core/pull/3219/files?diff=unified&w=0#diff-e85dd4e3e6c76641e9a06db20ed6c707c675dd8b4a1d19778b951a85def8c5b0L24-R24))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f30e69d</samp>

Fixed SCM repository title bug by using `path` instead of `toString` for `rootUri`. Changed `getSCMRepositoryDesc` function in `packages/scm/src/browser/scm-util.ts`.
