### PR TITLE
fix(style): update menubar right style

### DIFF
--- a/packages/core-browser/src/react-providers/slot.tsx
+++ b/packages/core-browser/src/react-providers/slot.tsx
@@ -1,3 +1,4 @@
+import cls from 'classnames';
 import React, { PropsWithChildren } from 'react';
 
 import { Button } from '@opensumi/ide-components';
@@ -101,8 +102,8 @@ export const SlotDecorator: React.FC<{
   color?: string;
   id?: string;
   children: React.ReactChild;
-  backgroundColor?: string;
-}> = ({ slot, id, ...props }) => {
+  className?: string;
+}> = ({ slot, id, children, className }) => {
   const ref = React.useRef<HTMLElement | null>();
   React.useEffect(() => {
     if (ref.current) {
@@ -110,8 +111,8 @@ export const SlotDecorator: React.FC<{
     }
   }, [ref]);
   return (
-    <div id={id} ref={(ele) => (ref.current = ele)} className='resize-wrapper'>
-      {props.children}
+    <div id={id} ref={(ele) => (ref.current = ele)} className={cls('resize-wrapper', className)}>
+      {children}
     </div>
   );
 };

--- a/packages/design/src/browser/menu-bar/menu-bar.module.less
+++ b/packages/design/src/browser/menu-bar/menu-bar.module.less
@@ -4,9 +4,11 @@
   align-items: center;
   width: 100%;
 
-  #design-menubar-right {
-    display: flex;
-    align-items: center;
+  :global {
+    #design-menubar-right {
+      display: flex;
+      align-items: center;
+    }
   }
 
   .container {

--- a/packages/design/src/browser/menu-bar/menu-bar.module.less
+++ b/packages/design/src/browser/menu-bar/menu-bar.module.less
@@ -4,6 +4,11 @@
   align-items: center;
   width: 100%;
 
+  #design-menubar-right {
+    display: flex;
+    align-items: center;
+  }
+
   .container {
     display: flex;
     justify-content: space-between;

--- a/packages/design/src/browser/menu-bar/menu-bar.view.tsx
+++ b/packages/design/src/browser/menu-bar/menu-bar.view.tsx
@@ -141,10 +141,10 @@ export const DesignMenuBarView = () => {
           <div className={styles.top_menus_bar}>
             <DesignMenuBarRender />
           </div>
-          <SlotRenderer slot={DESIGN_MENU_BAR_LEFT} flex={1} />
+          <SlotRenderer id='design-menubar-left' slot={DESIGN_MENU_BAR_LEFT} flex={1} />
         </div>
         <div className={styles.right}>
-          <SlotRenderer slot={DESIGN_MENU_BAR_RIGHT} flex={1} />
+          <SlotRenderer id='design-menubar-right' slot={DESIGN_MENU_BAR_RIGHT} flex={1} />
         </div>
       </div>
     </div>

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -2,11 +2,13 @@ import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
 import { MENU_BAR_FEATURE_TIP } from '@opensumi/ide-startup/lib/browser/menu-bar-help-icon';
 
+import { StartupModule } from '../../src/browser/index';
+
 import { getDefaultClientAppOpts, renderApp } from './render-app';
 
 renderApp(
   getDefaultClientAppOpts({
-    modules: [...AIModules],
+    modules: [...AIModules, StartupModule],
     opts: {
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,9 +1,18 @@
+import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
+import { MENU_BAR_FEATURE_TIP } from '@opensumi/ide-startup/lib/browser/menu-bar-help-icon';
 
 import { getDefaultClientAppOpts, renderApp } from './render-app';
 
 renderApp(
   getDefaultClientAppOpts({
     modules: [...AIModules],
+    opts: {
+      layoutConfig: {
+        [DESIGN_MENU_BAR_RIGHT]: {
+          modules: [MENU_BAR_FEATURE_TIP],
+        },
+      },
+    },
   }),
 );

--- a/packages/startup/entry/web/prod/app.tsx
+++ b/packages/startup/entry/web/prod/app.tsx
@@ -1,4 +1,6 @@
+import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
+import { MENU_BAR_FEATURE_TIP } from '@opensumi/ide-startup/lib/browser/menu-bar-help-icon';
 
 import { getDefaultClientAppOpts, renderApp } from '../render-app';
 
@@ -12,6 +14,11 @@ renderApp(
       webviewEndpoint: '/webview',
       extWorkerHost: '/worker-host.js',
       wsPath: window.location.protocol === 'https:' ? `wss://${hostname}:${port}` : `ws://${hostname}:${port}`,
+      layoutConfig: {
+        [DESIGN_MENU_BAR_RIGHT]: {
+          modules: [MENU_BAR_FEATURE_TIP],
+        },
+      },
     },
   }),
 );

--- a/packages/startup/entry/web/prod/app.tsx
+++ b/packages/startup/entry/web/prod/app.tsx
@@ -1,6 +1,4 @@
-import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
-import { MENU_BAR_FEATURE_TIP } from '@opensumi/ide-startup/lib/browser/menu-bar-help-icon';
 
 import { getDefaultClientAppOpts, renderApp } from '../render-app';
 
@@ -14,11 +12,6 @@ renderApp(
       webviewEndpoint: '/webview',
       extWorkerHost: '/worker-host.js',
       wsPath: window.location.protocol === 'https:' ? `wss://${hostname}:${port}` : `ws://${hostname}:${port}`,
-      layoutConfig: {
-        [DESIGN_MENU_BAR_RIGHT]: {
-          modules: [MENU_BAR_FEATURE_TIP],
-        },
-      },
     },
   }),
 );

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -85,40 +85,44 @@ export const getDefaultClientAppOpts = ({
 }: {
   modules?: ConstructorOf<BrowserModule>[];
   opts?: Partial<IClientAppOpts>;
-}): IClientAppOpts => ({
-  modules: [...CommonBrowserModules, ExpressFileServerModule, SampleModule, RemoteOpenerModule, ...modules],
-  layoutConfig: {
-    ...defaultConfig,
-    [SlotLocation.top]: {
-      modules: ['menubar', 'toolbar'],
+}): IClientAppOpts => {
+  const { layoutConfig, ...restOpt } = opts;
+
+  return {
+    modules: [...CommonBrowserModules, ExpressFileServerModule, SampleModule, RemoteOpenerModule, ...modules],
+    layoutConfig: {
+      ...defaultConfig,
+      [SlotLocation.top]: {
+        modules: ['menubar', 'toolbar'],
+      },
+      [SlotLocation.action]: {
+        modules: ['@opensumi/ide-toolbar-action'],
+      },
+      ...layoutConfig,
     },
-    [SlotLocation.action]: {
-      modules: ['@opensumi/ide-toolbar-action'],
+    useCdnIcon: true,
+    useExperimentalShadowDom: true,
+    defaultPreferences: {
+      'general.language': defaultLanguage,
+      'general.theme': 'opensumi-design-dark-theme',
+      'general.icon': 'vscode-icons',
+      'general.productIconTheme': 'opensumi-icons',
+      'application.confirmExit': 'never',
+      'editor.quickSuggestionsDelay': 100,
     },
-    ...opts.layoutConfig,
-  },
-  useCdnIcon: true,
-  useExperimentalShadowDom: true,
-  defaultPreferences: {
-    'general.language': defaultLanguage,
-    'general.theme': 'opensumi-dark',
-    'general.icon': 'vscode-icons',
-    'general.productIconTheme': 'opensumi-icons',
-    'application.confirmExit': 'never',
-    'editor.quickSuggestionsDelay': 100,
-  },
-  defaultPanels: {
-    bottom: '@opensumi/ide-terminal-next',
-    right: '',
-  },
-  // 当 `.sumi` 下不存在配置文件时，默认采用 `.vscode` 下的配置
-  useVSCodeWorkspaceConfiguration: true,
-  // 开启 core-browser 对 OpenSumi DevTools 的支持，默认为关闭
-  devtools: true,
-  designLayout: {
-    useMenubarView: true,
-    useMergeRightWithLeftPanel: true,
-  },
-  layoutComponent: AILayout,
-  ...opts,
-});
+    defaultPanels: {
+      bottom: '@opensumi/ide-terminal-next',
+      right: '',
+    },
+    // 当 `.sumi` 下不存在配置文件时，默认采用 `.vscode` 下的配置
+    useVSCodeWorkspaceConfiguration: true,
+    // 开启 core-browser 对 OpenSumi DevTools 的支持，默认为关闭
+    devtools: true,
+    designLayout: {
+      useMenubarView: true,
+      useMergeRightWithLeftPanel: true,
+    },
+    layoutComponent: AILayout,
+    ...restOpt,
+  };
+};

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -89,16 +89,13 @@ export const getDefaultClientAppOpts = ({
   modules: [...CommonBrowserModules, ExpressFileServerModule, SampleModule, RemoteOpenerModule, ...modules],
   layoutConfig: {
     ...defaultConfig,
-    ...{
-      [SlotLocation.top]: {
-        modules: ['menubar', 'toolbar'],
-      },
+    [SlotLocation.top]: {
+      modules: ['menubar', 'toolbar'],
     },
-    ...{
-      [SlotLocation.action]: {
-        modules: ['@opensumi/ide-toolbar-action'],
-      },
+    [SlotLocation.action]: {
+      modules: ['@opensumi/ide-toolbar-action'],
     },
+    ...opts.layoutConfig,
   },
   useCdnIcon: true,
   useExperimentalShadowDom: true,

--- a/packages/startup/src/browser/menu-bar-help-icon.tsx
+++ b/packages/startup/src/browser/menu-bar-help-icon.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { Icon } from '@opensumi/ide-components';
+
+export const MENU_BAR_FEATURE_TIP = 'MENU_BAR_FEATURE_TIP';
+
+export const MenuBarHelpIcon = () => (
+  <div>
+    <Icon icon='info-circle-fill' />
+  </div>
+);

--- a/packages/startup/src/browser/startup.contribution.ts
+++ b/packages/startup/src/browser/startup.contribution.ts
@@ -23,6 +23,7 @@ import { ISCMProvider } from '@opensumi/ide-scm';
 import { ExampleEditorBottomWidget } from './editor-bottom-example';
 import { ExampleEditorTopWidget } from './editor-top-example';
 import { ExamplePopover } from './exmaple-popover';
+import { MENU_BAR_FEATURE_TIP, MenuBarHelpIcon } from './menu-bar-help-icon';
 
 @Domain(
   ClientAppContribution,
@@ -79,7 +80,12 @@ export class StartupContribution
     });
   }
 
-  registerComponent(registry: ComponentRegistry) {}
+  registerComponent(registry: ComponentRegistry) {
+    registry.register(MENU_BAR_FEATURE_TIP, {
+      id: MENU_BAR_FEATURE_TIP,
+      component: MenuBarHelpIcon,
+    });
+  }
 
   registerCommands(commands: CommandRegistry): void {
     commands.registerCommand(

--- a/tools/electron/src/browser/index.ts
+++ b/tools/electron/src/browser/index.ts
@@ -94,7 +94,7 @@ export const CommonBrowserModules: ConstructorOf<BrowserModule>[] = [
 renderApp({
   useExperimentalShadowDom: true,
   defaultPreferences: {
-    'general.theme': 'opensumi-dark',
+    'general.theme': 'opensumi-design-dark-theme',
     'general.icon': 'vscode-icons',
     'application.confirmExit': 'never',
     'editor.quickSuggestionsDelay': 100,


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes


### Background or solution

右侧 menubar 的布局应该为 flex

before:
![CleanShot 2024-05-08 at 13 43 03@2x](https://github.com/opensumi/core/assets/13938334/4d2e88bd-f224-4e71-954e-3578b875de60)

after:

![CleanShot 2024-05-08 at 12 01 05@2x](https://github.com/opensumi/core/assets/13938334/05dffb86-b9bc-4300-9132-692fc1b4542a)


### Changelog
