### PR TITLE
style: merge editor style fix

### DIFF
--- a/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/merge-editor.module.less
@@ -8,7 +8,7 @@
     bottom: 0;
     width: 100%;
     padding: 0 50px;
-    padding-bottom: 30px;
+    margin-bottom: 30px;
 
     .actions {
       display: flex;

--- a/packages/preferences/src/browser/preferences.module.less
+++ b/packages/preferences/src/browser/preferences.module.less
@@ -273,7 +273,7 @@
     .preferences_flex_row {
       display: flex;
       align-items: center;
-      justify-content: start;
+      justify-content: flex-start;
     }
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 💄 Style Changes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ffe34b4</samp>

* Fix scroll bar overlap bug in merge editor by changing `padding-bottom` to `margin-bottom` for `.merge-editor` class ([link](https://github.com/opensumi/core/pull/3233/files?diff=unified&w=0#diff-1c44596746fd7ac18b3a6476363c06d222d28b064cf82282d4afd90593a82bfdL11-R11))

<!-- Additional content -->
<!-- 补充额外内容 -->

### Changelog
- style: merge editor bottom action buttons position fix

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ffe34b4</samp>

Fixed a UI bug in the merge editor that caused the content to overlap with the scroll bar. Changed the CSS property `padding-bottom` to `margin-bottom` in `merge-editor.module.less`.
