### PR TITLE
feat(rpc): add protocol for ext document service

### DIFF
--- a/packages/connection/src/common/protocols/common.ts
+++ b/packages/connection/src/common/protocols/common.ts
@@ -7,3 +7,22 @@ export const UriComponentsProto = Type.object('uri-components', {
   query: Type.string(),
   fragment: Type.string(),
 });
+
+export const RangeProto = Type.object('range', {
+  startLineNumber: Type.uint32(),
+  startColumn: Type.uint32(),
+  endLineNumber: Type.uint32(),
+  endColumn: Type.uint32(),
+});
+
+export const SelectionProto = Type.object('selection', {
+  selectionStartLineNumber: Type.uint32(),
+  selectionStartColumn: Type.uint32(),
+  positionLineNumber: Type.uint32(),
+  positionColumn: Type.uint32(),
+});
+
+export const PositionProto = Type.object('position', {
+  lineNumber: Type.uint32(),
+  column: Type.uint32(),
+});

--- a/packages/connection/src/common/protocols/extensions/ext-host-documents.ts
+++ b/packages/connection/src/common/protocols/extensions/ext-host-documents.ts
@@ -1,0 +1,69 @@
+import { Type } from '@furyjs/fury';
+
+import { TSumiProtocol } from '../../rpc';
+import { RangeProto } from '../common';
+
+/**
+ * {@link IExtensionHostDocService}
+ */
+export const ExtensionDocumentProtocol: TSumiProtocol = {
+  name: 'ExtHostDocuments',
+  methods: [
+    {
+      method: '$fireModelChangedEvent',
+      request: [
+        {
+          name: 'event',
+          type: Type.object('model-changed-event', {
+            changes: Type.array(
+              Type.object('model-changed-event-changes', {
+                range: RangeProto,
+                rangeLength: Type.uint32(),
+                rangeOffset: Type.uint32(),
+                text: Type.string(),
+              }),
+            ),
+            uri: Type.string(),
+            versionId: Type.uint32(),
+            eol: Type.string(),
+            dirty: Type.bool(),
+            isRedoing: Type.bool(),
+            isUndoing: Type.bool(),
+          }),
+        },
+      ],
+    },
+    {
+      method: '$fireModelOpenedEvent',
+      request: [
+        {
+          name: 'event',
+          type: Type.object('model-open-event', {
+            uri: Type.string(),
+            lines: Type.array(Type.string()),
+            eol: Type.string(),
+            versionId: Type.uint32(),
+            languageId: Type.string(),
+            dirty: Type.bool(),
+          }),
+        },
+      ],
+    },
+    {
+      method: '$provideTextDocumentContent',
+      request: [
+        {
+          name: 'path',
+          type: Type.string(),
+        },
+        {
+          name: 'encoding',
+          type: Type.string(),
+        },
+      ],
+      response: {
+        type: Type.string(),
+      },
+    },
+  ],
+};

--- a/packages/connection/src/common/rpc/message-io.ts
+++ b/packages/connection/src/common/rpc/message-io.ts
@@ -52,7 +52,12 @@ class SumiProtocolSerializer implements IProtocolSerializer {
     }
 
     const requestProto = Type.tuple(argsTuple);
-    const resultProto = methodProtocol.response.type || Type.any();
+
+    let resultProto: TypeDescription = Type.any();
+
+    if (methodProtocol.response && methodProtocol.response.type) {
+      resultProto = methodProtocol.response.type;
+    }
 
     this.request = this.fury.registerSerializer(requestProto);
     this.result = this.fury.registerSerializer(resultProto);

--- a/packages/connection/src/common/rpc/multiplexer.ts
+++ b/packages/connection/src/common/rpc/multiplexer.ts
@@ -1,6 +1,7 @@
 import { BaseConnection } from '../connection';
 
 import { ISumiConnectionOptions, SumiConnection } from './connection';
