### PR TITLE
fix: add null check before calling collapseNode and expandNode

### DIFF
--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
@@ -535,10 +535,11 @@ export class ExtensionTreeViewModel {
   };
 
   toggleDirectory = async (item: ExtensionCompositeTreeNode) => {
+    await this.treeHandlerReadyDeffer.promise;
     if (item.expanded) {
-      await this.extensionTreeHandle.collapseNode(item);
+      await this.extensionTreeHandle?.collapseNode(item);
     } else {
-      await this.extensionTreeHandle.expandNode(item);
+      await this.extensionTreeHandle?.expandNode(item);
     }
   };
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog

add null check before calling collapseNode and expandNode