### PR TITLE
fix: monaco keybinding registry

### DIFF
--- a/packages/monaco/src/browser/monaco.contribution.ts
+++ b/packages/monaco/src/browser/monaco.contribution.ts
@@ -490,7 +490,7 @@ export class MonacoClientContribution
           command,
           args: item.commandArgs,
           keybinding: rawKeybinding,
-          when: (item.when && item.when.serialize()) ?? undefined,
+          when: (when && when.serialize()) ?? undefined,
           // monaco内优先级计算时为双优先级相加，第一优先级权重 * 100
           priority: (item.weight1 ? item.weight1 * 100 : 0) + (item.weight2 || 0),
         };


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

修复部分 monaco 快捷键缺少 when 导致的异常触发问题

### Changelog

fix monaco keybinding registry