### PR TITLE
fix: menu bar items for design mode will be registered multiple times

### DIFF
--- a/packages/core-browser/src/common/common.contribution.ts
+++ b/packages/core-browser/src/common/common.contribution.ts
@@ -1,4 +1,5 @@
 import { Autowired } from '@opensumi/di';
+import { getIcon } from '@opensumi/ide-components';
 import {
   CommandContribution,
   CommandRegistry,
@@ -106,13 +107,41 @@ export class ClientCommonContribution
   }
 
   registerMenus(menus: IMenuRegistry): void {
-    menus.registerMenubarItem(MenuId.MenubarFileMenu, { label: localize('menu-bar.title.file'), order: 1 });
-    menus.registerMenubarItem(MenuId.MenubarEditMenu, { label: localize('menu-bar.title.edit'), order: 2 });
-    menus.registerMenubarItem(MenuId.MenubarSelectionMenu, { label: localize('menu-bar.title.selection'), order: 3 });
-    menus.registerMenubarItem(MenuId.MenubarViewMenu, { label: localize('menu-bar.title.view'), order: 4 });
-    menus.registerMenubarItem(MenuId.MenubarGoMenu, { label: localize('menu-bar.title.go'), order: 5 });
-    menus.registerMenubarItem(MenuId.MenubarTerminalMenu, { label: localize('menu-bar.title.terminal'), order: 5 });
-    menus.registerMenubarItem(MenuId.MenubarHelpMenu, { label: localize('menu-bar.title.help'), order: 999 });
+    menus.registerMenubarItem(MenuId.MenubarFileMenu, {
+      label: localize('menu-bar.title.file'),
+      order: 1,
+      iconClass: getIcon('menubar-file'),
+    });
+    menus.registerMenubarItem(MenuId.MenubarEditMenu, {
+      label: localize('menu-bar.title.edit'),
+      order: 2,
+      iconClass: getIcon('menubar-edit'),
+    });
+    menus.registerMenubarItem(MenuId.MenubarSelectionMenu, {
+      label: localize('menu-bar.title.selection'),
+      order: 3,
+      iconClass: getIcon('menubar-selection'),
+    });
+    menus.registerMenubarItem(MenuId.MenubarViewMenu, {
+      label: localize('menu-bar.title.view'),
+      order: 4,
+      iconClass: getIcon('menubar-view'),
+    });
+    menus.registerMenubarItem(MenuId.MenubarGoMenu, {
+      label: localize('menu-bar.title.go'),
+      order: 5,
+      iconClass: getIcon('menubar-go'),
+    });
+    menus.registerMenubarItem(MenuId.MenubarTerminalMenu, {
+      label: localize('menu-bar.title.terminal'),
+      order: 5,
+      iconClass: getIcon('terminal'),
+    });
+    menus.registerMenubarItem(MenuId.MenubarHelpMenu, {
+      label: localize('menu-bar.title.help'),
+      order: 999,
+      iconClass: getIcon('question-circle'),
+    });
 
     // File 菜单
     menus.registerMenuItems(MenuId.MenubarFileMenu, [

--- a/packages/core-browser/src/menu/next/base.ts
+++ b/packages/core-browser/src/menu/next/base.ts
@@ -149,7 +149,7 @@ export abstract class IMenuRegistry {
   readonly onDidChangeMenu: Event<string>;
 
   abstract getMenuCommand(command: string | MenuCommandDesc): PartialBy<MenuCommandDesc, 'label'>;
-  abstract registerMenuExtendInfo(menuId: MenuId | string, items: Array<ISumiMenuExtendInfo>): void;
+  abstract registerMenuExtendInfo(menuId: MenuId | string, items: Array<ISumiMenuExtendInfo>): IDisposable;
   abstract registerMenuItem(
     menuId: MenuId | string,
     item: IMenuItem | ISubmenuItem | IInternalComponentMenuItem,

--- a/packages/core-browser/src/menu/next/base.ts
+++ b/packages/core-browser/src/menu/next/base.ts
@@ -138,6 +138,9 @@ export type ICommandsMap = Map<string, Command>;
 
 export abstract class IMenuRegistry {
   readonly onDidChangeMenubar: Event<string>;
+  /**
+   * 注册菜单栏项
+   */
   abstract registerMenubarItem(menuId: string, item: PartialBy<IMenubarItem, 'id'>): IDisposable;
   abstract removeMenubarItem(menuId: string): void;
   abstract getMenubarItem(menuId: string): IMenubarItem | undefined;
@@ -146,23 +149,36 @@ export abstract class IMenuRegistry {
   readonly onDidChangeMenu: Event<string>;
 
   abstract getMenuCommand(command: string | MenuCommandDesc): PartialBy<MenuCommandDesc, 'label'>;
-  abstract registerMenuExtendInfo(menuId: MenuId | string, items: Array<ISumiMenuExtendInfo>);
+  abstract registerMenuExtendInfo(menuId: MenuId | string, items: Array<ISumiMenuExtendInfo>): void;
   abstract registerMenuItem(
     menuId: MenuId | string,
     item: IMenuItem | ISubmenuItem | IInternalComponentMenuItem,
   ): IDisposable;
   abstract unregisterMenuItem(menuId: MenuId | string, menuItemId: string): void;
+  /**
+   * Register multiple menu items at once
+   */
   abstract registerMenuItems(
     menuId: MenuId | string,
     items: Array<IMenuItem | ISubmenuItem | IInternalComponentMenuItem>,
   ): IDisposable;
+  /**
+   * 反注册 menuId, 会在页面上不展示这个 menuId, 但不会删掉已注册的 menu item
+   * 如有需要，请和 {@link deleteAllItemsForMenuId} 配合使用
+   */
   abstract unregisterMenuId(menuId: string): IDisposable;
+  /**
+   * 删除掉 registry 中指定 menu id 的所有 menu item, 不会通知页面更新
+   * 如有需要，请和 {@link unregisterMenuId} 配合使用
+   */
+  abstract deleteAllItemsForMenuId(menuId: string): void;
   abstract getMenuItems(menuId: MenuId | string): Array<IMenuItem | ISubmenuItem | IComponentMenuItem>;
 }
 
 export interface IMenubarItem {
   id: string; // 作为 menu-id 注册进来
   label: string;
+  group?: string;
   order?: number;
   nativeRole?: string; // electron menu 使用
   iconClass?: string;
@@ -303,6 +319,11 @@ export class CoreMenuRegistryImpl implements IMenuRegistry {
         this._onDidChangeMenu.fire(menuId);
       }
     });
+  }
+
+  deleteAllItemsForMenuId(menuId: string) {
+    this._menuItems.delete(menuId);
+    this._menuExtendInfo.delete(menuId);
   }
 
   getMenuItems(id: MenuId | string): Array<IMenuItem | ISubmenuItem | IComponentMenuItem> {

--- a/packages/design/src/browser/menu-bar/menu-bar.contribution.tsx
+++ b/packages/design/src/browser/menu-bar/menu-bar.contribution.tsx
@@ -22,6 +22,9 @@ export class DesignMenuBarContribution extends Disposable implements ComponentCo
 
     this.addDispose(
       this.menubarStore.onDidMenuBarChange((menubarItems: IMenubarItem[]) => {
+        this.menuRegistry.deleteAllItemsForMenuId(MenuId.DesignMenuBarTopExtra);
+        this.menuRegistry.unregisterMenuId(MenuId.DesignMenuBarTopExtra);
+
         this.menuRegistry.registerMenuItems(
           MenuId.DesignMenuBarTopExtra,
           menubarItems.map(
@@ -30,8 +33,8 @@ export class DesignMenuBarContribution extends Disposable implements ComponentCo
                 label: item.label,
                 submenu: item.id,
                 iconClass: item.iconClass,
-                group: '1_navigation',
-                order: 100,
+                group: item.group || '1_navigation',
+                order: item.order || 100,
               } as ISubmenuItem),
           ),
         );


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

之前的菜单会被注册多次：

![CleanShot 2024-05-10 at 16 31 40@2x](https://github.com/opensumi/core/assets/13938334/e776c4ad-2305-4829-9dd4-2f8907836759)


![CleanShot 2024-05-10 at 16 13 53@2x](https://github.com/opensumi/core/assets/13938334/ed0289bf-ab53-4a14-a4e6-b3d4dbe56e24)


### Changelog

fix menu bar items for design mode will be registered multiple times