### PR TITLE
fix: rename widget show keycode

### DIFF
--- a/packages/monaco/src/browser/index.ts
+++ b/packages/monaco/src/browser/index.ts
@@ -11,7 +11,6 @@ import {
 } from '@opensumi/ide-core-browser';
 import { IConfigurationService } from '@opensumi/monaco-editor-core/esm/vs/platform/configuration/common/configuration';
 
-import { MergeEditorService } from './contrib/merge-editor/merge-editor.service';
 import { ConfigurationService, MonacoContextKeyService } from './monaco.context-key.service';
 import { MonacoClientContribution } from './monaco.contribution';
 import MonacoServiceImpl from './monaco.service';


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

close: #3089

![CleanShot 2024-03-21 at 17 15 37@2x](https://github.com/opensumi/core/assets/13938334/c08c9770-ec35-4114-bad3-208e6fd4a27f)

### Changelog

Fix rename widget cannot show key code
