### PR TITLE
feat: optimize typescript interface navigation

### DIFF
--- a/packages/ai-native/src/browser/interface-navigation/interface-navigation.contribution.ts
+++ b/packages/ai-native/src/browser/interface-navigation/interface-navigation.contribution.ts
@@ -164,14 +164,8 @@ export class InterfaceNavigationDecorationsContribution implements IEditorFeatur
       // 检查当前节点是否是接口声明
       if (node.type === 'interface_declaration') {
         const interfaceNode = node.children.find((n) => n.type === 'type_identifier');
-        const body = node.children.find((n) => n.type === 'interface_body');
-
-        const members = body?.children
-          .filter((child) => child.type === 'property_signature' || child.type === 'method_signature')
-          .map((memberNode) => memberNode.children.find((n) => n.type === 'property_identifier'))
-          .filter((it) => !!it) as Parser.SyntaxNode[];
-
-        interfaces.push({ interfaceNode, members });
+        // TS 场景只处理 Interface 声明
+        interfaces.push({ interfaceNode, members: [] });
       }
 
       // 递归遍历所有子节点


### PR DESCRIPTION
### Types

优化 Typescript 场景下的 Interface 跳转功能，改成了只对 Interface 定义处增加快速跳转图标，取消了接口内部声明的跳转图标，避免编辑器左侧内容的混乱。

<img width="350" alt="image" src="https://github.com/opensumi/core/assets/12879047/293113ca-e517-44a5-a2ed-2d37bda4459f">



- [x] 🎉 New Features

### Background or solution
之前代码中对 Typescript 所有成员都有 Interface 快速跳转图标，但是在 Typescript 的场景中，接口成员很多并且相比 Java 而言空行和注释偏少，同时 Typescript 中对 Interface 用法也和 Java 有所不同，因此对 Typescript 做了逻辑精简。

### Changelog
- feat: optimize typescript interface navigation
