### PR TITLE
style: lint import statement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,8 @@
+const path = require('path');
+
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+rulesDirPlugin.RULES_DIR = path.join(__dirname, 'scripts', 'eslint_rules', 'rules');
+
 module.exports = {
   env: {
     browser: true,
@@ -5,7 +10,7 @@ module.exports = {
     node: true,
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'eslint-plugin-import', 'unused-imports'],
+  plugins: ['@typescript-eslint', 'rulesdir', 'import', 'unused-imports'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -188,5 +193,6 @@ module.exports = {
         ],
       },
     ],
+    'rulesdir/classnames-import-rule': ['error'],
   },
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "url": "git@github.com:opensumi/core.git"
   },
   "devDependencies": {
+    "@ast-grep/napi": "^0.17.1",
     "@opensumi/ide-dev-tool": "workspace:*",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.13",
@@ -109,6 +110,7 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-rulesdir": "^0.2.2",
     "eslint-plugin-unused-imports": "^2.0.0",
     "git-rev-sync": "^3.0.1",
     "got": "^12.1.0",

--- a/packages/comments/src/browser/comments-zone.view.tsx
+++ b/packages/comments/src/browser/comments-zone.view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -81,8 +81,8 @@ const CommentsZone: React.FC<ICommentProps> = observer(({ thread, widget }) => {
   }, []);
 
   return (
-    <div className={clx(thread.options.threadClassName, styles.comment_container)}>
-      <div className={clx(thread.options.threadHeadClassName, styles.head)}>
+    <div className={cls(thread.options.threadClassName, styles.comment_container)}>
+      <div className={cls(thread.options.threadHeadClassName, styles.head)}>
         <div className={styles.review_title}>{threadHeaderTitle}</div>
         <InlineActionBar<ICommentThreadTitle>
           menus={commentThreadTitle}

--- a/packages/components/src/badge/index.tsx
+++ b/packages/components/src/badge/index.tsx
@@ -1,10 +1,10 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import './styles.less';
 
 export const Badge: React.FC<{} & React.HTMLAttributes<HTMLSpanElement>> = ({ className, children, ...restProps }) => (
-  <span className={clx('kt-badge', className)} {...restProps}>
+  <span className={cls('kt-badge', className)} {...restProps}>
     {children}
   </span>
 );

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { Dropdown } from '../dropdown';
@@ -104,7 +104,7 @@ export const Button = React.memo(
     onVisibleChange,
     ...otherProps
   }: ButtonProps<T>): React.ReactElement<ButtonProps<T>> => {
-    const classes = classNames('kt-button', className, {
+    const classes = cls('kt-button', className, {
       [`kt-${type}-button-loading`]: loading,
       [`ghost-${type}-button`]: ghost && !loading && type !== 'link',
       [`${type}-button`]: type,
@@ -112,7 +112,7 @@ export const Button = React.memo(
       ['ghost-button']: ghost && type !== 'link',
       ['block-button']: block,
     });
-    const iconClesses = classNames(className, {
+    const iconClasses = cls(className, {
       ['kt-clickable-icon']: !!onClick,
     });
 
@@ -123,7 +123,7 @@ export const Button = React.memo(
           disabled={disabled}
           icon={icon}
           onClick={loading || disabled ? noop : onClick}
-          className={iconClesses}
+          className={iconClasses}
           iconClass={iconClass}
           {...otherProps}
         />

--- a/packages/components/src/checkbox/index.tsx
+++ b/packages/components/src/checkbox/index.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { warning } from '../utils/warning';
@@ -24,17 +24,18 @@ export const CheckBox: React.FC<
 > = ({ insertClass, className, label, size = 'default', disabled, checked, wrapTabIndex, ...restProps }) => {
   warning(!insertClass, '`insertClass` was deprecated, please use `className` instead');
 
-  const cls = classNames('kt-checkbox', insertClass, className, {
-    'kt-checkbox-large': size === 'large',
-    'kt-checkbox-disabled': disabled,
-  });
-
   const checkboxProps = restProps;
 
   checkboxProps['checked'] = checked ?? false;
 
   return (
-    <label className={cls} tabIndex={wrapTabIndex}>
+    <label
+      className={cls('kt-checkbox', insertClass, className, {
+        'kt-checkbox-large': size === 'large',
+        'kt-checkbox-disabled': disabled,
+      })}
+      tabIndex={wrapTabIndex}
+    >
       <span className='kt-checkbox-lump'>
         <input type='checkbox' disabled={disabled} {...checkboxProps} />
         <span className='kt-checkbox-icon'>

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { Button } from '../button';
@@ -83,7 +83,7 @@ export const Dialog: React.FC<IDialogProps> = ({
           {icon && (
             <div
               style={{ color: icon.color }}
-              className={clx('kt-dialog-icon', getIcon(icon.className) || getContextIcon(icon.className))}
+              className={cls('kt-dialog-icon', getIcon(icon.className) || getContextIcon(icon.className))}
             />
           )}
           <div className={'kt-dialog-content_area'}>
@@ -91,7 +91,7 @@ export const Dialog: React.FC<IDialogProps> = ({
             <span className={'kt-dialog-message'}>{message}</span>
           </div>
           {closable && type !== 'basic' && (
-            <button className={clx('kt-dialog-closex', getIcon('close'))} onClick={onClose}></button>
+            <button className={cls('kt-dialog-closex', getIcon('close'))} onClick={onClose}></button>
           )}
         </div>
         {messageType !== MessageType.Empty && type !== 'basic' && (

--- a/packages/components/src/dropdown/dropdown-button.tsx
+++ b/packages/components/src/dropdown/dropdown-button.tsx
@@ -1,5 +1,5 @@
 import EllipsisOutlined from '@ant-design/icons/EllipsisOutlined';
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
 
 import { Button } from '../button';
@@ -92,7 +92,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
   const [leftButtonToRender, rightButtonToRender] = buttonsRender([leftButton, rightButton]);
 
   return (
-    <div {...restProps} className={classNames(prefixCls, className)}>
+    <div {...restProps} className={cls(prefixCls, className)}>
       {leftButtonToRender}
       <Dropdown {...dropdownProps}>{rightButtonToRender}</Dropdown>
     </div>

--- a/packages/components/src/dropdown/dropdown.tsx
+++ b/packages/components/src/dropdown/dropdown.tsx
@@ -1,5 +1,5 @@
 import RightOutlined from '@ant-design/icons/RightOutlined';
-import classNames from 'classnames';
+import cls from 'classnames';
 import RCDropdown from 'rc-dropdown';
 import React, { PropsWithChildren } from 'react';
 
@@ -113,7 +113,7 @@ export default class Dropdown extends React.Component<PropsWithChildren<DropDown
     const child = React.Children.only(children) as React.ReactElement<any>;
 
     const dropdownTrigger = React.cloneElement(child, {
-      className: classNames(child.props.className, `${prefixCls}-trigger`),
+      className: cls(child.props.className, `${prefixCls}-trigger`),
       disabled,
     });
 

--- a/packages/components/src/icon/icon.tsx
+++ b/packages/components/src/icon/icon.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { defaultIconMap, defaultIconfont } from './iconfont/iconManager';
@@ -116,7 +116,7 @@ const IconBase = function <T>(props: IconProps<T>, ref: React.Ref<HTMLSpanElemen
       title={tooltip}
       onClick={onClick}
       ref={ref}
-      className={clx('kt-icon', iconClx, className, {
+      className={cls('kt-icon', iconClx, className, {
         'kt-icon-loading': loading,
         'kt-icon-disabled': !!disabled,
         [`kt-icon-${size}`]: !!size,

--- a/packages/components/src/icon/iconfont-cn.tsx
+++ b/packages/components/src/icon/iconfont-cn.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { _InternalIcon, IconProps } from './icon';
@@ -90,7 +90,7 @@ export function createFromIconfontCN<T>(options: CustomIconOptions = {}) {
 
       const iconShapeClx = getIconShapeClxList(iconShapeOptions);
       return (
-        <_InternalIcon {...extraCommonProps} {...restProps} className={clx(className, iconShapeClx)} ref={ref}>
+        <_InternalIcon {...extraCommonProps} {...restProps} className={cls(className, iconShapeClx)} ref={ref}>
           {content}
         </_InternalIcon>
       );

--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { Icon } from '../icon';
@@ -187,7 +187,7 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
       return null;
     }
     return (
-      <div className={clx('kt-input-addon', klassName)} {...persistFocusProps}>
+      <div className={cls('kt-input-addon', klassName)} {...persistFocusProps}>
         {React.Children.map(addonNodes, (child) =>
           React.isValidElement(child) ? React.cloneElement(child!, persistFocusProps) : null,
         )}
@@ -195,7 +195,7 @@ export const Input = React.forwardRef<HTMLInputElement, IInputBaseProps>((props,
     );
   };
 
-  const inputClx = clx('kt-input', className, {
+  const inputClx = cls('kt-input', className, {
     [`kt-input-${size}`]: size,
     ['kt-input-disabled']: props.disabled,
   });

--- a/packages/components/src/input/InputNumber.tsx
+++ b/packages/components/src/input/InputNumber.tsx
@@ -1,5 +1,5 @@
 import type { ValueType } from '@rc-component/mini-decimal';
-import clx from 'classnames';
+import cls from 'classnames';
 import type { InputNumberProps as RcInputNumberProps } from 'rc-input-number';
 import RcInputNumber from 'rc-input-number';
 import React from 'react';
@@ -24,7 +24,7 @@ export const InputNumber: React.FC<InputNumberProps> = (props: InputNumberProps)
     }
   };
 
-  const inputClx = clx('kt-input', 'kt-input-number', className, {
+  const inputClx = cls('kt-input', 'kt-input-number', className, {
     [`kt-input-${size}`]: size,
     ['kt-input-disabled']: disabled,
   });

--- a/packages/components/src/input/ValidateInput.tsx
+++ b/packages/components/src/input/ValidateInput.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { IInputBaseProps, Input } from './Input';
@@ -36,7 +36,7 @@ export const ValidateInput = React.forwardRef<HTMLInputElement, ValidateInputPro
       setValidateMessage(validateInfo);
     }, [validateInfo]);
 
-    const validateClx = classNames({
+    const validateClx = cls({
       'validate-error': validateMessage && validateMessage.type === VALIDATE_TYPE.ERROR,
       'validate-warning': validateMessage && validateMessage.type === VALIDATE_TYPE.WARNING,
       'validate-info': validateMessage && validateMessage.type === VALIDATE_TYPE.INFO,
@@ -44,7 +44,7 @@ export const ValidateInput = React.forwardRef<HTMLInputElement, ValidateInputPro
 
     const renderValidateMessage = () => {
       if (validateMessage && validateMessage.message) {
-        return <div className={classNames('validate-message', validateClx, { popup })}>{validateMessage.message}</div>;
+        return <div className={cls('validate-message', validateClx, { popup })}>{validateMessage.message}</div>;
       }
     };
 
@@ -78,11 +78,11 @@ export const ValidateInput = React.forwardRef<HTMLInputElement, ValidateInputPro
     };
 
     return (
-      <div className={classNames('input-box', { popup })}>
+      <div className={cls('input-box', { popup })}>
         <Input
           type={type}
           ref={ref}
-          className={classNames(className, validateMessage, validateClx)}
+          className={cls(className, validateMessage, validateClx)}
           onChange={handleChange}
           {...restProps}
         />

--- a/packages/components/src/menu/index.tsx
+++ b/packages/components/src/menu/index.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import RcMenu, { Divider, ItemGroup } from 'rc-menu';
 import React from 'react';
 import { polyfill } from 'react-lifecycles-compat';
@@ -264,7 +264,7 @@ class InternalMenu extends React.Component<InternalMenuProps, MenuState> {
     const menuOpenMotion = this.getOpenMotionProps(menuMode!);
 
     const prefixCls = customizePrefixCls || 'kt-inner-menu';
-    const menuClassName = classNames(className, {
+    const menuClassName = cls(className, {
       [`${prefixCls}-inline-collapsed`]: this.getInlineCollapsed(),
     });
 

--- a/packages/components/src/modal/Modal.tsx
+++ b/packages/components/src/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import classNames from 'classnames';
+import cls from 'classnames';
 import PropTypes from 'prop-types';
 import Dialog from 'rc-dialog';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
@@ -212,7 +212,7 @@ export default class Modal extends React.Component<PropsWithChildren<ModalProps>
         {...restProps}
         getContainer={getContainer}
         prefixCls={prefixCls}
-        wrapClassName={classNames({ [`${prefixCls}-centered`]: !!centered }, wrapClassName)}
+        wrapClassName={cls({ [`${prefixCls}-centered`]: !!centered }, wrapClassName)}
         footer={footer === undefined ? defaultFooter : footer}
         visible={visible}
         mousePosition={mousePosition}

--- a/packages/components/src/notification/index.tsx
+++ b/packages/components/src/notification/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { IAction } from '@opensumi/ide-core-common';
@@ -37,7 +37,7 @@ export function open<T = string>(
   return new Promise((resolve) => {
     const args: ArgsProps = {
       key,
-      className: clx('kt-notification-wrapper', {
+      className: cls('kt-notification-wrapper', {
         ['kt-notification-info']: type === MessageType.Info,
         ['kt-notification-error']: type === MessageType.Error,
         ['kt-notification-warn']: type === MessageType.Warning,
@@ -50,26 +50,26 @@ export function open<T = string>(
       },
       btn: buttons
         ? buttons.map((button, index) => {
-          const isStringButton = typeof button === 'string';
-          const buttonProps = {
-            className: `${clx('kt-notification-button')}${isStringButton ? '' : button.class}`,
-            ghost: isStringButton ? index === 0 : !button.primary,
-            key: isStringButton ? button : button.id,
-            onClick: () => {
-              resolve(button as any);
+            const isStringButton = typeof button === 'string';
+            const buttonProps = {
+              className: `${cls('kt-notification-button')}${isStringButton ? '' : button.class}`,
+              ghost: isStringButton ? index === 0 : !button.primary,
+              key: isStringButton ? button : button.id,
+              onClick: () => {
+                resolve(button as any);
                 antdNotification.close(key);
                 if (!isStringButton) {
                   button.run();
                 }
-            },
-          };
-          const text = isStringButton ? button : button.label;
-          return (
-            <Button size='small' {...buttonProps}>
-              {text}
-            </Button>
-          );
-        })
+              },
+            };
+            const text = isStringButton ? button : button.label;
+            return (
+              <Button size='small' {...buttonProps}>
+                {text}
+              </Button>
+            );
+          })
         : null,
       message,
       description,

--- a/packages/components/src/overlay/index.tsx
+++ b/packages/components/src/overlay/index.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import React, { PropsWithChildren } from 'react';
 
 import { Modal, ModalProps } from '../modal';
@@ -41,7 +41,7 @@ export const Overlay: React.FC<PropsWithChildren<IOverlayProps>> = ({
     onCancel={onClose}
     title={title}
     getContainer={getContainer}
-    className={clsx('kt-overlay', className)}
+    className={cls('kt-overlay', className)}
     keyboard={keyboard}
     {...restProps}
   >

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import './styles.less';
@@ -175,13 +175,13 @@ export const Popover: React.FC<{
   return (
     <div
       {...Object.assign({}, restProps)}
-      className={clx('kt-popover', insertClass)}
+      className={cls('kt-popover', insertClass)}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <div className={clx(popoverClass || '', 'kt-popover-content', `kt-popover-${position}`)} ref={contentEl} id={id}>
+      <div className={cls(popoverClass || '', 'kt-popover-content', `kt-popover-${position}`)} ref={contentEl} id={id}>
         {title && (
-          <p className={clx('kt-popover-title', titleClassName)}>
+          <p className={cls('kt-popover-title', titleClassName)}>
             {title}
             {action && (
               <Button size='small' type='link' onClick={onClickAction || noop}>

--- a/packages/components/src/recycle-tree/basic/menubar-item.tsx
+++ b/packages/components/src/recycle-tree/basic/menubar-item.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { IBasicTreeMenu } from './types';
@@ -27,7 +27,7 @@ export const BasicMenuItem: React.FC<
   }
   return (
     <div
-      className={clx('basic_menu_item', { ['menu-open']: menuOpen })}
+      className={cls('basic_menu_item', { ['menu-open']: menuOpen })}
       onMouseOver={handleMouseOver}
       onClick={handleMenuItemClick}
     >

--- a/packages/components/src/select/index.tsx
+++ b/packages/components/src/select/index.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import './style.less';
@@ -103,7 +103,7 @@ export const Option: React.FC<
 > = ({ value, children, disabled, onClick, className, ...otherProps }) => (
   <span
     {...otherProps}
-    className={classNames(className, { 'kt-option-disabled': disabled })}
+    className={cls(className, { 'kt-option-disabled': disabled })}
     onClick={() => onClick && !disabled && onClick(value)}
   >
     {children}
@@ -196,7 +196,7 @@ function isDataOptionGroup<T = any>(option: any): option is IDataOptionGroup<T> 
 function defaultOptionRenderer<T>(v: { data: IDataOption<T>; isCurrent: boolean }) {
   return (
     <React.Fragment>
-      {v.data.iconClass ? <div className={classNames(v.data.iconClass, 'kt-select-option-icon')}></div> : undefined}
+      {v.data.iconClass ? <div className={cls(v.data.iconClass, 'kt-select-option-icon')}></div> : undefined}
       {v.data.label}
     </React.Fragment>
   );
@@ -205,7 +205,7 @@ function defaultOptionRenderer<T>(v: { data: IDataOption<T>; isCurrent: boolean 
 function defaultGroupTitleRenderer<T>({ group, index }: { group: IDataOptionGroup<T>; index: number }) {
   return (
     <div key={'header_' + index} className={'kt-select-group-header'}>
-      {group.iconClass ? <div className={classNames(group.iconClass, 'kt-select-option-icon')}></div> : undefined}
+      {group.iconClass ? <div className={cls(group.iconClass, 'kt-select-option-icon')}></div> : undefined}
       <div>{group.groupName}</div>
     </div>
   );
@@ -328,14 +328,14 @@ export function Select<T = string>({
 
   const selected = getSelectedValue();
 
-  const optionsContainerClasses = classNames('kt-select-options', {
+  const optionsContainerClasses = cls('kt-select-options', {
     ['kt-select-options-visible']: open,
     [`kt-select-options-${size}`]: size,
   });
 
   const showWarning = notMatchWarning && selected.notMatch;
 
-  const selectClasses = classNames('kt-select-value', {
+  const selectClasses = cls('kt-select-value', {
     ['kt-select-warning']: showWarning,
     ['kt-select-disabled']: disabled,
     ['kt-select-value-active']: open,
@@ -361,7 +361,7 @@ export function Select<T = string>({
     return (
       <div
         key={`${element.props.value}_${index}`}
-        className={classNames({
+        className={cls({
           ['kt-select-option-select']: value === element.props.value,
         })}
         onMouseEnter={() => onMouseEnter?.(element.props.value, index)}
@@ -448,9 +448,7 @@ export function Select<T = string>({
           <CustomSC data={selected} />
         ) : (
           <React.Fragment>
-            {selected.iconClass ? (
-              <div className={classNames(selected.iconClass, 'kt-select-option-icon')}></div>
-            ) : undefined}
+            {selected.iconClass ? <div className={cls(selected.iconClass, 'kt-select-option-icon')}></div> : undefined}
             <span className={'kt-select-option'}>{selected.label}</span>
           </React.Fragment>
         )}
@@ -461,7 +459,7 @@ export function Select<T = string>({
 
   const renderSearch = () => (
     <input
-      className={classNames('kt-select-search')}
+      className={cls('kt-select-search')}
       onChange={(e) => {
         setSearchInput(e.target.value);
       }}
@@ -472,7 +470,7 @@ export function Select<T = string>({
   );
 
   return (
-    <div className={classNames('kt-select-container', className)} ref={selectRef}>
+    <div className={cls('kt-select-container', className)} ref={selectRef}>
       <div className={selectClasses} onClick={toggleOpen} style={style}>
         {showSearch && open ? renderSearch() : renderSelected()}
       </div>
@@ -558,7 +556,7 @@ export const SelectOptionsList = React.forwardRef(<T,>(props: ISelectOptionsList
     footerComponent: FC,
     emptyComponent: EC,
   } = props;
-  const optionsContainerClasses = classNames(
+  const optionsContainerClasses = cls(
     'kt-select-options',
     {
       [`kt-select-options-${size}`]: true,
@@ -587,7 +585,7 @@ export const SelectOptionsList = React.forwardRef(<T,>(props: ISelectOptionsList
           <Option
             value={index}
             key={index}
-            className={classNames({
+            className={cls({
               ['kt-select-option-select']: isCurrent,
               ['kt-select-option-default']: true,
               ['kt-option-with-check']: renderCheck,

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import './style.less';
@@ -21,14 +21,14 @@ export const Tabs = (props: ITabsProps) => {
   }, []);
 
   return (
-    <div {...restProps} style={style} className={clx('kt-tabs', className, { ['kt-tabs-mini']: mini })}>
+    <div {...restProps} style={style} className={cls('kt-tabs', className, { ['kt-tabs-mini']: mini })}>
       {tabs.map((tabContent, i) => {
         const selectedClassName = i === value ? 'kt-tab-selected' : '';
         if (typeof tabContent === 'string') {
           return (
             <div
               key={i}
-              className={clx('kt-tab', selectedClassName, { ['kt-mini-tab']: mini })}
+              className={cls('kt-tab', selectedClassName, { ['kt-mini-tab']: mini })}
               onClick={onClick.bind(null, i)}
             >
               {tabContent}
@@ -38,7 +38,7 @@ export const Tabs = (props: ITabsProps) => {
         return (
           <div
             key={i}
-            className={clx('kt-custom-tab', selectedClassName, { ['kt-mini-tab']: mini })}
+            className={cls('kt-custom-tab', selectedClassName, { ['kt-mini-tab']: mini })}
             onClick={onClick.bind(null, i)}
           >
             {tabContent}

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -1,4 +1,4 @@
-import cxs from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 import { useEffect, useState, useRef } from 'react';
 
@@ -61,7 +61,7 @@ export const Tooltip: React.FC<{
     <p ref={targetRef} className={'kt-tooltip-wrapper'} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       {children}
       {visible && (
-        <span ref={tooltipRef} className={cxs('kt-tooltip-content')}>
+        <span ref={tooltipRef} className={cls('kt-tooltip-content')}>
           {title}
           <span ref={arrowRef} className={'kt-tooltip-arrow-placeholder'} />
         </span>

--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import React, { useMemo, useState } from 'react';
 
 import { Button, CheckBox, Icon } from '@opensumi/ide-components';
@@ -32,7 +32,7 @@ const MenuAction: React.FC<{
   iconService?: IMenubarIconService;
 }> = ({ data, hasSubmenu, disabled, iconService }) => (
   // 这里遵循 native menu 的原则，保留一个 icon 位置
-  <div className={clsx(styles.menuAction, { [styles.disabled]: disabled, [styles.checked]: data.checked })}>
+  <div className={cls(styles.menuAction, { [styles.disabled]: disabled, [styles.checked]: data.checked })}>
     <div className={styles.icon}>{data.checked ? <Icon icon='check' /> : null}</div>
     <div className={styles.label}>
       {data.label
@@ -236,7 +236,7 @@ const InlineActionWidget: React.FC<
     return (
       <Button
         type={data.icon ? 'icon' : 'link'}
-        className={clsx(styles.iconAction, className, {
+        className={cls(styles.iconAction, className, {
           [styles.disabled]: data.disabled,
           [styles.submenuIconAction]: isSubmenuNode,
         })}
@@ -253,7 +253,7 @@ const InlineActionWidget: React.FC<
   if (data.type === 'checkbox') {
     return (
       <CheckBox
-        className={clsx(className, styles.btnAction)}
+        className={cls(className, styles.btnAction)}
         disabled={data.disabled}
         label={data.label}
         title={title}
@@ -267,7 +267,7 @@ const InlineActionWidget: React.FC<
   return (
     <Button
       loading={loading}
-      className={clsx(className, styles.btnAction)}
+      className={cls(className, styles.btnAction)}
       disabled={data.disabled}
       onClick={handleClick}
       size='small'
@@ -406,7 +406,7 @@ export const TitleActionList: React.FC<
       ) : null;
 
     return (
-      <div className={clsx([styles.titleActions, className])} data-menu-id={menuId}>
+      <div className={cls([styles.titleActions, className])} data-menu-id={menuId}>
         {moreAtFirst && moreAction}
         {primary.map((item) => {
           if (item.id === ComponentMenuItemNode.ID) {
@@ -438,7 +438,7 @@ export const TitleActionList: React.FC<
             <InlineActionWidget
               id={id}
               key={id}
-              className={clsx({ [styles.selected]: item.checked })}
+              className={cls({ [styles.selected]: item.checked })}
               type={type}
               data={item}
               afterClick={afterClick}

--- a/packages/core-browser/src/components/layout/box-panel.tsx
+++ b/packages/core-browser/src/components/layout/box-panel.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { useInjectable } from '../../react-hooks';
@@ -69,14 +69,14 @@ export const BoxPanel: React.FC<{
         }
       }}
       {...restProps}
-      className={clsx(styles['box-panel'], className)}
+      className={cls(styles['box-panel'], className)}
       style={{ flexDirection: Layout.getFlexDirection(direction), zIndex: restProps['z-index'] }}
     >
       {arrayChildren.map((child, index) => (
         <div
           key={index}
           id={child['props']?.['data-wrapper-id']}
-          className={clsx(styles.wrapper, child['props']?.['data-wrapper-class'])}
+          className={cls(styles.wrapper, child['props']?.['data-wrapper-class'])}
           style={
             child['props']
               ? {

--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { IEventBus } from '@opensumi/ide-core-common';
@@ -341,7 +341,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = ({
     <div
       ref={(ele) => (rootRef.current = ele!)}
       {...restProps}
-      className={clsx(styles['split-panel'], className)}
+      className={cls(styles['split-panel'], className)}
       style={{ flexDirection: Layout.getFlexDirection(direction), ...style }}
     >
       {elements}

--- a/packages/core-browser/src/components/resize/resize.tsx
+++ b/packages/core-browser/src/components/resize/resize.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import styles from './resize.module.less';
@@ -373,7 +373,7 @@ export const ResizeHandleHorizontal = (props: ResizeHandleProps) => {
       ref={(e) => {
         ref.current = e;
       }}
-      className={classnames({
+      className={cls({
         [styles['resize-handle-horizontal']]: true,
         [styles['with-color']]: !props.noColor,
         [props.className || '']: true,
@@ -679,7 +679,7 @@ export const ResizeHandleVertical = (props: ResizeHandleProps) => {
   return (
     <div
       ref={(e) => e && (ref.current = e)}
-      className={classnames({
+      className={cls({
         [styles['resize-handle-vertical']]: true,
         [props.className || '']: true,
         [styles['with-color']]: !props.noColor,

--- a/packages/core-browser/src/progress/progress-bar.tsx
+++ b/packages/core-browser/src/progress/progress-bar.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -10,9 +10,9 @@ export const ProgressBar: React.FC<{ progressModel: IProgressModel; className?: 
   ({ progressModel, className }) => {
     const { worked, total, show, fade } = progressModel;
     return (
-      <div className={clsx(className, styles.progressBar, { [styles.hide]: !show }, { [styles.fade]: fade })}>
+      <div className={cls(className, styles.progressBar, { [styles.hide]: !show }, { [styles.fade]: fade })}>
         <div
-          className={clsx(styles.progress, { [styles.infinite]: !total })}
+          className={cls(styles.progress, { [styles.infinite]: !total })}
           style={total ? { width: (worked / total || 0.02) * 100 + '%' } : { width: '2%' }}
         ></div>
       </div>
@@ -28,7 +28,7 @@ export const Progress: React.FC<{
   }
   return (
     <div className={styles.progressBar}>
-      <div className={clsx(styles.progress, styles.infinite)} style={{ width: '2%' }} />
+      <div className={cls(styles.progress, styles.infinite)} style={{ width: '2%' }} />
     </div>
   );
 });

--- a/packages/core-browser/src/services/label-service.ts
+++ b/packages/core-browser/src/services/label-service.ts
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import {
@@ -322,7 +322,7 @@ const getIconClass = (
   // 统一的图标类
   classes.push('icon-label');
   return {
-    iconClass: classnames(classes),
+    iconClass: cls(classes),
     // 对于首次没找到的，添加一个检测新语言注册的 change 事件
     onDidChange: _onDidChange?.event,
   };

--- a/packages/core-browser/src/toolbar/components/button.tsx
+++ b/packages/core-browser/src/toolbar/components/button.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import React, { PropsWithChildren } from 'react';
 import ReactDOM from 'react-dom';
 import ReactDOMClient from 'react-dom/client';
@@ -158,7 +158,7 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
   if (props.inDropDown) {
     buttonElement = (
       <div
-        className={classnames({ 'kt-toolbar-action-btn': true, 'action-btn-in-dropdown': true })}
+        className={cls({ 'kt-toolbar-action-btn': true, 'action-btn-in-dropdown': true })}
         {...bindings}
         {...backgroundBindings}
         ref={ref as any}
@@ -182,7 +182,7 @@ export const ToolbarActionBtn = (props: IToolbarActionBtnProps & IToolbarActionE
       }
       buttonElement = (
         <div
-          className={classnames({
+          className={cls({
             'kt-toolbar-action-btn': true,
             'kt-toolbar-action-btn-button': styles.btnStyle === 'button',
             'kt-toolbar-action-btn-inline': styles.btnStyle !== 'button',

--- a/packages/core-browser/src/toolbar/components/dropdown-button.tsx
+++ b/packages/core-browser/src/toolbar/components/dropdown-button.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import React, { useRef, useEffect, useCallback, useMemo } from 'react';
 
 import { DropdownButton, DropDownProps } from '@opensumi/ide-components';
@@ -32,9 +32,10 @@ export const ToolbarActionDropdownButton = <T,>(
     selectEmitter.current.fire(value);
   }, []);
 
-  const menu = useMemo(() => (
+  const menu = useMemo(
+    () => (
       <Menu
-        className={classnames('kt-menu', style.menu)}
+        className={cls('kt-menu', style.menu)}
         selectable={false}
         motion={{ motionLeave: false, motionEnter: false }}
       >
@@ -44,7 +45,9 @@ export const ToolbarActionDropdownButton = <T,>(
           </Menu.Item>
         ))}
       </Menu>
-    ), []);
+    ),
+    [],
+  );
 
   return (
     <DropdownButton size='small' onClick={() => handleClick(firstOption.value)} overlay={menu} trigger={trigger}>

--- a/packages/core-browser/src/toolbar/components/select.tsx
+++ b/packages/core-browser/src/toolbar/components/select.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import {
@@ -147,7 +147,7 @@ export function ToolbarActionSelect<T>(props: IToolbarActionSelectProps<T> & ITo
     const selectDropDown = <SelectOptionsList {...selectDropDownProps} ref={dropdownRef} />;
     return (
       <div
-        className={classnames({
+        className={cls({
           'kt-toolbar-action-btn': true,
           'action-btn-in-dropdown': true,
           'kt-toolbar-action-select': true,
@@ -158,7 +158,7 @@ export function ToolbarActionSelect<T>(props: IToolbarActionSelectProps<T> & ITo
         }}
       >
         {props.name || findCurrentValueLabel(value)}
-        <div className={classnames('kt-toolbar-action-btn-icon', getIcon('right'), 'kt-toolbar-action-select-right')} />
+        <div className={cls('kt-toolbar-action-btn-icon', getIcon('right'), 'kt-toolbar-action-select-right')} />
 
         {showDropdown ? selectDropDown : null}
       </div>

--- a/packages/core-browser/src/toolbar/toolbar.tsx
+++ b/packages/core-browser/src/toolbar/toolbar.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import throttle from 'lodash/throttle';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -153,7 +153,7 @@ export const ToolbarLocation = (props: IToolbarLocationProps & React.HTMLAttribu
   return (
     <div
       {...props}
-      className={classnames('kt-toolbar-location', props.className)}
+      className={cls('kt-toolbar-location', props.className)}
       id={'toolbar-location-' + location}
       ref={container as any}
       onContextMenu={(event: React.MouseEvent<HTMLElement>) => {

--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React, { CSSProperties } from 'react';
 
 import { Icon } from '@opensumi/ide-components/lib/icon/icon';
@@ -18,7 +18,7 @@ export function transformLabelWithCodicon(
   const ICON_ERROR_REGX = /\$\(([a-z.]+\/)?([a-z-]+)?(~[a-z]+)?\)/gi;
 
   const generateIconStyle = (icon?: string, styleProps?: CSSProperties | string) =>
-    typeof styleProps === 'string' ? { className: clx(icon, styleProps) } : { className: icon, style: styleProps };
+    typeof styleProps === 'string' ? { className: cls(icon, styleProps) } : { className: icon, style: styleProps };
 
   const splitLabel = label.split(SEPERATOR);
   const length = splitLabel.length;

--- a/packages/editor/src/browser/decoration-applier.ts
+++ b/packages/editor/src/browser/decoration-applier.ts
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { Disposable, URI, IEventBus, IMarkdownString } from '@opensumi/ide-core-common';
@@ -210,19 +210,19 @@ function assignModelDecorationOptions(
 
 function assignModelDecorationStyle(target: monaco.editor.IModelDecorationOptions, style: IThemedCssStyle) {
   if (style.className) {
-    target.className = clsx(target.className, style.className);
+    target.className = cls(target.className, style.className);
   }
   if (style.inlineClassName) {
-    target.inlineClassName = clsx(target.inlineClassName, style.inlineClassName);
+    target.inlineClassName = cls(target.inlineClassName, style.inlineClassName);
   }
   if (style.afterContentClassName) {
-    target.afterContentClassName = clsx(target.afterContentClassName, style.afterContentClassName);
+    target.afterContentClassName = cls(target.afterContentClassName, style.afterContentClassName);
   }
   if (style.beforeContentClassName) {
-    target.beforeContentClassName = clsx(target.beforeContentClassName, style.beforeContentClassName);
+    target.beforeContentClassName = cls(target.beforeContentClassName, style.beforeContentClassName);
   }
   if (style.glyphMarginClassName) {
-    target.glyphMarginClassName = clsx(target.glyphMarginClassName, style.glyphMarginClassName);
+    target.glyphMarginClassName = cls(target.glyphMarginClassName, style.glyphMarginClassName);
   }
   if (style.overviewRulerColor) {
     if (target.overviewRuler) {

--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -188,7 +188,7 @@ export const EditorGridView = ({ grid }: { grid: EditorGrid }) => {
     }
     children.push(
       <div
-        className={classnames({
+        className={cls({
           [styles.kt_grid_vertical_child]: grid.splitDirection === SplitDirection.Vertical,
           [styles.kt_grid_horizontal_child]: grid.splitDirection === SplitDirection.Horizontal,
         })}
@@ -203,7 +203,7 @@ export const EditorGridView = ({ grid }: { grid: EditorGrid }) => {
 
   return (
     <div
-      className={classnames({
+      className={cls({
         [styles.kt_grid_vertical]: grid.splitDirection === SplitDirection.Vertical,
         [styles.kt_grid_horizontal]: grid.splitDirection === SplitDirection.Horizontal,
       })}
@@ -365,7 +365,7 @@ export const EditorGroupBody = observer(({ group }: { group: EditorGroup }) => {
     components.push(
       <div
         key={component.uid}
-        className={classnames({
+        className={cls({
           [styles.kt_hidden]: !(group.currentOpenType && group.currentOpenType.componentId === component.uid),
         })}
       >
@@ -449,7 +449,7 @@ export const EditorGroupBody = observer(({ group }: { group: EditorGroup }) => {
       {!editorHasNoTab && <NavigationBar editorGroup={group} />}
       <div className={styles.kt_editor_components}>
         <div
-          className={classnames({
+          className={cls({
             [styles.kt_editor_component]: true,
             [styles.kt_hidden]: !group.currentOpenType || group.currentOpenType.type !== EditorOpenType.component,
           })}
@@ -457,7 +457,7 @@ export const EditorGroupBody = observer(({ group }: { group: EditorGroup }) => {
           {components}
         </div>
         <div
-          className={classnames({
+          className={cls({
             [styles.kt_editor_code_editor]: true,
             [styles.kt_editor_component]: true,
             [styles.kt_hidden]: !group.currentOpenType || group.currentOpenType.type !== EditorOpenType.code,
@@ -465,13 +465,13 @@ export const EditorGroupBody = observer(({ group }: { group: EditorGroup }) => {
           ref={codeEditorRef}
         />
         <div
-          className={classnames(styles.kt_editor_diff_editor, styles.kt_editor_component, {
+          className={cls(styles.kt_editor_diff_editor, styles.kt_editor_component, {
             [styles.kt_hidden]: !group.currentOpenType || group.currentOpenType.type !== EditorOpenType.diff,
           })}
           ref={diffEditorRef}
         />
         <div
-          className={classnames(styles.kt_editor_diff_3_editor, styles.kt_editor_component, {
+          className={cls(styles.kt_editor_diff_3_editor, styles.kt_editor_component, {
             [styles.kt_hidden]: !group.currentOpenType || group.currentOpenType.type !== EditorOpenType.mergeEditor,
           })}
           ref={mergeEditorRef}
@@ -537,7 +537,7 @@ export const ComponentWrapper = ({ component, resource, hidden, ...other }) => {
   return (
     <div
       key={resource.uri.toString()}
-      className={classnames({
+      className={cls({
         [styles.kt_hidden]: hidden,
       })}
     >
@@ -617,7 +617,7 @@ const EditorSideView = ({ side, resource }: { side: EditorSide; resource: IResou
   useDisposable(() => eventBus.on(RegisterEditorSideComponentEvent, forceUpdate), []);
 
   return (
-    <div className={classnames(styles['kt_editor_side_widgets'], styles['kt_editor_side_widgets_' + side])}>
+    <div className={cls(styles['kt_editor_side_widgets'], styles['kt_editor_side_widgets_' + side])}>
       {widgets.map((widget) => {
         const C = widget.component;
         return <C resource={resource} key={widget.id} {...(widget.initialProps || {})}></C>;

--- a/packages/editor/src/browser/navigation.view.tsx
+++ b/packages/editor/src/browser/navigation.view.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import { observable } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React, { useCallback, useEffect, useRef, memo } from 'react';
@@ -169,7 +169,7 @@ export const NavigationMenu = observer(({ model }: { model: NavigationMenuModel 
             <div
               onClick={clickToNavigate || clickToGetChild}
               ref={(el) => (itemRef = el)}
-              className={classnames(styles.navigation_menu_item, {
+              className={cls(styles.navigation_menu_item, {
                 [styles.navigation_menu_item_current]: i === model.initialIndex,
               })}
               key={'menu-' + p.name}

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import React, {
   useEffect,
   useState,
@@ -324,7 +324,7 @@ export const Tabs = ({ group }: ITabsProps) => {
           <div
             draggable={true}
             title={resource.title}
-            className={classnames({
+            className={cls({
               [styles.kt_editor_tab]: true,
               [styles.last_in_row]: tabMap.get(i),
               [styles.kt_editor_tab_current]: group.currentResource === resource,
@@ -387,17 +387,15 @@ export const Tabs = ({ group }: ITabsProps) => {
               e.dataTransfer.setData('uri-source-group', group.name);
             }}
           >
-            <div className={tabsLoadingMap[resource.uri.toString()] ? 'loading_indicator' : classnames(resource.icon)}>
-              {' '}
-            </div>
+            <div className={tabsLoadingMap[resource.uri.toString()] ? 'loading_indicator' : cls(resource.icon)}> </div>
             <div>{resource.name}</div>
             {subname ? <div className={styles.subname}>{subname}</div> : null}
             {decoration.readOnly ? (
-              <span className={classnames(getExternalIcon('lock'), styles.editor_readonly_icon)}></span>
+              <span className={cls(getExternalIcon('lock'), styles.editor_readonly_icon)}></span>
             ) : null}
             <div className={styles.tab_right}>
               <div
-                className={classnames({
+                className={cls({
                   [styles.kt_hidden]: !decoration.dirty,
                   [styles.dirty]: true,
                 })}
@@ -409,7 +407,7 @@ export const Tabs = ({ group }: ITabsProps) => {
                   group.close(resource.uri);
                 }}
               >
-                <div className={classnames(getIcon('close'), styles.kt_editor_close_icon)} />
+                <div className={cls(getIcon('close'), styles.kt_editor_close_icon)} />
               </div>
             </div>
           </div>
@@ -501,7 +499,7 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
     return (
       <div
         ref={ref}
-        className={classnames(styles.editor_actions, className)}
+        className={cls(styles.editor_actions, className)}
         style={{ height: LAYOUT_VIEW_SIZE.EDITOR_TABS_HEIGHT }}
       >
         <InlineMenuBar<URI, IEditorGroup, MaybeNull<URI>>

--- a/packages/extension/src/browser/components/extension-portal-root.tsx
+++ b/packages/extension/src/browser/components/extension-portal-root.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { useInjectable } from '@opensumi/ide-core-browser';
@@ -36,7 +36,7 @@ export const PortalRoot = (props: IPortalRootProps) => {
   return (
     <OriginalComponent
       {...props.otherProps}
-      className={clx(props.otherProps?.className, getThemeTypeSelector(themeType!))}
+      className={cls(props.otherProps?.className, getThemeTypeSelector(themeType!))}
       getContainer={() => {
         const portalRoot = extensionService.getPortalShadowRoot(props.extensionId);
         return portalRoot;

--- a/packages/extension/src/browser/components/walkthroughs-view.tsx
+++ b/packages/extension/src/browser/components/walkthroughs-view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Button, CheckBox } from '@opensumi/ide-components';
@@ -174,7 +174,7 @@ const StepItem: React.FC<{ step: IWalkthroughStep; isExpanded: boolean; onSelect
 
   return (
     <div
-      className={clx(styles.getting_started_step, isExpanded && styles.expanded)}
+      className={cls(styles.getting_started_step, isExpanded && styles.expanded)}
       onClick={() => onSelected(step.id)}
     >
       <div className={styles.checkbox}>

--- a/packages/extension/src/browser/shadowRoot.tsx
+++ b/packages/extension/src/browser/shadowRoot.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React, { useCallback } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -163,7 +163,7 @@ const ShadowRoot = ({
       {shadowRoot && (
         <ShadowContent root={shadowRoot}>
           <div
-            className={clx(getThemeTypeSelector(themeType!), 'shadow-context-wrapper', 'show-file-icons')}
+            className={cls(getThemeTypeSelector(themeType!), 'shadow-context-wrapper', 'show-file-icons')}
             style={{ width: '100%', height: '100%' }}
           >
             {children}

--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -87,7 +87,7 @@ export const TabbarViewBase: React.FC<ITabbarViewProps> = observer(
     });
 
     return (
-      <div className={clsx([styles.tab_bar, className])}>
+      <div className={cls([styles.tab_bar, className])}>
         <div className={styles.bar_content} style={{ flexDirection: Layout.getTabbarDirection(direction) }}>
           {visibleContainers.map((component) => {
             const containerId = component.options?.containerId;
@@ -138,7 +138,7 @@ export const TabbarViewBase: React.FC<ITabbarViewProps> = observer(
                 // 如果设置了可隐藏 Tabbar，那么就不允许点击 tab 时隐藏整个 panel 了 通过设置 forbidCollapse 来阻止这个动作
                 onClick={(e) => handleTabClick(e, willHideTabbar || forbidCollapse)}
                 ref={(el) => (ref = el)}
-                className={clsx({ active: currentContainerId === containerId }, tabClassName)}
+                className={cls({ active: currentContainerId === containerId }, tabClassName)}
               >
                 <TabView component={component} />
               </li>
@@ -180,7 +180,7 @@ export const IconTabView: React.FC<{ component: ComponentRegistryInfo }> = obser
 
   return (
     <div className={styles.icon_tab}>
-      <div className={clsx(component.options?.iconClass, 'activity-icon')} title={title}></div>
+      <div className={cls(component.options?.iconClass, 'activity-icon')} title={title}></div>
       {inProgress ? (
         <Badge className={styles.tab_badge}>
           <span className={styles.icon_wrapper}>
@@ -212,7 +212,7 @@ export const TextTabView: React.FC<{ component: ComponentRegistryInfo }> = obser
 export const IconElipses: React.FC = () => (
   <div className={styles.icon_tab}>
     {/* i18n */}
-    <div className={clsx(getIcon('ellipsis'), 'activity-icon')} title='extra tabs'></div>
+    <div className={cls(getIcon('ellipsis'), 'activity-icon')} title='extra tabs'></div>
   </div>
 );
 
@@ -259,7 +259,7 @@ export const LeftTabbarRenderer: React.FC = () => {
       className={styles.left_tab_bar}
       onContextMenu={tabbarService.handleContextMenu}
     >
-      <InlineMenuBar className={clsx(styles.vertical_icons, styles.extra_top_menus)} menus={extraTopMenus} />
+      <InlineMenuBar className={cls(styles.vertical_icons, styles.extra_top_menus)} menus={extraTopMenus} />
       <TabbarViewBase
         tabSize={48}
         MoreTabView={IconElipses}
@@ -282,7 +282,7 @@ export const BottomTabbarRenderer: React.FC = () => {
     <div
       id={VIEW_CONTAINERS.BOTTOM_TABBAR}
       onContextMenu={tabbarService.handleContextMenu}
-      className={clsx(styles.bottom_bar_container, 'next_bottom_bar')}
+      className={cls(styles.bottom_bar_container, 'next_bottom_bar')}
     >
       <TabbarViewBase
         // TODO: 暂时通过预估值来计算是否超出可视范围，实际上需要通过dom尺寸的计算

--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -56,7 +56,7 @@ export const BaseTabPanelView: React.FC<IBaseTabPanelView> = observer(({ PanelVi
   return (
     <div
       id={id}
-      className={clsx(styles.tab_panel, {
+      className={cls(styles.tab_panel, {
         [styles.tab_panel_hidden]: !currentContainerId,
       })}
     >
@@ -69,7 +69,7 @@ export const BaseTabPanelView: React.FC<IBaseTabPanelView> = observer(({ PanelVi
         return (
           <div
             key={containerId}
-            className={clsx(styles.panel_wrap, containerId) /* @deprecated: query by data-viewlet-id */}
+            className={cls(styles.panel_wrap, containerId) /* @deprecated: query by data-viewlet-id */}
             data-viewlet-id={containerId}
             style={currentContainerId === containerId ? panelVisible : panelInVisible}
             id={id}

--- a/packages/main-layout/src/browser/tabbar/renderer.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/renderer.view.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { ComponentRegistryInfo, useInjectable, IEventBus, ResizeEvent } from '@opensumi/ide-core-browser';
@@ -66,7 +66,7 @@ export const TabRendererBase: React.FC<{
     <div
       ref={rootRef}
       id={id}
-      className={clsx(styles.tab_container, className)}
+      className={cls(styles.tab_container, className)}
       style={{ flexDirection: Layout.getFlexDirection(direction) }}
     >
       <TabbarConfig.Provider value={{ side, direction, fullSize }}>
@@ -88,7 +88,7 @@ export const RightTabRenderer = ({
     side='right'
     direction='right-to-left'
     id={VIEW_CONTAINERS.RIGHT_TABBAR}
-    className={clsx(className, 'right-slot')}
+    className={cls(className, 'right-slot')}
     components={components}
     TabbarView={RightTabbarRenderer}
     TabpanelView={RightTabPanelRenderer}
@@ -106,7 +106,7 @@ export const LeftTabRenderer = ({
     side='left'
     direction='left-to-right'
     id={VIEW_CONTAINERS.LEFT_TABBAR_PANEL}
-    className={clsx(className, 'left-slot')}
+    className={cls(className, 'left-slot')}
     components={components}
     TabbarView={LeftTabbarRenderer}
     TabpanelView={LeftTabPanelRenderer}
@@ -124,7 +124,7 @@ export const BottomTabRenderer = ({
     side='bottom'
     id={VIEW_CONTAINERS.BOTTOM_TABBAR_PANEL}
     direction='bottom-to-top'
-    className={clsx(className, 'bottom-slot')}
+    className={cls(className, 'bottom-slot')}
     components={components}
     TabbarView={BottomTabbarRenderer}
     TabpanelView={BottomTabPanelRenderer}

--- a/packages/main-layout/src/browser/welcome.view.tsx
+++ b/packages/main-layout/src/browser/welcome.view.tsx
@@ -1,4 +1,4 @@
-import clsx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { Button } from '@opensumi/ide-components/lib/button';
@@ -105,7 +105,7 @@ const WelcomeContent = (props: { contents: IViewContentDescriptor[] }) => {
                 return (
                   <a
                     key={idx}
-                    className={clsx({ disabled: node.href.startsWith('command:') && disables[index] === false })}
+                    className={cls({ disabled: node.href.startsWith('command:') && disables[index] === false })}
                     title={node.title}
                     onClick={() => openerService.open(node.href)}
                   >

--- a/packages/menu-bar/src/browser/menu-bar.view.tsx
+++ b/packages/menu-bar/src/browser/menu-bar.view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -66,7 +66,7 @@ const MenubarItem = observer<
       trigger={focusMode ? ['click', 'hover'] : ['click']}
     >
       <div
-        className={clx(styles.menubar, { [styles['menu-open']]: menuOpen })}
+        className={cls(styles.menubar, { [styles['menu-open']]: menuOpen })}
         onMouseOver={handleMouseOver}
         onClick={handleMenubarItemClick}
       >
@@ -136,7 +136,7 @@ MenuBar.displayName = 'MenuBar';
 type MenuBarMixToolbarActionProps = Pick<React.HTMLProps<HTMLElement>, 'className'>;
 
 export const MenuBarMixToolbarAction: React.FC<MenuBarMixToolbarActionProps> = (props) => (
-  <div className={clx(styles.menubarWrapper, props.className)}>
+  <div className={cls(styles.menubarWrapper, props.className)}>
     <MenuBar />
     <SlotRenderer slot='action' flex={1} overflow={'initial'} />
   </div>

--- a/packages/menu-bar/src/browser/toolbar-action.view.tsx
+++ b/packages/menu-bar/src/browser/toolbar-action.view.tsx
@@ -1,11 +1,10 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { ToolbarLocation } from '@opensumi/ide-core-browser';
 
 import styles from './toolbar-action.module.less';
-
 
 // const ActionGroup = observer(({ group, id }: { group: IToolbarActionGroup; id: string }) => {
 //   return (<div className={styles.actionGroup} key={id}>
@@ -38,8 +37,8 @@ export const ToolbarAction = observer(() => (
     <ToolbarLocation
       location='menu-left'
       preferences={{ noDropDown: true }}
-      className={classnames(styles.toolbarActions, styles.toolbarActionsLeft)}
+      className={cls(styles.toolbarActions, styles.toolbarActionsLeft)}
     />
-    <ToolbarLocation location='menu-right' className={classnames(styles.toolbarActions, styles.toolbarActionsRight)} />
+    <ToolbarLocation location='menu-right' className={cls(styles.toolbarActions, styles.toolbarActionsRight)} />
   </div>
 ));

--- a/packages/preferences/src/browser/preferenceItem.view.tsx
+++ b/packages/preferences/src/browser/preferenceItem.view.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames';
+import cls from 'classnames';
 import debounce from 'lodash/debounce';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -131,7 +131,7 @@ export const NextPreferenceItem = ({
   if (!renderSchema) {
     return (
       <div
-        className={classnames({
+        className={cls({
           [styles.preference_item]: true,
         })}
       >
@@ -201,7 +201,7 @@ export const NextPreferenceItem = ({
 
   return (
     <div
-      className={classnames({
+      className={cls({
         [styles.preference_item]: true,
         [styles.modified]: isModified,
       })}
@@ -348,7 +348,7 @@ const SettingStatus = ({
       ) : undefined}
       {showReset ? (
         <span
-          className={classnames(styles.preference_reset, getIcon('rollback'))}
+          className={cls(styles.preference_reset, getIcon('rollback'))}
           onClick={() => {
             settingsService.reset(preferenceName, scope);
           }}
@@ -398,7 +398,7 @@ function InputPreferenceItem({
 
   return (
     <>
-      <div className={classnames(styles.key, styles.item)}>
+      <div className={cls(styles.key, styles.item)}>
         {localizedName}{' '}
         <SettingStatus
           preferenceName={preferenceName}
@@ -451,7 +451,7 @@ function CheckboxPreferenceItem({
 
   return (
     <>
-      <div className={classnames(styles.key)}>
+      <div className={cls(styles.key)}>
         {localizedName}{' '}
         <SettingStatus
           preferenceName={preferenceName}
@@ -696,7 +696,7 @@ function StringArrayPreferenceItem({
               onClick={() => {
                 editItem(idx);
               }}
-              className={classnames(getIcon('edit'), styles.array_item)}
+              className={cls(getIcon('edit'), styles.array_item)}
             ></Button>
             <Button
               type='icon'
@@ -704,7 +704,7 @@ function StringArrayPreferenceItem({
               onClick={() => {
                 removeItem(idx);
               }}
-              className={classnames(getIcon('delete'), styles.array_item)}
+              className={cls(getIcon('delete'), styles.array_item)}
             ></Button>
           </div>
         </li>

--- a/packages/quick-open/src/browser/components/keybinding/index.tsx
+++ b/packages/quick-open/src/browser/components/keybinding/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { Keybinding, KeybindingRegistry, useInjectable } from '@opensumi/ide-core-browser';
@@ -14,14 +14,14 @@ export const KeybindingView: React.FC<{
   const keybindingRegistry: KeybindingRegistry = useInjectable(KeybindingRegistry);
   const keyMaps = React.useMemo(() => keybindingRegistry.acceleratorFor(keybinding, ' '), [keybinding]);
   return (
-    <div className={clx(styles.keybinding, className)}>
+    <div className={cls(styles.keybinding, className)}>
       {keyMaps
         ? keyMaps.map((value, i) => {
             const keys = value.split(' ');
             return (
-              <div key={`${value}_${i}`} title={value} className={clx(styles.key_sequence, sequenceClassName)}>
+              <div key={`${value}_${i}`} title={value} className={cls(styles.key_sequence, sequenceClassName)}>
                 {keys.map((key, j) => (
-                  <span className={clx(styles.key, keyClassName)} key={`${key}_${i}_${j}`}>
+                  <span className={cls(styles.key, keyClassName)} key={`${key}_${i}_${j}`}>
                     {key}
                   </span>
                 ))}

--- a/packages/quick-open/src/browser/components/quick-open-tabs/index.tsx
+++ b/packages/quick-open/src/browser/components/quick-open-tabs/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React from 'react';
 
 import { KeybindingRegistry, useInjectable, localize, QuickOpenTab } from '@opensumi/ide-core-browser';
@@ -39,7 +39,7 @@ export const QuickOpenTabs: React.FC<Props> = ({ tabs, activePrefix, onChange, t
               }}
             >
               <div
-                className={clx(styles.quickopen_tabs_left_item_text, { [styles.selected]: activePrefix === prefix })}
+                className={cls(styles.quickopen_tabs_left_item_text, { [styles.selected]: activePrefix === prefix })}
               >
                 {title}
               </div>

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 import type { ListOnScrollProps } from 'react-window';
@@ -235,7 +235,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
     <div
       id={VIEW_CONTAINERS.QUICKPICK_ITEM}
       tabIndex={0}
-      className={clx(
+      className={cls(
         {
           [styles.item_selected]: widget.selectIndex === index,
           [styles.item_border]: showBorder,
@@ -256,21 +256,21 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
       {/* tabIndex is needed here, pls see https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null */}
       <div tabIndex={0} className={styles.item_label_container} onMouseDown={runQuickOpenItem}>
         <div className={styles.item_label}>
-          {iconClass && <span className={clx(styles.item_icon, iconClass)}></span>}
+          {iconClass && <span className={cls(styles.item_icon, iconClass)}></span>}
           <HighlightLabel
             className={styles.item_label_name}
             labelClassName={styles.label_icon_container}
             labelIconClassName={styles.item_label_name_icon}
-            hightLightClassName={clx(styles.item_label_highlight)}
+            hightLightClassName={cls(styles.item_label_highlight)}
             text={label}
             highlights={labelHighlights}
           />
           {description && (
             <HighlightLabel
               className={styles.item_label_description}
-              labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
-              labelIconClassName={clx(styles.label_has_icon, styles.item_label_description_icon)}
-              hightLightClassName={clx(styles.item_label_description_highlight)}
+              labelClassName={cls(styles.label_icon_container, styles.item_label_description_label)}
+              labelIconClassName={cls(styles.label_has_icon, styles.item_label_description_icon)}
+              hightLightClassName={cls(styles.item_label_description_highlight)}
               text={description}
               highlights={descriptionHighlights}
             />
@@ -280,9 +280,9 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           <HighlightLabel
             OutElementType='div'
             className={styles.item_label_detail}
-            labelClassName={clx(styles.label_icon_container, styles.item_label_description_label)}
-            labelIconClassName={clx(styles.label_has_icon, styles.item_label_detail_icon)}
-            hightLightClassName={clx(styles.item_label_description_highlight)}
+            labelClassName={cls(styles.label_icon_container, styles.item_label_description_label)}
+            labelIconClassName={cls(styles.label_has_icon, styles.item_label_detail_icon)}
+            hightLightClassName={cls(styles.item_label_description_highlight)}
             text={detail}
             highlights={detailHighlights}
           />
@@ -299,7 +299,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
           key={action.id}
           onMouseDown={() => runQuickOpenItemAction(action)}
           title={action.tooltip || action.label}
-          className={clx(styles.item_action, action.class)}
+          className={cls(styles.item_action, action.class)}
         ></span>
       ))}
       {(mouseOver || widget.selectIndex === index) &&
@@ -328,7 +328,7 @@ export const QuickOpenList: React.FC<{
     <RecycleList
       onReady={onReady}
       onScroll={onScroll}
-      className={clx(styles.quickopen_list, {
+      className={cls(styles.quickopen_list, {
         [styles.validate_error]: widget.validateType === VALIDATE_TYPE.ERROR,
         [styles.validate_warning]: widget.validateType === VALIDATE_TYPE.WARNING,
       })}

--- a/packages/scm/src/browser/components/scm-provider-list.tsx
+++ b/packages/scm/src/browser/components/scm-provider-list.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React, { useCallback, CSSProperties, FC } from 'react';
 
 import { Badge } from '@opensumi/ide-components';
@@ -36,7 +36,7 @@ const SCMProvider: FC<{
   );
 
   return (
-    <div className={clx(styles.provider, { [styles.selected]: selected })} {...restProps}>
+    <div className={cls(styles.provider, { [styles.selected]: selected })} {...restProps}>
       <div className={styles.info}>
         <div className={styles.title}>{title}&nbsp;</div>
         <div className={styles.type}>{type}&nbsp;</div>

--- a/packages/scm/src/browser/components/scm-resource-tree/index.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/index.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React, { FC, useState, useRef, useEffect, useCallback, memo } from 'react';
 
@@ -136,7 +136,7 @@ export const SCMResourceTree: FC<{
 
   return (
     <div
-      className={clx(styles.scm_tree_container, { 'scm-show-actions': viewModel.alwaysShowActions })}
+      className={cls(styles.scm_tree_container, { 'scm-show-actions': viewModel.alwaysShowActions })}
       tabIndex={-1}
       ref={wrapperRef}
       data-name={TREE_FIELD_NAME}

--- a/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.view.tsx
+++ b/packages/scm/src/browser/components/scm-resource-tree/scm-tree-node.view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import React, { useCallback } from 'react';
 
 import {
@@ -119,7 +119,7 @@ export const SCMResourceGroupNode: React.FC<ISCMResourceGroupRenderProps> = ({
       return (
         <div
           onClick={clickHandler}
-          className={clx(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
+          className={cls(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
             [`${styles.mod_collapsed}`]: !(node as SCMResourceGroup).expanded,
           })}
         />
@@ -147,7 +147,7 @@ export const SCMResourceGroupNode: React.FC<ISCMResourceGroupRenderProps> = ({
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
-      className={clx(styles.scm_tree_node, decorations ? decorations.classlist : null)}
+      className={cls(styles.scm_tree_node, decorations ? decorations.classlist : null)}
       style={{
         height: SCM_TREE_NODE_HEIGHT,
         lineHeight: `${SCM_TREE_NODE_HEIGHT}px`,
@@ -155,13 +155,13 @@ export const SCMResourceGroupNode: React.FC<ISCMResourceGroupRenderProps> = ({
       }}
       data-id={item.id}
     >
-      <div className={clx(styles.scm_tree_node_content)}>
+      <div className={cls(styles.scm_tree_node_content)}>
         {renderFolderToggle(item, handleTwistierClick)}
         <div className={styles.scm_tree_node_overflow_wrap}>
-          <div className={clx(styles.scm_tree_node_segment, styles.scm_tree_node_displayname)}>{item.displayName}</div>
+          <div className={cls(styles.scm_tree_node_segment, styles.scm_tree_node_displayname)}>{item.displayName}</div>
         </div>
         {renderActionBar()}
-        <div className={clx(styles.scm_tree_node_segment, styles.scm_tree_node_tail)}>
+        <div className={cls(styles.scm_tree_node_segment, styles.scm_tree_node_tail)}>
           <Badge>{item.resource.elements.length}</Badge>
         </div>
       </div>
@@ -250,7 +250,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
     const iconClass = labelService.getIcon(node.uri, { isDirectory: SCMResourceFolder.is(node) });
     return (
       <div
-        className={clx(styles.file_icon, iconClass)}
+        className={cls(styles.file_icon, iconClass)}
         style={{ height: SCM_TREE_NODE_HEIGHT, lineHeight: `${SCM_TREE_NODE_HEIGHT}px` }}
       />
     );
@@ -258,7 +258,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
 
   const renderDisplayName = useCallback(
     (node: SCMResourceFolder | SCMResourceFile) => (
-      <div className={clx(styles.scm_tree_node_segment, styles.scm_tree_node_displayname)}>
+      <div className={cls(styles.scm_tree_node_segment, styles.scm_tree_node_displayname)}>
         {SCMResourceFolder.is(node) ? node.displayName : labelService.getName(node.uri)}
       </div>
     ),
@@ -267,7 +267,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
 
   const renderDescription = useCallback(
     (node: SCMResourceFile | SCMResourceFolder) => (
-      <div className={clx(styles.scm_tree_node_segment_grow, styles.scm_tree_node_description)}>{node.description}</div>
+      <div className={cls(styles.scm_tree_node_segment_grow, styles.scm_tree_node_description)}>{node.description}</div>
     ),
     [],
   );
@@ -322,7 +322,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
       return (
         <div
           onClick={clickHandler}
-          className={clx(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
+          className={cls(styles.scm_tree_node_segment, styles.expansion_toggle, getIcon('arrow-right'), {
             [`${styles.mod_collapsed}`]: !(node as SCMResourceFolder).expanded,
           })}
         />
@@ -338,7 +338,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
       title={getItemTooltip()}
-      className={clx(styles.scm_tree_node, decorations ? decorations.classlist : null)}
+      className={cls(styles.scm_tree_node, decorations ? decorations.classlist : null)}
       style={{
         color: decoration ? decoration.color : '',
         paddingLeft,
@@ -347,7 +347,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
       }}
       data-id={item.id}
     >
-      <div className={clx(styles.scm_tree_node_content)}>
+      <div className={cls(styles.scm_tree_node_content)}>
         {renderFolderToggle(item, handleTwistierClick)}
         {renderIcon(item)}
         <div
@@ -361,7 +361,7 @@ export const SCMResourceNode: React.FC<ISCMResourceRenderProps> = ({
         </div>
         {renderActionBar()}
         {/* render decorations */}
-        <div className={clx(styles.scm_tree_node_segment, styles.scm_tree_node_tail)}>{renderDecos()}</div>
+        <div className={cls(styles.scm_tree_node_segment, styles.scm_tree_node_tail)}>{renderDecos()}</div>
       </div>
     </div>
   );

--- a/packages/terminal-next/src/browser/component/tab.item.tsx
+++ b/packages/terminal-next/src/browser/component/tab.item.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import debounce from 'lodash/debounce';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useRef, KeyboardEvent, createElement } from 'react';
@@ -49,7 +49,7 @@ export const renderInfoItem = observer((props: ItemProps) => {
   return (
     <div
       ref={ref}
-      className={clx({
+      className={cls({
         [styles.item_container]: true,
         [styles.item_selected]: !!props.selected,
       })}
@@ -88,7 +88,7 @@ export const renderInfoItem = observer((props: ItemProps) => {
         <div></div>
       ) : (
         <div
-          className={clx([getIcon('close'), styles.close_icon])}
+          className={cls([getIcon('close'), styles.close_icon])}
           onClick={(event) => {
             event.stopPropagation();
             handleClose();
@@ -109,7 +109,7 @@ export const renderAddItem = observer((props: ItemProps) => {
     <div className={styles.item_wrapper}>
       <div
         title={createTitle}
-        className={clx({
+        className={cls({
           [getIcon('plus')]: true,
           [styles.item_add]: true,
         })}
@@ -117,7 +117,7 @@ export const renderAddItem = observer((props: ItemProps) => {
       />
       <div
         title={localize('terminal.new.type')}
-        className={clx({
+        className={cls({
           [getIcon('down')]: true,
           [styles.item_more]: true,
         })}

--- a/packages/terminal-next/src/browser/component/terminal.view.tsx
+++ b/packages/terminal-next/src/browser/component/terminal.view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
@@ -106,7 +106,7 @@ export default observer(() => {
               onKeyDown={searchKeyDown}
             />
           </div>
-          <div className={clx(styles.closeBtn, getIcon('close'))} onClick={() => searchService.close()}></div>
+          <div className={cls(styles.closeBtn, getIcon('close'))} onClick={() => searchService.close()}></div>
         </div>
       )}
       {groups.map((group, index) => {

--- a/packages/toolbar/src/browser/toolbar.view.tsx
+++ b/packages/toolbar/src/browser/toolbar.view.tsx
@@ -1,4 +1,4 @@
-import clx from 'classnames';
+import cls from 'classnames';
 import debounce from 'lodash/debounce';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -53,7 +53,7 @@ export const ToolBar = observer<Pick<React.HTMLProps<HTMLElement>, 'className'>>
   }, []);
 
   return (
-    <div className={clx(styles['tool-bar'], className)} ref={toolbarRef as any}>
+    <div className={cls(styles['tool-bar'], className)} ref={toolbarRef as any}>
       <ToolbarLocation className={styles.left} location='toolbar-left' preferences={{ noDropDown: true }} />
       <div id={styles.space1}></div>
       <ToolbarLocation className={styles.center} location='toolbar-center' preferences={{ noDropDown: true }} />

--- a/scripts/ast-grep/replace-import-default.js
+++ b/scripts/ast-grep/replace-import-default.js
@@ -1,0 +1,48 @@
+const { tsx } = require('@ast-grep/napi');
+const MagicString = require('magic-string').default;
+
+/**
+ * Replace the local variable name of the import statement
+ */
+const replaceImportDefault = (source, pkgName, expectLocalName) => {
+  const magic = new MagicString(source);
+
+  const ast = tsx.parse(source); // 1. parse the source
+  const root = ast.root(); // 2. get the root
+  const node = root.find({
+    rule: {
+      pattern: `import $LOCAL from '${pkgName}';`,
+    },
+  });
+
+  // 3. find the node
+  const localNode = node.getMatch('LOCAL');
+  const localNodeText = localNode.text();
+
+  const range = localNode.range();
+  magic.overwrite(range.start.index, range.end.index, expectLocalName);
+
+  const matches = root.findAll({
+    rule: {
+      kind: 'call_expression',
+      pattern: `${localNodeText}($$$)`,
+    },
+  });
+
+  matches.forEach((v) => {
+    // must be identifier
+    const dd = v.child(0);
+    if (dd.kind() !== 'identifier') {
+      console.error(`cannot find ${pkgName} call expression`);
+      return;
+    }
+
+    const ddRange = dd.range();
+    magic.overwrite(ddRange.start.index, ddRange.end.index, expectLocalName);
+  });
+
+  const result = magic.toString();
+  return result;
+};
+
+exports.replaceImportDefault = replaceImportDefault;

--- a/scripts/eslint_rules/rules/classnames-import-rule.js
+++ b/scripts/eslint_rules/rules/classnames-import-rule.js
@@ -1,0 +1,49 @@
+const { ESLintUtils } = require('@typescript-eslint/utils');
+const { replaceImportDefault } = require('../../ast-grep/replace-import-default');
+
+const pkgName = 'classnames';
+const expectLocalName = 'cls';
+
+const rule = ESLintUtils.RuleCreator.withoutDocs({
+  defaultOptions: [{}],
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: `Enforce a consistent import name for the "${pkgName}" library`,
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      unexpectedImportName: `Expected "${pkgName}" to be imported as "${expectLocalName}".`,
+    },
+    fixable: 'code',
+    schema: [], // No options
+  },
+  create: (context) => {
+    return {
+      ImportDeclaration(node) {
+        const { source, specifiers } = node;
+        if (source.value === pkgName) {
+          specifiers.forEach((specifier) => {
+            if (specifier.type === 'ImportDefaultSpecifier' && specifier.local.name !== expectLocalName) {
+              // 报告问题并提供修复方案
+              context.report({
+                node: specifier.local,
+                messageId: 'unexpectedImportName',
+                fix: (fixer) => {
+                  const sourceCode = context.getSourceCode();
+                  const source = sourceCode.text;
+                  const result = replaceImportDefault(source, pkgName, expectLocalName);
+
+                  return fixer.replaceTextRange(sourceCode.ast.range, result);
+                },
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+});
+
+module.exports = rule;

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,85 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ast-grep/napi-darwin-arm64@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-darwin-arm64@npm:0.17.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi-darwin-x64@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-darwin-x64@npm:0.17.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi-linux-arm64-gnu@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-linux-arm64-gnu@npm:0.17.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi-linux-x64-gnu@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-linux-x64-gnu@npm:0.17.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi-win32-arm64-msvc@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-win32-arm64-msvc@npm:0.17.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi-win32-ia32-msvc@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-win32-ia32-msvc@npm:0.17.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi-win32-x64-msvc@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi-win32-x64-msvc@npm:0.17.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ast-grep/napi@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@ast-grep/napi@npm:0.17.1"
+  dependencies:
+    "@ast-grep/napi-darwin-arm64": 0.17.1
+    "@ast-grep/napi-darwin-x64": 0.17.1
+    "@ast-grep/napi-linux-arm64-gnu": 0.17.1
+    "@ast-grep/napi-linux-x64-gnu": 0.17.1
+    "@ast-grep/napi-win32-arm64-msvc": 0.17.1
+    "@ast-grep/napi-win32-ia32-msvc": 0.17.1
+    "@ast-grep/napi-win32-x64-msvc": 0.17.1
+  dependenciesMeta:
+    "@ast-grep/napi-darwin-arm64":
+      optional: true
+    "@ast-grep/napi-darwin-x64":
+      optional: true
+    "@ast-grep/napi-linux-arm64-gnu":
+      optional: true
+    "@ast-grep/napi-linux-x64-gnu":
+      optional: true
+    "@ast-grep/napi-win32-arm64-msvc":
+      optional: true
+    "@ast-grep/napi-win32-ia32-msvc":
+      optional: true
+    "@ast-grep/napi-win32-x64-msvc":
+      optional: true
+  checksum: 20fa9e760bb0eced3d4c2f0daa274aa757f2d9bb60a0647ef17c0c5d7ce59da822f7497681f524be46cf1c07553b0872a76cb1a2335e041be32f414f028e411c
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/code-frame@npm:7.18.6"
@@ -2005,6 +2084,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@opensumi/core@workspace:."
   dependencies:
+    "@ast-grep/napi": ^0.17.1
     "@commitlint/cli": ^15.0.0
     "@commitlint/config-conventional": ^7.1.2
     "@opensumi/ide-dev-tool": "workspace:*"
@@ -2038,6 +2118,7 @@ __metadata:
     eslint-config-prettier: ^8.4.0
     eslint-import-resolver-typescript: ^2.5.0
     eslint-plugin-import: ^2.25.4
+    eslint-plugin-rulesdir: ^0.2.2
     eslint-plugin-unused-imports: ^2.0.0
     execa: ^5.0.0
     fs-extra: ^10.1.0
@@ -8650,6 +8731,13 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
   checksum: f500571a380167e25d72a4d925ef9a7aae8899eada57653e5f3051ec3d3c16d08271fcefe41a30a9a2f4fefc232f066253673ee4ea77b30dba65ae173dade85d
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-rulesdir@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "eslint-plugin-rulesdir@npm:0.2.2"
+  checksum: 1d8c2583dccca7e167b0eaf1adb1ae0bca4ea65b3eb3e0124fc0e21382a29ca3988306419d3b34f7f984f53c2ecb16b0c6956e676e23d165c2bd629023d10704
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

使用这个包的时候，import 进来的命名千奇百怪的，加了个 lint 规则：import 进来的命名必须为 cls：
```js
import cls from 'classnames';
```

<img width="1053" alt="image" src="https://github.com/opensumi/core/assets/13938334/d746ce78-59ae-4f33-8bdc-0f8487da7e56">


### Changelog
