### PR TITLE
fix: diagnostics api iterable fix

### DIFF
--- a/packages/extension/src/hosted/api/vscode/language/diagnostics.ts
+++ b/packages/extension/src/hosted/api/vscode/language/diagnostics.ts
@@ -147,6 +147,14 @@ export class DiagnosticCollection implements vscode.DiagnosticCollection {
     });
   }
 
+  *[Symbol.iterator](): IterableIterator<[uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]]> {
+    this.ensureNotDisposed();
+    for (const uri of this.diagnostics.keys()) {
+      const uri2 = URI.parse(uri);
+      yield [uri2, this.get(uri2) || []];
+    }
+  }
+
   get(uri: URI): vscode.Diagnostic[] | undefined {
     this.ensureNotDisposed();
     return this.getDiagnosticsByUri(uri);
@@ -185,7 +193,7 @@ export class DiagnosticCollection implements vscode.DiagnosticCollection {
 
   private getDiagnosticsByUri(uri: URI): vscode.Diagnostic[] | undefined {
     const diagnostics = this.diagnostics.get(uri.toString());
-    return diagnostics instanceof Array ? (Object.freeze(diagnostics) as vscode.Diagnostic[]) : undefined;
+    return diagnostics instanceof Array ? (Object.freeze(diagnostics) as vscode.Diagnostic[]) : [];
   }
 
   private fireDiagnosticChangeEvent(arg: string | string[] | URI | URI[]): void {

--- a/packages/types/vscode/typings/vscode.language.d.ts
+++ b/packages/types/vscode/typings/vscode.language.d.ts
@@ -2714,7 +2714,7 @@ declare module 'vscode' {
    * To get an instance of a `DiagnosticCollection` use
    * [createDiagnosticCollection](#languages.createDiagnosticCollection).
    */
-  export interface DiagnosticCollection {
+  export interface DiagnosticCollection extends Iterable<[uri: Uri, diagnostics: readonly Diagnostic[]]>{
 
     /**
      * The name of this diagnostic collection, for instance `typescript`. Every diagnostic


### PR DESCRIPTION
### Types

修复了之前 DiagnosticCollection 不支持 Iterable 导致的插件处理诊断信息时的问题，有一定概率导致 Java 语言服务的错误诊断显示问题。

![image](https://github.com/opensumi/core/assets/12879047/f747735a-4542-41d9-be56-c97ca43cab2d)

- [x] 🐛 Bug Fixes

### Background or solution
Java 插件运行过程中报错，可能会导致语言服务错误诊断展示错误，或者小概率的语言服务挂掉。修复了 DiagnosticCollection 无法被 for of 循环的的问题。

### Changelog
- fix: diagnostics api iterable fix, support for of iteration
- fix: use empty array instead of undefined
