### PR TITLE
fix: language config maybe not match its location

### DIFF
--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -222,7 +222,8 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
         if (model && model.instance) {
           const langId = model.instance.getMonacoModel().getLanguageId();
           if (this.languageConfiguration.has(langId)) {
-            await this.loadLanguageConfiguration(this.languageConfiguration.get(langId)!, baseUri);
+            const location = this.languageConfigLocation.get(langId)!;
+            await this.loadLanguageConfiguration(this.languageConfiguration.get(langId)!, location);
             this.activateLanguage(langId);
           }
         }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

textmateService 注册多个同名 languageId 的 language 配置时，有一定几率使用其他同名 language id 的 language 配置。

registerLanguages 里面的 forEach 是 async 函数，因此不能保证在当前函数内，使用 this.languageConfiguration.get(langId) 得到的 language 配置，就是当前注册的 language，所以至少 Location 应该也从 languageConfigLocation 中读取来保证一致。

最好还应该把 languages.forEach 里面 async 移除，因为里面除了 addDispose 内需要使用 async 外，其实并不是 async 函数。这样整个代码不会有跨越 await 的问题。

该问题不是很好复现，似乎跟机器性能有关。

### Changelog

fix when language has multiple language config, location will not match the correct language config.