+import { TSumiProtocol } from './types';
 
 export class ProxyIdentifier<T = any> {
   public static count = 0;
@@ -15,6 +16,13 @@ export class ProxyIdentifier<T = any> {
   static for(serviceId: string) {
     return new ProxyIdentifier(serviceId);
   }
+}
+
+export interface ISumiMultiplexerConnectionOptions extends ISumiConnectionOptions {
+  /**
+   * Known protocols that will be loaded automatically when a proxy is created.
+   */
+  knownProtocols?: Record<string, TSumiProtocol>;
 }
 
 export const IRPCProtocol = Symbol('IRPCProtocol');
@@ -46,11 +54,13 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
 
   protected readonly _locals: Map<string, any>;
   protected readonly _proxies: Map<string, any>;
+  protected _knownProtocols: Record<string, TSumiProtocol>;
 
-  constructor(protected socket: BaseConnection<Uint8Array>, protected options: ISumiConnectionOptions = {}) {
+  constructor(protected socket: BaseConnection<Uint8Array>, protected options: ISumiMultiplexerConnectionOptions = {}) {
     super(socket, options);
     this._locals = new Map();
     this._proxies = new Map();
+    this._knownProtocols = options.knownProtocols || {};
 
     this.onRequestNotFound((rpcName: string, args: any[]) => this._doInvokeHandler(rpcName, args));
 
@@ -60,7 +70,13 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
   }
 
   public set<T>(identifier: ProxyIdentifier<T>, instance: any) {
-    this._locals.set(SumiConnectionMultiplexer.normalizeServiceId(identifier.serviceId), instance);
+    const id = SumiConnectionMultiplexer.normalizeServiceId(identifier.serviceId);
+    this._locals.set(id, instance);
+    const protocol = this._knownProtocols[identifier.serviceId];
+    if (protocol) {
+      this.loadProtocol(id, protocol);
+    }
+
     return instance;
   }
 
@@ -68,10 +84,21 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
     return this._locals.get(SumiConnectionMultiplexer.normalizeServiceId(identifier.serviceId));
   }
 
+  protected loadProtocol(rpcId: string, protocol: TSumiProtocol) {
+    this.io.loadProtocol(protocol, {
+      nameConverter: (str: string) => SumiConnectionMultiplexer.getRPCName(rpcId, str),
+    });
+  }
+
   public getProxy<T>(proxyId: ProxyIdentifier<T>) {
     const serviceId = SumiConnectionMultiplexer.normalizeServiceId(proxyId.serviceId);
 
     if (!this._proxies.has(serviceId)) {
+      const protocol = this._knownProtocols[proxyId.serviceId];
+      if (protocol) {
+        this.loadProtocol(serviceId, protocol);
+      }
+
       this._proxies.set(serviceId, this._createProxy(serviceId));
     }
 

--- a/packages/core-common/src/types/rpc.ts
+++ b/packages/core-common/src/types/rpc.ts
@@ -17,7 +17,7 @@ export interface Response<T> {
 export interface RPCProtocolMethod<T> {
   method: string;
   request: Request<T>[];
-  response: Response<T>;
+  response?: Response<T>;
 }
 
 export interface RPCProtocol<T> {

--- a/packages/extension/src/browser/extension-node.service.ts
+++ b/packages/extension/src/browser/extension-node.service.ts
@@ -21,6 +21,7 @@ import {
 import { ActivatedExtensionJSON } from '../common/activator';
 import { AbstractNodeExtProcessService } from '../common/extension.service';
 import { ExtHostAPIIdentifier } from '../common/vscode';
+import { knownProtocols } from '../common/vscode/protocols';
 
 import { createSumiApiFactory } from './sumi/main.thread.api.impl';
 import { createApiFactory as createVSCodeAPIFactory } from './vscode/api/main.thread.api.impl';
@@ -151,6 +152,7 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
     const mainThreadProtocol = new SumiConnectionMultiplexer(channel.createConnection(), {
       timeout: this.appConfig.rpcMessageTimeout,
       name: 'node-ext-host',
+      knownProtocols,
     });
 
     // 重启/重连时直接覆盖前一个连接

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -8,6 +8,7 @@ import { Disposable, IDisposable, path, toDisposable } from '@opensumi/ide-core-
 import { IExtension, IExtensionWorkerHost, WorkerHostAPIIdentifier } from '../common';
 import { ActivatedExtensionJSON } from '../common/activator';
 import { AbstractWorkerExtProcessService } from '../common/extension.service';
+import { knownProtocols } from '../common/vscode/protocols';
 
 import { getWorkerBootstrapUrl } from './loader';
 import { createSumiApiFactory } from './sumi/main.thread.api.impl';
@@ -200,6 +201,7 @@ export class WorkerExtProcessService
     const protocol = new SumiConnectionMultiplexer(msgPortConnection, {
       timeout: this.appConfig.rpcMessageTimeout,
       name: 'worker-ext-host',
+      knownProtocols,
     });
 
     this.logger.log('[Worker Host] web worker extension host ready');

--- a/packages/extension/src/common/vscode/protocols.ts
+++ b/packages/extension/src/common/vscode/protocols.ts
@@ -1,0 +1,7 @@
+import { ExtensionDocumentProtocol } from '@opensumi/ide-connection/lib/common/protocols/extensions/ext-host-documents';
+
+import { ExtHostAPIIdentifier } from '.';
+
+export const knownProtocols = {
+  [ExtHostAPIIdentifier.ExtHostDocuments.serviceId]: ExtensionDocumentProtocol,
+};

--- a/packages/extension/src/hosted/ext.process-base.ts
+++ b/packages/extension/src/hosted/ext.process-base.ts
@@ -20,6 +20,7 @@ import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 
 import { IExtensionHostService, KT_APP_CONFIG_KEY, KT_PROCESS_SOCK_OPTION_KEY, ProcessMessageType } from '../common';
 import { CommandHandler } from '../common/vscode';
+import { knownProtocols } from '../common/vscode/protocols';
 
 import { setPerformance } from './api/vscode/language/util';
 import { ExtensionLogger2 } from './extension-log2';
@@ -89,6 +90,7 @@ async function initRPCProtocol(extInjector: Injector): Promise<any> {
 
   const extProtocol = new SumiConnectionMultiplexer(new NetSocketConnection(socket), {
     timeout: appConfig.rpcMessageTimeout,
+    knownProtocols,
   });
 
   return { extProtocol, logger };

--- a/packages/extension/src/hosted/worker.host.ts
+++ b/packages/extension/src/hosted/worker.host.ts
@@ -21,6 +21,7 @@ import {
   MainThreadAPIIdentifier,
   SumiWorkerExtensionService,
 } from '../common/vscode';
+import { knownProtocols } from '../common/vscode/protocols';
 
 import { ExtensionContext } from './api/vscode/ext.host.extensions';
 import { ExtHostSecret } from './api/vscode/ext.host.secrets';
@@ -36,7 +37,9 @@ export function initRPCProtocol() {
 
   const msgPortConnection = new MessagePortConnection(channel.port1);
 
-  const extProtocol = new SumiConnectionMultiplexer(msgPortConnection);
+  const extProtocol = new SumiConnectionMultiplexer(msgPortConnection, {
+    knownProtocols,
+  });
 
   return extProtocol;
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

当我们打开一个文件的时候，会向插件进程发送一个 `fireModelOpenedEvent` 事件，这个事件包含了 model 的全文，如果我们使用 json 序列化的话，数据会膨胀的非常大。


过去：

9.5m -> 12.5m
![CleanShot 2024-05-06 at 15 30 19@2x](https://github.com/opensumi/core/assets/13938334/9592c66c-8cb2-4039-9757-738e8715c5ea)

10.5m -> 62.9m
![CleanShot 2024-05-06 at 15 30 43@2x](https://github.com/opensumi/core/assets/13938334/848aeb68-3a2d-4e66-809f-5d73c423456f)

现在：

9.5m -> 9.6m

![CleanShot 2024-05-06 at 15 36 02@2x](https://github.com/opensumi/core/assets/13938334/53853054-51b9-4497-91ae-438a8ff1fce3)

10.5m -> 10.5m

![CleanShot 2024-05-06 at 15 36 20@2x](https://github.com/opensumi/core/assets/13938334/9b5fe9f9-0fdc-4282-be27-c9943aeeefc7)



### Changelog
