### PR TITLE
fix: diff editor support revive

### DIFF
--- a/packages/editor/src/browser/diff/index.ts
+++ b/packages/editor/src/browser/diff/index.ts
@@ -85,6 +85,7 @@ export class DiffResourceProvider extends WithEventBus implements IResourceProvi
       name,
       icon,
       uri,
+      supportsRevive: true,
       metadata: {
         original: originalUri,
         modified: modifiedUri,

--- a/packages/editor/src/browser/doc-model/editor-document-model-service.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model-service.ts
@@ -1,7 +1,6 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import {
   Dispatcher,
-  Event,
   IDisposable,
   IEditorDocumentChange,
   IEditorDocumentModelSaveResult,
@@ -16,15 +15,12 @@ import {
   StorageProvider,
   URI,
   WithEventBus,
-  isUndefined,
   mapToSerializable,
   memoize,
   serializableToMap,
-  timeout,
 } from '@opensumi/ide-core-browser';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
-import { FileServiceClient } from '@opensumi/ide-file-service/lib/browser/file-service-client';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
 import { IEditorDocumentModel } from '../../common/editor';
@@ -63,7 +59,7 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
   private readonly hashCalculateService: IHashCalculateService;
 
   @Autowired(IFileServiceClient)
-  protected readonly fileSystem: FileServiceClient;
+  protected readonly fileSystem: IFileServiceClient;
 
   private storage: IStorage;
 

--- a/packages/editor/src/browser/merge-editor/merge-editor.provider.ts
+++ b/packages/editor/src/browser/merge-editor/merge-editor.provider.ts
@@ -22,8 +22,6 @@ export class MergeEditorResourceProvider extends WithEventBus implements IResour
       const resultEditorUri = new URI(output);
       const icon = this.labelService.getIcon(resultEditorUri);
       return {
-        // 如果设置为 true，再打开时没有找到对应的 provider 会报错
-        // TODO: 需要增加一个标记，说明这个资源要在某个插件加载后才能 revive
         supportsRevive: true,
         name,
         icon,

--- a/packages/editor/src/browser/merge-editor/merge-editor.provider.ts
+++ b/packages/editor/src/browser/merge-editor/merge-editor.provider.ts
@@ -24,7 +24,7 @@ export class MergeEditorResourceProvider extends WithEventBus implements IResour
       return {
         // 如果设置为 true，再打开时没有找到对应的 provider 会报错
         // TODO: 需要增加一个标记，说明这个资源要在某个插件加载后才能 revive
-        supportsRevive: false,
+        supportsRevive: true,
         name,
         icon,
         uri,

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -30,6 +30,7 @@ import {
 import { DebugConfigurationsReadyEvent } from '@opensumi/ide-debug';
 import { IExtensionStoragePathServer, IExtensionStorageService } from '@opensumi/ide-extension-storage';
 import { FileSearchServicePath, IFileSearchService } from '@opensumi/ide-file-search/lib/common';
+import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
@@ -51,6 +52,7 @@ import {
 } from '../common/extension.service';
 import { MainThreadAPIIdentifier } from '../common/vscode';
 
+import { ActivationEventServiceImpl } from './activation.service';
 import { Extension } from './extension';
 import { SumiContributionsService, SumiContributionsServiceToken } from './sumi/contributes';
 import {
@@ -80,7 +82,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   private readonly commandRegistry: CommandRegistry;
 
   @Autowired(IActivationEventService)
-  private readonly activationEventService: IActivationEventService;
+  private readonly activationEventService: ActivationEventServiceImpl;
 
   @Autowired(IWorkspaceService)
   private readonly workspaceService: IWorkspaceService;
@@ -138,6 +140,17 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
 
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
+
+  @Autowired(IFileServiceClient)
+  protected fileServiceClient: IFileServiceClient;
+
+  constructor() {
+    super();
+
+    this.addDispose(
+      this.fileServiceClient.onWillActivateFileSystemProvider((e) => this.activationEventService.getTopicsData('onFileSystem')),
+    );
+  }
 
   /**
    * 这里的 ready 是区分环境，将 node/worker 区分开使用

--- a/packages/file-service/__mocks__/file-service-client.ts
+++ b/packages/file-service/__mocks__/file-service-client.ts
@@ -22,6 +22,7 @@ export class MockFileServiceClient implements IFileServiceClient {
   listCapabilities() {
     return [];
   }
+  onWillActivateFileSystemProvider = Event.None;
   onDidChangeFileSystemProviderRegistrations = Event.None;
   onDidChangeFileSystemProviderCapabilities = Event.None;
 

--- a/packages/file-service/__mocks__/file-service-client.ts
+++ b/packages/file-service/__mocks__/file-service-client.ts
@@ -19,6 +19,9 @@ import { IFileServiceWatcher } from '../src/common/watcher';
 
 @Injectable()
 export class MockFileServiceClient implements IFileServiceClient {
+  shouldWaitProvider(scheme: string): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
   listCapabilities() {
     return [];
   }

--- a/packages/file-service/src/common/file-service-client.ts
+++ b/packages/file-service/src/common/file-service-client.ts
@@ -27,6 +27,8 @@ import { IFileServiceWatcher } from './watcher';
 export const IFileServiceClient = IFileServiceClientToken;
 
 export interface IFileServiceClient {
+  shouldWaitProvider(scheme: string): Promise<boolean>;
+
   onFilesChanged: Event<FileChangeEvent>;
 
   onFileProviderChanged: Event<string[]>;

--- a/packages/file-service/src/common/file-service-client.ts
+++ b/packages/file-service/src/common/file-service-client.ts
@@ -17,6 +17,7 @@ import {
   FileSetContentOptions,
   FileStat,
   FileSystemProvider,
+  IFileSystemProviderActivationEvent,
   IFileSystemProviderCapabilitiesChangeEvent,
   IFileSystemProviderRegistrationEvent,
   TextDocumentContentChangeEvent,
@@ -103,6 +104,8 @@ export interface IFileServiceClient {
   readonly onDidChangeFileSystemProviderRegistrations: Event<IFileSystemProviderRegistrationEvent>;
 
   readonly onDidChangeFileSystemProviderCapabilities: Event<IFileSystemProviderCapabilitiesChangeEvent>;
+
+  readonly onWillActivateFileSystemProvider: Event<IFileSystemProviderActivationEvent>;
 }
 
 export interface IBrowserFileSystemRegistry {

--- a/packages/file-service/src/common/files.ts
+++ b/packages/file-service/src/common/files.ts
@@ -473,3 +473,7 @@ export interface IFileSystemProviderCapabilitiesChangeEvent {
   provider: FileSystemProvider;
   scheme: string;
 }
+
+export interface IFileSystemProviderActivationEvent {
+  readonly scheme: string;
+}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

调整等待 file system provider 激活的逻辑

从插件的 metadata 元数据信息里扫描一遍 activateEvents 里的 onFileSystem 信息，来作为是否需要等待 file system provider 激活的判断依据，如果对应 schema 不在 activateEvents 里，则直接返回 not found

### Changelog
