### PR TITLE
feat: support registerInlineChatFeature api

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.service.ts
+++ b/packages/ai-native/src/browser/ai-chat.service.ts
@@ -15,6 +15,7 @@ import {
 } from '../common';
 
 import { MsgStreamManager } from './model/msg-stream-manager';
+import { AiMenubarService } from './override/layout/menu-bar/menu-bar.service';
 
 export interface IAiSearchResponse extends IAiBackServiceResponse {
   answer?: string;
@@ -38,6 +39,9 @@ export class AiChatService extends Disposable {
   @Autowired(MsgStreamManager)
   private readonly msgStreamManager: MsgStreamManager;
 
+  @Autowired(AiMenubarService)
+  private readonly aiMenubarService: AiMenubarService;
+
   private readonly _onChatMessageLaunch = new Emitter<IChatMessageStructure>();
   public readonly onChatMessageLaunch: Event<IChatMessageStructure> = this._onChatMessageLaunch.event;
 
@@ -57,6 +61,10 @@ export class AiChatService extends Disposable {
   }
 
   public launchChatMessage(data: IChatMessageStructure) {
+    if (this.aiMenubarService.getLatestWidth() !== 0) {
+      this.aiMenubarService.toggleRightPanel();
+    }
+
     this._onChatMessageLaunch.fire(data);
   }
 

--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -7,19 +7,13 @@ import { IMarkerService } from '@opensumi/ide-markers';
 import { Color, IThemeData, IThemeStore, registerColor, RGBA, ThemeContribution } from '@opensumi/ide-theme';
 import { ThemeStore } from '@opensumi/ide-theme/lib/browser/theme-store';
 
-import {
-  AiBackSerivcePath,
-  AiBackSerivceToken,
-  AiNativeContribution,
-  IAiChatService,
-  IAiRunFeatureRegistry,
-  IAIReporter,
-} from '../common';
+import { AiBackSerivcePath, AiBackSerivceToken, IAiChatService, IAIReporter } from '../common';
 
 import { AiChatService } from './ai-chat.service';
 import { AiNativeConfig } from './ai-config';
-import { AiNativeCoreContribution } from './ai-core.contribution';
+import { AiNativeBrowserContribution } from './ai-core.contribution';
 import { AIReporter } from './ai-reporter';
+import { InlineChatFeatureRegistry } from './inline-chat-widget/inline-chat.feature.registry';
 import { AiEditorTabService } from './override/ai-editor-tab.service';
 import { AiMarkerService } from './override/ai-marker.service';
 import { AiBrowserCtxMenuService } from './override/ai-menu.service';
@@ -27,15 +21,20 @@ import { AiChatLayoutConfig, AiTopLayoutConfig } from './override/layout/layout-
 import { AiMenuBarContribution } from './override/layout/menu-bar/menu-bar.contribution';
 import defaultTheme from './override/theme/default-theme';
 import { AiRunFeatureRegistry } from './run/run.feature.registry';
+import { AiNativeCoreContribution, IAiRunFeatureRegistry, IInlineChatFeatureRegistry } from './types';
 
 @Injectable()
 export class AiNativeModule extends BrowserModule {
-  contributionProvider = AiNativeContribution;
+  contributionProvider = AiNativeCoreContribution;
   providers: Provider[] = [
-    AiNativeCoreContribution,
+    AiNativeBrowserContribution,
     {
       token: IAiRunFeatureRegistry,
       useClass: AiRunFeatureRegistry,
+    },
+    {
+      token: IInlineChatFeatureRegistry,
+      useClass: InlineChatFeatureRegistry,
     },
     {
       token: IAiChatService,

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-chat.feature.registry.ts
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-chat.feature.registry.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@opensumi/di';
+import { Disposable, getDebugLogger } from '@opensumi/ide-core-common';
+
+import { IInlineChatFeatureRegistry, InlineChatAction, InlineChatHandler } from '../types';
+
+@Injectable()
+export class InlineChatFeatureRegistry extends Disposable implements IInlineChatFeatureRegistry {
+  private readonly logger = getDebugLogger();
+  private actionsMap: Map<string, InlineChatAction> = new Map();
+  private handlerMap: Map<string, InlineChatHandler> = new Map();
+
+  override dispose() {
+    super.dispose();
+    this.actionsMap.clear();
+    this.handlerMap.clear();
+  }
+
+  public registerInlineChat(operational: InlineChatAction, handler: InlineChatHandler): void {
+    const { id } = operational;
+
+    if (this.actionsMap.has(id)) {
+      this.logger.warn(`InlineChatFeatureRegistry: id ${id} already exists`);
+      return;
+    }
+
+    this.actionsMap.set(id, operational);
+    this.handlerMap.set(id, handler);
+  }
+
+  public getActionButtons(): InlineChatAction[] {
+    return Array.from(this.actionsMap.values()).filter((item) => item.renderType === 'button');
+  }
+
+  public getActionMenus(): InlineChatAction[] {
+    return Array.from(this.actionsMap.values()).filter((item) => item.renderType === 'dropdown');
+  }
+
+  public getHandler(id: string): InlineChatHandler | undefined {
+    return this.handlerMap.get(id);
+  }
+
+  public getAction(id: string): InlineChatAction | undefined {
+    return this.actionsMap.get(id);
+  }
+}

--- a/packages/ai-native/src/browser/inline-chat-widget/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/inline-chat-widget/inline-content-widget.tsx
@@ -10,7 +10,7 @@ import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 import { AiInlineChatContentWidget } from '../../common/index';
 import { AiNativeContextKey } from '../contextkey/ai-native.contextkey.service';
 
-import { AiInlineChatController, EInlineOperation } from './inline-chat-controller';
+import { AiInlineChatController } from './inline-chat-controller';
 import { AiInlineChatService, EInlineChatStatus } from './inline-chat.service';
 
 export interface IInlineContentWidget extends monaco.editor.IContentWidget {
@@ -52,8 +52,8 @@ export class AiInlineContentWidget extends Disposable implements IInlineContentW
   // 记录最开始时的 top 值
   private originTop = 0;
 
-  private readonly _onClickOperation = new Emitter<EInlineOperation>();
-  public readonly onClickOperation: Event<EInlineOperation> = this._onClickOperation.event;
+  private readonly _onClickActions = new Emitter<string>();
+  public readonly onClickActions: Event<string> = this._onClickActions.event;
 
   constructor(private readonly editor: IMonacoCodeEditor) {
     super();
@@ -95,7 +95,7 @@ export class AiInlineContentWidget extends Disposable implements IInlineContentW
   private renderView(): void {
     ReactDOM.render(
       <ConfigProvider value={this.configContext}>
-        <AiInlineChatController onClickOperation={this._onClickOperation} onClose={() => this.dispose()} />
+        <AiInlineChatController onClickActions={this._onClickActions} onClose={() => this.dispose()} />
       </ConfigProvider>,
       this.getDomNode(),
     );

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -1,0 +1,115 @@
+import { CancellationToken, MaybePromise } from '@opensumi/ide-core-common';
+import { IEditor } from '@opensumi/ide-editor/lib/browser';
+
+import { IAiBackService } from '../common/index';
+
+export type InlineChatOperationalRenderType = 'button' | 'dropdown';
+export const enum EditMode {
+  diffEditor = 'diffEditor',
+}
+
+export interface InlineChatAction {
+  /**
+   * 唯一标识的 id
+   */
+  id: string;
+  /**
+   * 用于展示的名称
+   */
+  name: string;
+  /**
+   * hover 上去的 popover 提示
+   */
+  title?: string;
+  renderType?: InlineChatOperationalRenderType;
+  /**
+   * 排序
+   */
+  order?: number;
+}
+
+export class ReplyResponse {
+  constructor(readonly message: string) {}
+}
+
+export class ErrorResponse {
+  constructor(readonly error: any, readonly message?: string) {}
+
+  static is(response: any): boolean {
+    return response instanceof ErrorResponse || (typeof response === 'object' && response.error !== undefined);
+  }
+}
+
+export class CancelResponse {
+  readonly cancellation: boolean = true;
+
+  constructor(readonly message?: string) {}
+
+  static is(response: any): boolean {
+    return response instanceof CancelResponse || (typeof response === 'object' && response.cancellation !== undefined);
+  }
+}
+
+export interface InlineChatHandler {
+  /**
+   * 直接执行 action 的操作，点击后 inline chat 立即消失
+   */
+  execute?: (editor: IEditor) => MaybePromise<void>;
+  /**
+   * 提供 diff editor 的预览策略
+   */
+  providerDiffPreviewStrategy?: (
+    editor: IEditor,
+    cancelToken: CancellationToken,
+  ) => MaybePromise<ReplyResponse | ErrorResponse | CancelResponse>;
+}
+
+export const IInlineChatFeatureRegistry = Symbol('IInlineChatFeatureRegistry');
+
+export interface IInlineChatFeatureRegistry {
+  registerInlineChat(operational: InlineChatAction, handler: InlineChatHandler): void;
+}
+
+export type AiRunHandler = () => MaybePromise<void>;
+export interface IAiRunAnswerComponentProps {
+  input: string;
+}
+
+export const IAiRunFeatureRegistry = Symbol('IAiRunFeatureRegistry');
+
+export interface IAiRunFeatureRegistry {
+  /**
+   * 注册 run 运行的能力
+   */
+  registerRun(handler: AiRunHandler): void;
+  /**
+   * 返回 answer 时渲染的组件
+   */
+  registerAnswerComponent(component: React.FC<IAiRunAnswerComponentProps>): void;
+
+  registerRequest(request: IAiBackService['request']): void;
+
+  registerStreamRequest(streamRequest: IAiBackService['requestStream']): void;
+
+  getRuns(): AiRunHandler[];
+
+  getAnswerComponent(): React.FC<IAiRunAnswerComponentProps> | undefined;
+
+  getRequest(): IAiBackService['request'];
+
+  getStreamRequest(): IAiBackService['requestStream'];
+}
+
+export const AiNativeCoreContribution = Symbol('AiNativeCoreContribution');
+export interface AiNativeCoreContribution {
+  /**
+   * 注册 ai run 的能力
+   * @param registry
+   */
+  registerRunFeature?(registry: IAiRunFeatureRegistry): void;
+  /**
+   * 注册 inline chat
+   * @param registry
+   */
+  registerInlineChatFeature?(registry: IInlineChatFeatureRegistry): void;
+}

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -123,45 +123,6 @@ export enum AISerivceType {
   Completion = 'completion',
 }
 
-export type AiRunHandler = () => MaybePromise<void>;
-export interface IAiRunAnswerComponentProps {
-  input: string;
-}
-
-export const IAiRunFeatureRegistry = Symbol('IAiRunFeatureRegistry');
-
-export interface IAiRunFeatureRegistry {
-  /**
-   * 注册 run 运行的能力
-   */
-  registerRun(handler: AiRunHandler): void;
-  /**
-   * 返回 answer 时渲染的组件
-   */
-  registerAnswerComponent(component: React.FC<IAiRunAnswerComponentProps>): void;
-
-  registerRequest(request: IAiBackService['request']): void;
-
-  registerStreamRequest(streamRequest: IAiBackService['requestStream']): void;
-
-  getRuns(): AiRunHandler[];
-
-  getAnswerComponent(): React.FC<IAiRunAnswerComponentProps> | undefined;
-
-  getRequest(): IAiBackService['request'];
-
-  getStreamRequest(): IAiBackService['requestStream'];
-}
-
-export const AiNativeContribution = Symbol('AiNativeContribution');
-export interface AiNativeContribution {
-  /**
-   * 注册 ai run 的能力
-   * @param registry
-   */
-  registerRunFeature?(registry: IAiRunFeatureRegistry): void;
-}
-
 export enum AiNativeSettingSectionsId {
   INLINE_CHAT_AUTO_VISIBLE = 'inlineChat.auto.visible',
 }

--- a/packages/startup/entry/sample-modules/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native.contribution.ts
@@ -1,9 +1,153 @@
-import { AiNativeContribution as AiNativeCoreContribution, IAiRunFeatureRegistry } from '@opensumi/ide-ai-native';
+import { Autowired } from '@opensumi/di';
+import { AiBackSerivcePath, IAiBackService, InstructionEnum } from '@opensumi/ide-ai-native';
+import { AiChatService } from '@opensumi/ide-ai-native/lib/browser/ai-chat.service';
+import {
+  IAiRunFeatureRegistry,
+  IInlineChatFeatureRegistry,
+  AiNativeCoreContribution,
+  ReplyResponse,
+  ErrorResponse,
+  CancelResponse,
+} from '@opensumi/ide-ai-native/lib/browser/types';
 import { Domain } from '@opensumi/ide-core-browser';
+import { IEditor } from '@opensumi/ide-editor';
+
+enum EInlineOperation {
+  Explain = 'Explain',
+  Comments = 'Comments',
+  Test = 'Test',
+  Optimize = 'Optimize',
+}
 
 @Domain(AiNativeCoreContribution)
 export class AiNativeContribution implements AiNativeCoreContribution {
+  @Autowired(AiChatService)
+  private readonly aiChatService: AiChatService;
+
+  @Autowired(AiBackSerivcePath)
+  private readonly aiBackService: IAiBackService;
+
   registerRunFeature(registry: IAiRunFeatureRegistry) {
     // Not implements
+  }
+
+  private getCrossCode(editor: IEditor): string {
+    const { monacoEditor } = editor;
+    const model = monacoEditor.getModel();
+    if (!model) {
+      return '';
+    }
+
+    const selection = monacoEditor.getSelection();
+
+    if (!selection) {
+      return '';
+    }
+
+    const crossSelection = selection
+      .setStartPosition(selection.startLineNumber, 1)
+      .setEndPosition(selection.endLineNumber, Number.MAX_SAFE_INTEGER);
+    const crossCode = model.getValueInRange(crossSelection);
+    return crossCode;
+  }
+
+  registerInlineChatFeature(registry: IInlineChatFeatureRegistry) {
+    registry.registerInlineChat(
+      {
+        id: 'ai-explain',
+        name: EInlineOperation.Explain,
+        title: '解释代码',
+        renderType: 'button',
+      },
+      {
+        execute: (editor: IEditor) => {
+          const { monacoEditor } = editor;
+          const model = monacoEditor.getModel();
+          if (!model) {
+            return;
+          }
+
+          const crossCode = this.getCrossCode(editor);
+
+          this.aiChatService.launchChatMessage({
+            message: `${InstructionEnum.aiExplainKey}\n\`\`\`${model.getLanguageId()}\n${crossCode}\n\`\`\``,
+            prompt: this.aiChatService.explainCodePrompt(),
+          });
+        },
+      },
+    );
+
+    registry.registerInlineChat(
+      {
+        id: 'ai-comments',
+        name: EInlineOperation.Comments,
+        title: '添加注释',
+        renderType: 'button',
+      },
+      {
+        providerDiffPreviewStrategy: async (editor: IEditor, token) => {
+          const crossCode = this.getCrossCode(editor);
+          const prompt = `为以下代码添加注释: \`\`\`\n ${crossCode}\`\`\`。要求只返回代码结果，不需要解释`;
+
+          const result = await this.aiBackService.request(prompt, {}, token);
+
+          if (result.isCancel) {
+            return new CancelResponse();
+          }
+
+          if (result.errorCode !== 0) {
+            return new ErrorResponse('');
+          }
+
+          return new ReplyResponse(result.data!);
+        },
+      },
+    );
+
+    registry.registerInlineChat(
+      {
+        id: 'ai-test',
+        name: EInlineOperation.Test,
+        title: '生成单测',
+        renderType: 'button',
+      },
+      {
+        execute: (editor: IEditor) => {
+          const crossCode = this.getCrossCode(editor);
+          const prompt = this.aiChatService.generateTestCodePrompt(crossCode);
+
+          this.aiChatService.launchChatMessage({
+            message: prompt,
+            prompt,
+          });
+        },
+      },
+    );
+
+    registry.registerInlineChat(
+      {
+        id: 'ai-optimize',
+        name: EInlineOperation.Optimize,
+        renderType: 'dropdown',
+      },
+      {
+        providerDiffPreviewStrategy: async (editor: IEditor, token) => {
+          const crossCode = this.getCrossCode(editor);
+          const prompt = this.aiChatService.optimzeCodePrompt(crossCode);
+
+          const result = await this.aiBackService.request(prompt, {}, token);
+
+          if (result.isCancel) {
+            return new CancelResponse();
+          }
+
+          if (result.errorCode !== 0) {
+            return new ErrorResponse('');
+          }
+
+          return new ReplyResponse(result.data!);
+        },
+      },
+    );
   }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

- [x] 支持上层注册 inline chat 的能力

api 接口定义
```typescript
export interface AiNativeCoreContribution {
  /**
   * 注册 inline chat
   * @param registry
   */
  registerInlineChatFeature?(registry: IInlineChatFeatureRegistry): void;
}

export interface IInlineChatFeatureRegistry {
  registerInlineChat(operational: InlineChatAction, handler: InlineChatHandler): void;
}

export interface InlineChatHandler {
  /**
   * 直接执行 action 的操作，点击后 inline chat 立即消失
   */
  execute?: (editor: IEditor) => MaybePromise<void>;
  /**
   * 提供 diff editor 的预览策略
   */
  providerDiffPreviewStrategy?: (
    editor: IEditor,
    cancelToken: CancellationToken,
  ) => MaybePromise<ReplyResponse | ErrorResponse | CancelResponse>;
}
```

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f83670f</samp>

*  Refactor the logic of handling inline chat actions and diff preview strategies using the inline chat feature registry and the new types and interfaces defined in the `./types.ts` module ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L225-R385), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL56-R60), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL75-R82), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL142-R135), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL151-R144), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL178-R175), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL211-R204), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-e982bfb28e92e893db1f08d32f572099eeb48d8b0389f7d53a75e04bb3a5d454R1-R45), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L55-R56), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L98-R98), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-7da74f50d6ab937f784f4446a8522aa7be534ddc32cb925e71ce765cc605682aR1-R115), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-858c57776ee1c1059bfbb70b5d4968b9555f362cba1636b7b0e57ba89948e3a2L1-R152))
*  Add a conditional statement to check if the contribution has a `registerInlineChatFeature` method, and if so, calls it with the `inlineChatFeatureRegistry` as an argument in the `initialize` method of the `AiNativeCoreContribution` class ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dR157-R159))
*  Add a provider for the `IInlineChatFeatureRegistry` token that uses the `InlineChatFeatureRegistry` class in the `providers` property of the `AiNativeModule` class ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746R36-R39))
*  Rename the class `AiNativeCoreContribution` to `AiNativeBrowserContribution` in the `./ai-core.contribution.ts` module and use the interface `AiNativeCoreContribution` defined in the `./types.ts` module as the contribution provider ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL87-R81), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L30-R30))
*  Add a conditional statement to check if the latest width of the AI menubar is not zero, and if so, calls the `toggleRightPanel` method of the `AiMenubarService` in the `toggleChat` method of the `AiChatService` class ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R64-R67))
*  Add a conditional statement to check if the `aiNativeConfig.capabilities.supportsAiTerminal` is true, and if so, registers the menu item for `AI_EXPLAIN_TERMINAL_COMMANDS` in the `registerMenus` method of the `AiNativeCoreContribution` class ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL340-R285))
*  Add a conditional statement to check if the `aiNativeConfig.capabilities.supportsOpenSumiDesign` is true, and if so, registers the slot renderers for `AiLeftTabRenderer`, `AiRightTabRenderer`, `AiBottomTabRenderer`, and `AiChatTabRenderer` in the `registerRenderer` method of the `AiNativeCoreContribution` class ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL367-R344))
*  Remove the unused and deprecated commands and dependencies from the `./ai-core.contribution.ts` and `./ai-editor.contribution.ts` modules ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL3), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL9), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL28), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL36-L37), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL104-L112), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL227-L277), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L20-R31), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L44-L46), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L62-L64))
*  Relocate the imports of `AiNativeSettingSectionsId`, `Ai_CHAT_CONTAINER_VIEW_ID`, `InstructionEnum`, `IAIReporter`, `AiBackSerivcePath`, `IAiBackService`, and `AiNativeContextKey` to the `./ai-chat.service.ts` module where they are actually used ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-1b9043cb627d28116d634fb875d1c2e82f87fef940cafad460d44019a6ae96e1R18), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-855c5554d1efefe80055f344730e7791aa5da283fa8a7772d0e620925a7c2f3dL43-R39), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818L20-R31), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-3d40fb4b9a4ffad0c46f70f12c679e890c6964da50b6817809b2adb486be0746L10-R16), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-d17c8714a53d0d51d7718846bf3e77d605688ffcb08bc4988e0dd944001ab24cL15-R22), [link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-1b9bbf5fddc5856a06b8c21c842168b6717ee18ec16ca67d4fb1a422bba980f8L13-R13))
*  Import the `CancellationToken` type from the `@opensumi/ide-core-common` module to the `./ai-editor.contribution.ts` module and use it for the cancel token parameter of the inline chat handler ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-fd75f3cca707171f787f698e5a37b85a530f4892c5b17d2663b12241d6722818R14))
*  Implement the `registerInlineChatFeature` method of the `AiNativeCoreContribution` interface and register some inline chat actions and handlers for the AI chat widget in the `./ai-native.contribution.ts` module ([link](https://github.com/opensumi/core/pull/3230/files?diff=unified&w=0#diff-858c57776ee1c1059bfbb70b5d4968b9555f362cba1636b7b0e57ba89948e3a2L1-R152))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f83670f</samp>

This pull request refactors and enhances the AI native contribution and feature registries, and the AI chat widget. It introduces new types and interfaces in `./types.ts`, a new class in `./inline-chat-widget/inline-chat.feature.registry.ts`, and uses them in various modules. It also integrates the AI chat widget with the `AiMenubarService` and allows hiding the right panel.
