### PR TITLE
fix: hide editor readonly popup on output view

### DIFF
--- a/packages/output/src/browser/output.service.ts
+++ b/packages/output/src/browser/output.service.ts
@@ -127,6 +127,7 @@ export class OutputService extends WithEventBus {
       lineDecorationsWidth: 20,
       automaticLayout: true,
       readOnly: true,
+      domReadOnly: true,
       extraEditorClassName: 'kt-output-monaco',
       scrollbar: {
         useShadows: false,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

Hide editor readonly popup on output view.

<img width="274" alt="image" src="https://github.com/opensumi/core/assets/6882794/a20acb31-c439-4736-9045-025603a14e45">


### Changelog
Hide editor readonly popup on output view