### PR TITLE
refactor: update ext protocol registration

### DIFF
--- a/packages/connection/src/common/rpc/multiplexer.ts
+++ b/packages/connection/src/common/rpc/multiplexer.ts
@@ -111,4 +111,8 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
 
     return method.apply(actor, args);
   }
+
+  getSocket() {
+    return this.socket;
+  }
 }

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -123,7 +123,6 @@ export interface AppConfig {
   webviewEndpoint?: string;
   /**
    * Worker 插件的默认启动路径
-   * 默认值为: https://dev.g.alicdn.com/tao-ide/ide-lite/${version}/worker-host.js
    */
   extWorkerHost?: string;
   /**

--- a/packages/extension/__tests__/browser/main.thread.task.test.ts
+++ b/packages/extension/__tests__/browser/main.thread.task.test.ts
@@ -4,7 +4,7 @@ import { FileUri, ITaskDefinitionRegistry, TaskDefinitionRegistryImpl } from '@o
 import { addEditorProviders } from '@opensumi/ide-dev-tool/src/injector-editor';
 import { ExtensionService } from '@opensumi/ide-extension';
 import { ExtensionServiceImpl } from '@opensumi/ide-extension/lib/browser/extension.service';
-import { MainthreadTasks } from '@opensumi/ide-extension/lib/browser/vscode/api/main.thread.tasks';
+import { MainThreadTasks } from '@opensumi/ide-extension/lib/browser/vscode/api/main.thread.tasks';
 import { MainThreadWorkspace } from '@opensumi/ide-extension/lib/browser/vscode/api/main.thread.workspace';
 import { ExtHostAPIIdentifier, MainThreadAPIIdentifier } from '@opensumi/ide-extension/lib/common/vscode';
 import { ShellExecution, Task } from '@opensumi/ide-extension/lib/common/vscode/ext-types';
@@ -123,7 +123,7 @@ describe('MainThreadTask Test Suite', () => {
 
   const testProvider = new TestTaskProvider();
   let extHostTask: ExtHostTasks;
-  let mainthreadTask: MainthreadTasks;
+  let mainthreadTask: MainThreadTasks;
   let extHostTaskApi: ReturnType<typeof createTaskApiFactory>;
   const workspaceService = injector.get<MockWorkspaceService>(IWorkspaceService);
 
@@ -157,7 +157,7 @@ describe('MainThreadTask Test Suite', () => {
     const extHostTerminal = new ExtHostTerminal(rpcProtocolExt);
     const extHostWorkspace = new ExtHostWorkspace(rpcProtocolExt, extHostMessage, extHostDocs);
     extHostTask = new ExtHostTasks(rpcProtocolExt, extHostTerminal, extHostWorkspace);
-    mainthreadTask = injector.get(MainthreadTasks, [rpcProtocolMain]);
+    mainthreadTask = injector.get(MainThreadTasks, [rpcProtocolMain]);
     rpcProtocolExt.set(ExtHostAPIIdentifier.ExtHostWorkspace, extHostWorkspace);
     rpcProtocolExt.set(ExtHostAPIIdentifier.ExtHostTasks, extHostTask);
     rpcProtocolExt.set(ExtHostAPIIdentifier.ExtHostStorage, new ExtHostStorage(rpcProtocolExt));

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.comments.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.comments.test.ts
@@ -6,7 +6,7 @@ import { IContextKeyService } from '@opensumi/ide-core-browser';
 import { Deferred, Disposable, IEventBus, URI, Uri, sleep } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { WorkbenchEditorServiceImpl } from '@opensumi/ide-editor/lib/browser/workbench-editor.service';
-import { MainthreadComments } from '@opensumi/ide-extension/lib/browser/vscode/api/main.thread.comments';
+import { MainThreadComments } from '@opensumi/ide-extension/lib/browser/vscode/api/main.thread.comments';
 import {
   ExtHostAPIIdentifier,
   IMainThreadComments,
@@ -77,7 +77,7 @@ describe('extension/__tests__/hosted/api/vscode/ext.host.comments.test.ts', () =
     );
     mainThreadComments = rpcProtocolExt.set(
       MainThreadAPIIdentifier.MainThreadComments,
-      injector.get(MainthreadComments, [rpcProtocolExt, mainCommands]),
+      injector.get(MainThreadComments, [rpcProtocolExt, mainCommands]),
     );
     vscodeComments = createCommentsApiFactory(extension, extComments);
   });

--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.task.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.task.test.ts
@@ -54,7 +54,7 @@ import { IWorkspaceService } from '@opensumi/ide-workspace';
 
 import { mockExtensionProps } from '../../../../__mocks__/extensions';
 import { createMockPairRPCProtocol } from '../../../../__mocks__/initRPCProtocol';
-import { MainthreadTasks } from '../../../../src/browser/vscode/api/main.thread.tasks';
+import { MainThreadTasks } from '../../../../src/browser/vscode/api/main.thread.tasks';
 import { MainThreadTerminal } from '../../../../src/browser/vscode/api/main.thread.terminal';
 import { ExtHostAPIIdentifier, MainThreadAPIIdentifier } from '../../../../src/common/vscode';
 import { ExtHostTerminal } from '../../../../src/hosted/api/vscode/ext.host.terminal';
@@ -70,7 +70,7 @@ const { rpcProtocolExt, rpcProtocolMain } = createMockPairRPCProtocol();
 let extHostTask: ExtHostTasks;
 let extHostTerminal: ExtHostTerminal;
 let mainThreadTerminal: MainThreadTerminal;
-let mainThreadTask: MainthreadTasks;
+let mainThreadTask: MainThreadTasks;
 
 describe('ExtHostTask API', () => {
   const injector = createBrowserInjector([]);
@@ -237,7 +237,7 @@ describe('ExtHostTask API', () => {
   rpcProtocolExt.set(ExtHostAPIIdentifier.ExtHostTerminal, extHostTerminal);
   extHostTask = new ExtHostTasks(rpcProtocolExt, extHostTerminal, extHostWorkspace);
   mainThreadTerminal = injector.get(MainThreadTerminal, [rpcProtocolMain]);
-  mainThreadTask = injector.get(MainthreadTasks, [rpcProtocolMain]);
+  mainThreadTask = injector.get(MainThreadTasks, [rpcProtocolMain]);
 
   rpcProtocolExt.set(ExtHostAPIIdentifier.ExtHostTasks, extHostTask);
   rpcProtocolMain.set(MainThreadAPIIdentifier.MainThreadTerminal, mainThreadTerminal);

--- a/packages/extension/src/browser/extension-command-management.ts
+++ b/packages/extension/src/browser/extension-command-management.ts
@@ -31,7 +31,7 @@ export class ExtCommandManagementImpl extends Disposable implements IExtCommandM
   public async executeExtensionCommand(env: ExtensionHostType, command: string, args: any[]): Promise<any> {
     const targetProxyCommandExecutor = this.proxyCommandExecutorRegistry.get(env);
     if (!targetProxyCommandExecutor) {
-      throw new Error('Proxy command executor"' + env + '" is not existed');
+      throw new Error('Proxy command executor "' + env + '" is not existed');
     }
     return targetProxyCommandExecutor.$executeExtensionCommand(command, ...args);
   }

--- a/packages/extension/src/browser/extension-node.service.ts
+++ b/packages/extension/src/browser/extension-node.service.ts
@@ -1,6 +1,7 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { IRPCProtocol, SumiConnectionMultiplexer } from '@opensumi/ide-connection';
 import { WSChannelHandler as IWSChannelHandler } from '@opensumi/ide-connection/lib/browser';
+import { BaseConnection } from '@opensumi/ide-connection/lib/common/connection';
 import {
   AppConfig,
   Deferred,
@@ -22,8 +23,9 @@ import { ActivatedExtensionJSON } from '../common/activator';
 import { AbstractNodeExtProcessService } from '../common/extension.service';
 import { ExtHostAPIIdentifier } from '../common/vscode';
 
-import { createSumiApiFactory } from './sumi/main.thread.api.impl';
-import { createApiFactory as createVSCodeAPIFactory } from './vscode/api/main.thread.api.impl';
+import { createSumiAPIFactory } from './sumi/main.thread.api.impl';
+import { initNodeThreadAPIProxy } from './vscode/api/main.thread.api.impl';
+import { initSharedAPIProxy } from './vscode/api/main.thread.api.shared-impl';
 
 @Injectable()
 export class NodeExtProcessService implements AbstractNodeExtProcessService<IExtensionHostService> {
@@ -119,9 +121,12 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
   }
 
   private async createBrowserMainThreadAPI(protocol: IRPCProtocol) {
+    const apiProxy = initSharedAPIProxy(this.protocol, this.injector);
+    await apiProxy.setup();
     this._apiFactoryDisposables.push(
-      toDisposable(await createVSCodeAPIFactory(protocol, this.injector, this)),
-      toDisposable(createSumiApiFactory(protocol, this.injector)),
+      apiProxy,
+      toDisposable(initNodeThreadAPIProxy(protocol, this.injector, this)),
+      toDisposable(createSumiAPIFactory(protocol, this.injector)),
     );
   }
 
@@ -144,11 +149,14 @@ export class NodeExtProcessService implements AbstractNodeExtProcessService<IExt
     return this.initExtProtocol();
   }
 
+  connection: BaseConnection<Uint8Array>;
   private async initExtProtocol() {
     const channelHandler = this.injector.get(IWSChannelHandler);
     const channel = await channelHandler.openChannel(CONNECTION_HANDLE_BETWEEN_EXTENSION_AND_MAIN_THREAD);
 
-    const mainThreadProtocol = new SumiConnectionMultiplexer(channel.createConnection(), {
+    this.connection = channel.createConnection();
+
+    const mainThreadProtocol = new SumiConnectionMultiplexer(this.connection, {
       timeout: this.appConfig.rpcMessageTimeout,
       name: 'node-ext-host',
     });

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -1,5 +1,6 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { warning } from '@opensumi/ide-components/lib/utils';
+import { BaseConnection } from '@opensumi/ide-connection/lib/common/connection';
 import { MessagePortConnection } from '@opensumi/ide-connection/lib/common/connection/drivers/message-port';
 import { IRPCProtocol, SumiConnectionMultiplexer } from '@opensumi/ide-connection/lib/common/rpc/multiplexer';
 import { AppConfig, Deferred, IExtensionProps, ILogger, URI } from '@opensumi/ide-core-browser';
@@ -10,8 +11,9 @@ import { ActivatedExtensionJSON } from '../common/activator';
 import { AbstractWorkerExtProcessService } from '../common/extension.service';
 
 import { getWorkerBootstrapUrl } from './loader';
-import { createSumiApiFactory } from './sumi/main.thread.api.impl';
+import { createSumiAPIFactory } from './sumi/main.thread.api.impl';
 import { initWorkerThreadAPIProxy } from './vscode/api/main.thread.api.impl';
+import { initSharedAPIProxy } from './vscode/api/main.thread.api.shared-impl';
 import { startInsideIframe } from './workerHostIframe';
 
 const { posix } = path;
@@ -57,9 +59,12 @@ export class WorkerExtProcessService
     if (this.protocol) {
       this.ready.resolve();
       this.logger.log('[Worker Host] init worker thread api proxy');
+      const apiProxy = initSharedAPIProxy(this.protocol, this.injector);
+      await apiProxy.setup();
       this.apiFactoryDisposable.push(
-        toDisposable(await initWorkerThreadAPIProxy(this.protocol, this.injector, this)),
-        toDisposable(createSumiApiFactory(this.protocol, this.injector)),
+        apiProxy,
+        toDisposable(initWorkerThreadAPIProxy(this.protocol, this.injector, this)),
+        toDisposable(createSumiAPIFactory(this.protocol, this.injector)),
       );
       this.addDispose(this.apiFactoryDisposable);
 
@@ -194,10 +199,11 @@ export class WorkerExtProcessService
     });
   }
 
+  connection: BaseConnection<Uint8Array>;
   private createProtocol(port: MessagePort) {
-    const msgPortConnection = new MessagePortConnection(port);
+    this.connection = new MessagePortConnection(port);
 
-    const protocol = new SumiConnectionMultiplexer(msgPortConnection, {
+    const protocol = new SumiConnectionMultiplexer(this.connection, {
       timeout: this.appConfig.rpcMessageTimeout,
       name: 'worker-ext-host',
     });

--- a/packages/extension/src/browser/sumi/main.thread.api.impl.ts
+++ b/packages/extension/src/browser/sumi/main.thread.api.impl.ts
@@ -12,7 +12,7 @@ import { MainThreadTheme } from './main.thread.theme';
 import { MainThreadToolbar } from './main.thread.toolbar';
 import { MainThreadIDEWindow } from './main.thread.window';
 
-export function createSumiApiFactory(rpcProtocol: IRPCProtocol, injector: Injector) {
+export function createSumiAPIFactory(rpcProtocol: IRPCProtocol, injector: Injector) {
   const disposer = new Disposable();
   const lifeCycle = injector.get(MainThreadLifeCycle, [injector]);
 

--- a/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.impl.ts
@@ -1,305 +1,72 @@
 import { Injector } from '@opensumi/di';
 import { IRPCProtocol } from '@opensumi/ide-connection';
 
-import { IMainThreadExtensionLog, MainThreadExtensionLogIdentifier } from '../../../common/extension-log';
 import {
-  IMainThreadAuthentication,
-  IMainThreadCommands,
-  IMainThreadComments,
-  IMainThreadCustomEditor,
-  IMainThreadDecorationsShape,
-  IMainThreadEditorTabsShape,
-  IMainThreadEnv,
-  IMainThreadLanguages,
-  IMainThreadMessage,
-  IMainThreadOutput,
-  IMainThreadPreference,
-  IMainThreadProgress,
-  IMainThreadQuickOpen,
-  IMainThreadSCMShape,
-  IMainThreadSecret,
-  IMainThreadStorage,
   IMainThreadTasks,
   IMainThreadTerminal,
   IMainThreadTesting,
-  IMainThreadTheming,
-  IMainThreadUrls,
-  IMainThreadWebview,
-  IMainThreadWebviewView,
-  IMainThreadWorkspace,
   MainThreadAPIIdentifier,
   VSCodeExtensionService,
 } from '../../../common/vscode';
 
-import { MainThreadProgress } from './main.thread.api.progress';
-import { MainThreadWebview, MainThreadWebviewView } from './main.thread.api.webview';
-import { MainThreadAuthentication } from './main.thread.authentication';
-import { MainThreadCommands } from './main.thread.commands';
-import { MainthreadComments } from './main.thread.comments';
 import { MainThreadConnection } from './main.thread.connection';
-import { MainThreadCustomEditor } from './main.thread.custom-editor';
 import { MainThreadDebug } from './main.thread.debug';
-import { MainThreadDecorations } from './main.thread.decoration';
-import { MainThreadExtensionDocumentData } from './main.thread.doc';
-import { MainThreadEditorService } from './main.thread.editor';
-import { MainThreadEditorTabsService } from './main.thread.editor-tabs';
-import { MainThreadEnv } from './main.thread.env';
-import { MainThreadFileSystem } from './main.thread.file-system';
-import { MainThreadFileSystemEvent } from './main.thread.file-system-event';
-import { MainThreadLanguages } from './main.thread.language';
-import { MainThreadLocalization } from './main.thread.localization';
-import { MainThreadExtensionLog } from './main.thread.log';
-import { MainThreadMessage } from './main.thread.message';
-import { MainThreadOutput } from './main.thread.output';
-import { MainThreadPreference } from './main.thread.preference';
-import { MainThreadQuickOpen } from './main.thread.quickopen';
-import { MainThreadSCM } from './main.thread.scm';
-import { MainThreadSecret } from './main.thread.secret';
-import { MainThreadStatusBar } from './main.thread.statusbar';
-import { MainThreadStorage } from './main.thread.storage';
-import { MainthreadTasks } from './main.thread.tasks';
+import { MainThreadTasks } from './main.thread.tasks';
 import { MainThreadTerminal } from './main.thread.terminal';
 import { MainThreadTestsImpl } from './main.thread.tests';
-import { MainThreadTheming } from './main.thread.theming';
 import { MainThreadTreeView } from './main.thread.treeview';
-import { MainThreadUrls } from './main.thread.urls';
 import { MainThreadWindow } from './main.thread.window';
 import { MainThreadWindowState } from './main.thread.window-state';
-import { MainThreadWorkspace } from './main.thread.workspace';
 
-export async function createApiFactory(
+export function initNodeThreadAPIProxy(
   rpcProtocol: IRPCProtocol,
   injector: Injector,
   extensionService: VSCodeExtensionService,
 ) {
-  const MainThreadLanguagesAPI = injector.get(MainThreadLanguages, [rpcProtocol]);
-  const MainThreadCommandsAPI = injector.get(MainThreadCommands, [rpcProtocol]);
-  const MainThreadExtensionDocumentDataAPI = injector.get(MainThreadExtensionDocumentData, [rpcProtocol]);
-  const MainThreadEditorServiceAPI = injector.get(MainThreadEditorService, [
-    rpcProtocol,
-    MainThreadExtensionDocumentDataAPI,
-  ]);
-  const MainThreadStatusBarAPI = injector.get(MainThreadStatusBar, [rpcProtocol]);
-  const MainThreadMessageAPI = injector.get(MainThreadMessage, [rpcProtocol]);
-  const MainThreadWorkspaceAPI = injector.get(MainThreadWorkspace, [rpcProtocol]);
-  const MainThreadPreferenceAPI = injector.get(MainThreadPreference, [rpcProtocol]);
-  const MainThreadStorageAPI = injector.get(MainThreadStorage, [rpcProtocol]);
-  const MainThreadEnvAPI = injector.get(MainThreadEnv, [rpcProtocol, MainThreadStorageAPI]);
-  const MainThreadQuickOpenAPI = injector.get(MainThreadQuickOpen, [rpcProtocol]);
-  const MainThreadOutputAPI = injector.get(MainThreadOutput);
-  const MainThreadFileSystemAPI = injector.get(MainThreadFileSystem, [rpcProtocol]);
-  const MainThreadFileSystemEventAPI = injector.get(MainThreadFileSystemEvent, [rpcProtocol]);
-  const MainThreadWebviewAPI = injector.get(MainThreadWebview, [rpcProtocol]);
-  const MainThreadWebviewViewAPI = injector.get(MainThreadWebviewView, [rpcProtocol, MainThreadWebviewAPI]);
-  const MainThreadSCMAPI = injector.get(MainThreadSCM, [rpcProtocol]);
+  rpcProtocol.set<VSCodeExtensionService>(MainThreadAPIIdentifier.MainThreadExtensionService, extensionService);
+
   const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [rpcProtocol, 'node']);
-  const MainThreadDecorationsAPI = injector.get(MainThreadDecorations, [rpcProtocol]);
   const MainThreadWindowStateAPI = injector.get(MainThreadWindowState, [rpcProtocol]);
   const MainThreadWindowAPI = injector.get(MainThreadWindow, [rpcProtocol]);
   const MainThreadConnectionAPI = injector.get(MainThreadConnection, [rpcProtocol]);
   const MainThreadDebugAPI = injector.get(MainThreadDebug, [rpcProtocol, MainThreadConnectionAPI]);
   const MainThreadTerminalAPI = injector.get(MainThreadTerminal, [rpcProtocol]);
-  const MainThreadProgressAPI = injector.get(MainThreadProgress, [rpcProtocol]);
-  const MainthreadTasksAPI = injector.get(MainthreadTasks, [rpcProtocol]);
-  const MainthreadCommentsAPI = injector.get(MainthreadComments, [rpcProtocol, MainThreadCommandsAPI]);
-  const MainthreadUrlsAPI = injector.get(MainThreadUrls, [rpcProtocol]);
-  const MainthreadThemingAPI = injector.get(MainThreadTheming, [rpcProtocol]);
-  const MainThreadCustomEditorAPI = injector.get(MainThreadCustomEditor, [rpcProtocol, MainThreadWebviewAPI]);
-  const MainThreadAuthenticationAPI = injector.get(MainThreadAuthentication, [rpcProtocol]);
-  const MainThreadSecretAPI = injector.get(MainThreadSecret, [rpcProtocol]);
+  const MainThreadTasksAPI = injector.get(MainThreadTasks, [rpcProtocol]);
   const MainthreadTestAPI = injector.get(MainThreadTestsImpl, [rpcProtocol]);
-  const MainThreadEditorTabsAPI = injector.get(MainThreadEditorTabsService, [rpcProtocol]);
-  const MainThreadLocalizationAPI = injector.get(MainThreadLocalization, [rpcProtocol]);
 
-  rpcProtocol.set<VSCodeExtensionService>(MainThreadAPIIdentifier.MainThreadExtensionService, extensionService);
-  rpcProtocol.set<IMainThreadCommands>(MainThreadAPIIdentifier.MainThreadCommands, MainThreadCommandsAPI);
-  rpcProtocol.set<IMainThreadLanguages>(MainThreadAPIIdentifier.MainThreadLanguages, MainThreadLanguagesAPI);
-  rpcProtocol.set<MainThreadExtensionDocumentData>(
-    MainThreadAPIIdentifier.MainThreadDocuments,
-    MainThreadExtensionDocumentDataAPI,
-  );
-  rpcProtocol.set<MainThreadEditorService>(MainThreadAPIIdentifier.MainThreadEditors, MainThreadEditorServiceAPI);
-  rpcProtocol.set<MainThreadStatusBar>(MainThreadAPIIdentifier.MainThreadStatusBar, MainThreadStatusBarAPI);
-  rpcProtocol.set<IMainThreadMessage>(MainThreadAPIIdentifier.MainThreadMessages, MainThreadMessageAPI);
-  rpcProtocol.set<IMainThreadWorkspace>(MainThreadAPIIdentifier.MainThreadWorkspace, MainThreadWorkspaceAPI);
-  rpcProtocol.set<IMainThreadPreference>(MainThreadAPIIdentifier.MainThreadPreference, MainThreadPreferenceAPI);
-  rpcProtocol.set<IMainThreadEnv>(MainThreadAPIIdentifier.MainThreadEnv, MainThreadEnvAPI);
-  rpcProtocol.set<IMainThreadQuickOpen>(MainThreadAPIIdentifier.MainThreadQuickOpen, MainThreadQuickOpenAPI);
-  rpcProtocol.set<IMainThreadStorage>(MainThreadAPIIdentifier.MainThreadStorage, MainThreadStorageAPI);
-  rpcProtocol.set<IMainThreadOutput>(MainThreadAPIIdentifier.MainThreadOutput, MainThreadOutputAPI);
-  rpcProtocol.set<MainThreadFileSystem>(MainThreadAPIIdentifier.MainThreadFileSystem, MainThreadFileSystemAPI);
-  rpcProtocol.set<IMainThreadWebview>(MainThreadAPIIdentifier.MainThreadWebview, MainThreadWebviewAPI);
-  rpcProtocol.set<IMainThreadWebviewView>(MainThreadAPIIdentifier.MainThreadWebviewView, MainThreadWebviewViewAPI);
-  rpcProtocol.set<MainThreadSCM>(MainThreadAPIIdentifier.MainThreadSCM, MainThreadSCMAPI);
   rpcProtocol.set<MainThreadTreeView>(MainThreadAPIIdentifier.MainThreadTreeView, MainThreadTreeViewAPI);
-  rpcProtocol.set<MainThreadDecorations>(MainThreadAPIIdentifier.MainThreadDecorations, MainThreadDecorationsAPI);
   rpcProtocol.set<MainThreadWindowState>(MainThreadAPIIdentifier.MainThreadWindowState, MainThreadWindowStateAPI);
   rpcProtocol.set<MainThreadWindow>(MainThreadAPIIdentifier.MainThreadWindow, MainThreadWindowAPI);
   rpcProtocol.set<MainThreadConnection>(MainThreadAPIIdentifier.MainThreadConnection, MainThreadConnectionAPI);
   rpcProtocol.set<MainThreadDebug>(MainThreadAPIIdentifier.MainThreadDebug, MainThreadDebugAPI);
   rpcProtocol.set<IMainThreadTerminal>(MainThreadAPIIdentifier.MainThreadTerminal, MainThreadTerminalAPI);
-  rpcProtocol.set<IMainThreadProgress>(MainThreadAPIIdentifier.MainThreadProgress, MainThreadProgressAPI);
-  rpcProtocol.set<IMainThreadTasks>(MainThreadAPIIdentifier.MainThreadTasks, MainthreadTasksAPI);
-  rpcProtocol.set<IMainThreadComments>(MainThreadAPIIdentifier.MainThreadComments, MainthreadCommentsAPI);
-  rpcProtocol.set<IMainThreadUrls>(MainThreadAPIIdentifier.MainThreadUrls, MainthreadUrlsAPI);
-  rpcProtocol.set<IMainThreadTheming>(MainThreadAPIIdentifier.MainThreadTheming, MainthreadThemingAPI);
-  rpcProtocol.set<IMainThreadExtensionLog>(MainThreadExtensionLogIdentifier, injector.get(MainThreadExtensionLog));
-  rpcProtocol.set<IMainThreadCustomEditor>(MainThreadAPIIdentifier.MainThreadCustomEditor, MainThreadCustomEditorAPI);
-  rpcProtocol.set<IMainThreadAuthentication>(
-    MainThreadAPIIdentifier.MainThreadAuthentication,
-    MainThreadAuthenticationAPI,
-  );
-  rpcProtocol.set<IMainThreadSecret>(MainThreadAPIIdentifier.MainThreadSecret, MainThreadSecretAPI);
-  rpcProtocol.set<IMainThreadTesting>(MainThreadAPIIdentifier.MainThreadTests, MainthreadTestAPI);
-  rpcProtocol.set<IMainThreadEditorTabsShape>(MainThreadAPIIdentifier.MainThreadEditorTabs, MainThreadEditorTabsAPI);
-  rpcProtocol.set<MainThreadLocalization>(MainThreadAPIIdentifier.MainThreadLocalization, MainThreadLocalizationAPI);
+  rpcProtocol.set<IMainThreadTasks>(MainThreadAPIIdentifier.MainThreadTasks, MainThreadTasksAPI);
 
-  await MainThreadWebviewAPI.init();
+  rpcProtocol.set<IMainThreadTesting>(MainThreadAPIIdentifier.MainThreadTests, MainthreadTestAPI);
 
   return () => {
-    MainThreadLanguagesAPI.dispose();
-    MainThreadCommandsAPI.dispose();
-    MainThreadExtensionDocumentDataAPI.dispose();
-    MainThreadEditorServiceAPI.dispose();
-    MainThreadStatusBarAPI.dispose();
-    MainThreadMessageAPI.dispose();
-    MainThreadWorkspaceAPI.dispose();
-    MainThreadPreferenceAPI.dispose();
-    MainThreadEnvAPI.dispose();
-    MainThreadQuickOpenAPI.dispose();
-    MainThreadStorageAPI.dispose();
-    MainThreadOutputAPI.dispose();
-    MainThreadFileSystemAPI.dispose();
-    MainThreadFileSystemEventAPI.dispose();
-    MainThreadWebviewAPI.dispose();
-    MainThreadSCMAPI.dispose();
     MainThreadTreeViewAPI.dispose();
-    MainThreadDecorationsAPI.dispose();
     MainThreadWindowStateAPI.dispose();
     MainThreadWindowAPI.dispose();
     MainThreadConnectionAPI.dispose();
     MainThreadDebugAPI.dispose();
     MainThreadTerminalAPI.dispose();
-    MainThreadProgressAPI.dispose();
-    MainthreadTasksAPI.dispose();
-    MainthreadCommentsAPI.dispose();
-    MainthreadUrlsAPI.dispose();
-    MainthreadThemingAPI.dispose();
-    MainThreadAuthenticationAPI.dispose();
-    MainThreadSecretAPI.dispose();
+    MainThreadTasksAPI.dispose();
     MainthreadTestAPI.dispose();
-    MainThreadEditorTabsAPI.dispose();
   };
 }
 
-export async function initWorkerThreadAPIProxy(workerProtocol: IRPCProtocol, injector: Injector, extensionService) {
-  const MainThreadCommandsAPI = injector.get(MainThreadCommands, [workerProtocol, true]);
-  const MainThreadExtensionLogAPI = injector.get(MainThreadExtensionLog);
+export function initWorkerThreadAPIProxy(
+  rpcProtocol: IRPCProtocol,
+  injector: Injector,
+  extensionService: VSCodeExtensionService,
+) {
+  rpcProtocol.set<VSCodeExtensionService>(MainThreadAPIIdentifier.MainThreadExtensionService, extensionService);
 
-  workerProtocol.set<VSCodeExtensionService>(MainThreadAPIIdentifier.MainThreadExtensionService, extensionService);
-  workerProtocol.set<IMainThreadCommands>(MainThreadAPIIdentifier.MainThreadCommands, MainThreadCommandsAPI);
-  workerProtocol.set<IMainThreadExtensionLog>(MainThreadExtensionLogIdentifier, MainThreadExtensionLogAPI);
-
-  const MainThreadLanguagesAPI = injector.get(MainThreadLanguages, [workerProtocol]);
-  const MainThreadStatusBarAPI = injector.get(MainThreadStatusBar, [workerProtocol]);
-  const MainThreadQuickOpenAPI = injector.get(MainThreadQuickOpen, [workerProtocol]);
-  const MainThreadExtensionDocumentDataAPI = injector.get(MainThreadExtensionDocumentData, [workerProtocol]);
-  const MainThreadEditorServiceAPI = injector.get(MainThreadEditorService, [
-    workerProtocol,
-    MainThreadExtensionDocumentDataAPI,
-  ]);
-  const MainThreadProgressAPI = injector.get(MainThreadProgress, [workerProtocol]);
-  const MainThreadWorkspaceAPI = injector.get(MainThreadWorkspace, [workerProtocol]);
-  const MainThreadFileSystemAPI = injector.get(MainThreadFileSystem, [workerProtocol]);
-  const MainThreadFileSystemEventAPI = injector.get(MainThreadFileSystemEvent, [workerProtocol]);
-  const MainThreadPreferenceAPI = injector.get(MainThreadPreference, [workerProtocol]);
-  const MainThreadOutputAPI = injector.get(MainThreadOutput);
-  const MainThreadMessageAPI = injector.get(MainThreadMessage, [workerProtocol]);
-  const MainThreadWebviewAPI = injector.get(MainThreadWebview, [workerProtocol]);
-  const MainThreadWebviewViewAPI = injector.get(MainThreadWebviewView, [workerProtocol, MainThreadWebviewAPI]);
-  const MainThreadStorageAPI = injector.get(MainThreadStorage, [workerProtocol]);
-  const MainThreadEnvAPI = injector.get(MainThreadEnv, [workerProtocol, MainThreadStorageAPI]);
-  const MainThreadUrlsAPI = injector.get(MainThreadUrls, [workerProtocol]);
-  const MainthreadCommentsAPI = injector.get(MainthreadComments, [workerProtocol, MainThreadCommandsAPI]);
-  const MainThreadThemingAPI = injector.get(MainThreadTheming, [workerProtocol]);
-  const MainThreadCustomEditorAPI = injector.get(MainThreadCustomEditor, [workerProtocol, MainThreadWebviewAPI]);
-  const MainThreadAuthenticationAPI = injector.get(MainThreadAuthentication, [workerProtocol]);
-  const MainThreadSecretAPI = injector.get(MainThreadSecret, [workerProtocol]);
-  const MainThreadSCMAPI = injector.get(MainThreadSCM, [workerProtocol]);
-  const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [workerProtocol, 'worker']);
-  const MainThreadDecorationsAPI = injector.get(MainThreadDecorations, [workerProtocol]);
-  const MainThreadLocalizationAPI = injector.get(MainThreadLocalization, [workerProtocol]);
-  const MainThreadEditorTabsAPI = injector.get(MainThreadEditorTabsService, [workerProtocol]);
-
-  workerProtocol.set<IMainThreadLanguages>(MainThreadAPIIdentifier.MainThreadLanguages, MainThreadLanguagesAPI);
-  workerProtocol.set<MainThreadExtensionDocumentData>(
-    MainThreadAPIIdentifier.MainThreadDocuments,
-    MainThreadExtensionDocumentDataAPI,
-  );
-  workerProtocol.set<IMainThreadEnv>(MainThreadAPIIdentifier.MainThreadEnv, MainThreadEnvAPI);
-  workerProtocol.set<IMainThreadWebviewView>(MainThreadAPIIdentifier.MainThreadWebviewView, MainThreadWebviewViewAPI);
-  workerProtocol.set<MainThreadStatusBar>(MainThreadAPIIdentifier.MainThreadStatusBar, MainThreadStatusBarAPI);
-  workerProtocol.set<IMainThreadQuickOpen>(MainThreadAPIIdentifier.MainThreadQuickOpen, MainThreadQuickOpenAPI);
-  workerProtocol.set<IMainThreadWorkspace>(MainThreadAPIIdentifier.MainThreadWorkspace, MainThreadWorkspaceAPI);
-  workerProtocol.set<MainThreadFileSystem>(MainThreadAPIIdentifier.MainThreadFileSystem, MainThreadFileSystemAPI);
-  workerProtocol.set<IMainThreadPreference>(MainThreadAPIIdentifier.MainThreadPreference, MainThreadPreferenceAPI);
-  workerProtocol.set<IMainThreadOutput>(
-    MainThreadAPIIdentifier.MainThreadOutput,
-    MainThreadOutputAPI,
-  ) as MainThreadOutput;
-  workerProtocol.set<MainThreadEditorService>(MainThreadAPIIdentifier.MainThreadEditors, MainThreadEditorServiceAPI);
-  workerProtocol.set<IMainThreadMessage>(MainThreadAPIIdentifier.MainThreadMessages, MainThreadMessageAPI);
-  workerProtocol.set<IMainThreadWebview>(MainThreadAPIIdentifier.MainThreadWebview, MainThreadWebviewAPI);
-  workerProtocol.set<IMainThreadStorage>(MainThreadAPIIdentifier.MainThreadStorage, MainThreadStorageAPI);
-  workerProtocol.set<IMainThreadUrls>(MainThreadAPIIdentifier.MainThreadUrls, MainThreadUrlsAPI);
-  workerProtocol.set<IMainThreadComments>(MainThreadAPIIdentifier.MainThreadComments, MainthreadCommentsAPI);
-  workerProtocol.set<IMainThreadProgress>(MainThreadAPIIdentifier.MainThreadProgress, MainThreadProgressAPI);
-  workerProtocol.set<IMainThreadTheming>(MainThreadAPIIdentifier.MainThreadTheming, MainThreadThemingAPI);
-  workerProtocol.set<IMainThreadCustomEditor>(
-    MainThreadAPIIdentifier.MainThreadCustomEditor,
-    MainThreadCustomEditorAPI,
-  );
-  workerProtocol.set<IMainThreadAuthentication>(
-    MainThreadAPIIdentifier.MainThreadAuthentication,
-    MainThreadAuthenticationAPI,
-  );
-  workerProtocol.set<IMainThreadSecret>(MainThreadAPIIdentifier.MainThreadSecret, MainThreadSecretAPI);
-  workerProtocol.set<IMainThreadSCMShape>(MainThreadAPIIdentifier.MainThreadSCM, MainThreadSCMAPI);
-  workerProtocol.set<MainThreadTreeView>(MainThreadAPIIdentifier.MainThreadTreeView, MainThreadTreeViewAPI);
-  workerProtocol.set<IMainThreadDecorationsShape>(
-    MainThreadAPIIdentifier.MainThreadDecorations,
-    MainThreadDecorationsAPI,
-  );
-  workerProtocol.set<IMainThreadEditorTabsShape>(MainThreadAPIIdentifier.MainThreadEditorTabs, MainThreadEditorTabsAPI);
-  workerProtocol.set<MainThreadLocalization>(MainThreadAPIIdentifier.MainThreadLocalization, MainThreadLocalizationAPI);
-  // 作用和 node extension service 等同，用来设置 webview resourceRoots
-  await MainThreadWebviewAPI.init();
+  const MainThreadTreeViewAPI = injector.get(MainThreadTreeView, [rpcProtocol, 'worker']);
+  rpcProtocol.set<MainThreadTreeView>(MainThreadAPIIdentifier.MainThreadTreeView, MainThreadTreeViewAPI);
 
   return () => {
-    MainThreadCommandsAPI.dispose();
-    MainThreadLanguagesAPI.dispose();
-    MainThreadStatusBarAPI.dispose();
-    MainThreadQuickOpenAPI.dispose();
-    MainThreadExtensionDocumentDataAPI.dispose();
-    MainThreadEditorServiceAPI.dispose();
-    MainThreadEnvAPI.dispose();
-    MainThreadProgressAPI.dispose();
-    MainThreadWorkspaceAPI.dispose();
-    MainThreadFileSystemAPI.dispose();
-    MainThreadFileSystemEventAPI.dispose();
-    MainThreadPreferenceAPI.dispose();
-    MainThreadOutputAPI.dispose();
-    MainThreadMessageAPI.dispose();
-    MainThreadWebviewAPI.dispose();
-    MainThreadStorageAPI.dispose();
-    MainThreadUrlsAPI.dispose();
-    MainthreadCommentsAPI.dispose();
-    MainThreadThemingAPI.dispose();
-    MainThreadCustomEditorAPI.dispose();
-    MainThreadAuthenticationAPI.dispose();
-    MainThreadSecretAPI.dispose();
-    MainThreadSCMAPI.dispose();
-    MainThreadDecorationsAPI.dispose();
     MainThreadTreeViewAPI.dispose();
   };
 }

--- a/packages/extension/src/browser/vscode/api/main.thread.api.shared-impl.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.api.shared-impl.ts
@@ -1,0 +1,182 @@
+import { Injector } from '@opensumi/di';
+import { IRPCProtocol } from '@opensumi/ide-connection';
+
+import { IMainThreadExtensionLog, MainThreadExtensionLogIdentifier } from '../../../common/extension-log';
+import {
+  IMainThreadAuthentication,
+  IMainThreadCommands,
+  IMainThreadComments,
+  IMainThreadCustomEditor,
+  IMainThreadEditorTabsShape,
+  IMainThreadEnv,
+  IMainThreadLanguages,
+  IMainThreadMessage,
+  IMainThreadOutput,
+  IMainThreadPreference,
+  IMainThreadProgress,
+  IMainThreadQuickOpen,
+  IMainThreadSecret,
+  IMainThreadStorage,
+  IMainThreadTheming,
+  IMainThreadUrls,
+  IMainThreadWebview,
+  IMainThreadWebviewView,
+  IMainThreadWorkspace,
+  MainThreadAPIIdentifier,
+} from '../../../common/vscode';
+
+import { MainThreadProgress } from './main.thread.api.progress';
+import { MainThreadWebview, MainThreadWebviewView } from './main.thread.api.webview';
+import { MainThreadAuthentication } from './main.thread.authentication';
+import { MainThreadCommands } from './main.thread.commands';
+import { MainThreadComments } from './main.thread.comments';
+import { MainThreadCustomEditor } from './main.thread.custom-editor';
+import { MainThreadDecorations } from './main.thread.decoration';
+import { MainThreadExtensionDocumentData } from './main.thread.doc';
+import { MainThreadEditorService } from './main.thread.editor';
+import { MainThreadEditorTabsService } from './main.thread.editor-tabs';
+import { MainThreadEnv } from './main.thread.env';
+import { MainThreadFileSystem } from './main.thread.file-system';
+import { MainThreadFileSystemEvent } from './main.thread.file-system-event';
+import { MainThreadLanguages } from './main.thread.language';
+import { MainThreadLocalization } from './main.thread.localization';
+import { MainThreadExtensionLog } from './main.thread.log';
+import { MainThreadMessage } from './main.thread.message';
+import { MainThreadOutput } from './main.thread.output';
+import { MainThreadPreference } from './main.thread.preference';
+import { MainThreadQuickOpen } from './main.thread.quickopen';
+import { MainThreadSCM } from './main.thread.scm';
+import { MainThreadSecret } from './main.thread.secret';
+import { MainThreadStatusBar } from './main.thread.statusbar';
+import { MainThreadStorage } from './main.thread.storage';
+import { MainThreadTheming } from './main.thread.theming';
+import { MainThreadUrls } from './main.thread.urls';
+import { MainThreadWorkspace } from './main.thread.workspace';
+
+export function initSharedAPIProxy(rpcProtocol: IRPCProtocol, injector: Injector) {
+  const MainThreadLanguagesAPI = injector.get(MainThreadLanguages, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadLanguages>(MainThreadAPIIdentifier.MainThreadLanguages, MainThreadLanguagesAPI);
+
+  const MainThreadCommandsAPI = injector.get(MainThreadCommands, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadCommands>(MainThreadAPIIdentifier.MainThreadCommands, MainThreadCommandsAPI);
+
+  const MainThreadExtensionDocumentDataAPI = injector.get(MainThreadExtensionDocumentData, [rpcProtocol]);
+  rpcProtocol.set<MainThreadExtensionDocumentData>(
+    MainThreadAPIIdentifier.MainThreadDocuments,
+    MainThreadExtensionDocumentDataAPI,
+  );
+
+  const MainThreadEditorServiceAPI = injector.get(MainThreadEditorService, [
+    rpcProtocol,
+    MainThreadExtensionDocumentDataAPI,
+  ]);
+  rpcProtocol.set<MainThreadEditorService>(MainThreadAPIIdentifier.MainThreadEditors, MainThreadEditorServiceAPI);
+
+  const MainThreadStatusBarAPI = injector.get(MainThreadStatusBar, [rpcProtocol]);
+  rpcProtocol.set<MainThreadStatusBar>(MainThreadAPIIdentifier.MainThreadStatusBar, MainThreadStatusBarAPI);
+
+  const MainThreadMessageAPI = injector.get(MainThreadMessage, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadMessage>(MainThreadAPIIdentifier.MainThreadMessages, MainThreadMessageAPI);
+
+  const MainThreadStorageAPI = injector.get(MainThreadStorage, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadStorage>(MainThreadAPIIdentifier.MainThreadStorage, MainThreadStorageAPI);
+
+  const MainThreadWorkspaceAPI = injector.get(MainThreadWorkspace, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadWorkspace>(MainThreadAPIIdentifier.MainThreadWorkspace, MainThreadWorkspaceAPI);
+
+  const MainThreadQuickOpenAPI = injector.get(MainThreadQuickOpen, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadQuickOpen>(MainThreadAPIIdentifier.MainThreadQuickOpen, MainThreadQuickOpenAPI);
+
+  const MainThreadPreferenceAPI = injector.get(MainThreadPreference, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadPreference>(MainThreadAPIIdentifier.MainThreadPreference, MainThreadPreferenceAPI);
+
+  const MainThreadEnvAPI = injector.get(MainThreadEnv, [rpcProtocol, MainThreadStorageAPI]);
+  rpcProtocol.set<IMainThreadEnv>(MainThreadAPIIdentifier.MainThreadEnv, MainThreadEnvAPI);
+
+  const MainThreadExtensionLogAPI = injector.get(MainThreadExtensionLog);
+  rpcProtocol.set<IMainThreadExtensionLog>(MainThreadExtensionLogIdentifier, MainThreadExtensionLogAPI);
+
+  const MainThreadProgressAPI = injector.get(MainThreadProgress, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadProgress>(MainThreadAPIIdentifier.MainThreadProgress, MainThreadProgressAPI);
+
+  const MainThreadOutputAPI = injector.get(MainThreadOutput);
+  rpcProtocol.set<IMainThreadOutput>(MainThreadAPIIdentifier.MainThreadOutput, MainThreadOutputAPI);
+
+  const MainThreadFileSystemAPI = injector.get(MainThreadFileSystem, [rpcProtocol]);
+  rpcProtocol.set<MainThreadFileSystem>(MainThreadAPIIdentifier.MainThreadFileSystem, MainThreadFileSystemAPI);
+
+  const MainThreadFileSystemEventAPI = injector.get(MainThreadFileSystemEvent, [rpcProtocol]);
+
+  const MainThreadWebviewAPI = injector.get(MainThreadWebview, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadWebview>(MainThreadAPIIdentifier.MainThreadWebview, MainThreadWebviewAPI);
+
+  const MainThreadWebviewViewAPI = injector.get(MainThreadWebviewView, [rpcProtocol, MainThreadWebviewAPI]);
+  rpcProtocol.set<IMainThreadWebviewView>(MainThreadAPIIdentifier.MainThreadWebviewView, MainThreadWebviewViewAPI);
+
+  const MainThreadUrlsAPI = injector.get(MainThreadUrls, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadUrls>(MainThreadAPIIdentifier.MainThreadUrls, MainThreadUrlsAPI);
+
+  const MainThreadCommentsAPI = injector.get(MainThreadComments, [rpcProtocol, MainThreadCommandsAPI]);
+  rpcProtocol.set<IMainThreadComments>(MainThreadAPIIdentifier.MainThreadComments, MainThreadCommentsAPI);
+
+  const MainThreadAuthenticationAPI = injector.get(MainThreadAuthentication, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadAuthentication>(
+    MainThreadAPIIdentifier.MainThreadAuthentication,
+    MainThreadAuthenticationAPI,
+  );
+
+  const MainThreadLocalizationAPI = injector.get(MainThreadLocalization, [rpcProtocol]);
+  rpcProtocol.set<MainThreadLocalization>(MainThreadAPIIdentifier.MainThreadLocalization, MainThreadLocalizationAPI);
+
+  const MainThreadEditorTabsAPI = injector.get(MainThreadEditorTabsService, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadEditorTabsShape>(MainThreadAPIIdentifier.MainThreadEditorTabs, MainThreadEditorTabsAPI);
+
+  const MainThreadSCMAPI = injector.get(MainThreadSCM, [rpcProtocol]);
+  rpcProtocol.set<MainThreadSCM>(MainThreadAPIIdentifier.MainThreadSCM, MainThreadSCMAPI);
+
+  const MainThreadSecretAPI = injector.get(MainThreadSecret, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadSecret>(MainThreadAPIIdentifier.MainThreadSecret, MainThreadSecretAPI);
+
+  const MainThreadDecorationsAPI = injector.get(MainThreadDecorations, [rpcProtocol]);
+  rpcProtocol.set<MainThreadDecorations>(MainThreadAPIIdentifier.MainThreadDecorations, MainThreadDecorationsAPI);
+
+  const MainThreadThemingAPI = injector.get(MainThreadTheming, [rpcProtocol]);
+  rpcProtocol.set<IMainThreadTheming>(MainThreadAPIIdentifier.MainThreadTheming, MainThreadThemingAPI);
+
+  const MainThreadCustomEditorAPI = injector.get(MainThreadCustomEditor, [rpcProtocol, MainThreadWebviewAPI]);
+  rpcProtocol.set<IMainThreadCustomEditor>(MainThreadAPIIdentifier.MainThreadCustomEditor, MainThreadCustomEditorAPI);
+
+  return {
+    setup: async () => {
+      await MainThreadWebviewAPI.init();
+    },
+    dispose: () => {
+      MainThreadLanguagesAPI.dispose();
+      MainThreadCommandsAPI.dispose();
+      MainThreadStatusBarAPI.dispose();
+      MainThreadExtensionDocumentDataAPI.dispose();
+      MainThreadEditorServiceAPI.dispose();
+      MainThreadMessageAPI.dispose();
+      MainThreadStorageAPI.dispose();
+      MainThreadWorkspaceAPI.dispose();
+      MainThreadQuickOpenAPI.dispose();
+      MainThreadPreferenceAPI.dispose();
+      MainThreadEnvAPI.dispose();
+      MainThreadProgressAPI.dispose();
+      MainThreadOutputAPI.dispose();
+      MainThreadFileSystemAPI.dispose();
+      MainThreadFileSystemEventAPI.dispose();
+      MainThreadWebviewAPI.dispose();
+      MainThreadWebviewViewAPI.dispose();
+      MainThreadUrlsAPI.dispose();
+      MainThreadAuthenticationAPI.dispose();
+      MainThreadCommentsAPI.dispose();
+      MainThreadEditorTabsAPI.dispose();
+      MainThreadSCMAPI.dispose();
+      MainThreadSecretAPI.dispose();
+      MainThreadDecorationsAPI.dispose();
+      MainThreadThemingAPI.dispose();
+      MainThreadCustomEditorAPI.dispose();
+    },
+  };
+}

--- a/packages/extension/src/browser/vscode/api/main.thread.commands.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.commands.ts
@@ -33,7 +33,7 @@ export class MainThreadCommands implements IMainThreadCommands {
 
   private disposable = new Disposable();
 
-  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol, fromWorker?: boolean) {
+  constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
     this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostCommands);
     this.proxy.$registerBuiltInCommands();
     this.proxy.$registerCommandConverter();

--- a/packages/extension/src/browser/vscode/api/main.thread.comments.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.comments.ts
@@ -48,7 +48,7 @@ import {
 } from '../../../common/vscode/models';
 
 @Injectable({ multiple: true })
-export class MainthreadComments implements IDisposable, IMainThreadComments {
+export class MainThreadComments implements IDisposable, IMainThreadComments {
   @Autowired(ICommentsService)
   private commentsService: ICommentsService;
 

--- a/packages/extension/src/browser/vscode/api/main.thread.tasks.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tasks.ts
@@ -457,7 +457,7 @@ namespace TaskDTO {
 }
 
 @Injectable({ multiple: true })
-export class MainthreadTasks extends Disposable implements IMainThreadTasks {
+export class MainThreadTasks extends Disposable implements IMainThreadTasks {
   protected readonly proxy: IExtHostTasks;
 
   private providers: Map<number, { disposable: IDisposable; provider: ITaskProvider }>;

--- a/packages/extension/src/common/extension.service.ts
+++ b/packages/extension/src/common/extension.service.ts
@@ -1,3 +1,4 @@
+import { BaseConnection } from '@opensumi/ide-connection/lib/common/connection';
 import { IRPCProtocol } from '@opensumi/ide-connection/lib/common/rpc/multiplexer';
 import { Deferred } from '@opensumi/ide-core-common';
 
@@ -17,6 +18,7 @@ export interface IExtensionChangeEvent {
 abstract class BaseExtProcessService {
   public ready: Deferred<void>;
   abstract protocol: IRPCProtocol;
+  abstract connection: BaseConnection<Uint8Array>;
   abstract disposeApiFactory(): void;
   abstract disposeProcess(): void | Promise<void>;
   abstract activate(): Promise<IRPCProtocol>;

--- a/packages/extension/src/common/vscode/index.ts
+++ b/packages/extension/src/common/vscode/index.ts
@@ -23,7 +23,7 @@ import {
   IMainThreadCustomEditor,
   IMainThreadEditorsService,
 } from './editor';
-import { IExtHostEditorTabs, IExtHostEditorTabsLegacyProposed, IMainThreadEditorTabsShape } from './editor-tabs';
+import { IExtHostEditorTabs, IMainThreadEditorTabsShape } from './editor-tabs';
 import { IExtHostEnv, IMainThreadEnv } from './env';
 import { IMainThreadFileSystemShape } from './file-system';
 import { IMainThreadLanguages } from './languages';


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors


### Background or solution

我们有两个 ext host: worker 和 node，每次给这俩发消息，同一个内容要序列化两遍，实际上只需要序列化一次发一遍就好。

比如说： #3614 这里面提到的，fireModelOpenedEvent，打开一个 10M 文件，会对这个 10M 文件序列化两遍

要改动的话会非常大，这里先做一下 refactor

### Changelog
