### PR TITLE
chore: remove unused StartupModule from web app entry

### DIFF
--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -2,13 +2,11 @@ import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
 import { MENU_BAR_FEATURE_TIP } from '@opensumi/ide-startup/lib/browser/menu-bar-help-icon';
 
-import { StartupModule } from '../../src/browser/index';
-
 import { getDefaultClientAppOpts, renderApp } from './render-app';
 
 renderApp(
   getDefaultClientAppOpts({
-    modules: [...AIModules, StartupModule],
+    modules: [...AIModules],
     opts: {
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

### Changelog

 remove unused StartupModule from web app entry