### PR TITLE
ci: use node 18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
       - v*.*
     paths:
       - 'packages/**'
+      - package.json
+      - yarn.lock
 
 jobs:
   unittest:
@@ -24,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        node-version: [20.x]
+        node-version: [18.x]
         ci-project: [node, jsdom]
 
     steps:
@@ -53,7 +55,7 @@ jobs:
         run: |
           yarn run ci --selectProjects ${{ matrix.ci-project }}
 
-      - if: ${{ matrix.node-version == '20.x' && matrix.os == 'ubuntu-latest' }}
+      - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-jasmine2": "^28.0.3",
     "jsdom": "^20.0.0",
-    "jsdom-worker": "^0.2.1",
+    "jsdom-worker": "^0.3.0",
     "lerna": "^8.0.2",
     "lint-staged": "^15.2.2",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,7 +2136,7 @@ __metadata:
     jest-fetch-mock: ^3.0.3
     jest-jasmine2: ^28.0.3
     jsdom: ^20.0.0
-    jsdom-worker: ^0.2.1
+    jsdom-worker: ^0.3.0
     lerna: ^8.0.2
     lint-staged: ^15.2.2
     lodash: ^4.17.21
@@ -12444,15 +12444,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom-worker@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "jsdom-worker@npm:0.2.1"
+"jsdom-worker@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "jsdom-worker@npm:0.3.0"
   dependencies:
-    mitt: ^1.1.3
+    mitt: ^3.0.0
     uuid-v4: ^0.1.0
   peerDependencies:
     node-fetch: "*"
-  checksum: e27582f5b64f1fe664af168d1e9b5e543907869a3424c4b1da7da894075dc53742d194aedc48ca5a431438e1f17a58ae5f3d7746fcb4daf84dc3dded28d2d07e
+  checksum: 43bc1777752cbc5c5bf9a1dc456300e853b0b0c2ef274b31ce0f4bbdaf093f0837e25e654f6fc173addaef22213c0329eaaf925c18aa580de46bfcc1ac145167
   languageName: node
   linkType: hard
 
@@ -14133,10 +14133,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mitt@npm:^1.1.3":
-  version: 1.2.0
-  resolution: "mitt@npm:1.2.0"
-  checksum: 53abb94c6203250e2498e152ae096288c4866c6aab1dc093922084a7414af4aa6cda5a51d480267a8f0bd7908b0e896099bc953317aca8a18672dc67ee7e923d
+"mitt@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: b55a489ac9c2949ab166b7f060601d3b6d893a852515ae9eca4e11df01c013876df777ea109317622b5c1c60e8aae252558e33c8c94e14124db38f64a39614b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

- [x] ⏱ Tests

### Background or solution

### Changelog
