### PR TITLE
fix: hightlight light theme

### DIFF
--- a/packages/ai-native/src/browser/components/ChatMarkdown.tsx
+++ b/packages/ai-native/src/browser/components/ChatMarkdown.tsx
@@ -88,7 +88,9 @@ export const ChatMarkdown = (props: MarkdownProps) => {
     return () => {
       if (codeRenderedElements.size > 0) {
         codeRenderedElements.forEach(({ root }) => {
-          root.unmount();
+          requestAnimationFrame(() => {
+            root.unmount();
+          });
         });
       }
     };

--- a/packages/ai-native/src/browser/components/highlightTheme.less
+++ b/packages/ai-native/src/browser/components/highlightTheme.less
@@ -1,5 +1,3 @@
-@import '~highlight.js/styles/a11y-dark.css';
-
 .design-light {
   .hljs-comment,
   .hljs-quote {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

修复浅色主题下 chat 面板展示代码区域时的样式问题

before
![image](https://github.com/opensumi/core/assets/20262815/4d870e34-41df-42bf-8d01-6c0cc2b79a63)

after
![image](https://github.com/opensumi/core/assets/20262815/beb8ba7a-4473-402d-8f01-ffdeafb59fda)


### Changelog
