### PR TITLE
chore: remove github copilot for prs supported

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,16 +16,4 @@
 
 ### Background or solution
 
-<!-- Copilot for PRs will automatically generate detailed revisions based on PRs here, and you can add additional content on the end -->
-<!-- Copilot for PRs 会在这里了自动生成基于 PR 的详细修改，可在后面补充进一步内容 -->
-
-copilot:walkthrough
-
-<!-- Additional content -->
-<!-- 补充额外内容 -->
-
 ### Changelog
-
-<!-- Copilot for PRs will automatically generate a PR-based summary here. If you need to modify it, you can remove the following content for modification --><!-- Copilot for PRs 会在这里了自动生成基于 PR 的总结，如需修改，可移除下面内容进行修改 -->
-
-copilot:summary


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

### Changelog

remove github copilot for prs supported