### PR TITLE
fix: dirty-diff editor hide unchanged regions

### DIFF
--- a/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
+++ b/packages/scm/__tests__/browser/dirty-diff/dirty-diff-model.test.ts
@@ -437,7 +437,11 @@ describe('scm/src/browser/dirty-diff/dirty-diff-model.ts', () => {
         // createDiffEditor
         expect(createDiffEditorSpy).toHaveBeenCalledTimes(1);
         expect((createDiffEditorSpy.mock.calls[0][0] as HTMLDivElement).tagName).toBe('DIV');
-        expect(createDiffEditorSpy.mock.calls[0][1]).toEqual({ automaticLayout: true, renderSideBySide: false });
+        expect(createDiffEditorSpy.mock.calls[0][1]).toEqual({
+          automaticLayout: true,
+          renderSideBySide: false,
+          hideUnchangedRegions: { enabled: false },
+        });
 
         // editor.compare
         expect(mockCompare).toHaveBeenCalledTimes(1);

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-model.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-model.ts
@@ -357,6 +357,9 @@ export class DirtyDiffModel extends Disposable implements IDirtyDiffModel {
       const editor = this.editorService.createDiffEditor(widget.getContentNode(), {
         automaticLayout: true,
         renderSideBySide: false,
+        hideUnchangedRegions: {
+          enabled: false,
+        },
       });
       const original = await this.documentModelManager.createModelReference(originalUri);
       const edit = await this.documentModelManager.createModelReference(editorUri);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

dirty diff editor 不开启 hideUnchangedRegions

### Changelog
