### PR TITLE
fix: terminal ai suggest z-index fix, remove click event

### DIFF
--- a/packages/ai-native/src/browser/ai-terminal/component/terminal-command-suggest-controller.module.less
+++ b/packages/ai-native/src/browser/ai-terminal/component/terminal-command-suggest-controller.module.less
@@ -3,7 +3,7 @@
   background-color: var(--editorGroupHeader-tabsBackground);
   bottom: 0;
   left: 0;
-  z-index: 3;
+  z-index: var(--stacking-level-xterm-decoration, 8);
   width: 500px;
   padding: 8px 10px 8px 14px;
   border-radius: 12px;

--- a/packages/ai-native/src/browser/ai-terminal/ps1-terminal.service.tsx
+++ b/packages/ai-native/src/browser/ai-terminal/ps1-terminal.service.tsx
@@ -104,10 +104,6 @@ export class PS1TerminalService extends Disposable {
     aiHinitDecoration?.onRender((element) => {
       element.innerText = localize('terminal.ai.inputSharpToGetHint');
       element.style.opacity = '0.3';
-      // 提示框点击也可以触发 AI 弹窗
-      element.onclick = () => {
-        this.showAICommandPopup(xterm, xOffset2);
-      };
     });
 
     this.onDataDisposable = xterm.onData((e) => {

--- a/packages/core-browser/src/design/rule.ts
+++ b/packages/core-browser/src/design/rule.ts
@@ -12,6 +12,9 @@ export const StackingLevel = {
   WorkbenchEditor: 1,
 
   Toolbar: 2,
+
+  XtermDecoration: 8, // xterm.css 中 decoration 的 z-index 是 7，所以这里要比它大一点
+
   ToolbarDropdown: 10,
 
   ResizeHandle: 12,


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

修复了终端 AI 自然语言生成命令时的布局 Z-Index 问题：
<img width="828" alt="image" src="https://github.com/opensumi/core/assets/12879047/2aa6a390-918a-4462-b578-5e393e241016">

另外就是终端「输入 # 来获取 AI 建议命令」这个文本的点击事件，可能会造成用户的误触与误解，因此去掉这个点击事件，现在只会被键盘的 「#」 触发。


<img width="818" alt="image" src="https://github.com/opensumi/core/assets/12879047/4c9a1cb5-75bc-4ce2-8af8-ecdfa89f4a52">
新版 Xterm.js 里面的底层 CSS 代码中，z-index 是 7，我们需要改到更大的，避免 z-index 问题。

### Changelog
update terminal ai suggest z-index and remove click event
