### PR TITLE
fix: remove deprecated usage of less import statement

### DIFF
--- a/packages/status-bar/src/browser/status-bar.module.less
+++ b/packages/status-bar/src/browser/status-bar.module.less
@@ -1,4 +1,4 @@
-@import '~@opensumi/ide-core-browser/lib/style/variable.less';
+@import '@opensumi/ide-core-browser/lib/style/variable.less';
 
 /* Statusbar */
 @statusBar-font-size: 12px;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

### Changelog
