### PR TITLE
fix(electron): keep defaultWebPreferences field

### DIFF
--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -78,12 +78,6 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
     this.browser = new BrowserWindow({
       show: false,
-      webPreferences: {
-        ...defaultWebPreferences,
-        ...this.appConfig?.overrideWebPreferences,
-        nodeIntegration: this.appConfig?.browserNodeIntegrated,
-        preload: this.appConfig?.browserPreload,
-      },
       frame: isMacintosh,
       titleBarStyle: 'hidden',
       height: DEFAULT_WINDOW_HEIGHT,
@@ -92,6 +86,13 @@ export class CodeWindow extends Disposable implements ICodeWindow {
       trafficLightPosition: { x: 10, y: 10 },
       ...this.appConfig.overrideBrowserOptions,
       ...options,
+      webPreferences: {
+        ...defaultWebPreferences,
+        ...this.appConfig?.overrideWebPreferences,
+        nodeIntegration: this.appConfig?.browserNodeIntegrated,
+        preload: this.appConfig?.browserPreload,
+        ...options.webPreferences,
+      },
     });
 
     if (options) {


### PR DESCRIPTION
…nces don't have these fields

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

如果 loadWorkspace API 的 options 参数中包含 webPreferences 字段的话，目前这个 options 的 webPreferences 直接覆盖原有的所有内容，导致启动前端 preload 等失败。 options 的 webPreferences 应该放到默认参数里面的，进行展开操作。

### Changelog

fix: default webPreference filed should be left if options webPreferences don't have these fields
