### PR TITLE
fix: restart extProcess on reconnect

### DIFF
--- a/packages/extension/src/browser/extension.contribution.ts
+++ b/packages/extension/src/browser/extension.contribution.ts
@@ -125,6 +125,10 @@ export class ExtensionClientAppContribution implements ClientAppContribution {
      */
     this.extensionNodeClient.disposeClientExtProcess(this.clientId, false);
   }
+  // restart extProcess on reconnect
+  onReconnect() {
+    this.extensionService.restartExtProcess();
+  }
 
   /**
    * 当前客户端 id


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a6b7dde</samp>

* Add a method to restart the extension process on reconnection ([link](https://github.com/opensumi/core/pull/3245/files?diff=unified&w=0#diff-b09f275754e0faf70db5040b3193f1d05e50016f89bcf82907b98bd52f01b85eR128-R131))

<!-- Additional content -->
<!-- 补充额外内容 -->

fix: #3244 

### Changelog

<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a6b7dde</samp>

This change improves the resilience of extensions running in a separate process by restarting them when the client reconnects. It adds a `restartExtensionProcess` method to `ExtensionClientAppContribution` in `extension.contribution.ts`.
