### PR TITLE
fix: wschannel timing issues

### DIFF
--- a/packages/connection/__test__/browser/index.test.ts
+++ b/packages/connection/__test__/browser/index.test.ts
@@ -10,62 +10,66 @@ const randomPortFn = () => Math.floor(Math.random() * 10000) + 10000;
 const randomPort = randomPortFn();
 
 describe('connection browser', () => {
-  it('init connection', async () => {
-    const fakeWSURL = `ws://127.0.0.1:${randomPort}`;
-    const mockServer = new Server(fakeWSURL);
+  it(
+    'init connection',
+    async () => {
+      const fakeWSURL = `ws://127.0.0.1:${randomPort}`;
+      const mockServer = new Server(fakeWSURL);
 
-    let receivedHeartbeat = false;
-    mockServer.on('connection', (socket) => {
-      socket.on('message', (msg) => {
-        const msgObj = parse(msg as Uint8Array);
-        if (msgObj.kind === 'open') {
-          socket.send(
-            stringify({
-              id: msgObj.id,
-              kind: 'server-ready',
-            }),
-          );
-        } else if (msgObj.kind === 'ping') {
-          receivedHeartbeat = true;
-        }
+      let receivedHeartbeat = false;
+      mockServer.on('connection', (socket) => {
+        socket.on('message', (msg) => {
+          const msgObj = parse(msg as Uint8Array);
+          if (msgObj.kind === 'open') {
+            socket.send(
+              stringify({
+                id: msgObj.id,
+                kind: 'server-ready',
+              }),
+            );
+          } else if (msgObj.kind === 'ping') {
+            receivedHeartbeat = true;
+          }
+        });
       });
-    });
 
-    const wsChannelHandler = new WSChannelHandler(
-      ReconnectingWebSocketConnection.forURL(fakeWSURL),
-      console,
-      'test-client-id',
-    );
+      const wsChannelHandler = new WSChannelHandler(
+        ReconnectingWebSocketConnection.forURL(fakeWSURL),
+        console,
+        'test-client-id',
+      );
 
-    await wsChannelHandler.initHandler();
-    await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 7000);
-    });
-    expect(receivedHeartbeat).toBe(true);
-    receivedHeartbeat = false;
+      await wsChannelHandler.initHandler();
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 12000);
+      });
+      expect(receivedHeartbeat).toBe(true);
+      receivedHeartbeat = false;
 
-    const channel = await wsChannelHandler.openChannel('test');
+      const channel = await wsChannelHandler.openChannel('test');
 
-    expect(channel).not.toBeNull();
+      expect(channel).not.toBeNull();
 
-    await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 4000);
-    });
-    // 第七秒后有请求，则不需要再发送心跳
-    expect(receivedHeartbeat).toBe(false);
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 4000);
+      });
+      // 第七秒后有请求，则不需要再发送心跳
+      expect(receivedHeartbeat).toBe(false);
 
-    await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 2000);
-    });
-    expect(receivedHeartbeat).toBe(true);
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 2000);
+      });
+      expect(receivedHeartbeat).toBe(true);
 
-    mockServer.close();
-    wsChannelHandler.dispose();
-  }, 20000);
+      mockServer.close();
+      wsChannelHandler.dispose();
+    },
+    30 * 1000,
+  );
 });

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -65,7 +65,7 @@ describe('connection', () => {
       const msgObj = parse(msg);
       if (msgObj.kind === 'server-ready') {
         if (msgObj.id === 'TEST_CHANNEL_ID') {
-          channel.dispatchChannelMessage(msgObj);
+          channel.dispatch(msgObj);
         }
       }
     });

--- a/packages/connection/src/browser/ws-channel-handler.ts
+++ b/packages/connection/src/browser/ws-channel-handler.ts
@@ -54,17 +54,11 @@ export class WSChannelHandler {
 
       const msg = parse(message);
 
-      switch (msg.kind) {
-        case 'pong':
-          break;
-        default: {
-          const channel = this.channelMap.get(msg.id);
-          if (channel) {
-            channel.dispatch(msg);
-          } else {
-            this.logger.warn(this.LOG_TAG, `channel ${msg.id} not found`);
-          }
-        }
+      const channel = this.channelMap.get(msg.id);
+      if (channel) {
+        channel.dispatch(msg);
+      } else {
+        this.logger.warn(this.LOG_TAG, `channel ${msg.id} not found`);
       }
     });
 

