### PR TITLE
fix: require interceptor handle react error

### DIFF
--- a/packages/extension/__tests__/browser/extension-service/__snapshots__/extension.service.test.ts.snap
+++ b/packages/extension/__tests__/browser/extension-service/__snapshots__/extension.service.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Extension service load browser require interceptor contribution should get ReactDOM interceptor 1`] = `
+{
+  "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED": {
+    "Events": [
+      [Function],
+      [Function],
+      [Function],
+      [Function],
+      [Function],
+      [Function],
+    ],
+    "usingClientEntryPoint": false,
+  },
+  "createPortal": [Function],
+  "createRoot": [Function],
+  "findDOMNode": [Function],
+  "flushSync": [Function],
+  "hydrate": [Function],
+  "hydrateRoot": [Function],
+  "render": [Function],
+  "unmountComponentAtNode": [Function],
+  "unstable_batchedUpdates": [Function],
+  "unstable_renderSubtreeIntoContainer": [Function],
+  "version": "18.2.0",
+}
+`;

--- a/packages/extension/__tests__/browser/extension-service/extension.service.test.ts
+++ b/packages/extension/__tests__/browser/extension-service/extension.service.test.ts
@@ -1,5 +1,3 @@
-import ReactDom from 'react-dom/client';
-
 import {
   CommandRegistry,
   CommandRegistryImpl,
@@ -12,7 +10,12 @@ import { IToolbarRegistry } from '@opensumi/ide-core-browser/lib/toolbar';
 import { IMenuItem, IMenuRegistry, MenuRegistryImpl } from '@opensumi/ide-core-browser/src/menu/next';
 import { NextToolbarRegistryImpl } from '@opensumi/ide-core-browser/src/toolbar/toolbar.registry';
 import { AppLifeCycleServiceToken, IAppLifeCycleService, IEventBus, LifeCyclePhase } from '@opensumi/ide-core-common';
-import { ExtensionBeforeActivateEvent, IActivationEventService } from '@opensumi/ide-extension/lib/browser/types';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
+import {
+  AbstractExtInstanceManagementService,
+  ExtensionBeforeActivateEvent,
+  IActivationEventService,
+} from '@opensumi/ide-extension/lib/browser/types';
 import { IMainLayoutService } from '@opensumi/ide-main-layout';
 import { LayoutService } from '@opensumi/ide-main-layout/lib/browser/layout.service';
 import { TabbarService } from '@opensumi/ide-main-layout/lib/browser/tabbar/tabbar.service';
@@ -22,9 +25,7 @@ import { IThemeService, getColorRegistry } from '@opensumi/ide-theme/lib/common'
 
 import '@opensumi/ide-i18n';
 
-import { MockInjector } from '../../../../../tools/dev-tool/src/mock-injector';
 import { SumiContributionsServiceToken } from '../../../src/browser/sumi/contributes';
-import { AbstractExtInstanceManagementService } from '../../../src/browser/types';
 import { VSCodeContributesService, VSCodeContributesServiceToken } from '../../../src/browser/vscode/contributes';
 import {
   AbstractExtensionManagementService,
@@ -242,7 +243,7 @@ describe('Extension service', () => {
       const requireInterceptorService: IRequireInterceptorService = injector.get(IRequireInterceptorService);
       const interceptor = requireInterceptorService.getRequireInterceptor('ReactDOM');
       const result = interceptor?.load({});
-      expect(result).toBe(ReactDom);
+      expect(result).toMatchSnapshot();
     });
   });
 

--- a/packages/extension/__tests__/common/__snapshots__/require-interceptor.test.ts.snap
+++ b/packages/extension/__tests__/common/__snapshots__/require-interceptor.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`require-interceptor test registerRequireInterceptor 1`] = `
+{
+  "Children": {
+    "count": [Function],
+    "forEach": [Function],
+    "map": [Function],
+    "only": [Function],
+    "toArray": [Function],
+  },
+  "Component": [Function],
+  "Fragment": Symbol(react.fragment),
+  "Profiler": Symbol(react.profiler),
+  "PureComponent": [Function],
+  "StrictMode": Symbol(react.strict_mode),
+  "Suspense": Symbol(react.suspense),
+  "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED": {
+    "ReactCurrentActQueue": {
+      "current": null,
+      "didScheduleLegacyUpdate": false,
+      "isBatchingLegacy": false,
+    },
+    "ReactCurrentBatchConfig": {
+      "transition": null,
+    },
+    "ReactCurrentDispatcher": {
+      "current": null,
+    },
+    "ReactCurrentOwner": {
+      "current": null,
+    },
+    "ReactDebugCurrentFrame": {
+      "getCurrentStack": null,
+      "getStackAddendum": [Function],
+      "setExtraStackFrame": [Function],
+    },
+  },
+  "cloneElement": [Function],
+  "createContext": [Function],
+  "createElement": [Function],
+  "createFactory": [Function],
+  "createRef": [Function],
+  "forwardRef": [Function],
+  "isValidElement": [Function],
+  "lazy": [Function],
+  "memo": [Function],
+  "startTransition": [Function],
+  "unstable_act": [Function],
+  "useCallback": [Function],
+  "useContext": [Function],
+  "useDebugValue": [Function],
+  "useDeferredValue": [Function],
+  "useEffect": [Function],
+  "useId": [Function],
+  "useImperativeHandle": [Function],
+  "useInsertionEffect": [Function],
+  "useLayoutEffect": [Function],
+  "useMemo": [Function],
+  "useReducer": [Function],
+  "useRef": [Function],
+  "useState": [Function],
+  "useSyncExternalStore": [Function],
+  "useTransition": [Function],
+  "version": "18.2.0",
+}
+`;

--- a/packages/extension/__tests__/common/require-interceptor.test.ts
+++ b/packages/extension/__tests__/common/require-interceptor.test.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+
 import { IRequireInterceptorService, RequireInterceptorService } from '../../src/common/require-interceptor';
 
 describe('require-interceptor test', () => {
@@ -26,6 +27,6 @@ describe('require-interceptor test', () => {
     });
     const interceptor = requireInterceptorService.getRequireInterceptor('react');
     const request = interceptor?.load({});
-    expect(request).toBe(React);
+    expect(request).toMatchSnapshot();
   });
 });

--- a/packages/extension/src/browser/extension-view.service.ts
+++ b/packages/extension/src/browser/extension-view.service.ts
@@ -549,7 +549,7 @@ export class ViewExtProcessService extends Disposable implements AbstractViewExt
     return pendingFetch;
   }
 
-  private getMockAmdLoader<T>(extension: IExtension, rpcProtocol?: IRPCProtocol) {
+  private getSumiAMDLoader<T>(extension: IExtension, rpcProtocol?: IRPCProtocol) {
     const _exports: { default?: any } | T = {};
     const _module = { exports: _exports };
     const _require = (request: string) => {
@@ -571,7 +571,7 @@ export class ViewExtProcessService extends Disposable implements AbstractViewExt
     const loadTimer = this.reporterService.time(REPORT_NAME.LOAD_EXTENSION_MAIN);
     const pendingFetch = await this.doFetch(decodeURIComponent(browserPath));
     loadTimer.timeEnd(extension.id);
-    const { _module, _exports, _require } = this.getMockAmdLoader<T>(extension, this.nodeExtensionService.protocol);
+    const { _module, _exports, _require } = this.getSumiAMDLoader<T>(extension, this.nodeExtensionService.protocol);
     const initFn = new Function(
       'module',
       'exports',
@@ -652,7 +652,7 @@ export class ViewExtProcessService extends Disposable implements AbstractViewExt
     const loadTimer = this.reporterService.time(REPORT_NAME.LOAD_EXTENSION_MAIN);
     const pendingFetch = await this.doFetch(decodeURIComponent(browserPath));
     loadTimer.timeEnd(extension.id);
-    const { _module, _exports, _require } = this.getMockAmdLoader<T>(extension, this.nodeExtensionService.protocol);
+    const { _module, _exports, _require } = this.getSumiAMDLoader<T>(extension, this.nodeExtensionService.protocol);
     const stylesCollection = [];
     const proxiedHead = document.createElement('head');
     const proxiedDocument = createProxiedDocument(proxiedHead);

--- a/packages/extension/src/browser/require-interceptor.contribution.ts
+++ b/packages/extension/src/browser/require-interceptor.contribution.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
+import ReactDOMClient from 'react-dom/client';
 
 import { Domain } from '@opensumi/ide-core-browser';
 
@@ -11,6 +12,11 @@ import {
 
 import { createBrowserApi } from './sumi-browser';
 
+const reactDom16Wrapper = {
+  ...ReactDOM,
+  ...ReactDOMClient,
+};
+
 @Domain(RequireInterceptorContribution)
 export class BrowserRequireInterceptorContribution implements RequireInterceptorContribution {
   registerRequireInterceptor(registry: IRequireInterceptorService<IBrowserRequireInterceptorArgs>): void {
@@ -19,9 +25,15 @@ export class BrowserRequireInterceptorContribution implements RequireInterceptor
       load: () => React,
     });
 
+    // compatible with react-dom v16
     registry.registerRequireInterceptor({
       moduleName: 'ReactDOM',
-      load: () => ReactDOM,
+      load: () => reactDom16Wrapper,
+    });
+
+    registry.registerRequireInterceptor({
+      moduleName: 'ReactDOMClient',
+      load: () => ReactDOMClient,
     });
 
     registry.registerRequireInterceptor({

--- a/packages/extension/src/browser/require-interceptor.contribution.ts
+++ b/packages/extension/src/browser/require-interceptor.contribution.ts
@@ -12,7 +12,8 @@ import {
 
 import { createBrowserApi } from './sumi-browser';
 
-const reactDom16Wrapper = {
+// `react-dom/18.2.0/umd/react-dom.production.min.js` is do the same thing, it export both `react-dom` and `react-dom/client`.
+const umdReactDOM = {
   ...ReactDOM,
   ...ReactDOMClient,
 };
@@ -25,10 +26,9 @@ export class BrowserRequireInterceptorContribution implements RequireInterceptor
       load: () => React,
     });
 
-    // compatible with react-dom v16
     registry.registerRequireInterceptor({
       moduleName: 'ReactDOM',
-      load: () => reactDom16Wrapper,
+      load: () => umdReactDOM,
     });
 
     registry.registerRequireInterceptor({


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

我们拦截了 browser 里的 require, 如果一个插件 require 了 react-dom，我们会返回 react-dom/client 的内容给它，会导致它报错。

![CleanShot 2024-04-22 at 11 51 48@2x](https://github.com/opensumi/core/assets/13938334/305c6cb6-41de-4d24-bfd3-f399505747f1)


### Changelog

fix require interceptor return `react-dom/client` when using `react-dom`