### PR TITLE
feat: support registerTerminalProvider API

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -32,6 +32,7 @@ import {
 } from '@opensumi/ide-core-browser/lib/ai-native/command';
 import { InlineChatIsVisible } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
 import { DesignLayoutConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
+import { TerminalRegistryToken } from '@opensumi/ide-core-common';
 import {
   AI_NATIVE_SETTING_GROUP_TITLE,
   ChatFeatureRegistryToken,
@@ -75,6 +76,7 @@ import {
   IInlineChatFeatureRegistry,
   IRenameCandidatesProviderRegistry,
   IResolveConflictRegistry,
+  ITerminalProviderRegistry,
 } from './types';
 
 @Domain(
@@ -121,6 +123,9 @@ export class AINativeBrowserContribution
 
   @Autowired(RenameCandidatesProviderRegistryToken)
   private readonly renameCandidatesProviderRegistry: IRenameCandidatesProviderRegistry;
+
+  @Autowired(TerminalRegistryToken)
+  private readonly terminalProviderRegistry: ITerminalProviderRegistry;
 
   @Autowired(AINativeService)
   private readonly aiNativeService: AINativeService;
@@ -200,6 +205,9 @@ export class AINativeBrowserContribution
       }
       if (contribution.registerChatRender) {
         contribution.registerChatRender(this.chatRenderRegistry);
+      }
+      if (contribution.registerTerminalProvider) {
+        contribution.registerTerminalProvider(this.terminalProviderRegistry);
       }
     });
   }

--- a/packages/ai-native/src/browser/ai-terminal/component/terminal-command-suggest-controller.module.less
+++ b/packages/ai-native/src/browser/ai-terminal/component/terminal-command-suggest-controller.module.less
@@ -5,22 +5,24 @@
   bottom: 0;
   left: 0;
   z-index: 3;
-  height: 80px;
+  // height: 80px;
   width: 500px;
   padding: 8px 10px 8px 14px;
   border-radius: 12px;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .header {
   display: flex;
   flex-direction: row;
   font-size: 14px;
+  padding-bottom: 12px;
 }
 
 .statusContainer {
-  position: absolute;
-  bottom: 0;
-  right: 12px;
+  text-align: right;
   font-size: 8px;
   opacity: 0.5;
 }
@@ -32,13 +34,7 @@
 }
 
 .input {
-  flex: 1;
-  width: 100%;
-  color: var(--design-title-foreground);
   border: none;
-  padding: 10px;
-  font-size: 14px;
-  height: 28px;
   padding-left: 0;
   background-color: transparent;
 }

--- a/packages/ai-native/src/browser/ai-terminal/terminal-ai.contributon.ts
+++ b/packages/ai-native/src/browser/ai-terminal/terminal-ai.contributon.ts
@@ -1,30 +1,38 @@
 import { Autowired } from '@opensumi/di';
 import { AINativeConfigService, ClientAppContribution, Domain } from '@opensumi/ide-core-browser';
+import { TerminalRegistryToken } from '@opensumi/ide-core-common';
 
 import { AITerminalService } from './ai-terminal.service';
 import { AITerminalDecorationService } from './decoration/terminal-decoration';
 import { PS1TerminalService } from './ps1-terminal.service';
