### PR TITLE
fix: lock tree-sitter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0 ",
     "@opensumi/ide-dev-tool": "workspace:*",
-    "@opensumi/tree-sitter-wasm": "^0.0.2",
+    "@opensumi/tree-sitter-wasm": "0.0.2",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0 ",
     "@opensumi/ide-dev-tool": "workspace:*",
-    "@opensumi/tree-sitter-wasm": "^0.0.1",
+    "@opensumi/tree-sitter-wasm": "^0.0.2",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^7.1.1",

--- a/packages/ai-native/package.json
+++ b/packages/ai-native/package.json
@@ -38,7 +38,7 @@
     "dom-align": "^1.7.0",
     "react-chat-elements": "^12.0.10",
     "react-highlight": "^0.15.0",
-    "web-tree-sitter": "^0.22.2"
+    "web-tree-sitter": "0.22.6"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "workspace:*"

--- a/packages/ai-native/src/browser/languages/service.ts
+++ b/packages/ai-native/src/browser/languages/service.ts
@@ -14,7 +14,7 @@ export class LanguageParserService {
     const treeSitterLang = parserNameMap[language];
     if (treeSitterLang) {
       if (!this.pool.has(treeSitterLang)) {
-        this.pool.set(treeSitterLang, this.injector.get(LanguageParser, [language]));
+        this.pool.set(treeSitterLang, this.injector.get(LanguageParser, [treeSitterLang]));
       }
 
       return this.pool.get(treeSitterLang);

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
@@ -73,9 +73,10 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
 
   override getDomNode(): HTMLElement {
     const domNode = super.getDomNode();
-    domNode.style.padding = '6px';
-    domNode.style.zIndex = StackingLevelStr.OverlayTop;
-
+    requestAnimationFrame(() => {
+      domNode.style.padding = '6px';
+      domNode.style.zIndex = StackingLevelStr.OverlayTop;
+    });
     return domNode;
   }
 
@@ -104,7 +105,8 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
 
   public offsetTop(top: number): void {
     if (this.originTop === 0) {
-      this.originTop = this.domNode.style.top ? parseInt(this.domNode.style.top, 10) : 0;
+      const top = this.domNode.style.top;
+      this.originTop = top ? parseInt(top, 10) : 0;
     }
 
     this.domNode.style.top = `${this.originTop + top}px`;

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-widget.tsx
@@ -130,7 +130,7 @@ export class InlineDiffWidget extends ZoneWidget {
   protected applyStyle(): void {}
 
   protected _fillContainer(container: HTMLElement): void {
-    this.setCssClass('ai_diff-widget');
+    this.setCssClass('inline-diff-widget');
     this.root = ReactDOMClient.createRoot(container);
 
     this.root.render(
@@ -198,6 +198,12 @@ export class InlineDiffWidget extends ZoneWidget {
   }
 
   public showByLine(line: number, lineNumber = 20): void {
+    /**
+     * 暂时通过 hack 的方式使其能让 zonewidget 在空白处显示出来，后续需要升级 monaco 来实现
+     */
+    // @ts-ignore
+    this.editor._modelData.viewModel.coordinatesConverter.modelPositionIsVisible = () => true;
+
     super.show(
       {
         startLineNumber: line,

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-widget.tsx
@@ -199,7 +199,7 @@ export class InlineDiffWidget extends ZoneWidget {
 
   public showByLine(line: number, lineNumber = 20): void {
     /**
-     * 暂时通过 hack 的方式使其能让 zonewidget 在空白处显示出来，后续需要升级 monaco 来实现
+     * 暂时通过 hack 的方式使其能让 zonewidget 在空白处显示出来
      */
     // @ts-ignore
     this.editor._modelData.viewModel.coordinatesConverter.modelPositionIsVisible = () => true;

--- a/packages/core-browser/src/application/runtime/constants.ts
+++ b/packages/core-browser/src/application/runtime/constants.ts
@@ -4,4 +4,4 @@ export enum ESupportRuntime {
 }
 
 export const onigWasmCDNUri = 'https://g.alicdn.com/kaitian/vscode-oniguruma-wasm/1.5.1/onig.wasm';
-export const treeSitterWasmCDNUri = 'https://gw.alipayobjects.com/os/lib/opensumi/tree-sitter-wasm/0.0.1/';
+export const treeSitterWasmCDNUri = 'https://gw.alipayobjects.com/os/lib/opensumi/tree-sitter-wasm/0.0.2';

--- a/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
+++ b/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
@@ -24,10 +24,10 @@ export interface ShowAIContentOptions {
 @Injectable({ multiple: true })
 export abstract class ReactInlineContentWidget extends Disposable implements IInlineContentWidget {
   @Autowired(AppConfig)
-  private configContext: AppConfig;
+  private appConfig: AppConfig;
 
-  allowEditorOverflow?: boolean | undefined = false;
-  suppressMouseDown?: boolean | undefined = true;
+  allowEditorOverflow = false;
+  suppressMouseDown = true;
 
   protected domNode: HTMLElement;
   protected options: ShowAIContentOptions | undefined;
@@ -39,7 +39,7 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
     this.addDispose(
       runWhenIdle(() => {
         this.root = ReactDOMClient.createRoot(this.getDomNode());
-        this.root.render(<ConfigProvider value={this.configContext}>{this.renderView()}</ConfigProvider>);
+        this.root.render(<ConfigProvider value={this.appConfig}>{this.renderView()}</ConfigProvider>);
         this.layoutContentWidget();
       }),
     );
@@ -89,8 +89,10 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
   getDomNode(): HTMLElement {
     if (!this.domNode) {
       this.domNode = document.createElement('div');
-      this.domNode.classList.add(this.getId());
-      this.domNode.style.zIndex = StackingLevelStr.Overlay;
+      requestAnimationFrame(() => {
+        this.domNode.classList.add(this.getId());
+        this.domNode.style.zIndex = StackingLevelStr.Overlay;
+      });
     }
 
     const throttled = throttle(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,7 +1956,7 @@ __metadata:
     "@commitlint/cli": "npm:^19.2.1"
     "@commitlint/config-conventional": "npm:^19.1.0 "
     "@opensumi/ide-dev-tool": "workspace:*"
-    "@opensumi/tree-sitter-wasm": "npm:^0.0.2"
+    "@opensumi/tree-sitter-wasm": "npm:0.0.2"
     "@types/debug": "npm:^4.1.5"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/glob": "npm:^7.1.1"
@@ -3143,7 +3143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opensumi/tree-sitter-wasm@npm:^0.0.2":
+"@opensumi/tree-sitter-wasm@npm:0.0.2":
   version: 0.0.2
   resolution: "@opensumi/tree-sitter-wasm@npm:0.0.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,7 +1956,7 @@ __metadata:
     "@commitlint/cli": "npm:^19.2.1"
     "@commitlint/config-conventional": "npm:^19.1.0 "
     "@opensumi/ide-dev-tool": "workspace:*"
-    "@opensumi/tree-sitter-wasm": "npm:^0.0.1"
+    "@opensumi/tree-sitter-wasm": "npm:^0.0.2"
     "@types/debug": "npm:^4.1.5"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/glob": "npm:^7.1.1"
@@ -2082,7 +2082,7 @@ __metadata:
     dom-align: "npm:^1.7.0"
     react-chat-elements: "npm:^12.0.10"
     react-highlight: "npm:^0.15.0"
-    web-tree-sitter: "npm:^0.22.2"
+    web-tree-sitter: "npm:0.22.6"
   languageName: unknown
   linkType: soft
 
@@ -3143,10 +3143,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opensumi/tree-sitter-wasm@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@opensumi/tree-sitter-wasm@npm:0.0.1"
-  checksum: 10/5385a7966e2220d3e2fb13a7cc1fb58f26d13b9bc878084481a1b17392cb902b3da5ddfbfa77376da4bdc2de8a644dd0292972bc15b2cb4a7bcb2b6157e0b2b9
+"@opensumi/tree-sitter-wasm@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "@opensumi/tree-sitter-wasm@npm:0.0.2"
+  dependencies:
+    web-tree-sitter: "npm:0.22.6"
+  checksum: 10/38e61a05b0696ed69144ece0d48f1ef9a0c9e19c20aaf6270e687a8ad78fda8342836cdf3bb29b722be73b9749f7f003f5bf6933008a70cbed99861797ab530d
   languageName: node
   linkType: hard
 
@@ -19825,10 +19827,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-tree-sitter@npm:^0.22.2":
-  version: 0.22.2
-  resolution: "web-tree-sitter@npm:0.22.2"
-  checksum: 10/f9c83a5ddab3ecd0ac33c8ccc00aec1184c9513255c00fdaf2d35f8fff49a9fcdd0b0545f4b86ea3e020d2bdcfde2e4a792642794d3a353530f3a55c15385464
+"web-tree-sitter@npm:0.22.6":
+  version: 0.22.6
+  resolution: "web-tree-sitter@npm:0.22.6"
+  checksum: 10/0b4378feff9d49466a2d63bccf3fcf2fd12184f80c009739e68a1201ae778196bc68bcc18641906659d42ce1a01fd8383637b3dd5c5c2c069288559fe7721d5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

web-tree-sitter 之前用的是 ^ 号版本，会导致构建的 wasm 和版本对不上，要锁一下。

### Changelog
fix tree-sitter not work
