### PR TITLE
fix: esc & inline completion reporter

### DIFF
--- a/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
+++ b/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
@@ -1,0 +1,22 @@
+import { Optional, Injectable, Autowired } from '@opensumi/di';
+import { IContextKeyService, IContextKey, IScopedContextKeyService } from '@opensumi/ide-core-browser';
+import { InlineChatIsVisible, InlineCompletionIsTrigger } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
+import { ContextKeyService } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/browser/contextKeyService';
+import { IContextKeyServiceTarget } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
+
+@Injectable()
+export class AiNativeContextKey {
+  @Autowired(IContextKeyService)
+  private readonly globalContextKeyService: IContextKeyService;
+
+  private _contextKeyService: IScopedContextKeyService | undefined;
+
+  public readonly inlineChatIsVisible: IContextKey<boolean>;
+  public readonly inlineCompletionIsTrigger: IContextKey<boolean>;
+
+  constructor(@Optional() dom?: HTMLElement | IContextKeyServiceTarget | ContextKeyService) {
+    this._contextKeyService = this.globalContextKeyService.createScoped(dom);
+    this.inlineChatIsVisible = InlineChatIsVisible.bind(this._contextKeyService);
+    this.inlineCompletionIsTrigger = InlineCompletionIsTrigger.bind(this._contextKeyService);
+  }
+}

--- a/packages/ai-native/src/common/command.ts
+++ b/packages/ai-native/src/common/command.ts
@@ -24,6 +24,10 @@ export const AI_INLINE_CHAT_VISIBLE = {
   id: 'ai.inline.chat.visible',
 };
 
+export const AI_INLINE_COMPLETION_VISIBLE = {
+  id: 'ai.inline.completion.visible',
+};
+
 export const AI_INLINE_COMPLETION_REPORTET = {
   id: 'ai.inline.completion.reporter',
 };

--- a/packages/core-browser/src/contextkey/ai-native.ts
+++ b/packages/core-browser/src/contextkey/ai-native.ts
@@ -1,0 +1,4 @@
+import { RawContextKey } from '../raw-context-key';
+
+export const InlineChatIsVisible = new RawContextKey('ai.native.inlineChatIsVisible', false);
+export const InlineCompletionIsTrigger = new RawContextKey('ai.native.inlineCompletionIsTrigger', false);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- [x] 修复 esc 快捷键问题
- [x] 修复 inline completion 埋点统计错误问题

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39d46a4</samp>

*  Add `AiNativeContextKey` class to create and bind context keys for inline chat and completion ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-f2c176df9d106fdc6764c1e9186c41b1bb729b45b7561e50883f36f8884d1a95R1-R22))
*  Import and inject `AiNativeContextKey` in `AiInlineContentWidget` and `AiInlineCompletionsProvider` classes ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L4-R4),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8R11),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L37-R45),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8R11),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L230-R250))
*  Update `InlineChatIsVisible` and `InlineCompletionIsTrigger` context keys when inline chat and completion widgets are created, disposed, or triggered ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L107-R115),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8R124),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8R344-R347),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8R362))
*  Add `AI_INLINE_COMPLETION_VISIBLE` command and keybinding to control the visibility of inline completion suggestions ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-b522a979c75faf01e15417d06022d5297aac16f0249464e1a1ff23e17636d42aR27-R30),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794L22-R24),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794R55),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794R313-R323),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794L348-R383))
*  Import and inject `AiInlineCompletionsProvider` and `AiCompletionsService` in `AiNativeCoreContribution` and `AiEditorContribution` classes ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794R65-R66),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-722b0551ba2e73b05b0bb241859e1b4666bc36faf75d4381e41a21b5039c9794R139-R147),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L32-R37),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L66-R68))
*  Register and dispose `AiInlineCompletionsProvider` for the active editor in `AiEditorContribution` class ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L111-L112),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818R117-R118),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L434-R435),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818R451),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L468-R479))
*  Simplify error handling and range calculation in `complete` method of `RequestImp` class ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L111-R121),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8R127),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8R136),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L140-L144),[link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L176-R173))
*  Rename `TypeScriptCompletionsProvider` to `AiInlineCompletionsProvider` and change `multiple` option to `false` ([link](https://github.com/opensumi/core/pull/3221/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L230-R250))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39d46a4</samp>

This pull request enhances the AI editor feature by adding and refactoring the inline completion and chat widgets. It introduces new context keys, commands, and services to manage the visibility and triggers of the widgets. It also fixes some bugs and improves the error handling and range calculation of the inline completion provider.
