### PR TITLE
feat: when click file node, resize the bottom panel

### DIFF
--- a/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
@@ -7,6 +7,7 @@ import {
   IApplicationService,
   Emitter,
   OS,
+  CommandRegistry,
 } from '@opensumi/ide-core-browser';
 import { ICtxMenuRenderer } from '@opensumi/ide-core-browser/lib/menu/next';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
@@ -27,6 +28,7 @@ import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 import { createMockedMonaco } from '../../../monaco/__mocks__/monaco';
 import styles from '../../src/browser/file-tree-node.modules.less';
 import { Directory, File } from '../../src/common/file-tree-node.define';
+import { RETRACT_BOTTOM_PANEL } from '@opensumi/ide-main-layout/lib/browser/main-layout.contribution';
 
 class TempDirectory {}
 class TempFile {}
@@ -207,6 +209,14 @@ describe('FileTreeModelService should be work', () => {
 
     fileTreeModelService = injector.get(FileTreeModelService);
     fileTreeModelService.initTreeModel();
+
+    // register a command that will be used while click file
+    const commandRegistry = injector.get(CommandRegistry) as CommandRegistry;
+
+    commandRegistry.registerCommand(RETRACT_BOTTOM_PANEL, {
+      execute: () => {},
+    });
+
     await fileTreeModelService.whenReady;
   });
 

--- a/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
@@ -19,6 +19,7 @@ import { FileContextKey } from '@opensumi/ide-file-tree-next/lib/browser/file-co
 import { FileTreeModelService } from '@opensumi/ide-file-tree-next/lib/browser/services/file-tree-model.service';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 import { IThemeService } from '@opensumi/ide-theme';
+import { IMainLayoutService } from '@opensumi/ide-main-layout';
 
 import { MockContextKeyService } from '../../..//monaco/__mocks__/monaco.context-key.service';
 import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
