### PR TITLE
feat: support codicon transform on popover markdown content

### DIFF
--- a/packages/components/src/markdown/render.tsx
+++ b/packages/components/src/markdown/render.tsx
@@ -29,7 +29,10 @@ export const RenderWrapper = (props: { html: string; opener?: IOpenerShape }) =>
    * 拦截 a 标签的点击事件，触发 commands
    */
   const listenClick = (event: PointerEvent) => {
-    const target = event.target as HTMLElement;
+    let target = event.target as HTMLElement;
+    if (target.className.includes('codicon')) {
+      target = target.parentNode as HTMLElement;
+    }
     if (target.tagName.toLowerCase() === 'a' && target.hasAttribute(DATA_SET_COMMAND)) {
       const dataCommand = target.getAttribute(DATA_SET_COMMAND);
       if (dataCommand && opener) {

--- a/packages/components/src/markdown/styles.less
+++ b/packages/components/src/markdown/styles.less
@@ -2,4 +2,9 @@
 
 .@{prefix}-md-renderer-wrap {
   word-break: break-all;
+  color: var(--foreground);
+
+  hr {
+    border-top: 1px solid var(--activityBar-border);
+  }
 }

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -75,9 +75,14 @@ export const Popover: React.FC<IPopoverProps> = ({
     [onClickAction],
   );
 
-  const overlayContent = useMemo(
-    () =>
-      overlay || (
+  const overlayContent = useMemo(() => {
+    if (overlay) {
+      return overlay;
+    } else {
+      if (!title && !content) {
+        return null;
+      }
+      return (
         <>
           {title && (
             <p className={cls('kt-popover-title', titleClassName)}>
@@ -91,9 +96,13 @@ export const Popover: React.FC<IPopoverProps> = ({
           )}
           {content || ''}
         </>
-      ),
-    [overlay],
-  );
+      );
+    }
+  }, [overlay, content, action, handleActionClick]);
+
+  if (!overlayContent) {
+    return children;
+  }
 
   return (
     <Tooltip

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -3,7 +3,6 @@ import Tooltip from 'rc-tooltip';
 import React, { useCallback, useMemo } from 'react';
 
 import './styles.less';
-import { StackingLevel } from '@opensumi/ide-core-browser';
 
 import { Button } from '../button';
 
@@ -63,7 +62,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   overlayStyle,
   action,
   delay,
-  zIndex = StackingLevel.PopoverComponent,
+  zIndex = 1000,
   onClickAction,
   onVisibleChange,
   ...restProps

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -109,7 +109,7 @@ export const Popover: React.FC<IPopoverProps> = ({
       {...restProps}
       visible={visible}
       placement={position}
-      mouseEnterDelay={delay}
+      mouseEnterDelay={delay ? delay / 1000 : undefined}
       trigger={trigger}
       showArrow={showArrow}
       onVisibleChange={onVisibleChange}

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -3,6 +3,8 @@ import Tooltip from 'rc-tooltip';
 import React, { useCallback, useMemo } from 'react';
 
 import './styles.less';
+import { StackingLevel } from '@opensumi/ide-core-browser';
+
 import { Button } from '../button';
 
 export enum PopoverTriggerType {
@@ -61,7 +63,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   overlayStyle,
   action,
   delay,
-  zIndex = 10000,
+  zIndex = StackingLevel.PopoverComponent,
   onClickAction,
   onVisibleChange,
   ...restProps

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -61,7 +61,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   overlayStyle,
   action,
   delay,
-  zIndex = 100,
+  zIndex = 10000,
   onClickAction,
   onVisibleChange,
   ...restProps

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -120,7 +120,7 @@ export const Popover: React.FC<IPopoverProps> = ({
       overlay={overlayContent}
       zIndex={zIndex}
     >
-      {children}
+      <div className='kt-popover-trigger'>{children}</div>
     </Tooltip>
   );
 };

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -32,6 +32,10 @@
     .overlay-shadow();
     padding: 8px 10px;
     z-index: 10001;
+    img {
+      max-width: 300px;
+      display: inline-block;
+    }
   }
 
   &-hidden {

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -3,7 +3,7 @@
 
 .@{prefix}-popover {
   position: absolute;
-  z-index: 1070;
+  z-index: var(--stacking-level-popover-container, 1070);
   display: block;
   visibility: visible;
   font-size: 12px;
@@ -31,7 +31,7 @@
     border-radius: 2px;
     .overlay-shadow();
     padding: 8px 10px;
-    z-index: 10000;
+    z-index: var(--stacking-level-popover-component, 10000);
     img {
       max-width: 300px;
       display: inline-block;
@@ -70,7 +70,7 @@
     position: absolute;
     width: 0;
     height: 0;
-    z-index: 10001;
+    z-index: var(--stacking-level-popover-component-arrow, 10001);
     border-color: transparent;
     border-style: solid;
   }

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -30,7 +30,7 @@
     border-radius: 2px;
     .overlay-shadow();
     padding: 8px 10px;
-    z-index: var(--stacking-level-popover-component, 10000);
+    z-index: var(--stacking-level-popover-component, 1000);
     img {
       max-width: 300px;
       display: inline-block;
@@ -69,7 +69,7 @@
     position: absolute;
     width: 0;
     height: 0;
-    z-index: var(--stacking-level-popover-component-arrow, 10001);
+    z-index: var(--stacking-level-popover-component-arrow, 1001);
     border-color: transparent;
     border-style: solid;
   }

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -31,7 +31,7 @@
     border-radius: 2px;
     .overlay-shadow();
     padding: 8px 10px;
-    z-index: 10001;
+    z-index: 10000;
     img {
       max-width: 300px;
       display: inline-block;
@@ -70,6 +70,7 @@
     position: absolute;
     width: 0;
     height: 0;
+    z-index: 10001;
     border-color: transparent;
     border-style: solid;
   }

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -3,7 +3,6 @@
 
 .@{prefix}-popover {
   position: absolute;
-  z-index: var(--stacking-level-popover-container, 1070);
   display: block;
   visibility: visible;
   font-size: 12px;

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -14,7 +14,8 @@
     font-size: 12px;
     display: flex;
     justify-content: space-between;
-    margin-bottom: 4px;
+    margin-bottom: 0;
+    margin-top: 0;
 
     &.@{prefix}-button,
     .small-button-size {
@@ -29,7 +30,7 @@
     border-color: var(--kt-popover-border);
     border-radius: 2px;
     .overlay-shadow();
-    padding: 8px 10px;
+    padding: 4px 8px;
     z-index: var(--stacking-level-popover-component, 1000);
     img {
       max-width: 300px;

--- a/packages/components/src/style/base.less
+++ b/packages/components/src/style/base.less
@@ -90,6 +90,7 @@ hr {
   box-sizing: content-box; // 1
   height: 0; // 1
   overflow: visible; // 2
+  margin-bottom: 0.5em;
 }
 
 //
@@ -115,10 +116,10 @@ h6 {
 // Reset margins on paragraphs
 //
 // Similarly, the top margin on `<p>`s get reset. However, we also reset the
-// bottom margin to use `em` units instead of `em`.
+// bottom margin to use `em` units instead of `px`.
 p {
   margin-top: 0;
-  margin-bottom: 1em;
+  margin-bottom: 0.5em;
 }
 
 // Abbreviations

--- a/packages/core-browser/src/design/rule.ts
+++ b/packages/core-browser/src/design/rule.ts
@@ -18,7 +18,10 @@ export const StackingLevel = {
    * 一级弹窗
    */
   Popup: 100,
-  Popover: 100,
+
+  PopoverContainer: 1070,
+  PopoverComponent: 10000,
+  PopoverComponentArrow: 10001,
   Overlay: 800,
   OverlayTop: 1000,
 } as const;

--- a/packages/core-browser/src/design/rule.ts
+++ b/packages/core-browser/src/design/rule.ts
@@ -18,10 +18,8 @@ export const StackingLevel = {
    * 一级弹窗
    */
   Popup: 100,
-
-  PopoverContainer: 1070,
-  PopoverComponent: 10000,
-  PopoverComponentArrow: 10001,
+  PopoverComponent: 1000,
+  PopoverComponentArrow: 1001,
   Overlay: 800,
   OverlayTop: 1000,
 } as const;

--- a/packages/core-browser/src/markdown/index.tsx
+++ b/packages/core-browser/src/markdown/index.tsx
@@ -2,19 +2,26 @@ import React from 'react';
 
 import { DATA_SET_COMMAND, RenderWrapper } from '@opensumi/ide-components/lib/markdown/render';
 import { IMarkedOptions, createMarkedRenderer, toMarkdownHtml as toHtml } from '@opensumi/ide-components/lib/utils';
+import { isString } from '@opensumi/ide-core-common';
 
 import { IOpenerService } from '../opener';
 
 export const toMarkdown = (
-  message: string | React.ReactNode,
+  content: string | React.ReactNode,
   opener?: IOpenerService,
   options?: IMarkedOptions,
-): React.ReactNode =>
-  typeof message === 'string' ? (
-    <RenderWrapper opener={opener} html={toMarkdownHtml(message, options)}></RenderWrapper>
+  justUseContent?: boolean,
+): React.ReactNode => {
+  if (justUseContent && content && isString(content)) {
+    return <RenderWrapper opener={opener} html={content}></RenderWrapper>;
+  }
+
+  return typeof content === 'string' ? (
+    <RenderWrapper opener={opener} html={toMarkdownHtml(content, options)}></RenderWrapper>
   ) : (
-    message
+    content
   );
+};
 
 export const toMarkdownHtml = (message: string, options?: IMarkedOptions): string => {
   const renderer = createMarkedRenderer();

--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -60,16 +60,12 @@ export function transformLabelWithCodicon(
 
 export function transformLabelWithCodiconHtml(
   label: string,
-  iconStyleProps: CSSProperties | string = {},
   transformer?: (str: string) => string | undefined,
 ): string {
   const ICON_REGX = /\$\(([a-z.]+\/)?([a-z-]+)(~[a-z]+)?\)/gi;
   const ICON_WITH_ANIMATE_REGX = /\$\(([a-z.]+\/)?([a-z-]+)~([a-z]+)\)/gi;
   // some string like $() $(~spin)
   const ICON_ERROR_REGX = /\$\(([a-z.]+\/)?([a-z-]+)?(~[a-z]+)?\)/gi;
-
-  const generateIconStyle = (icon?: string, styleProps?: CSSProperties | string) =>
-    typeof styleProps === 'string' ? { className: cls(icon, styleProps) } : { className: icon, style: styleProps };
 
   const splitLabel = label.split(SEPERATOR);
   const length = splitLabel.length;
@@ -81,22 +77,18 @@ export function transformLabelWithCodiconHtml(
       }
       const icon = transformer(e);
       if (icon) {
-        return `<span style="${generateIconStyle(icon, iconStyleProps).style}" class="${
-          generateIconStyle(icon, iconStyleProps).className
-        }" />`;
+        return `<span class="${icon}" />`;
       } else if (ICON_REGX.test(e)) {
         if (e.includes('~')) {
           const [, , icon, animate] = ICON_WITH_ANIMATE_REGX.exec(e) || [];
           if (animate && icon) {
-            return `<span style="${generateIconStyle(icon, iconStyleProps).style}" class="${
-              generateIconStyle(icon, iconStyleProps).className
-            }" />`;
+            return `<span class="${icon}" style="animation: kt-icon-${animate} 1.5s steps(30) infinite;" />`;
           }
         }
         const newStr = e.replaceAll(ICON_REGX, (e) => `${SEPERATOR}${e}${SEPERATOR}`);
-        return transformLabelWithCodiconHtml(newStr, iconStyleProps, transformer);
+        return transformLabelWithCodiconHtml(newStr, transformer);
       } else if (ICON_ERROR_REGX.test(e)) {
-        return transformLabelWithCodiconHtml(e.replaceAll(ICON_ERROR_REGX, ''), iconStyleProps, transformer);
+        return transformLabelWithCodiconHtml(e.replaceAll(ICON_ERROR_REGX, ''), transformer);
       } else {
         const withSeperator = e + (index === length - 1 ? '' : SEPERATOR);
         return withSeperator;

--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -57,3 +57,50 @@ export function transformLabelWithCodicon(
     }
   });
 }
+
+export function transformLabelWithCodiconHtml(
+  label: string,
+  iconStyleProps: CSSProperties | string = {},
+  transformer?: (str: string) => string | undefined,
+): string {
+  const ICON_REGX = /\$\(([a-z.]+\/)?([a-z-]+)(~[a-z]+)?\)/gi;
+  const ICON_WITH_ANIMATE_REGX = /\$\(([a-z.]+\/)?([a-z-]+)~([a-z]+)\)/gi;
+  // some string like $() $(~spin)
+  const ICON_ERROR_REGX = /\$\(([a-z.]+\/)?([a-z-]+)?(~[a-z]+)?\)/gi;
+
+  const generateIconStyle = (icon?: string, styleProps?: CSSProperties | string) =>
+    typeof styleProps === 'string' ? { className: cls(icon, styleProps) } : { className: icon, style: styleProps };
+
+  const splitLabel = label.split(SEPERATOR);
+  const length = splitLabel.length;
+
+  return splitLabel
+    .map((e, index) => {
+      if (!transformer) {
+        return e;
+      }
+      const icon = transformer(e);
+      if (icon) {
+        return `<span style="${generateIconStyle(icon, iconStyleProps).style}" class="${
+          generateIconStyle(icon, iconStyleProps).className
+        }" />`;
+      } else if (ICON_REGX.test(e)) {
+        if (e.includes('~')) {
+          const [, , icon, animate] = ICON_WITH_ANIMATE_REGX.exec(e) || [];
+          if (animate && icon) {
+            return `<span style="${generateIconStyle(icon, iconStyleProps).style}" class="${
+              generateIconStyle(icon, iconStyleProps).className
+            }" />`;
+          }
+        }
+        const newStr = e.replaceAll(ICON_REGX, (e) => `${SEPERATOR}${e}${SEPERATOR}`);
+        return transformLabelWithCodiconHtml(newStr, iconStyleProps, transformer);
+      } else if (ICON_ERROR_REGX.test(e)) {
+        return transformLabelWithCodiconHtml(e.replaceAll(ICON_ERROR_REGX, ''), iconStyleProps, transformer);
+      } else {
+        const withSeperator = e + (index === length - 1 ? '' : SEPERATOR);
+        return withSeperator;
+      }
+    })
+    .join('');
+}

--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -77,12 +77,12 @@ export function transformLabelWithCodiconHtml(
       }
       const icon = transformer(e);
       if (icon) {
-        return `<span class="${icon}" />`;
+        return `<span class="kt-icon ${icon}" style="font-size: 14px;" ></span>`;
       } else if (ICON_REGX.test(e)) {
         if (e.includes('~')) {
           const [, , icon, animate] = ICON_WITH_ANIMATE_REGX.exec(e) || [];
           if (animate && icon) {
-            return `<span class="${icon}" style="animation: kt-icon-${animate} 1.5s steps(30) infinite;" />`;
+            return `<span class="kt-icon ${icon} codicon-animation-${animate}" style="font-size: 14px;" ></span>`;
           }
         }
         const newStr = e.replaceAll(ICON_REGX, (e) => `${SEPERATOR}${e}${SEPERATOR}`);

--- a/packages/core-browser/src/utils/label.tsx
+++ b/packages/core-browser/src/utils/label.tsx
@@ -94,5 +94,5 @@ export function transformLabelWithCodiconHtml(
         return withSeperator;
       }
     })
-    .join('');
+    .join(SEPERATOR);
 }

--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -6,6 +6,7 @@ import {
   IOpenerService,
   replaceLocalizePlaceholder,
   toMarkdown,
+  toMarkdownHtml,
   transformLabelWithCodicon,
   transformLabelWithCodiconHtml,
 } from '@opensumi/ide-core-browser';
@@ -85,12 +86,9 @@ export const StatusBarItem = memo((props: StatusBarEntry) => {
       return <StatusBarPopover contents={hoverContents} />;
     }
     if (tooltip && (tooltip as IMarkdownString).value) {
-      const value = transformLabelWithCodiconHtml(
-        (tooltip as IMarkdownString).value,
-        {},
-        iconService.fromString.bind(iconService),
-      );
-      return toMarkdown(value, openerService);
+      const html = toMarkdownHtml((tooltip as IMarkdownString).value);
+      const value = transformLabelWithCodiconHtml(html, iconService.fromString.bind(iconService));
+      return toMarkdown(value, openerService, undefined, true);
     }
     return (
       isString(tooltip) && (

--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -7,6 +7,7 @@ import {
   replaceLocalizePlaceholder,
   toMarkdown,
   transformLabelWithCodicon,
+  transformLabelWithCodiconHtml,
 } from '@opensumi/ide-core-browser';
 import { useInjectable } from '@opensumi/ide-core-browser/lib/react-hooks';
 import { StatusBarEntry, StatusBarHoverContent } from '@opensumi/ide-core-browser/lib/services';
@@ -84,7 +85,12 @@ export const StatusBarItem = memo((props: StatusBarEntry) => {
       return <StatusBarPopover contents={hoverContents} />;
     }
     if (tooltip && (tooltip as IMarkdownString).value) {
-      return toMarkdown((tooltip as IMarkdownString).value, openerService);
+      const value = transformLabelWithCodiconHtml(
+        (tooltip as IMarkdownString).value,
+        {},
+        iconService.fromString.bind(iconService),
+      );
+      return toMarkdown(value, openerService);
     }
     return (
       isString(tooltip) && (

--- a/packages/theme/src/common/rule.ts
+++ b/packages/theme/src/common/rule.ts
@@ -1,4 +1,4 @@
-import kabebCase from 'lodash/kebabCase';
+import kebabCase from 'lodash/kebabCase';
 
 import { StackingLevelStr } from '@opensumi/ide-core-browser';
 
@@ -8,5 +8,5 @@ import { registerCSSVar } from './css-var';
 // e.g. --stacking-level-base: 0;
 // e.g. --stacking-level-popover-component: 10000;
 Object.entries(StackingLevelStr).forEach(([key, value]) => {
-  registerCSSVar(`stacking-level-${kabebCase(key).toLowerCase()}`, value);
+  registerCSSVar(`stacking-level-${kebabCase(key).toLowerCase()}`, value);
 });

--- a/packages/theme/src/common/rule.ts
+++ b/packages/theme/src/common/rule.ts
@@ -8,5 +8,5 @@ import { registerCSSVar } from './css-var';
 // e.g. --stacking-level-base: 0;
 // e.g. --stacking-level-popover-component: 10000;
 Object.entries(StackingLevelStr).forEach(([key, value]) => {
-  registerCSSVar(`stacking-level-${key.toLowerCase()}`, kabebCase(value));
+  registerCSSVar(`stacking-level-${kabebCase(key).toLowerCase()}`, value);
 });

--- a/packages/theme/src/common/rule.ts
+++ b/packages/theme/src/common/rule.ts
@@ -1,8 +1,12 @@
+import kabebCase from 'lodash/kebabCase';
+
 import { StackingLevelStr } from '@opensumi/ide-core-browser';
 
 import { registerCSSVar } from './css-var';
 
 // Register all stacking levels as CSS variables
+// e.g. --stacking-level-base: 0;
+// e.g. --stacking-level-popover-component: 10000;
 Object.entries(StackingLevelStr).forEach(([key, value]) => {
-  registerCSSVar(`stacking-level-${key.toLowerCase()}`, value);
+  registerCSSVar(`stacking-level-${key.toLowerCase()}`, kabebCase(value));
 });


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

Before:
<img width="549" alt="截屏2024-04-29 15 32 45" src="https://github.com/opensumi/core/assets/9823838/bddfc230-3a59-4458-b042-e75535ede8d7">

After:
<img width="364" alt="截屏2024-04-29 17 31 45" src="https://github.com/opensumi/core/assets/9823838/b356e7bf-eeeb-4fcd-b572-488bd0ae409d">

### Changelog
support codicon transform on popover content