+import { TerminalFeatureRegistry } from './terminal.feature.registry';
 
 @Domain(ClientAppContribution)
 export class TerminalAIContribution implements ClientAppContribution {
   @Autowired(AITerminalService)
-  aiTerminalService: AITerminalService;
+  private readonly aiTerminalService: AITerminalService;
 
   @Autowired(AITerminalDecorationService)
-  aiTerminalDecorationService: AITerminalDecorationService;
+  private readonly aiTerminalDecorationService: AITerminalDecorationService;
 
   @Autowired(PS1TerminalService)
-  ps1TerminalService: PS1TerminalService;
+  private readonly ps1TerminalService: PS1TerminalService;
 
   @Autowired(AINativeConfigService)
-  aiNativeConfigService: AINativeConfigService;
+  private readonly aiNativeConfigService: AINativeConfigService;
+
+  @Autowired(TerminalRegistryToken)
+  private readonly terminalFeatureRegistry: TerminalFeatureRegistry;
 
   onDidStart() {
     if (this.aiNativeConfigService.capabilities.supportsTerminalDetection) {
       this.aiTerminalService.active();
       this.aiTerminalDecorationService.active();
     }
-    if (this.aiNativeConfigService.capabilities.supportsTerminalCommandSuggest) {
+    if (
+      this.aiNativeConfigService.capabilities.supportsTerminalCommandSuggest &&
+      this.terminalFeatureRegistry.hasProvider()
+    ) {
       this.ps1TerminalService.active();
     }
   }

--- a/packages/ai-native/src/browser/ai-terminal/terminal.feature.registry.ts
+++ b/packages/ai-native/src/browser/ai-terminal/terminal.feature.registry.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@opensumi/di';
+import { CancellationToken, Disposable } from '@opensumi/ide-core-common';
+import { IReadableStream, isReadableStream, listenGroupReadable, listenReadable } from '@opensumi/ide-utils/lib/stream';
+
+import { ITerminalCommandSuggestionDesc } from '../../common/index';
+import {
+  ITerminalProviderRegistry,
+  TTerminalCommandSuggestionsProviderFn,
+  TerminalSuggestionReadableStream,
+} from '../types';
+
+@Injectable()
+export class TerminalFeatureRegistry extends Disposable implements ITerminalProviderRegistry {
+  private readonly providerMap = new Set<TTerminalCommandSuggestionsProviderFn>();
+
+  public hasProvider(): boolean {
+    return this.providerMap.size > 0;
+  }
+
+  registerCommandSuggestionsProvider(provider: TTerminalCommandSuggestionsProviderFn): void {
+    this.providerMap.add(provider);
+  }
+
+  async readableCommandSuggestions(
+    message: string,
+    token: CancellationToken,
+  ): Promise<TerminalSuggestionReadableStream> {
+    const providers = Array.from(this.providerMap);
+    const collectStream: IReadableStream<ITerminalCommandSuggestionDesc>[] = [];
+    const collectDesc: ITerminalCommandSuggestionDesc[] = [];
+
+    for await (const provider of providers) {
+      const result = await provider(message, token);
+
+      if (isReadableStream(result)) {
+        collectStream.push(result);
+        continue;
+      }
+
+      collectDesc.push(...(result as ITerminalCommandSuggestionDesc[]));
+    }
+
+    const terminalReadableStream = TerminalSuggestionReadableStream.create();
+
+    collectDesc.forEach(terminalReadableStream.emitData.bind(terminalReadableStream));
+
+    // 如果没有 stream 的 provider，则直接结束
+    if (collectStream.length === 0) {
+      queueMicrotask(() => {
+        terminalReadableStream.end();
+      });
+    } else {
+      listenGroupReadable(collectStream, {
+        onData: terminalReadableStream.emitData.bind(terminalReadableStream),
+        onEnd: terminalReadableStream.end.bind(terminalReadableStream),
+      });
+    }
+
+    return terminalReadableStream;
+  }
+}

--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -12,6 +12,7 @@ import {
   RenameCandidatesProviderRegistryToken,
   ResolveConflictRegistryToken,
 } from '@opensumi/ide-core-browser';
+import { TerminalRegistryToken } from '@opensumi/ide-core-common';
 
 import {
   ChatProxyServiceToken,
@@ -24,6 +25,7 @@ import {
 import { AINativeBrowserContribution } from './ai-core.contribution';
 import { AINativeService } from './ai-native.service';
 import { TerminalAIContribution } from './ai-terminal/terminal-ai.contributon';
+import { TerminalFeatureRegistry } from './ai-terminal/terminal.feature.registry';
 import { ChatAgentService } from './chat/chat-agent.service';
 import { ChatAgentViewService } from './chat/chat-agent.view.service';
 import { ChatManagerService } from './chat/chat-manager.service';
@@ -100,6 +102,10 @@ export class AINativeModule extends BrowserModule {
     {
       token: RenameCandidatesProviderRegistryToken,
       useClass: RenameCandidatesProviderRegistry,
+    },
+    {
+      token: TerminalRegistryToken,
+      useClass: TerminalFeatureRegistry,
     },
     {
       token: LanguageParserService,

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -14,8 +14,9 @@ import {
   ReplyResponse,
 } from '@opensumi/ide-core-common';
 import { ICodeEditor, ITextModel, NewSymbolNamesProvider, Position } from '@opensumi/ide-monaco';
+import { SumiReadableStream } from '@opensumi/ide-utils/lib/stream';
 
-import { IChatWelcomeMessageContent, ISampleQuestions } from '../common';
+import { IChatWelcomeMessageContent, ISampleQuestions, ITerminalCommandSuggestionDesc } from '../common';
 
 import { BaseTerminalDetectionLineMatcher } from './ai-terminal/matcher';
 import { CompletionRequestBean } from './inline-completions/model/competionModel';
@@ -135,6 +136,21 @@ export interface IRenameCandidatesProviderRegistry {
   getRenameSuggestionsProviders(): NewSymbolNamesProviderFn[];
 }
 
+export class TerminalSuggestionReadableStream extends SumiReadableStream<ITerminalCommandSuggestionDesc> {
+  static create() {
+    return new TerminalSuggestionReadableStream();
+  }
+}
+
+export type TTerminalCommandSuggestionsProviderFn = (
+  message: string,
+  token: CancellationToken,
+) => MaybePromise<ITerminalCommandSuggestionDesc[] | TerminalSuggestionReadableStream>;
+
+export interface ITerminalProviderRegistry {
+  registerCommandSuggestionsProvider(provider: TTerminalCommandSuggestionsProviderFn): void;
+}
+
 export const AINativeCoreContribution = Symbol('AINativeCoreContribution');
 
 export interface AINativeCoreContribution {
@@ -164,6 +180,10 @@ export interface AINativeCoreContribution {
    * 注册智能重命名相关功能
    */
   registerRenameProvider?(registry: IRenameCandidatesProviderRegistry): void;
+  /**
+   * 注册智能终端相关功能
+   */
+  registerTerminalProvider?(registry: ITerminalProviderRegistry): void;
 }
 
 export interface IChatComponentConfig {

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -216,3 +216,11 @@ export interface IChatAgentWelcomeMessage {
   content: IChatWelcomeMessageContent;
   sampleQuestions?: IChatReplyFollowup[];
 }
+
+/**
+ * Terminal type
+ */
+export interface ITerminalCommandSuggestionDesc {
+  description: string;
+  command: string;
+}

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -14,7 +14,9 @@ import {
   IInlineChatFeatureRegistry,
   IRenameCandidatesProviderRegistry,
   IResolveConflictRegistry,
+  ITerminalProviderRegistry,
   TChatSlashCommandSend,
+  TerminalSuggestionReadableStream,
 } from '@opensumi/ide-ai-native/lib/browser/types';
 import { MergeConflictPromptManager } from '@opensumi/ide-ai-native/lib/common/prompts/merge-conflict-prompt';
 import { RenamePromptManager } from '@opensumi/ide-ai-native/lib/common/prompts/rename-prompt';
@@ -319,6 +321,24 @@ export class AiNativeContribution implements AINativeCoreContribution {
           tags: [NewSymbolNameTag.AIGenerated],
         }));
       }
+    });
+  }
+
+  registerTerminalProvider(register: ITerminalProviderRegistry): void {
+    register.registerCommandSuggestionsProvider(async (message, token) => {
+      const stream = TerminalSuggestionReadableStream.create();
+
+      setTimeout(() => {
+        stream.emitData({
+          command: 'Terminal Command Suggestion',
+          description: '✨ This is a terminal command suggestion',
+        });
+      }, 1000);
+
+      setTimeout(() => {
+        stream.end();
+      }, 2000);
+      return stream;
     });
   }
 }

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -32,6 +32,27 @@ export function listenReadable<T = Uint8Array>(stream: IReadableStream<T>, optio
   });
 }
 
