### PR TITLE
fix: ai chat panel cannot be persisted after closing the panel

### DIFF
--- a/packages/ai-native/src/browser/ai-chat.view.tsx
+++ b/packages/ai-native/src/browser/ai-chat.view.tsx
@@ -9,10 +9,12 @@ import {
   getIcon,
   useInjectable,
 } from '@opensumi/ide-core-browser';
+import { AI_CHAT_PANEL_TOGGLE_VISIBLE } from '@opensumi/ide-core-browser/lib/ai-native/command';
 import { Button, Icon, Popover, Tooltip } from '@opensumi/ide-core-browser/lib/components';
 import { EnhanceIcon } from '@opensumi/ide-core-browser/lib/components/ai-native';
 import { CommandOpener } from '@opensumi/ide-core-browser/lib/opener/command-opener';
 import { Command, URI, isMacintosh, uuid } from '@opensumi/ide-core-common';
+import { CommandService } from '@opensumi/ide-core-common';
 import { IAiBackServiceResponse } from '@opensumi/ide-core-common/lib/ai-native';
 import { AISerivceType, IAIReporter } from '@opensumi/ide-core-common/lib/ai-native/reporter';
 
@@ -31,7 +33,7 @@ import { Markdown } from './components/Markdown';
 import { StreamMsgWrapper } from './components/StreamMsg';
 import { Thinking } from './components/Thinking';
 import { EMsgStreamStatus, MsgStreamManager } from './model/msg-stream-manager';
-import { AiMenubarService } from './override/layout/menu-bar/menu-bar.service';
+// import { AiMenubarService } from './override/layout/menu-bar/menu-bar.service';
 import { AiRunService } from './run/run.service';
 
 import 'react-chat-elements/dist/main.css';