--- a/packages/connection/src/browser/ws-channel-handler.ts
+++ b/packages/connection/src/browser/ws-channel-handler.ts
@@ -44,7 +44,7 @@ export class WSChannelHandler {
     this.heartbeatMessageTimer = global.setTimeout(() => {
       this.connection.send(pingMessage);
       this.heartbeatMessage();
-    }, 5000);
+    }, 10 * 1000);
   }
 
   public async initHandler() {
@@ -60,7 +60,7 @@ export class WSChannelHandler {
         default: {
           const channel = this.channelMap.get(msg.id);
           if (channel) {
-            channel.dispatchChannelMessage(msg);
+            channel.dispatch(msg);
           } else {
             this.logger.warn(this.LOG_TAG, `channel ${msg.id} not found`);
           }
@@ -72,8 +72,6 @@ export class WSChannelHandler {
       if (this.channelMap.size > 0) {
         this.channelMap.forEach((channel) => {
           channel.open(channel.channelPath, this.clientId);
-          // 针对前端需要重新设置下后台状态的情况
-          channel.fireReopen();
         });
       }
     };
@@ -106,10 +104,24 @@ export class WSChannelHandler {
     const channel = new WSChannel(this.connection, {
       id: `${this.clientId}:${channelPath}`,
       logger: this.logger,
+      ensureServerReady: true,
     });
     this.channelMap.set(channel.id, channel);
 
+    let channelOpenedCount = 0;
+
     channel.onOpen(() => {
+      channelOpenedCount++;
+      if (channelOpenedCount > 1) {
+        channel.fireReopen();
+        this.logger.log(
+          this.LOG_TAG,
+          `channel reconnect ${this.clientId}:${channel.channelPath}, count: ${channelOpenedCount}`,
+        );
+      } else {
+        this.logger.log(this.LOG_TAG, `channel open ${this.clientId}:${channel.channelPath}`);
+      }
+
       const closeInfo = this.channelCloseEventMap.get(channel.id);
       if (closeInfo) {
         closeInfo.forEach((info) => {
@@ -118,10 +130,6 @@ export class WSChannelHandler {
         });
 
         this.channelCloseEventMap.delete(channel.id);
-
-        this.logger.log(this.LOG_TAG, `channel reconnect ${this.clientId}:${channel.channelPath}`);
-      } else {
-        this.logger.log(this.LOG_TAG, `channel open ${this.clientId}:${channel.channelPath}`);
       }
     });
 

--- a/packages/connection/src/common/rpc/multiplexer.ts
+++ b/packages/connection/src/common/rpc/multiplexer.ts
@@ -65,7 +65,7 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
     this._knownProtocols = options.knownProtocols || {};
     this.io.setAnySerializer(new AnyProtocolSerializer(this.io.writer, this.io.reader, ExtObjectTransfer));
 
-    this.onRequestNotFound((rpcName: string, args: any[]) => this._doInvokeHandler(rpcName, args));
+    this.onRequestNotFound((rpcName: string, args: any[]) => this.invoke(rpcName, args));
 
     // call `listen` implicitly
     // compatible behavior with the RPCProtocol
@@ -127,7 +127,7 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
     return new Proxy(Object.create(null), handler);
   }
 
-  protected async _doInvokeHandler(rpcName: string, args: any[]): Promise<any> {
+  public async invoke(rpcName: string, args: any[]): Promise<any> {
     const [rpcId, methodName] = SumiConnectionMultiplexer.extractServiceAndMethod(rpcName);
 
     const actor = this._locals.get(rpcId);

--- a/packages/connection/src/common/server-handler.ts
+++ b/packages/connection/src/common/server-handler.ts
@@ -1,6 +1,6 @@
 import { IConnectionShape } from './connection/types';
 import { ILogger } from './types';
-import { ChannelMessage, WSChannel, parse, pongMessage } from './ws-channel';
+import { ChannelMessage, WSChannel, WSServerChannel, parse, pongMessage } from './ws-channel';
 
 export interface IPathHandler {
   dispose: (channel: WSChannel, connectionId: string) => void;
@@ -137,7 +137,7 @@ export abstract class BaseCommonChannelHandler {
             clientId = msg.clientId;
             this.logger.log(`open a new connection channel ${clientId} with path ${path}`);
 
-            const channel = new WSChannel(connection, { id, logger: this.logger });
+            const channel = new WSServerChannel(connection, { id, logger: this.logger });
             this.channelMap.set(id, channel);
 
             commonChannelPathHandler.dispatchChannelOpen(path, channel, clientId);
@@ -148,7 +148,7 @@ export abstract class BaseCommonChannelHandler {
             const { id } = msg;
             const channel = this.channelMap.get(id);
             if (channel) {
-              channel.dispatchChannelMessage(msg);
+              channel.dispatch(msg);
             } else {
               this.logger.warn(`channel ${id} is not found`);
             }

--- a/packages/connection/src/common/ws-channel.ts
+++ b/packages/connection/src/common/ws-channel.ts
@@ -1,7 +1,7 @@
 import { Type } from '@furyjs/fury';
 
 import { EventEmitter } from '@opensumi/events';
-import { DisposableCollection } from '@opensumi/ide-core-common';
+import { DisposableCollection, DisposableStore, EventQueue } from '@opensumi/ide-core-common';
 
 import { IConnectionShape } from './connection/types';
 import { oneOf7 } from './fury-extends/one-of';
@@ -86,16 +86,27 @@ export interface IWSChannelCreateOptions {
    */
   id: string;
   logger?: ILogger;
+
+  ensureServerReady?: boolean;
 }
 
 export class WSChannel {
-  protected emitter = new EventEmitter<{
-    message: [data: string];
-    open: [id: string];
-    reopen: [];
-    close: [code?: number, reason?: string];
-    binary: [data: Uint8Array];
-  }>();
+  protected _disposables = new DisposableStore();
+  protected emitter = this._disposables.add(
+    new EventEmitter<{
+      message: [data: string];
+      open: [id: string];
+      reopen: [];
+      close: [code?: number, reason?: string];
+      binary: [data: Uint8Array];
+    }>(),
+  );
+
+  protected onBinaryQueue = this._disposables.add(new EventQueue<Uint8Array>());
+
+  protected sendQueue: Uint8Array[] = [];
+  protected _isServerReady = false;
+  protected _ensureServerReady: boolean | undefined;
 
   public id: string;
 
@@ -109,34 +120,46 @@ export class WSChannel {
 
     disposable.push(
       connection.onMessage((data) => {
-        channel.dispatchChannelMessage(parse(data));
+        channel.dispatch(parse(data));
       }),
     );
-    disposable.push(channel);
 
-    disposable.push(
-      connection.onceClose(() => {
-        disposable.dispose();
-      }),
-    );
+    connection.onceClose(() => {
+      disposable.dispose();
+    });
 
     return channel;
   }
 
   constructor(public connection: IConnectionShape<Uint8Array>, options: IWSChannelCreateOptions) {
-    const { id, logger } = options;
+    const { id, logger, ensureServerReady } = options;
     this.id = id;
 
     if (logger) {
       this.logger = logger;
     }
+
+    this._ensureServerReady = Boolean(ensureServerReady);
+
+    this._disposables.add(this.emitter.on('binary', (data) => this.onBinaryQueue.push(data)));
+  }
+
+  protected inqueue(data: Uint8Array) {
+    if (this._ensureServerReady && !this._isServerReady) {
+      if (!this.sendQueue) {
+        this.sendQueue = [];
+      }
+      this.sendQueue.push(data);
+      return;
+    }
+    this.connection.send(data);
   }
 
   onMessage(cb: (data: string) => any) {
     return this.emitter.on('message', cb);
   }
   onBinary(cb: (data: Uint8Array) => any) {
-    return this.emitter.on('binary', cb);
+    return this.onBinaryQueue.on(cb);
   }
   onOpen(cb: (id: string) => void) {
     return this.emitter.on('open', cb);
@@ -145,18 +168,16 @@ export class WSChannel {
     return this.emitter.on('reopen', cb);
   }
 
-  serverReady() {
-    this.connection.send(
-      stringify({
-        kind: 'server-ready',
-        id: this.id,
-      }),
-    );
-  }
-
-  dispatchChannelMessage(msg: ChannelMessage) {
+  dispatch(msg: ChannelMessage) {
     switch (msg.kind) {
       case 'server-ready':
+        this._isServerReady = true;
+        if (this.sendQueue) {
+          for (const item of this.sendQueue) {
+            this.connection.send(item);
+          }
+          this.sendQueue = [];
+        }
         this.emitter.emit('open', msg.id);
         break;
       case 'data':
@@ -181,7 +202,7 @@ export class WSChannel {
   }
 
   send(content: string) {
-    this.connection.send(
+    this.inqueue(
       stringify({
         kind: 'data',
         id: this.id,
@@ -191,7 +212,7 @@ export class WSChannel {
   }
 
   sendBinary(data: Uint8Array) {
-    this.connection.send(
+    this.inqueue(
       stringify({
         kind: 'binary',
         id: this.id,
@@ -201,6 +222,7 @@ export class WSChannel {
   }
   onError() {}
   close(code?: number, reason?: string) {
+    this._isServerReady = false;
     this.emitter.emit('close', code, reason);
   }
   fireReopen() {
@@ -230,10 +252,23 @@ export class WSChannel {
   }
 
   dispose() {
-    this.emitter.dispose();
+    this._disposables.dispose();
   }
 }
 
+/**
+ * The server side channel, it will send a `server-ready` message after it receive a `open` message.
+ */
+export class WSServerChannel extends WSChannel {
+  serverReady() {
+    this.connection.send(
+      stringify({
+        kind: 'server-ready',
+        id: this.id,
+      }),
+    );
+  }
+}
 export const PingProtocol = Type.object('ping', {
   clientId: Type.string(),
   id: Type.string(),


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

WSChannel 在连接开始和重连都会有丢消息的可能性。

1. Browser 层和 Node 连接， Node 和 Ext 未连接，此时 Browser 发给 Ext 的信息全部被丢弃。
2. 重连时，onReconnect 时机太早，此时仅仅时 websocket 重连成功，WSChannel 还没有协商重连成功。

### Changelog
fix WSChannel timing issues