### PR TITLE
feat: render ext icon in menubar

### DIFF
--- a/packages/extension/src/browser/sumi/contributes/menubar.ts
+++ b/packages/extension/src/browser/sumi/contributes/menubar.ts
@@ -1,9 +1,12 @@
 import { Autowired, Injectable } from '@opensumi/di';
+import { getIcon } from '@opensumi/ide-components';
 import { IMenuRegistry } from '@opensumi/ide-core-browser/lib/menu/next';
 import { IJSONSchema, LifeCyclePhase, localize } from '@opensumi/ide-core-common';
+import { IIconService, IconType } from '@opensumi/ide-theme';
 
 import { Contributes, LifeCycle, VSCodeContributePoint } from '../../../common';
 import { IContributeMenubarItem } from '../../../common/sumi/extension';
+import { AbstractExtInstanceManagementService } from '../../types';
 
 export type KtMenubarsSchema = IContributeMenubarItem[];
 
@@ -13,6 +16,12 @@ export type KtMenubarsSchema = IContributeMenubarItem[];
 export class MenubarsContributionPoint extends VSCodeContributePoint<KtMenubarsSchema> {
   @Autowired(IMenuRegistry)
   private readonly menuRegistry: IMenuRegistry;
+
+  @Autowired(AbstractExtInstanceManagementService)
+  protected readonly extensionManageService: AbstractExtInstanceManagementService;
+
+  @Autowired(IIconService)
+  protected readonly iconService: IIconService;
 
   static schema: IJSONSchema = {
     description: localize('sumiContributes.menubars'),
@@ -52,12 +61,22 @@ export class MenubarsContributionPoint extends VSCodeContributePoint<KtMenubarsS
   contribute() {
     for (const contrib of this.contributesMap) {
       const { extensionId, contributes } = contrib;
+      const extension = this.extensionManageService.getExtensionInstanceByExtId(extensionId);
+      if (!extension) {
+        continue;
+      }
+
       for (const menubarItem of contributes) {
+        const iconClass = extension.icon
+          ? this.iconService.fromIcon('', extension.icon, IconType.Background)
+          : getIcon('default-menu-icon');
+
         this.addDispose(
           this.menuRegistry.registerMenubarItem(menubarItem.id, {
             label: this.getLocalizeFromNlsJSON(menubarItem.title, extensionId),
             order: menubarItem.order,
             nativeRole: menubarItem.nativeRole,
+            iconClass,
           }),
         );
       }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

插件注册的菜单没有显示图标

![CleanShot 2024-04-23 at 20 06 35@2x](https://github.com/opensumi/core/assets/13938334/47d33ca2-9336-4eb1-8091-c0bb4fc5a8ca)



### Changelog
