### PR TITLE
fix: show all types debug session output

### DIFF
--- a/packages/debug/__tests__/browser/tree/debug-tree-node.define.test.ts
+++ b/packages/debug/__tests__/browser/tree/debug-tree-node.define.test.ts
@@ -286,7 +286,7 @@ describe('DebugConsoleRoot —— DebugConsoleNode —— DebugConsoleVariableCo
       mockContainerNodeOptions.variable,
       root,
     );
-    node = new DebugConsoleNode(mockSession, expression, root);
+    node = new DebugConsoleNode({ session: mockSession }, expression, root);
   });
 
   it('should have correct property', () => {

--- a/packages/debug/__tests__/browser/view/console/debug-console-tree.model.service.test.ts
+++ b/packages/debug/__tests__/browser/view/console/debug-console-tree.model.service.test.ts
@@ -231,7 +231,7 @@ describe('Debug Console Tree Model', () => {
 
   it('initTreeModel method should be work', () => {
     const mockSession = {
-      on: jest.fn(),
+      on: jest.fn(() => Disposable.create(() => {})),
       hasSeparateRepl: () => true,
       parentSession: undefined,
     } as Partial<IDebugSession>;
@@ -241,7 +241,7 @@ describe('Debug Console Tree Model', () => {
 
   it('clear method should be work', () => {
     const mockSession = {
-      on: jest.fn(),
+      on: jest.fn(() => Disposable.create(() => {})),
       hasSeparateRepl: () => true,
       parentSession: undefined,
     } as Partial<IDebugSession>;
@@ -252,7 +252,7 @@ describe('Debug Console Tree Model', () => {
 
   it('activeNodeDecoration method should be work', () => {
     const mockSession = {
-      on: jest.fn(),
+      on: jest.fn(() => Disposable.create(() => {})),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
     const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
@@ -263,7 +263,7 @@ describe('Debug Console Tree Model', () => {
 
   it('enactiveNodeDecoration method should be work', () => {
     const mockSession = {
-      on: jest.fn(),
+      on: jest.fn(() => Disposable.create(() => {})),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
     const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
@@ -278,7 +278,7 @@ describe('Debug Console Tree Model', () => {
 
   it('removeNodeDecoration method should be work', () => {
     const mockSession = {
-      on: jest.fn(),
+      on: jest.fn(() => Disposable.create(() => {})),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
     const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
@@ -298,7 +298,7 @@ describe('Debug Console Tree Model', () => {
 
   it('handleTreeBlur method should be work', () => {
     const mockSession = {
-      on: jest.fn(),
+      on: jest.fn(() => Disposable.create(() => {})),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
     const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);

--- a/packages/debug/__tests__/browser/view/console/debug-console-tree.model.service.test.ts
+++ b/packages/debug/__tests__/browser/view/console/debug-console-tree.model.service.test.ts
@@ -255,7 +255,7 @@ describe('Debug Console Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugConsoleModelService.activeNodeDecoration(node);
     const decoration = debugConsoleModelService.decorations.getDecorations(node);
     expect(decoration).toBeDefined();
@@ -266,7 +266,7 @@ describe('Debug Console Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugConsoleModelService.activeNodeDecoration(node);
     let decoration = debugConsoleModelService.decorations.getDecorations(node);
     expect(decoration).toBeDefined();
@@ -281,7 +281,7 @@ describe('Debug Console Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugConsoleModelService.activeNodeDecoration(node);
     let decoration = debugConsoleModelService.decorations.getDecorations(node);
     debugConsoleModelService.removeNodeDecoration();
@@ -301,7 +301,7 @@ describe('Debug Console Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugConsoleModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugConsoleModelService.initDecorations(mockRoot);
     debugConsoleModelService.activeNodeDecoration(node);
     let decoration = debugConsoleModelService.decorations.getDecorations(node);

--- a/packages/debug/__tests__/browser/view/variables/debug-variables-tree.model.service.test.ts
+++ b/packages/debug/__tests__/browser/view/variables/debug-variables-tree.model.service.test.ts
@@ -147,7 +147,7 @@ describe('Debug Variables Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugVariablesModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugVariablesModelService.activeNodeDecoration(node);
     const decoration = debugVariablesModelService.decorations.getDecorations(node);
     expect(decoration).toBeDefined();
@@ -159,7 +159,7 @@ describe('Debug Variables Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugVariablesModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugVariablesModelService.activeNodeDecoration(node);
     let decoration = debugVariablesModelService.decorations.getDecorations(node);
     expect(decoration).toBeDefined();
@@ -175,7 +175,7 @@ describe('Debug Variables Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugVariablesModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugVariablesModelService.activeNodeDecoration(node);
     let decoration = debugVariablesModelService.decorations.getDecorations(node);
     debugVariablesModelService.removeNodeDecoration();
@@ -195,7 +195,7 @@ describe('Debug Variables Tree Model', () => {
       on: jest.fn(),
     } as any;
     debugVariablesModelService.initDecorations(mockRoot);
-    const node = new DebugConsoleNode(mockSession, 'test', mockRoot);
+    const node = new DebugConsoleNode({ session: mockSession }, 'test', mockRoot);
     debugVariablesModelService.initDecorations(mockRoot);
     debugVariablesModelService.activeNodeDecoration(node);
     let decoration = debugVariablesModelService.decorations.getDecorations(node);

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -982,6 +982,14 @@ export class DebugSession implements IDebugSession {
     return response.body;
   }
 
+  async variables(
+    variablesReference: number,
+    filter: 'indexed' | 'named' = 'named',
+  ): Promise<DebugProtocol.VariablesResponse['body']> {
+    const response = await this.sendRequest('variables', { variablesReference, filter });
+    return response.body;
+  }
+
   async goto(args: DebugProtocol.GotoArguments): Promise<DebugProtocol.GotoResponse | void> {
     if (this.capabilities.supportsGotoTargetsRequest) {
       const res = await this.sendRequest('goto', args);

--- a/packages/debug/src/browser/view/console/debug-console-tree.model.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console-tree.model.service.ts
@@ -259,6 +259,7 @@ export class DebugConsoleModelService implements IDebugConsoleModelService {
 
     if (this.debugSessionModelMap.has(sessionId) && !force) {
       const model = this.debugSessionModelMap.get(sessionId);
+      model?.debugConsoleSession.addChildSession(session);
       this._activeDebugSessionModel = model;
     } else {
       // 根据是否为多工作区创建不同根节点
@@ -533,7 +534,11 @@ export class DebugConsoleModelService implements IDebugConsoleModelService {
     const parent: DebugConsoleRoot = this.treeModel.root as DebugConsoleRoot;
     const textNode = new AnsiConsoleNode(value, parent, this.linkDetector);
     this.dispatchWatchEvent(parent, parent.path, { type: WatchEvent.Added, node: textNode, id: parent.id });
-    const expressionNode = new DebugConsoleNode(this.manager.currentSession, value, parent as ExpressionContainer);
+    const expressionNode = new DebugConsoleNode(
+      { session: this.manager.currentSession },
+      value,
+      parent as ExpressionContainer,
+    );
     await expressionNode.evaluate();
     this.dispatchWatchEvent(parent, parent.path, { type: WatchEvent.Added, node: expressionNode, id: parent.id });
     this.treeHandle.ensureVisible(expressionNode, 'end', true);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

修复调试 NodeJS 情况下，代码的 Console 无法正常输出的问题。
![image](https://github.com/opensumi/core/assets/9823838/a9192dbe-c935-4677-b1ba-d0070e4d2d11)

### Changelog

show all types debug session output
