### PR TITLE
feat: support set language id for output channel

### DIFF
--- a/packages/extension/__tests__/browser/main.thread.output.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.output.test.ts
@@ -1,9 +1,9 @@
 import { Injector } from '@opensumi/di';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { ExtHostAPIIdentifier } from '@opensumi/ide-extension/lib/common/vscode';
 import { OutputPreferences } from '@opensumi/ide-output/lib/browser/output-preference';
 import { OutputService } from '@opensumi/ide-output/lib/browser/output.service';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
 import { MockOutputService } from '../../__mocks__/api/output.service';
 import { createMockPairRPCProtocol } from '../../__mocks__/initRPCProtocol';
 import * as types from '../../src/common/vscode/ext-types';
@@ -85,5 +85,24 @@ describe('MainThreadOutput Test Suites', () => {
     outputChannel.dispose();
     const existing = service.getChannels().find((c) => c.name === name);
     expect(existing).toBeUndefined();
+  });
+
+  it('can create log output channel', () => {
+    const name = 'test-output-6';
+    const outputChannel = extOutput.createOutputChannel(name, { log: true });
+    disposables.push(outputChannel);
+    expect(outputChannel.name).toBe(name);
+    expect(service.getChannel(name).name).toBe(name);
+    expect(typeof outputChannel.append).toBe('function');
+    expect(typeof outputChannel.appendLine).toBe('function');
+    expect(typeof outputChannel.clear).toBe('function');
+    expect(typeof outputChannel.dispose).toBe('function');
+    expect(typeof outputChannel.hide).toBe('function');
+    expect(typeof outputChannel.trace).toBe('function');
+    expect(typeof outputChannel.debug).toBe('function');
+    expect(typeof outputChannel.info).toBe('function');
+    expect(typeof outputChannel.warn).toBe('function');
+    expect(typeof outputChannel.error).toBe('function');
+    expect(typeof outputChannel.show).toBe('function');
   });
 });

--- a/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
@@ -28,8 +28,8 @@ import {
   IMainThreadWebviewView,
   IMainThreadWorkspace,
   MainThreadAPIIdentifier,
-} from '../../../common/vscode'; // '../../common';
-import { VSCodeExtensionService } from '../../../common/vscode';
+  VSCodeExtensionService,
+} from '../../../common/vscode';
 
 import { MainThreadProgress } from './main.thread.api.progress';
 import { MainThreadWebview, MainThreadWebviewView } from './main.thread.api.webview';

--- a/packages/extension/src/browser/vscode/api/main.thread.output.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.output.ts
@@ -85,4 +85,11 @@ export class MainThreadOutput implements IMainThreadOutput {
 
     return outputChannel;
   }
+
+  async $setLanguageId(channelName: string, languageId: string): Promise<void> {
+    const outputChannel = this.getChannel(channelName);
+    if (outputChannel) {
+      await outputChannel.setLanguageId(languageId);
+    }
+  }
 }

--- a/packages/extension/src/common/vscode/window.ts
+++ b/packages/extension/src/common/vscode/window.ts
@@ -186,13 +186,20 @@ export interface IMainThreadOutput {
   $dispose(channelName: string): PromiseLike<void>;
   $reveal(channelName: string, preserveFocus: boolean): PromiseLike<void>;
   $close(channelName: string): PromiseLike<void>;
+
+  $setLanguageId(channelName: string, languageId: string): PromiseLike<void>;
+}
+
+export interface ICreateOutputChannelOptions {
+  log?: boolean;
+  languageId?: string;
 }
 
 export interface IExtHostOutput {
   createOutputChannel(
     name: string,
-    options: { /** literal-type defines return type */ log: true } | undefined,
-  ): types.OutputChannel;
+    optionsOrLanguageId: string | ICreateOutputChannelOptions | undefined,
+  ): types.OutputChannel | types.LogOutputChannel;
 }
 
 export interface IExtHostWindowState {

--- a/packages/extension/src/hosted/api/vscode/ext.host.window.api.impl.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.window.api.impl.ts
@@ -2,6 +2,7 @@ import { IRPCProtocol } from '@opensumi/ide-connection';
 import { CancellationToken, Emitter, IDisposable, IExtensionInfo, MessageType } from '@opensumi/ide-core-common';
 
 import {
+  ICreateOutputChannelOptions,
   IExtHostMessage,
   IExtHostOutput,
   IExtHostQuickOpen,
@@ -103,8 +104,7 @@ export function createWindowApiFactory(
       }
       return extHostStatusBar.createStatusBarItem(extension, id, alignment, priority);
     },
-    // @ts-ignore
-    createOutputChannel(name: string, options?: { log: true } | undefined) {
+    createOutputChannel(name: string, options: string | ICreateOutputChannelOptions | undefined): any {
       return extHostOutput.createOutputChannel(name, options);
     },
     setStatusBarMessage(text: string, arg?: number | Thenable<any>): vscode.Disposable {

--- a/packages/output/src/browser/output.channel.ts
+++ b/packages/output/src/browser/output.channel.ts
@@ -216,6 +216,11 @@ export class OutputChannel extends Disposable {
     }
   }
 
+  async setLanguageId(languageId: string): Promise<void> {
+    await this.modelReady.promise;
+    this.outputModel.instance.languageId = languageId;
+  }
+
   get isVisible(): boolean {
     return this.visible;
   }

--- a/packages/types/vscode/typings/vscode.editor.d.ts
+++ b/packages/types/vscode/typings/vscode.editor.d.ts
@@ -542,6 +542,10 @@ declare module 'vscode' {
 
 
   export namespace window {
+		/**
+		 * Represents the grid widget within the main editor area
+		 */
+		export const tabGroups: TabGroups;
 
     /**
      * The currently active editor or `undefined`. The active editor is the one

--- a/packages/types/vscode/typings/vscode.window.d.ts
+++ b/packages/types/vscode/typings/vscode.window.d.ts
@@ -364,12 +364,18 @@ declare module 'vscode' {
      */
     export function createStatusBarItem(id: string, alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
 
-    /**
-     * Creates a new [output channel](#OutputChannel) with the given name.
-     *
-     * @param name Human-readable string which will be used to represent the channel in the UI.
-     */
-    export function createOutputChannel(name: string): OutputChannel;
+		/**
+		 * Creates a new {@link OutputChannel output channel} with the given name and language id
+		 * If language id is not provided, then **Log** is used as default language id.
+		 *
+		 * You can access the visible or active output channel as a {@link TextDocument text document} from {@link window.visibleTextEditors visible editors} or {@link window.activeTextEditor active editor}
+		 * and use the language id to contribute language features like syntax coloring, code lens etc.,
+		 *
+		 * @param name Human-readable string which will be used to represent the channel in the UI.
+		 * @param languageId The identifier of the language associated with the channel.
+		 * @returns A new output channel.
+		 */
+		export function createOutputChannel(name: string, languageId?: string): OutputChannel;
 
     /**
      * Creates a new {@link LogOutputChannel log output channel} with the given name.
@@ -378,7 +384,7 @@ declare module 'vscode' {
      * @param options Options for the log output channel.
      * @returns A new log output channel.
      */
-    export function createOutputChannel(name: string, options: { /** literal-type defines return type */log: true }): LogOutputChannel;
+    export function createOutputChannel(name: string, options: { /** literal-type defines return type */log: true; languageId?: string }): LogOutputChannel;
 
     /**
      * The currently opened terminals or an empty array.


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

1. we should bind `LogOutputChannel`'s log methods.
2. implements set language id

### Changelog
