### PR TITLE
fix: ext get file stat will cause error

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.file-system.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.file-system.ts
@@ -93,7 +93,12 @@ export class MainThreadFileSystem implements IMainThreadFileSystemShape {
   $stat(uri: UriComponents): Promise<FileStat> {
     return this._fileService
       .getFileStat(URI.revive(uri).toString())
-      .then((stat) => toFileStat(stat!))
+      .then((stat) => {
+        if (stat) {
+          return toFileStat(stat);
+        }
+        throw new FileOperationError('File not found', FileOperationResult.FILE_NOT_FOUND);
+      })
       .catch(MainThreadFileSystem._handleError);
   }
 

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -186,6 +186,7 @@ export class FileServiceClient implements IFileServiceClient, IDisposable {
       if (FileSystemError.FileNotFound.is(err)) {
         return undefined;
       }
+      throw err;
     }
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

![CleanShot 2024-04-23 at 19 57 02@2x](https://github.com/opensumi/core/assets/13938334/ae681467-9b60-4844-be63-cb5905117bed)

getFileStat 如果文件不存在，会返回 undefined, 插件层没有判断这个

### Changelog

extension get file stat will throw unexpected error if file is not exists