### PR TITLE
fix: tree do not need refresh when invisible

### DIFF
--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -1485,47 +1485,58 @@ export class CompositeTreeNode extends TreeNode implements ICompositeTreeNode {
    */
   private handleWatchEvent = async (event: IWatcherEvent) => {
     this.watcher.notifyWillProcessWatchEvent(this, event);
-    if (event.type === WatchEvent.Moved) {
-      const { oldPath, newPath } = event;
-      if (typeof oldPath !== 'string') {
-        throw new TypeError('Expected oldPath to be a string');
-      }
-      if (typeof newPath !== 'string') {
-        throw new TypeError('Expected newPath to be a string');
-      }
-      if (Path.isRelative(oldPath)) {
-        throw new TypeError('oldPath must be absolute');
-      }
-      if (Path.isRelative(newPath)) {
-        throw new TypeError('newPath must be absolute');
-      }
-      this.transferItem(oldPath, newPath);
-    } else if (event.type === WatchEvent.Added) {
-      const { node } = event;
-      if (!TreeNode.is(node)) {
-        throw new TypeError('Expected node to be a TreeNode');
-      }
-      this.insertItem(node);
-    } else if (event.type === WatchEvent.Removed) {
-      const { path } = event;
-      const pathObject = new Path(path);
-      const dirName = pathObject.dir.toString();
-      const name = pathObject.base.toString();
-      if (dirName === this.path && !!this.children) {
-        const item = this.children.find((c) => c.name === name);
-        if (item) {
-          this.unlinkItem(item);
+
+    switch (event.type) {
+      case WatchEvent.Moved: {
+        const { oldPath, newPath } = event;
+        if (typeof oldPath !== 'string') {
+          throw new TypeError('Expected oldPath to be a string');
         }
+        if (typeof newPath !== 'string') {
+          throw new TypeError('Expected newPath to be a string');
+        }
+        if (Path.isRelative(oldPath)) {
+          throw new TypeError('oldPath must be absolute');
+        }
+        if (Path.isRelative(newPath)) {
+          throw new TypeError('newPath must be absolute');
+        }
+        this.transferItem(oldPath, newPath);
+        break;
       }
-    } else {
-      // 如果当前变化的节点已在数据视图（并非滚动到不可见区域）中不可见，则将该节点折叠，待下次更新即可，
-      if (!this.isItemVisibleAtRootSurface(this)) {
-        this.isExpanded = false;
-        this._children = null;
-      } else {
-        await this.refresh();
+      case WatchEvent.Added: {
+        const { node } = event;
+        if (!TreeNode.is(node)) {
+          throw new TypeError('Expected node to be a TreeNode');
+        }
+        this.insertItem(node);
+        break;
       }
+
+      case WatchEvent.Removed: {
+        const { path } = event;
+        const pathObject = new Path(path);
+        const dirName = pathObject.dir.toString();
+        const name = pathObject.base.toString();
+        if (dirName === this.path && !!this.children) {
+          const item = this.children.find((c) => c.name === name);
+          if (item) {
+            this.unlinkItem(item);
+          }
+        }
+        break;
+      }
+      default:
+        // 如果当前变化的节点已在数据视图（并非滚动到不可见区域）中不可见，则将该节点折叠，待下次更新即可，
+        if (!this.isItemVisibleAtRootSurface(this)) {
+          this.isExpanded = false;
+          this._children = null;
+        } else {
+          await this.refresh();
+        }
+        break;
     }
+
     this.watcher.notifyDidProcessWatchEvent(this, event);
   };
 

--- a/packages/core-browser/src/contextkey/markers.ts
+++ b/packages/core-browser/src/contextkey/markers.ts
@@ -1,0 +1,13 @@
+import { RawContextKey } from '../raw-context-key';
+
+export const MarkersTreeVisibilityContextKey = new RawContextKey<boolean>('problemsVisibility', false);
+export const MarkerFocusContextKey = new RawContextKey<boolean>('problemFocus', false);
+
+// not implemented
+export const MarkerViewFilterFocusContextKey = new RawContextKey<boolean>('problemsFilterFocus', false);
+export const RelatedInformationFocusContextKey = new RawContextKey<boolean>('relatedInformationFocus', false);
+export const ShowErrorsFilterContextKey = new RawContextKey<boolean>('problems.filter.errors', true);
+export const ShowWarningsFilterContextKey = new RawContextKey<boolean>('problems.filter.warnings', true);
+export const ShowInfoFilterContextKey = new RawContextKey<boolean>('problems.filter.info', true);
+export const ShowActiveFileFilterContextKey = new RawContextKey<boolean>('problems.filter.activeFile', false);
+export const ShowExcludedFilesFilterContextKey = new RawContextKey<boolean>('problems.filter.excludedFiles', true);

--- a/packages/core-browser/src/contextkey/search.ts
+++ b/packages/core-browser/src/contextkey/search.ts
@@ -5,9 +5,9 @@ export const SearchViewFocusedKey = new RawContextKey<boolean>('searchViewletFoc
 export const SearchInputBoxFocusedKey = new RawContextKey<boolean>('searchInputBoxFocus', false);
 export const ReplaceInputBoxFocusedKey = new RawContextKey<boolean>('replaceInputBoxFocus', false);
 export const HasSearchResults = new RawContextKey<boolean>('hasSearchResult', false);
+export const SearchViewVisibleKey = new RawContextKey<boolean>('searchViewletVisible', true);
 
 // not impliments
-export const SearchViewVisibleKey = new RawContextKey<boolean>('searchViewletVisible', true);
 export const InputBoxFocusedKey = new RawContextKey<boolean>('inputBoxFocus', false);
 export const PatternIncludesFocusedKey = new RawContextKey<boolean>('patternIncludesInputBoxFocus', false);
 export const PatternExcludesFocusedKey = new RawContextKey<boolean>('patternExcludesInputBoxFocus', false);

--- a/packages/markers/src/browser/markers-contextkey.ts
+++ b/packages/markers/src/browser/markers-contextkey.ts
@@ -1,0 +1,27 @@
+import { Autowired, Injectable } from '@opensumi/di';
+import { IContextKey, IContextKeyService } from '@opensumi/ide-core-browser';
+import {
+  MarkerFocusContextKey,
+  MarkersTreeVisibilityContextKey,
+} from '@opensumi/ide-core-browser/lib/contextkey/markers';
+
+@Injectable()
+export class MarkersContextKey {
+  @Autowired(IContextKeyService)
+  private readonly globalContextkeyService: IContextKeyService;
+
+  public markersTreeVisibility: IContextKey<boolean>;
+  public markerFocus: IContextKey<boolean>;
+
+  private _contextKeyService: IContextKeyService;
+
+  initScopedContext(dom: HTMLDivElement) {
+    this._contextKeyService = this.globalContextkeyService.createScoped(dom);
+    this.markersTreeVisibility = MarkersTreeVisibilityContextKey.bind(this._contextKeyService);
+    this.markerFocus = MarkerFocusContextKey.bind(this._contextKeyService);
+  }
+
+  get service() {
+    return this._contextKeyService;
+  }
+}

--- a/packages/markers/src/browser/markers-contribution.ts
+++ b/packages/markers/src/browser/markers-contribution.ts
@@ -20,6 +20,7 @@ import { MarkerFilterPanel } from './markers-filter.view';
 import { MarkerService } from './markers-service';
 import { MarkerPanel } from './markers-tree.view';
 import Messages from './messages';
+import { MarkerModelService } from './tree/tree-model.service';
 
 function normalize(num: number) {
   const limit = 100;
@@ -46,6 +47,9 @@ export class MarkersContribution
   @Autowired(IStatusBarService)
   private readonly statusBar: IStatusBarService;
 
+  @Autowired(MarkerModelService)
+  private readonly markerModelService: MarkerModelService;
+
   onDidRender() {
     const handler = this.mainlayoutService.getTabbarHandler(MARKER_CONTAINER_ID);
     if (handler) {
@@ -53,6 +57,27 @@ export class MarkersContribution
         this.markerService.getManager().onMarkerChanged(() => {
           const badge = this.markerService.getBadge();
           handler.setBadge(badge || '');
+        }),
+      );
+
+      this.markerModelService.whenReady.then(() => {
+        if (this.markerService.contextKey) {
+          this.markerService.contextKey.markersTreeVisibility.set(handler.isActivated());
+        }
+      });
+
+      this.addDispose(
+        handler.onActivate(() => {
+          if (this.markerService.contextKey) {
+            this.markerService.contextKey.markersTreeVisibility.set(true);
+          }
+        }),
+      );
+      this.addDispose(
+        handler.onInActivate(() => {
+          if (this.markerService.contextKey) {
+            this.markerService.contextKey.markersTreeVisibility.set(false);
+          }
         }),
       );
     }

--- a/packages/markers/src/browser/markers-contribution.ts
+++ b/packages/markers/src/browser/markers-contribution.ts
@@ -60,24 +60,18 @@ export class MarkersContribution
         }),
       );
 
-      this.markerModelService.whenReady.then(() => {
-        if (this.markerService.contextKey) {
-          this.markerService.contextKey.markersTreeVisibility.set(handler.isActivated());
-        }
+      this.markerService.viewReady.promise.then(() => {
+        this.markerService.contextKey.markersTreeVisibility.set(handler.isActivated());
       });
 
       this.addDispose(
         handler.onActivate(() => {
-          if (this.markerService.contextKey) {
-            this.markerService.contextKey.markersTreeVisibility.set(true);
-          }
+          this.markerModelService.activate();
         }),
       );
       this.addDispose(
         handler.onInActivate(() => {
-          if (this.markerService.contextKey) {
-            this.markerService.contextKey.markersTreeVisibility.set(false);
-          }
+          this.markerModelService.deactivate();
         }),
       );
     }

--- a/packages/markers/src/browser/markers-service.ts
+++ b/packages/markers/src/browser/markers-service.ts
@@ -1,9 +1,8 @@
-'use strict';
 import { makeObservable, observable } from 'mobx';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
-import { Emitter, Event, IBaseMarkerManager, MarkerManager, OnEvent } from '@opensumi/ide-core-common';
+import { Deferred, Emitter, Event, IBaseMarkerManager, MarkerManager, OnEvent } from '@opensumi/ide-core-common';
 import { EditorGroupCloseEvent, EditorGroupOpenEvent } from '@opensumi/ide-editor/lib/browser';
 import { ThemeType } from '@opensumi/ide-theme';
 import { Themable } from '@opensumi/ide-theme/lib/browser/workbench.theme.service';
@@ -38,6 +37,8 @@ export class MarkerService extends Themable implements IMarkerService {
   @Autowired(MarkersContextKey)
   markersContextKey: MarkersContextKey;
 
+  viewReady = new Deferred<void>();
+
   // marker filter 事件
   protected readonly onMarkerFilterChangedEmitter = new Emitter<FilterOptions | undefined>();
   public readonly onMarkerFilterChanged: Event<FilterOptions | undefined> = this.onMarkerFilterChangedEmitter.event;
@@ -61,6 +62,7 @@ export class MarkerService extends Themable implements IMarkerService {
 
   initContextKey(dom: HTMLDivElement) {
     this.markersContextKey.initScopedContext(dom);
+    this.viewReady.resolve();
   }
 
   @OnEvent(EditorGroupOpenEvent)

--- a/packages/markers/src/browser/markers-service.ts
+++ b/packages/markers/src/browser/markers-service.ts
@@ -10,6 +10,7 @@ import { Themable } from '@opensumi/ide-theme/lib/browser/workbench.theme.servic
 
 import { IMarkerService } from '../common/types';
 
+import { MarkersContextKey } from './markers-contextkey';
 import { FilterOptions } from './markers-filter.model';
 import { MarkerViewModel } from './markers.model';
 import { MarkerGroupNode, MarkerNode, MarkerRoot } from './tree/tree-node.defined';
@@ -34,6 +35,9 @@ export class MarkerService extends Themable implements IMarkerService {
   @observable
   public viewSize: ViewSize = { h: 0 };
 
+  @Autowired(MarkersContextKey)
+  markersContextKey: MarkersContextKey;
+
   // marker filter 事件
   protected readonly onMarkerFilterChangedEmitter = new Emitter<FilterOptions | undefined>();
   public readonly onMarkerFilterChanged: Event<FilterOptions | undefined> = this.onMarkerFilterChangedEmitter.event;
@@ -49,6 +53,14 @@ export class MarkerService extends Themable implements IMarkerService {
     super();
     makeObservable(this);
     this.markerViewModel = new MarkerViewModel(this, this.labelService);
+  }
+
+  get contextKey() {
+    return this.markersContextKey;
+  }
+
+  initContextKey(dom: HTMLDivElement) {
+    this.markersContextKey.initScopedContext(dom);
   }
 
   @OnEvent(EditorGroupOpenEvent)

--- a/packages/markers/src/browser/markers-tree.view.tsx
+++ b/packages/markers/src/browser/markers-tree.view.tsx
@@ -101,6 +101,7 @@ const Empty: FC = () => {
  */
 export const MarkerPanel = ({ viewState }: { viewState: ViewState }) => {
   const markerModelService = useInjectable<MarkerModelService>(MarkerModelService);
+  const markerService = useInjectable<MarkerService>(IMarkerService);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   const handleOuterClick = useCallback(() => {
@@ -113,6 +114,10 @@ export const MarkerPanel = ({ viewState }: { viewState: ViewState }) => {
     const handleBlur = () => {
       markerModelService.handleTreeBlur();
     };
+    if (wrapperRef.current) {
+      markerService.initContextKey(wrapperRef.current);
+    }
+
     wrapperRef.current?.addEventListener('blur', handleBlur, true);
     return () => {
       wrapperRef.current?.removeEventListener('blur', handleBlur, true);

--- a/packages/markers/src/browser/tree/tree-model.service.ts
+++ b/packages/markers/src/browser/tree/tree-model.service.ts
@@ -8,6 +8,8 @@ import { IMarkerService } from '../../common/types';
 import { MarkerGroupNode, MarkerNode, MarkerRoot } from './tree-node.defined';
 import styles from './tree-node.module.less';
 
+import type { MarkerService } from '../markers-service';
+
 export interface IEditorTreeHandle extends IRecycleTreeHandle {
   hasDirectFocus: () => boolean;
 }
@@ -23,7 +25,7 @@ export class MarkerTreeModel extends TreeModel {
 @Injectable()
 export class MarkerModelService {
   @Autowired(IMarkerService)
-  private readonly markerService: IMarkerService;
+  private readonly markerService: MarkerService;
 
   @Autowired(WorkbenchEditorService)
   private readonly workbenchEditorService: WorkbenchEditorService;
@@ -194,9 +196,12 @@ export class MarkerModelService {
 
   async refresh() {
     await this.whenReady;
-    runWhenIdle(() => {
-      this.treeModel.root.refresh();
-    });
+
+    if (this.markerService.contextKey && this.markerService.contextKey.markersTreeVisibility.get()) {
+      runWhenIdle(() => {
+        this.treeModel.root.refresh();
+      });
+    }
   }
 
   dispose() {

--- a/packages/markers/src/browser/tree/tree-model.service.ts
+++ b/packages/markers/src/browser/tree/tree-model.service.ts
@@ -194,6 +194,8 @@ export class MarkerModelService {
     }
   };
 
+  isDirtyTree = false;
+
   async refresh() {
     await this.whenReady;
 
@@ -201,6 +203,25 @@ export class MarkerModelService {
       runWhenIdle(() => {
         this.treeModel.root.refresh();
       });
+    } else {
+      this.isDirtyTree = true;
+    }
+  }
+
+  activate() {
+    if (this.markerService.contextKey) {
+      this.markerService.contextKey.markersTreeVisibility.set(true);
+
+      if (this.isDirtyTree) {
+        this.refresh();
+        this.isDirtyTree = false;
+      }
+    }
+  }
+
+  deactivate() {
+    if (this.markerService.contextKey) {
+      this.markerService.contextKey.markersTreeVisibility.set(false);
     }
   }
 

--- a/packages/search/src/browser/search-contextkey.ts
+++ b/packages/search/src/browser/search-contextkey.ts
@@ -4,6 +4,7 @@ import {
   HasSearchResults,
   SearchInputBoxFocusedKey,
   SearchViewFocusedKey,
+  SearchViewVisibleKey,
 } from '@opensumi/ide-core-browser/lib/contextkey/search';
 
 @Injectable()
@@ -15,6 +16,8 @@ export class SearchContextKey {
   public searchViewFocusedKey: IContextKey<boolean>;
   public searchInputBoxFocusedKey: IContextKey<boolean>;
 
+  public searchViewVisibleKey: IContextKey<boolean>;
+
   private _contextKeyService: IContextKeyService;
 
   initScopedContext(dom: HTMLDivElement) {
@@ -22,6 +25,7 @@ export class SearchContextKey {
     this.searchViewFocusedKey = SearchViewFocusedKey.bind(this._contextKeyService);
     this.searchInputBoxFocusedKey = SearchInputBoxFocusedKey.bind(this._contextKeyService);
     this.hasSearchResults = HasSearchResults.bind(this._contextKeyService);
+    this.searchViewVisibleKey = SearchViewVisibleKey.bind(this._contextKeyService);
   }
 
   get service() {

--- a/packages/search/src/browser/search.contribution.ts
+++ b/packages/search/src/browser/search.contribution.ts
@@ -334,7 +334,7 @@ export class SearchContribution
   onDidRender() {
     const handler = this.mainLayoutService.getTabbarHandler(SEARCH_CONTAINER_ID);
     if (handler) {
-      this.searchModelService.whenReady.then(() => {
+      this.searchTreeService.viewReady.promise.then(() => {
         this.searchTreeService.contextKey.searchViewVisibleKey.set(handler.isActivated());
       });
 

--- a/packages/search/src/browser/search.contribution.ts
+++ b/packages/search/src/browser/search.contribution.ts
@@ -334,13 +334,19 @@ export class SearchContribution
   onDidRender() {
     const handler = this.mainLayoutService.getTabbarHandler(SEARCH_CONTAINER_ID);
     if (handler) {
+      this.searchModelService.whenReady.then(() => {
+        this.searchTreeService.contextKey.searchViewVisibleKey.set(handler.isActivated());
+      });
+
       handler.onActivate(() => {
         this.searchBrowserService.initSearchHistory();
         this.searchBrowserService.focus();
+        this.searchModelService.activate();
       });
       handler.onInActivate(() => {
         this.searchTreeService.removeHighlightRange();
         this.searchBrowserService.blur();
+        this.searchModelService.deactivate();
       });
     }
   }

--- a/packages/search/src/browser/search.service.ts
+++ b/packages/search/src/browser/search.service.ts
@@ -413,27 +413,32 @@ export class ContentSearchClientService extends Disposable implements IContentSe
 
       const oldResults = this.searchResults.get(uriString);
 
+      let didChanged = false;
       if (!oldResults) {
         // 不在结果树中，新增结果
         if (resultData.result.length > 0) {
           this.resultTotal.fileNum++;
           this.resultTotal.resultNum = this.resultTotal.resultNum + resultData.result.length;
+          didChanged = true;
         }
       } else if (resultData.result.length < 1) {
         // 搜索结果被删除完了，清理结果树
         this.searchResults.delete(uriString);
         this.resultTotal.fileNum = this.resultTotal.fileNum - 1;
         this.resultTotal.resultNum = this.resultTotal.resultNum - oldResults.length;
-        return;
+        didChanged = true;
       } else if (resultData.result.length !== oldResults?.length) {
         // 搜索结果变多了，更新数据
         this.resultTotal.resultNum = this.resultTotal.resultNum - oldResults!.length + resultData.result.length;
+        didChanged = true;
       }
+
       if (resultData.result.length > 0) {
         // 更新结果树
         this.searchResults.set(uriString, resultData.result);
       }
-      this.onDidChangeEmitter.fire();
+
+      didChanged && this.onDidChangeEmitter.fire();
       docModel.dispose();
     });
   }

--- a/packages/search/src/browser/tree/search-tree.service.ts
+++ b/packages/search/src/browser/tree/search-tree.service.ts
@@ -209,7 +209,7 @@ export class SearchTreeService extends Disposable implements ISearchTreeService 
   private readonly fileServiceClient: IFileServiceClient;
 
   @Autowired(SearchContextKey)
-  private readonly searchContextKey: SearchContextKey;
+  public readonly searchContextKey: SearchContextKey;
 
   @Autowired(LabelService)
   private readonly labelService: LabelService;

--- a/packages/search/src/browser/tree/search-tree.service.ts
+++ b/packages/search/src/browser/tree/search-tree.service.ts
@@ -1,6 +1,7 @@
 import { Autowired, Injectable } from '@opensumi/di';
 import { LabelService } from '@opensumi/ide-core-browser';
 import {
+  Deferred,
   Disposable,
   DisposableStore,
   Emitter,
@@ -214,6 +215,8 @@ export class SearchTreeService extends Disposable implements ISearchTreeService 
   @Autowired(LabelService)
   private readonly labelService: LabelService;
 
+  viewReady = new Deferred<void>();
+
   constructor() {
     super();
     this.addDispose(this.rangeHighlightDecorations);
@@ -236,6 +239,7 @@ export class SearchTreeService extends Disposable implements ISearchTreeService 
 
   initContextKey(dom: HTMLDivElement) {
     this.contextKey.initScopedContext(dom);
+    this.viewReady.resolve();
   }
 
   removeHighlightRange() {

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -87,6 +87,8 @@ export class SearchModelService extends Disposable {
 
   private disposableCollection: DisposableCollection = new DisposableCollection();
 
+  public treeIsDirty = false;
+
   constructor() {
     super();
     this._whenReady = this.initTreeModel();
@@ -145,7 +147,12 @@ export class SearchModelService extends Disposable {
         } else {
           this.searchTreeService.contextKey.hasSearchResults.set(false);
         }
-        this.refresh();
+
+        if (this.searchTreeService.contextKey.searchViewVisibleKey) {
+          this.refresh();
+        } else {
+          this.treeIsDirty = true;
+        }
       }),
     );
 
@@ -314,6 +321,10 @@ export class SearchModelService extends Disposable {
 
   async refresh() {
     await this.whenReady;
+    if (!this.searchTreeService.contextKey.searchViewVisibleKey) {
+      return;
+    }
+
     runWhenIdle(() => {
       this.treeModel.root.refresh();
     });
@@ -333,6 +344,23 @@ export class SearchModelService extends Disposable {
       .withScheme(Schemes.internal)
       .withFragment(REPLACE_PREVIEW)
       .withQuery(JSON.stringify({ scheme: fileResource.scheme }));
+  }
+
+  activate() {
+    if (this.searchTreeService.contextKey) {
+      this.searchTreeService.contextKey.searchViewVisibleKey.set(true);
+    }
+
+    if (this.treeIsDirty) {
+      this.refresh();
+      this.treeIsDirty = false;
+    }
+  }
+
+  deactivate() {
+    if (this.searchTreeService.contextKey) {
+      this.searchTreeService.contextKey.searchViewVisibleKey.set(false);
+    }
   }
 
   dispose() {

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -148,7 +148,7 @@ export class SearchModelService extends Disposable {
           this.searchTreeService.contextKey.hasSearchResults.set(false);
         }
 
-        if (this.searchTreeService.contextKey.searchViewVisibleKey) {
+        if (this.searchTreeService.contextKey.searchViewVisibleKey.get()) {
           this.refresh();
         } else {
           this.treeIsDirty = true;
@@ -321,13 +321,11 @@ export class SearchModelService extends Disposable {
 
   async refresh() {
     await this.whenReady;
-    if (!this.searchTreeService.contextKey.searchViewVisibleKey) {
-      return;
+    if (this.searchTreeService.contextKey && this.searchTreeService.contextKey.searchViewVisibleKey.get()) {
+      runWhenIdle(() => {
+        this.treeModel.root.refresh();
+      });
     }
-
-    runWhenIdle(() => {
-      this.treeModel.root.refresh();
-    });
   }
 
   collapsedAll() {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

when search panel and markers panel are hidden, the tree refresh still happening, this is no need

![CleanShot 2024-03-14 at 11 44 38@2x](https://github.com/opensumi/core/assets/13938334/625f8ddf-7ad4-41f7-ac87-d0940352b7e3)


### Changelog

