### PR TITLE
fix: comment thread update

### DIFF
--- a/packages/comments/src/browser/comments-thread.ts
+++ b/packages/comments/src/browser/comments-thread.ts
@@ -1,4 +1,4 @@
-import { autorun, computed, makeObservable, observable } from 'mobx';
+import { action, autorun, computed, makeObservable, observable } from 'mobx';
 
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { Disposable, Emitter, IContextKeyService, IRange, URI, localize, uuid } from '@opensumi/ide-core-browser';
@@ -32,9 +32,8 @@ export class CommentsThread extends Disposable implements ICommentsThread {
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
-  // FIXME: update by https://github.com/opensumi/core/blob/82ab63b916c8fe90cf5898d55c0fe335dd852b91/packages/extension/src/browser/vscode/api/main.thread.comments.ts#L319
-  @observable
-  public comments: IThreadComment[];
+  @observable.shallow
+  public comments: IThreadComment[] = [];
 
   @observable
   public label: string | undefined;
@@ -127,6 +126,12 @@ export class CommentsThread extends Disposable implements ICommentsThread {
     });
     this.onDidChangeEmitter.fire();
   }
+
+  @action
+  updateComments(comments: IThreadComment[]) {
+    this.comments = comments;
+  }
+
   getWidgetByEditor(editor: IEditor): ICommentsZoneWidget | undefined {
     return this.widgets.get(editor);
   }

--- a/packages/comments/src/common/index.ts
+++ b/packages/comments/src/common/index.ts
@@ -518,6 +518,11 @@ export interface ICommentsThread extends IDisposable {
    */
   contextKeyService: IContextKeyService;
   /**
+   * 更新当前 thread 的评论列表
+   * @param comments
+   */
+  updateComments(comments: IComment[]): void;
+  /**
    * 添加评论
    * @param comment
    */

--- a/packages/extension/src/browser/vscode/api/main.thread.comments.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.comments.ts
@@ -316,9 +316,9 @@ export class MainThreadCommentThread extends Disposable implements CommentThread
 
   public set comments(newComments: CoreComment[] | undefined) {
     if (newComments) {
-      this._thread.comments = newComments.map((comment) => this.convertToIThreadComment(comment));
+      this._thread.updateComments(newComments.map((comment) => this.convertToIThreadComment(comment)));
     } else {
-      this._thread.comments = [];
+      this._thread.updateComments([]);
     }
 
     this._onDidChangeComments.fire(newComments);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

修改原有代码中不合理的 `thread.commands = [...]` 更新视图的方式，后续需通过如下方式更新评论列表

```
thread.updateComments([...]); // 包裹了 @action 方法
```

### Changelog

fix comment thread update logic