### PR TITLE
fix: to #3224,  Omit display description information

### DIFF
--- a/packages/opened-editor/src/browser/opened-editor-node.tsx
+++ b/packages/opened-editor/src/browser/opened-editor-node.tsx
@@ -110,7 +110,7 @@ export const EditorTreeNode: React.FC<EditorNodeRenderedProps> = ({
   );
 
   const renderDescription = (node: EditorFileGroup | EditorFile) => {
-    if (EditorFileGroup.is(node)) {
+    if (EditorFileGroup.is(node) || (EditorFile.is(node) && node.tooltip === getNodeName(node))) {
       return null;
     }
     return (


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at badc0b8</samp>

*  Prevent showing redundant tooltips for editor files ([link](https://github.com/opensumi/core/pull/3225/files?diff=unified&w=0#diff-8f4f8b84bb2e83a494ec15496ac38165f731809d39abb8f149866910bba57db2L113-R113))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at badc0b8</samp>

Improved editor tab bar UI by hiding tooltips that match file names. Changed `renderDescription` logic in `opened-editor-node.tsx`.
