### PR TITLE
feat: support chat visible preference

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -14,6 +14,7 @@ import {
   KeybindingContribution,
   KeybindingRegistry,
   KeybindingScope,
+  PreferenceService,
   SlotLocation,
   SlotRendererContribution,
   SlotRendererRegistry,
@@ -21,6 +22,7 @@ import {
   localize,
 } from '@opensumi/ide-core-browser';
 import {
+  AI_CHAT_VISIBLE,
   AI_INLINE_CHAT_VISIBLE,
   AI_INLINE_COMPLETION_REPORTER,
   AI_INLINE_COMPLETION_VISIBLE,
@@ -34,9 +36,12 @@ import {
   InlineChatFeatureRegistryToken,
   RenameCandidatesProviderRegistryToken,
   ResolveConflictRegistryToken,
+  isUndefined,
+  runWhenIdle,
 } from '@opensumi/ide-core-common';
 import { IEditor } from '@opensumi/ide-editor';
 import { BrowserEditorContribution, IEditorFeatureRegistry } from '@opensumi/ide-editor/lib/browser';
+import { IMainLayoutService } from '@opensumi/ide-main-layout';
 import { ISettingRegistry, SettingContribution } from '@opensumi/ide-preferences';
 
 import { AI_CHAT_CONTAINER_ID, AI_CHAT_VIEW_ID } from '../common';
@@ -115,6 +120,12 @@ export class AINativeBrowserContribution
   @Autowired(CommandService)
   private readonly commandService: CommandService;
 
+  @Autowired(PreferenceService)
+  private readonly preferenceService: PreferenceService;
+
+  @Autowired(IMainLayoutService)
+  private readonly layoutService: IMainLayoutService;
+
   constructor() {
     this.registerFeature();
   }
@@ -153,6 +164,18 @@ export class AINativeBrowserContribution
     this.appConfig.layoutViewSize = layoutViewSize;
   }
 
+  onDidStart() {
+    runWhenIdle(() => {
+      const prefChatVisibleType = this.preferenceService.getValid(AINativeSettingSectionsId.CHAT_VISIBLE_TYPE);
+
+      if (prefChatVisibleType === 'always') {
+        this.commandService.executeCommand(AI_CHAT_VISIBLE.id, true);
+      } else if (prefChatVisibleType === 'never') {
+        this.commandService.executeCommand(AI_CHAT_VISIBLE.id, false);
+      }
+    });
+  }
+
   private registerFeature() {
     this.contributions.getContributions().forEach((contribution) => {
       if (contribution.registerInlineChatFeature) {
@@ -178,6 +201,16 @@ export class AINativeBrowserContribution
       id: AI_NATIVE_SETTING_GROUP_ID,
       title: AI_NATIVE_SETTING_GROUP_ID,
       iconClass: getIcon('magic-wand'),
+    });
+
+    registry.registerSettingSection(AI_NATIVE_SETTING_GROUP_ID, {
+      title: localize('preference.aiNative.chat.title'),
+      preferences: [
+        {
+          id: AINativeSettingSectionsId.CHAT_VISIBLE_TYPE,
+          localized: 'preference.aiNative.chat.visible.type',
+        },
+      ],
     });
 
     if (this.aiNativeConfigService.capabilities.supportsInlineChat) {
@@ -212,6 +245,12 @@ export class AINativeBrowserContribution
     commands.registerCommand(AI_INLINE_COMPLETION_REPORTER, {
       execute: (relationId: string, sessionId: string, accept: boolean) => {
         this.aiCompletionsService.report({ sessionId, accept, relationId });
+      },
+    });
+
+    commands.registerCommand(AI_CHAT_VISIBLE, {
+      execute: (visible?: boolean) => {
+        this.layoutService.toggleSlot(AI_CHAT_VIEW_ID, isUndefined(visible) ? true : visible);
       },
     });
 

--- a/packages/core-browser/src/ai-native/command.ts
+++ b/packages/core-browser/src/ai-native/command.ts
@@ -9,3 +9,7 @@ export const AI_INLINE_COMPLETION_VISIBLE = {
 export const AI_INLINE_COMPLETION_REPORTER = {
   id: 'ai.inline.completion.reporter',
 };
+
+export const AI_CHAT_VISIBLE = {
+  id: 'ai.chat.visible',
+};

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -301,6 +301,11 @@ export const corePreferenceSchema: PreferenceSchema = {
       type: 'boolean',
       default: true,
     },
+    [AINativeSettingSectionsId.CHAT_VISIBLE_TYPE]: {
+      type: 'string',
+      enum: ['never', 'always', 'default'],
+      default: 'default',
+    },
     'editor.codeActionWidget.showHeaders': {
       type: 'boolean',
       default: true,

--- a/packages/core-common/src/settings/ai-native.ts
+++ b/packages/core-common/src/settings/ai-native.ts
@@ -1,4 +1,5 @@
 export enum AINativeSettingSectionsId {
-  INLINE_CHAT_AUTO_VISIBLE = 'inlineChat.auto.visible',
+  INLINE_CHAT_AUTO_VISIBLE = 'ai.native.inlineChat.auto.visible',
+  CHAT_VISIBLE_TYPE = 'ai.native.chat.visible.type',
 }
 export const AI_NATIVE_SETTING_GROUP_ID = 'AI-Native';

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -585,11 +585,6 @@ export const localizationBundle = {
 
     'preference.item.notValid': '{0} is not a valid option',
 
-    // AI Native
-    'preference.aiNative.inlineChat.title': 'Inline Chat',
-    'preference.aiNative.inlineChat.auto.visible':
-      'Does Inline Chat automatically appear when code snippets are selected ?',
-
     // Editor Configurations
     'editor.configuration.formatOnSaveTimeout':
       'Control the timeout time of formatting (ms). Effective Only when `#editor.formatOnSave#` enables.',
@@ -1473,6 +1468,12 @@ export const localizationBundle = {
     'aiNative.operate.clear.title': 'Clear',
 
     'aiNative.chat.welcome.loading.text': 'Initializing...',
+
+    'preference.aiNative.inlineChat.title': 'Inline Chat',
+    'preference.aiNative.chat.title': 'Chat',
+    'preference.aiNative.inlineChat.auto.visible':
+      'Does Inline Chat automatically appear when code snippets are selected ?',
+    'preference.aiNative.chat.visible.type': 'Control how the chat panel is displayed by default',
     // #endregion AI Native
 
     // #endregion merge editor

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -523,10 +523,6 @@ export const localizationBundle = {
 
     'preference.item.notValid': '{0} 不是有效选项',
 
-    // AI Native Preference
-    'preference.aiNative.inlineChat.title': 'Inline Chat',
-    'preference.aiNative.inlineChat.auto.visible': '是否在选中代码片段时自动显示 Inline Chat ？',
-
     'editor.saveAll': '保存全部',
     'editor.saveCodeActions.getting': '从 {0} 中获取 CodeAction',
     'editor.saveCodeActions.saving': '保存 "{0}"',
@@ -1241,6 +1237,11 @@ export const localizationBundle = {
     'aiNative.operate.clear.title': '清空',
 
     'aiNative.chat.welcome.loading.text': '初始化中...',
+
+    'preference.aiNative.inlineChat.title': 'Inline Chat',
+    'preference.aiNative.chat.title': 'Chat',
+    'preference.aiNative.inlineChat.auto.visible': '是否在选中代码片段时自动显示 Inline Chat ？',
+    'preference.aiNative.chat.visible.type': '控制 Chat 面板默认的展示方式',
     // #endregion AI Native
 
     'webview.webviewTagUnavailable': '非 Electron 环境不支持 webview 标签，请使用 iframe 标签',


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

新增 ai.native.chat.visible.type 配置项，用于控制 chat 面板默认的展示方式

always 表示总是默认展开，never 表示总是默认收起，default 表示跟随 localstorage 走

### Changelog