@@ -178,6 +179,13 @@ describe('FileTreeModelService should be work', () => {
         token: IContextKeyService,
         useClass: MockContextKeyService,
       },
+      {
+        token: IMainLayoutService,
+        useValue: {
+          bottomExpanded: true,
+        },
+      },
+
       {
         token: IApplicationService,
         useValue: {

--- a/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree-model.service.test.ts
@@ -210,12 +210,7 @@ describe('FileTreeModelService should be work', () => {
     fileTreeModelService = injector.get(FileTreeModelService);
     fileTreeModelService.initTreeModel();
 
-    // register a command that will be used while click file
-    const commandRegistry = injector.get(CommandRegistry) as CommandRegistry;
-
-    commandRegistry.registerCommand(RETRACT_BOTTOM_PANEL, {
-      execute: () => {},
-    });
+    injector.mockCommand(RETRACT_BOTTOM_PANEL.id, () => {});
 
     await fileTreeModelService.whenReady;
   });

--- a/packages/file-tree-next/__tests__/browser/file-tree.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.test.ts
@@ -317,15 +317,10 @@ describe('FileTree should be work while on single workspace model', () => {
     it('Style decoration should be right while click the item', async () => {
       const { handleItemClick, decorations } = fileTreeModelService;
 
-      // register a command that will be used while click file
-      const commandRegistry = injector.get(CommandRegistry) as CommandRegistry;
-
       let retracted = jest.fn();
-      commandRegistry.registerCommand(RETRACT_BOTTOM_PANEL, {
-        execute: () => {
-          mockMainLayoutService.bottomExpanded = false;
-          retracted();
-        },
+      injector.mockCommand(RETRACT_BOTTOM_PANEL.id, () => {
+        mockMainLayoutService.bottomExpanded = false;
+        retracted();
       });
 
       const treeModel = fileTreeModelService.treeModel;
@@ -334,7 +329,6 @@ describe('FileTree should be work while on single workspace model', () => {
       const openFile = jest.fn();
       // first, click directory item
       handleItemClick(directoryNode, TreeNodeType.CompositeTreeNode);
-      expect(retracted).toHaveBeenCalledTimes(1);
       const dirDecoration = decorations.getDecorations(directoryNode);
       expect(dirDecoration?.classlist).toEqual([styles.mod_selected, styles.mod_focused]);
       // second, click normal file
@@ -342,7 +336,7 @@ describe('FileTree should be work while on single workspace model', () => {
       injector.mockCommand(EDITOR_COMMANDS.OPEN_RESOURCE.id, openFile);
       handleItemClick(fileNode, TreeNodeType.TreeNode);
       expect(retracted).toHaveBeenCalledTimes(1);
-
+      expect(mockMainLayoutService.bottomExpanded).toBeFalsy();
       const fileDecoration = decorations.getDecorations(fileNode);
       expect(fileDecoration?.classlist).toEqual([styles.mod_selected, styles.mod_focused]);
       expect(openFile).toBeCalledWith(fileNode.uri, { disableNavigate: true, preview: true });

--- a/packages/file-tree-next/__tests__/browser/file-tree.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.test.ts
@@ -48,6 +48,7 @@ import { FileTreeService } from '../../src/browser/file-tree.service';
 import { FileTreeModelService } from '../../src/browser/services/file-tree-model.service';
 import { IFileTreeAPI, IFileTreeService } from '../../src/common';
 import { Directory, File } from '../../src/common/file-tree-node.define';
+import { IMainLayoutService } from '@opensumi/ide-main-layout';
 
 describe('FileTree should be work while on single workspace model', () => {
   let track;
@@ -198,6 +199,12 @@ describe('FileTree should be work while on single workspace model', () => {
       {
         token: IClipboardService,
         useValue: mockClipboardService,
+      },
+      {
+        token: IMainLayoutService,
+        useValue: {
+          bottomExpanded: true,
+        },
       },
     );
     const fileServiceClient: FileServiceClient = injector.get(IFileServiceClient);

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -39,10 +39,8 @@ import { AbstractContextMenuService, ICtxMenuRenderer, MenuId } from '@opensumi/
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileStat, IFileServiceClient } from '@opensumi/ide-file-service';
-import {
-  IS_VISIBLE_BOTTOM_PANEL_COMMAND,
-  RETRACT_BOTTOM_PANEL,
-} from '@opensumi/ide-main-layout/lib/browser/main-layout.contribution';
+import { IMainLayoutService } from '@opensumi/ide-main-layout';
+import { RETRACT_BOTTOM_PANEL } from '@opensumi/ide-main-layout/lib/browser/main-layout.contribution';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 
 import { IFileTreeAPI, IFileTreeService, PasteTypes } from '../../common';
@@ -123,6 +121,9 @@ export class FileTreeModelService {
 
   @Autowired(CommandService)
   private readonly commandService: CommandService;
+
+  @Autowired(IMainLayoutService)
+  protected readonly mainlayoutService: IMainLayoutService;
 
   @Autowired(IClipboardService)
   private readonly clipboardService: IClipboardService;
@@ -805,12 +806,10 @@ export class FileTreeModelService {
         }
         // 对于文件的单击事件，走 openFile 去执行 editor.previewMode 配置项
         this.fileTreeService.openFile(item.uri);
-        // 如果panel打开，则将最大化的panel, 变小
-        this.commandService.executeCommand(IS_VISIBLE_BOTTOM_PANEL_COMMAND.id).then((flag) => {
-          if (flag) {
-            this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id);
-          }
-        });
+        // 如果存在最大化面板，则将最大化的面板缩小
+        if (this.mainlayoutService.bottomExpanded) {
+          this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id);
+        }
       }
     }
   };

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -808,7 +808,10 @@ export class FileTreeModelService {
         this.fileTreeService.openFile(item.uri);
         // 如果存在最大化面板，则将最大化的面板缩小
         if (this.mainlayoutService.bottomExpanded) {
-          this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id);
+          this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id).then(
+            () => {},
+            () => {},
+          );
         }
       }
     }

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -808,10 +808,7 @@ export class FileTreeModelService {
         this.fileTreeService.openFile(item.uri);
         // 如果存在最大化面板，则将最大化的面板缩小
         if (this.mainlayoutService.bottomExpanded) {
-          this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id).then(
-            () => {},
-            () => {},
-          );
+          this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id);
         }
       }
     }

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -39,6 +39,10 @@ import { AbstractContextMenuService, ICtxMenuRenderer, MenuId } from '@opensumi/
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileStat, IFileServiceClient } from '@opensumi/ide-file-service';
+import {
+  IS_VISIBLE_BOTTOM_PANEL_COMMAND,
+  RETRACT_BOTTOM_PANEL,
+} from '@opensumi/ide-main-layout/lib/browser/main-layout.contribution';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 
 import { IFileTreeAPI, IFileTreeService, PasteTypes } from '../../common';
@@ -763,7 +767,6 @@ export class FileTreeModelService {
     if (!this.treeModel) {
       return;
     }
-
     if (!item) {
       item = this.treeModel.root as Directory | File;
     }
@@ -802,6 +805,12 @@ export class FileTreeModelService {
         }
         // 对于文件的单击事件，走 openFile 去执行 editor.previewMode 配置项
         this.fileTreeService.openFile(item.uri);
+        // 如果panel打开，则将最大化的panel, 变小
+        this.commandService.executeCommand(IS_VISIBLE_BOTTOM_PANEL_COMMAND.id).then((flag) => {
+          if (flag) {
+            this.commandService.executeCommand(RETRACT_BOTTOM_PANEL.id);
+          }
+        });
       }
     }
   };


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution
如果之前用户点击pannel 放大按钮，把teminal 终端放到最大时，回头点击文件树中的文件，
一般情况下，还是期望直接看到文件内容的， 所以 点击文件树时，把放大的pannel 重新缩小

### Changelog

when click file node, resize the bottom panel
