### PR TITLE
fix: ensure valid theme

### DIFF
--- a/packages/design/src/browser/index.ts
+++ b/packages/design/src/browser/index.ts
@@ -13,6 +13,7 @@ import {
 import { IEditorTabService } from '@opensumi/ide-editor/lib/browser';
 import { IThemeContribution, IThemeService, IThemeStore } from '@opensumi/ide-theme';
 import { ThemeStore } from '@opensumi/ide-theme/lib/browser/theme-store';
+import { WorkbenchThemeService } from '@opensumi/ide-theme/lib/browser/workbench.theme.service';
 
 import { DesignCoreContribution } from './design.contribution';
 import { DesignMenuBarContribution } from './menu-bar/menu-bar.contribution';
@@ -71,6 +72,16 @@ export class DesignModule extends BrowserModule {
               document.body.classList.add(lightTheme.designThemeType);
             }
             return newTheme;
+          }
+        },
+        override: true,
+        isDefault: true,
+      },
+      {
+        token: IThemeService,
+        useClass: class extends WorkbenchThemeService {
+          override async ensureValidTheme(): Promise<string> {
+            return super.ensureValidTheme(defaultTheme.id);
           }
         },
         override: true,

--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -83,11 +83,12 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
    */
   private registerDefaultColorTheme() {
     const themeId = this.preferenceService.get<string>(GeneralSettingsId.Theme);
-    const shouldApplyDefaultThemeId = !themeId || themeId.includes('dark');
 
-    if (shouldApplyDefaultThemeId) {
-      this.themeService.applyTheme(DEFAULT_THEME_ID);
-    }
+    this.themeService.ensureValidTheme().then((validTheme) => {
+      if (themeId !== validTheme) {
+        this.themeService.applyTheme(validTheme);
+      }
+    });
   }
 
   private registerDefaultTokenModifier() {

--- a/packages/theme/src/common/mocks/theme.service.ts
+++ b/packages/theme/src/common/mocks/theme.service.ts
@@ -20,6 +20,11 @@ export class MockThemeService implements IThemeService {
       dispose: () => {},
     };
   }
+
+  ensureValidTheme(themeId: string): Promise<string> {
+    return Promise.resolve(themeId);
+  }
+
   async applyTheme(id: string) {
     this.colorThemeLoaded.resolve();
     throw new Error('Method not implemented.');

--- a/packages/theme/src/common/theme.service.ts
+++ b/packages/theme/src/common/theme.service.ts
@@ -126,6 +126,7 @@ export interface IThemeService {
   colorThemeLoaded: Deferred<void>;
   onThemeChange: Event<ITheme>;
   registerThemes(themeContributions: IThemeContribution[], extPath: URI): IDisposable;
+  ensureValidTheme(defaultThemeId?: string): Promise<string>;
   /**
    * 应用主题（外部需要改主题请直接修改preference）
    * @param id 主题ID


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- [x] 确保从 local storage 取的主题值是有效的
- [x] 如果主题值无效，则使用默认主题，若使用了 design module 的情况下，默认主题是 design dark theme

### Changelog