@@ -161,7 +163,7 @@ export const AiChatView = observer(() => {
   const aiProjectGenerateService = useInjectable<AiProjectGenerateService>(AiProjectGenerateService);
   const aiSumiService = useInjectable<AiSumiService>(AiSumiService);
   const aiRunService = useInjectable<AiRunService>(AiRunService);
-  const aiMenubarService = useInjectable<AiMenubarService>(AiMenubarService);
+  // const aiMenubarService = useInjectable<AiMenubarService>(AiMenubarService);
   const aiReporter = useInjectable<IAIReporter>(IAIReporter);
   const opener = useInjectable<CommandOpener>(CommandOpener);
   const msgStreamManager = useInjectable<MsgStreamManager>(MsgStreamManager);
@@ -171,6 +173,7 @@ export const AiChatView = observer(() => {
   const [messageListData, setMessageListData] = React.useState<MessageData[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [loading2, setLoading2] = React.useState(false);
+  const commandService = useInjectable<CommandService>(CommandService);
 
   // TODO: theme 基于 command 改造成 command 形式
   const [agentId, setAgentId] = React.useState('');
@@ -456,8 +459,8 @@ export const AiChatView = observer(() => {
   }, [messageListData]);
 
   const handleClose = React.useCallback(() => {
-    aiMenubarService.toggleRightPanel();
-  }, [aiMenubarService]);
+    commandService.executeCommand(AI_CHAT_PANEL_TOGGLE_VISIBLE.id);
+  }, []);
 
   const handleThemeClick = (value) => {
     if (loading || loading2) {

--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -47,6 +47,7 @@ import {
   AI_NATIVE_SETTING_GROUP_ID,
   AiNativeSettingSectionsId,
   Ai_CHAT_CONTAINER_VIEW_ID,
+  AI_CHAT_DEFAULT_SIZE,
   InstructionEnum,
 } from '../common';
 
@@ -281,16 +282,17 @@ export class AiNativeBrowserContribution
     commands.registerCommand(AI_CHAT_PANEL_TOGGLE_VISIBLE, {
       execute: (visible: boolean) => {
         const { layout } = getStorageValue();
-        // 更新layout的值
         if (layout[Ai_CHAT_CONTAINER_VIEW_ID]?.currentId) {
           this.updateLayoutState({
             currentId: '',
-            size: 300,
+            // 默认初始化尺寸有问题，在这里修正
+            size: AI_CHAT_DEFAULT_SIZE,
           });
         } else {
           this.updateLayoutState({
             currentId: Ai_CHAT_CONTAINER_VIEW_ID,
-            size: 300,
+            // 默认初始化尺寸有问题，在这里修正
+            size: AI_CHAT_DEFAULT_SIZE,
           });
         }
         if (visible === true) {

--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -29,7 +29,9 @@ import {
   AI_INLINE_COMPLETION_VISIBLE,
   AI_RUN_DEBUG_COMMANDS,
 } from '@opensumi/ide-core-browser/lib/ai-native/command';
+import { getStorageValue } from '@opensumi/ide-core-browser/lib/components';
 import { InlineChatIsVisible, InlineCompletionIsTrigger } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
+import { LayoutState, LAYOUT_STATE } from '@opensumi/ide-core-browser/lib/layout/layout-state';
 import { IMenuRegistry, MenuContribution, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { DebugConsoleNode } from '@opensumi/ide-debug/lib/browser/tree';
 import { IEditor, IResource, ResourceService } from '@opensumi/ide-editor';
@@ -135,6 +137,9 @@ export class AiNativeBrowserContribution
 
   @Autowired(AiMenubarService)
   private readonly aiMenubarService: AiMenubarService;
+
+  @Autowired(LayoutState)
+  private layoutState: LayoutState;
 
   constructor() {
     this.registerFeature();
@@ -275,6 +280,19 @@ export class AiNativeBrowserContribution
 
     commands.registerCommand(AI_CHAT_PANEL_TOGGLE_VISIBLE, {
       execute: (visible: boolean) => {
+        const { layout } = getStorageValue();
+        // 更新layout的值
+        if (layout[Ai_CHAT_CONTAINER_VIEW_ID]?.currentId) {
+          this.updateLayoutState({
+            currentId: '',
+            size: 300,
+          });
+        } else {
+          this.updateLayoutState({
+            currentId: Ai_CHAT_CONTAINER_VIEW_ID,
+            size: 300,
+          });
+        }
         if (visible === true) {
           if (this.aiMenubarService.getLatestWidth() !== 0) {
             this.aiMenubarService.toggleRightPanel();
@@ -361,5 +379,12 @@ export class AiNativeBrowserContribution
         when: `editorFocus && ${InlineCompletionIsTrigger.raw}`,
       });
     }
+  }
+
+  private updateLayoutState(stateVal: { currentId: string; size: number }) {
+    this.layoutState.setState(LAYOUT_STATE.MAIN, {
+      ...this.layoutState.getState(LAYOUT_STATE.MAIN, {}),
+      [Ai_CHAT_CONTAINER_VIEW_ID]: stateVal,
+    });
   }
 }

--- a/packages/ai-native/src/browser/override/layout/main-slot-renderer.tsx
+++ b/packages/ai-native/src/browser/override/layout/main-slot-renderer.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { SlotRenderer } from '@opensumi/ide-core-browser';
 import { IChildComponentProps, SplitPanel, getStorageValue } from '@opensumi/ide-core-browser/lib/components';
 
-import { Ai_CHAT_CONTAINER_VIEW_ID } from '../../../common';
+import { Ai_CHAT_CONTAINER_VIEW_ID, AI_CHAT_DEFAULT_SIZE } from '../../../common';
 
 import * as styles from './layout.module.less';
 
@@ -43,7 +43,7 @@ export const AiMainSlotRenderer = (props?: IChildComponentProps) => {
       <SlotRenderer
         slot={Ai_CHAT_CONTAINER_VIEW_ID}
         isTabbar={true}
-        defaultSize={layout['ai_chat']?.currentId ? 360 : 0}
+        defaultSize={layout['ai_chat']?.currentId ? AI_CHAT_DEFAULT_SIZE : 0}
         maxResize={420}
         minResize={280}
         minSize={0}

--- a/packages/ai-native/src/browser/override/layout/main-slot-renderer.tsx
+++ b/packages/ai-native/src/browser/override/layout/main-slot-renderer.tsx
@@ -43,7 +43,7 @@ export const AiMainSlotRenderer = (props?: IChildComponentProps) => {
       <SlotRenderer
         slot={Ai_CHAT_CONTAINER_VIEW_ID}
         isTabbar={true}
-        defaultSize={360}
+        defaultSize={layout['ai_chat']?.currentId ? 360 : 0}
         maxResize={420}
         minResize={280}
         minSize={0}

--- a/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.service.ts
+++ b/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Autowired } from '@opensumi/di';
 import { BasicEvent, Dispatcher, Disposable } from '@opensumi/ide-core-common';
 
+import { AI_CHAT_DEFAULT_SIZE } from '../../../../common';
+
 @Injectable()
 export class AiMenubarService extends Disposable {
   private latestWidth = 0;
@@ -24,7 +26,7 @@ export class AiMenubarService extends Disposable {
       if (preWidth !== 0) {
         chatPanel.style.width = '0px';
       } else {
-        chatPanel.style.width = this.latestWidth + 'px';
+        chatPanel.style.width = `${this.latestWidth || AI_CHAT_DEFAULT_SIZE}px`;
       }
 
       this.latestWidth = preWidth;

--- a/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.view.tsx
+++ b/packages/ai-native/src/browser/override/layout/menu-bar/menu-bar.view.tsx
@@ -1,14 +1,9 @@
 import clsx from 'classnames';
 import * as React from 'react';
 
-import {
-  getIcon,
-  useInjectable,
-  SlotRenderer,
-  SlotLocation,
-  AiNativeConfigService,
-} from '@opensumi/ide-core-browser';
+import { getIcon, useInjectable, SlotRenderer, SlotLocation, AiNativeConfigService } from '@opensumi/ide-core-browser';
 // import { AI_RUN_DEBUG_COMMANDS } from '@opensumi/ide-core-browser/lib/ai-native/command';
+import { AI_CHAT_PANEL_TOGGLE_VISIBLE } from '@opensumi/ide-core-browser/lib/ai-native/command';
 import { Icon } from '@opensumi/ide-core-browser/lib/components';
 import { AILogoAvatar, EnhanceIcon } from '@opensumi/ide-core-browser/lib/components/ai-native';
 import { LAYOUT_VIEW_SIZE } from '@opensumi/ide-core-browser/lib/layout/constants';
@@ -20,7 +15,6 @@ import { IMainLayoutService } from '@opensumi/ide-main-layout';
 import { AI_MENU_BAR_LEFT, AI_MENU_BAR_RIGHT } from '../layout-config';
 
 import * as styles from './menu-bar.module.less';
-import { AiMenubarService } from './menu-bar.service';
 
 const AiMenuBarRender = () => {
   const contextmenuService = useInjectable<AbstractContextMenuService>(AbstractContextMenuService);
@@ -79,31 +73,17 @@ const AiMenuBarRender = () => {
 
 export const AiMenuBarView = () => {
   const commandService = useInjectable<CommandService>(CommandService);
-  const aiMenubarService = useInjectable<AiMenubarService>(AiMenubarService);
   const mainLayoutService = useInjectable<IMainLayoutService>(IMainLayoutService);
   const aiNativeConfigService = useInjectable<AiNativeConfigService>(AiNativeConfigService);
   const [isVisiablePanel, setIsVisiablePanel] = React.useState<boolean>(false);
-
-  const [isOpen, setIsOpen] = React.useState<boolean>(true);
 
   // const handleRun = () => {
   //   commandService.executeCommand(AI_RUN_DEBUG_COMMANDS.id);
   // };
 
   const handleRightPanel = () => {
-    aiMenubarService.toggleRightPanel();
+    commandService.executeCommand(AI_CHAT_PANEL_TOGGLE_VISIBLE.id);
   };
-
-  React.useEffect(() => {
-    const dispose = aiMenubarService.onDidChangeDispatcher.on('latestWidth')((data: number) => {
-      if (!data) {
-        setIsOpen(true);
-      } else {
-        setIsOpen(false);
-      }
-    });
-    return () => dispose.dispose();
-  }, [aiMenubarService]);
 
   const isVisiable = React.useCallback(() => {
     const tabbarService = mainLayoutService.getTabbarService(SlotLocation.left);
@@ -161,7 +141,7 @@ export const AiMenuBarView = () => {
             ></Input>
           </div> */}
           {aiNativeConfigService.capabilities.supportsAiChatAssistant && (
-            <div className={clsx(styles.ai_switch, isOpen ? '' : styles.closed)} onClick={handleRightPanel}>
+            <div className={styles.ai_switch} onClick={handleRightPanel}>
               <AILogoAvatar iconClassName={styles.avatar_icon_large} />
             </div>
           )}

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -5,6 +5,7 @@ export const AiInlineChatContentWidget = 'Ai-inline-chat-content-widget';
 
 export const Ai_CHAT_CONTAINER_VIEW_ID = 'ai_chat';
 export const Ai_MENUBAR_CONTAINER_VIEW_ID = 'ai_menubar';
+export const AI_CHAT_DEFAULT_SIZE = 360;
 
 export interface IChatMessageStructure {
   /**


### PR DESCRIPTION
### Types

- [X] 🐛 Bug Fixes


### Background or solution
Ai Chat面板关闭后，重新刷新页面还是默认展开
### Changelog
修复Ai Chat面板关闭后下载进来还是默认展开的问题