### PR TITLE
WIP: chore: add log for nsfw watcher

### DIFF
--- a/packages/file-service/src/node/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/recursive/file-service-watcher.ts
@@ -322,6 +322,7 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
     }
 
     for (const event of events) {
+      this.logger.log('NSFW watcher events: ', event.action, event.file || event.newFile || event.oldFile)
       if (event.action === INsfw.actions.RENAMED) {
         const deletedPath = this.resolvePath(event.directory, event.oldFile!);
         if (isIgnored(watcherId, deletedPath)) {


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eda3b85</samp>

*  Add a log statement to the file system watcher server ([link](https://github.com/opensumi/core/pull/3237/files?diff=unified&w=0#diff-b3033e19860cda99bfb03b51dca5ea2fcf6590cb34f6cbfb640891d357f732abR325))

<!-- Additional content -->
<!-- 补充额外内容 -->

#3236 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eda3b85</samp>

Add logging of file system events to `FileSystemWatcherServer`. This helps to track the changes detected by the NSFW library in `packages/file-service`.
