### PR TITLE
fix: inline completion inserText

### DIFF
--- a/packages/ai-native/src/browser/ai-editor.contribution.ts
+++ b/packages/ai-native/src/browser/ai-editor.contribution.ts
@@ -477,6 +477,10 @@ export class AiEditorContribution extends Disposable implements IEditorFeatureCo
               context,
               token,
             );
+            this.logger.log(
+              'inline Completions:>>> ',
+              list.items.map((e) => e.insertText),
+            );
             return list;
           },
           freeInlineCompletions(completions: InlineCompletions<InlineCompletion>) {},

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-content-widget.tsx
@@ -44,7 +44,7 @@ export class AiInlineContentWidget extends Disposable implements IInlineContentW
   private readonly aiNativeContextKey: AiNativeContextKey;
 
   allowEditorOverflow?: boolean | undefined = false;
-  suppressMouseDown?: boolean | undefined = false;
+  suppressMouseDown?: boolean | undefined = true;
 
   private domNode: HTMLElement;
   protected options: ShowAiContentOptions | undefined;

--- a/packages/ai-native/src/common/reporter.ts
+++ b/packages/ai-native/src/common/reporter.ts
@@ -37,6 +37,10 @@ export interface RunInfo extends Partial<CommonLogInfo> {
 
 export interface Completion extends Partial<CommonLogInfo> {
   isReceive: boolean;
+  // 是否取消
+  isStop: boolean;
+  // 补全条数
+  completionNum: number;
 }
 
 export type ReportInfo =


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- [x] 修复补全列表为空时的埋点采集问题
- [x] 修复内联补全偶现不显示的问题

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 839b6ca</samp>

*  Add log statement to print the insert text of inline completions for debugging ([link](https://github.com/opensumi/core/pull/3222/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818R480-R483))
*  Prevent mouse down event on inline content widget from propagating to editor to avoid unwanted cursor movements or selections ([link](https://github.com/opensumi/core/pull/3222/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L47-R47))
*  Reorder logic of handling AI service response in `RequestImp` class to check `sessionId` before `isCancel` flag and report completion status with `completionNum` property ([link](https://github.com/opensumi/core/pull/3222/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L115-R139))
*  Report cache usage and set `completionNum` to zero when providing completions from cache in `RequestImp` class ([link](https://github.com/opensumi/core/pull/3222/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8R148))
*  Append text after cursor to insert text of completion and adjust range accordingly in `RequestImp` class to prevent overwriting existing text ([link](https://github.com/opensumi/core/pull/3222/files?diff=unified&w=0#diff-9aa7928e5554ec3678eb646c82f0e4e143766f3240e9cf7c4230baf1d4b8c2e8L164-R190))
*  Add `isStop` and `completionNum` properties to `Completion` interface in `reporter.ts` file to provide more detailed data for AI service reporting and analysis ([link](https://github.com/opensumi/core/pull/3222/files?diff=unified&w=0#diff-d0fd7520ce5cd047ba1beac6d5f5594a0b3d164234bf7191af3c7c6c49a811f7R40-R43))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 839b6ca</samp>

This pull request enhances the inline completions feature of the AI-native package. It fixes a bug with the cancellation logic, adds more properties to the completion report data, adds a log statement for debugging, and improves the mouse interaction with the inline content widget. The changes affect the files `completeProvider.ts`, `ai-editor.contribution.ts`, `inline-content-widget.tsx`, and `reporter.ts`.
