### PR TITLE
fix: restore resource missing editor open types menu

### DIFF
--- a/packages/editor/src/browser/menu/open-type-menu.contribution.ts
+++ b/packages/editor/src/browser/menu/open-type-menu.contribution.ts
@@ -43,6 +43,7 @@ export class OpenTypeMenuContribution extends Disposable implements CommandContr
 
   constructor() {
     super();
+    this.registerEditorOpenTypes();
     this.disposables.push(
       this.workbenchEditorService.onActiveResourceChange((e) => {
         this.registerEditorOpenTypes();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

当打开 workspace 时默认打开的文件，有多种打开方式时，右上角的“打开方式”不会显示，需要进行一次切换才能显示。

阅读对应代码，发现之前是通过 workbenchEditorService 的 onActiveResourceChange 事件注册打开方式。而第一次打开 workspace 时，不会触发该事件，导致 menu 没有注册。
因此这边在初始化的时候，额外调用一次，作为初始状态。

在我们的项目中，可以稳定复现，添加上述逻辑后，问题修复。

其他修复方式：

可以修改`workbench-editor.service.ts`，使其在`restoreState`操作中，也触发一下这个事件。这种解决办法的改动较大，担心有额外牵连（`@opensumi/ide-core-browser`里面有一个类似的情况，由于其中的 `src/preferences/preference-provider.ts`会在拿到注入的默认值时，会调用一次`PreferencesChangedEvent`，导致 preference contribution 会在注入到 DI 之前就运行一次，导致 console 会有`no Provider`的报错，不过暂时不影响实际运行）。
目前改动方式，没有看到什么问题，因此我没有选择。

复现办法：

在工作区，打开一个注册了多种打开方式的文件，然后关闭整个工作区项目，然后重新打开。

### Changelog

fix: restore resource missing editor open types menu