### PR TITLE
fix: output monaco instance will be init twice

### DIFF
--- a/packages/output/src/browser/output.service.ts
+++ b/packages/output/src/browser/output.service.ts
@@ -112,6 +112,10 @@ export class OutputService extends WithEventBus {
   }
 
   public async initOutputMonacoInstance(container: HTMLDivElement) {
+    if (this.outputEditor) {
+      this.outputEditor.dispose();
+    }
+
     this.outputEditor = this.editorCollectionService.createCodeEditor(container, {
       ...getSimpleEditorOptions(),
       lineDecorationsWidth: 20,


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

we change `createRef` to `useRef`, after this change, the useEffect hook will run twice:
![image](https://github.com/opensumi/core/assets/13938334/e54eb3cc-5c39-4a4f-bb54-48ebd3fc74e2)

so there will be two monaco instance in the DOM tree.
![image](https://github.com/opensumi/core/assets/13938334/e2428a92-920f-48c0-8b54-42165346e53f)

but I didn't know why the hook will run twice:
![image](https://github.com/opensumi/core/assets/13938334/47d0301a-e17f-4c01-8a57-b83fd7af2794)

these ref are all the same.


### Changelog

fix output monaco instance will be init twice