### PR TITLE
fix: multiplexer rpc id can have slash

### DIFF
--- a/packages/connection/__test__/common/multiplexer.test.ts
+++ b/packages/connection/__test__/common/multiplexer.test.ts
@@ -1,0 +1,14 @@
+import { extractServiceAndMethod, getRPCName } from '@opensumi/ide-connection/lib/common/rpc/multiplexer';
+
+describe('Multiplexer', () => {
+  it('can construct rpc name', () => {
+    const rpcId = '@opensumi/runner';
+    const method = '$fetch';
+
+    const name = getRPCName(rpcId, method);
+    const [serviceId, methodName] = extractServiceAndMethod(name);
+
+    expect(serviceId).toBe(rpcId);
+    expect(methodName).toBe(method);
+  });
+});

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -5,8 +5,8 @@ import WebSocket from 'ws';
 import { WSWebSocketConnection } from '@opensumi/ide-connection/src/common/connection';
 import { SumiConnection } from '@opensumi/ide-connection/src/common/rpc/connection';
 import { Deferred, Emitter, Uri } from '@opensumi/ide-core-common';
+import { createMockPairRPCProtocol } from '@opensumi/ide-extension/__mocks__/initRPCProtocol';
 
-import { createMockPairRPCProtocol } from '../../../extension/__mocks__/initRPCProtocol';
 import { ProxyIdentifier, RPCService } from '../../src';
 import { RPCServiceCenter, initRPCService } from '../../src/common';
 import { SimpleConnection } from '../../src/common/connection/drivers/simple';
@@ -264,5 +264,20 @@ describe('connection', () => {
     await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(
       'method testTimeoutIdentifier/$test timeout',
     );
+  });
+  it('multiplexer rpc id can have slash', async () => {
+    const { rpcProtocolExt, rpcProtocolMain } = createMockPairRPCProtocol();
+
+    const rpcId = '@opensumi/runner';
+    const method = '$fetchConfigurations';
+
+    rpcProtocolMain.set(ProxyIdentifier.for(rpcId), {
+      [method]: () => 'mock',
+    });
+
+    const runner = rpcProtocolExt.getProxy(ProxyIdentifier.for(rpcId));
+
+    const result = await runner.$fetchConfigurations();
+    expect(result).toBe('mock');
   });
 });

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -261,8 +261,8 @@ describe('connection', () => {
 
     await expect(timeoutBProtocol.getProxy(testTimeoutIdentifier).$test()).resolves.toBe(undefined);
 
-    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(
-      'method testTimeoutIdentifier!$test timeout',
+    await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"method testTimeoutIdentifier||$test timeout"',
     );
   });
   it('multiplexer rpc id can have slash', async () => {

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -262,7 +262,7 @@ describe('connection', () => {
     await expect(timeoutBProtocol.getProxy(testTimeoutIdentifier).$test()).resolves.toBe(undefined);
 
     await expect(timeoutCProtocol.getProxy(testTimeoutIdentifier).$test()).rejects.toThrow(
-      'method testTimeoutIdentifier/$test timeout',
+      'method testTimeoutIdentifier!$test timeout',
     );
   });
   it('multiplexer rpc id can have slash', async () => {

--- a/packages/connection/src/common/rpc/multiplexer.ts
+++ b/packages/connection/src/common/rpc/multiplexer.ts
@@ -24,7 +24,7 @@ export interface IRPCProtocol {
   get<T>(identifier: ProxyIdentifier<T>): T;
 }
 
-const SEP = '/';
+const SEP = '!';
 
 function getRPCName(serviceId: string, methodName: string) {
   return `${serviceId}${SEP}${methodName}`;

--- a/packages/connection/src/common/rpc/multiplexer.ts
+++ b/packages/connection/src/common/rpc/multiplexer.ts
@@ -24,15 +24,16 @@ export interface IRPCProtocol {
   get<T>(identifier: ProxyIdentifier<T>): T;
 }
 
-const SEP = '!';
+const SEP = '||';
+const SEP_LENGTH = SEP.length;
 
-function getRPCName(serviceId: string, methodName: string) {
+export function getRPCName(serviceId: string, methodName: string) {
   return `${serviceId}${SEP}${methodName}`;
 }
 
-function extractServiceAndMethod(rpcId: string): [string, string] {
+export function extractServiceAndMethod(rpcId: string): [string, string] {
   const idx = rpcId.indexOf(SEP);
-  return [rpcId.substring(0, idx), rpcId.substring(idx + 1)];
+  return [rpcId.substring(0, idx), rpcId.substring(idx + SEP_LENGTH)];
 }
 
 /**


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

if rpc id has a slash, rpc wouldn't work:

```
Error handling request extension_extend_service:kaitian.@opensumi/runner/$fetch with args  [] Error: Unknown actor extension_extend_service:kaitian.@opensumi
```
### Changelog
