### PR TITLE
chore: remove ai top config

### DIFF
--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -94,11 +94,6 @@ export class AiNativeModule extends BrowserModule {
         };
       }
 
-      layoutConfig = {
-        ...layoutConfig,
-        ...AiTopLayoutConfig,
-      };
-
       injector.overrideProviders(
         {
           token: IBrowserCtxMenu,


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

顶部的 top layout config 应该由集成方控制，不默认内置。

### Changelog