+export function listenGroupReadable<T = Uint8Array>(
+  streams: IReadableStream<T>[],
+  options: IListenReadableOptions<T>,
+): void {
+  let endCount = streams.length;
+
+  streams.map((stream) => {
+    listenReadable(stream, {
+      onData: options.onData.bind(options),
+      onError: options.onError?.bind(options),
+      onEnd: () => {
+        endCount--;
+
+        if (endCount === 0) {
+          options.onEnd();
+        }
+      },
+    });
+  });
+}
+
 export class SumiReadableStream<T> implements IReadableStream<T> {
   protected dataQueue = new EventQueue<T>();
   protected endQueue = new EventQueue<void>();


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🪚 Refactors

### Background or solution

- [x] 新增 registerTerminalProvider API，支持贡献 terminal command suggestions。并且支持流式读取或直接返回 suggestion 列表
```typescript
registerTerminalProvider(register: ITerminalProviderRegistry): void {
  register.registerCommandSuggestionsProvider(async (message, token) => {
    const stream = TerminalSuggestionReadableStream.create();

    setTimeout(() => {
      stream.emitData({ command: 'Terminal Command Suggestion', description: '✨ This is a terminal command suggestion' })
    }, 1000)

    setTimeout(() => {
      stream.end();
    }, 2000)
    return stream;
  })
}

// 或
registerTerminalProvider(register: ITerminalProviderRegistry): void {
  register.registerCommandSuggestionsProvider(async (message, token) => {
    return [
        { command: 'Terminal Command Suggestion', description: '✨ This is a terminal command suggestion' }
      ]
  })
}

```
- [x] 重构 command suggestion 组件以及部分代码

### Changelog
