### PR TITLE
fix: fixes electron header rendering error in full screen mode

### DIFF
--- a/packages/electron-basic/src/browser/header/header.view.tsx
+++ b/packages/electron-basic/src/browser/header/header.view.tsx
@@ -163,6 +163,14 @@ export const ElectronHeaderBar = observer(
       TitleComponent = HeaderBarTitleComponent;
     }
 
+    const safeHeight = useMemo(() => {
+      if (height) {
+        return height;
+      }
+
+      return defaultHeight(appConfig);
+    }, [appConfig, height]);
+
     // in Mac, hide the header bar if it is in full screen mode
     if (isMacintosh && isFullScreen && autoHide) {
       return (
@@ -171,14 +179,6 @@ export const ElectronHeaderBar = observer(
         </div>
       );
     }
-
-    const safeHeight = useMemo(() => {
-      if (height) {
-        return height;
-      }
-
-      return defaultHeight(appConfig);
-    }, [appConfig, height]);
 
     return (
       <div


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

Electron's Header Component won't work  in full screen mode, complaining about fewer hooks rendered. This PR fixes it.
 

### Changelog

Fixes electron header rendering error in full screen mode
