### PR TITLE
style: improve monaco hover widget style

### DIFF
--- a/packages/core-browser/src/style/monaco-hover.less
+++ b/packages/core-browser/src/style/monaco-hover.less
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Copied from https://github.com/microsoft/vscode/blob/a984153d6a98fba04f0a39a5ab9918c7b6e47511/src/vs/base/browser/ui/hover/hoverWidget.css
+.monaco-hover {
+  cursor: default;
+  position: absolute;
+  overflow: hidden;
+  user-select: text;
+  -webkit-user-select: text;
+  box-sizing: border-box;
+  animation: fadein 100ms linear;
+  line-height: 1.5em;
+  white-space: var(--vscode-hover-whiteSpace, normal);
+}
+
+.monaco-hover.hidden {
+  display: none;
+}
+
+.monaco-hover a:hover:not(.disabled) {
+  cursor: pointer;
+}
+
+.monaco-hover .hover-contents:not(.html-hover-contents) {
+  padding: 4px 8px;
+}
+
+.monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
+  max-width: var(--vscode-hover-maxWidth, 500px);
+  word-wrap: break-word;
+}
+
+.monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) hr {
+  min-width: 100%;
+}
+
+.monaco-hover p,
+.monaco-hover .code,
+.monaco-hover ul,
+.monaco-hover h1,
+.monaco-hover h2,
+.monaco-hover h3,
+.monaco-hover h4,
+.monaco-hover h5,
+.monaco-hover h6 {
+  margin: 8px 0;
+}
+
+.monaco-hover h1,
+.monaco-hover h2,
+.monaco-hover h3,
+.monaco-hover h4,
+.monaco-hover h5,
+.monaco-hover h6 {
+  line-height: 1.1;
+}
+
+.monaco-hover code {
+  font-family: var(--monaco-monospace-font);
+}
+
+.monaco-hover hr {
+  box-sizing: border-box;
+  border-left: 0px;
+  border-right: 0px;
+  margin-top: 4px;
+  margin-bottom: -4px;
+  margin-left: -8px;
+  margin-right: -8px;
+  height: 1px;
+}
+
+.monaco-hover p:first-child,
+.monaco-hover .code:first-child,
+.monaco-hover ul:first-child {
+  margin-top: 0;
+}
+
+.monaco-hover p:last-child,
+.monaco-hover .code:last-child,
+.monaco-hover ul:last-child {
+  margin-bottom: 0;
+}
+
+/* MarkupContent Layout */
+.monaco-hover ul {
+  padding-left: 20px;
+}
+
+.monaco-hover ol {
+  padding-left: 20px;
+}
+
+.monaco-hover li > p {
+  margin-bottom: 0;
+}
+
+.monaco-hover li > ul {
+  margin-top: 0;
+}
+
+.monaco-hover code {
+  border-radius: 3px;
+  padding: 0 0.4em;
+}
+
+.monaco-hover .monaco-tokenized-source {
+  white-space: var(--vscode-hover-sourceWhiteSpace, pre-wrap);
+}
+
+.monaco-hover .hover-row.status-bar {
+  font-size: 12px;
+  line-height: 22px;
+}
+
+.monaco-hover .hover-row.status-bar .info {
+  font-style: italic;
+  padding: 0px 8px;
+}
+
+.monaco-hover .hover-row.status-bar .actions {
+  display: flex;
+  padding: 0px 8px;
+}
+
+.monaco-hover .hover-row.status-bar .actions .action-container {
+  margin-right: 16px;
+  cursor: pointer;
+}
+
+.monaco-hover .hover-row.status-bar .actions .action-container .action .icon {
+  padding-right: 4px;
+}
+
+.monaco-hover .markdown-hover .hover-contents .codicon {
+  color: inherit;
+  font-size: inherit;
+  vertical-align: middle;
+}
+
+.monaco-hover .hover-contents a.code-link:hover,
+.monaco-hover .hover-contents a.code-link {
+  color: inherit;
+}
+
+.monaco-hover .hover-contents a.code-link:before {
+  content: '(';
+}
+
+.monaco-hover .hover-contents a.code-link:after {
+  content: ')';
+}
+
+.monaco-hover .hover-contents a.code-link > span {
+  text-decoration: underline;
+  /** Hack to force underline to show **/
+  border-bottom: 1px solid transparent;
+  text-underline-position: under;
+  color: var(--vscode-textLink-foreground);
+}
+
+.monaco-hover .hover-contents a.code-link > span:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
+/** Spans in markdown hovers need a margin-bottom to avoid looking cramped: https://github.com/microsoft/vscode/issues/101496 **/
+.monaco-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span {
+  margin-bottom: 4px;
+  display: inline-block;
+}
+
+.monaco-hover-content .action-container a {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.monaco-hover-content .action-container.disabled {
+  pointer-events: none;
+  opacity: 0.4;
+  cursor: default;
+}
+
+.monaco-hover img {
+  display: inline;
+}
+
+.monaco-action-bar .action-label {
+  box-sizing: content-box;
+}

--- a/packages/core-browser/src/style/monaco-override.less
+++ b/packages/core-browser/src/style/monaco-override.less
@@ -1,3 +1,5 @@
+@import './monaco-hover.less';
+
 .kt-output-monaco {
   .margin,
   .monaco-editor-background {

--- a/packages/core-browser/src/style/override.less
+++ b/packages/core-browser/src/style/override.less
@@ -1,10 +1,6 @@
 @import '@opensumi/ide-components/lib/style/mixins.less';
 @import './variable.less';
 
-.codicon[class*='codicon-'] {
-  display: inline-flex !important;
-}
-
 .overrideMenu(@n, @i: 1) when (@i =< @n) {
   @clsx: extract(@menuClx, @i);
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

After:

![image](https://github.com/opensumi/core/assets/9823838/f98220ec-ae01-42f8-bec5-f8e05446dfc5)
![image](https://github.com/opensumi/core/assets/9823838/2a346cb0-6481-43f3-a103-7126993af805)

### Changelog

improve monaco hover widget style