### PR TITLE
style: improve design tabbar style

### DIFF
--- a/packages/design/src/browser/style/design.module.less
+++ b/packages/design/src/browser/style/design.module.less
@@ -512,10 +512,6 @@ div[class*='design-editor_tab_block_container__'] {
   overflow: hidden;
   margin-right: 1px;
 
-  .design-tab_bar {
-    padding-top: 10px;
-  }
-
   .design-tab_panel {
     border-right: none;
   }
@@ -692,6 +688,7 @@ div[class*='design-editor_tab_block_container__'] {
 
   .design-left_tab_bar,
   .design-right_tab_bar {
+    padding-top: 10px;
     border-right: none;
     border-top: none;
     width: 48px;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution
before:
<img width="57" alt="image" src="https://github.com/opensumi/core/assets/9823838/246dd90a-eb61-45a8-8bac-775e4ea1ff55">

after:
![截屏2024-03-28 16 57 02](https://github.com/opensumi/core/assets/9823838/a6d37089-dcf4-42b5-9574-e813c246a048)

### Changelog
improve design tabbar style
