### PR TITLE
fix: activating extension should not abort the whole restart progress

### DIFF
--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -434,7 +434,14 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
   }
 
   private async getExtProcessPID(): Promise<number | null> {
-    return await Promise.race([this.extensionNodeClient.pid(), sleep(300).then(() => null)]);
+    return await Promise.race([
+      this.extensionNodeClient.pid().catch(async (err) => {
+        this.logger.error(`[ext-restart]: get ext process pid error, ${err}`);
+        await sleep(200);
+        return null;
+      }),
+      sleep(1000).then(() => null),
+    ]);
   }
 
   private async startExtProcess(init: boolean) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

重启进程的时候，会重新发送所有 activation event，但是是使用的 Promise.all 发送的，如果此时某个插件激活失败，会导致整体重连失败。

### Changelog

fix activating extension should not abort the whole restart progress