### PR TITLE
fix(ext-tree-view): reveal an element is not work

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.treeview.ts
@@ -274,10 +274,10 @@ export class MainThreadTreeView extends WithEventBus implements IMainThreadTreeV
     }
   }
 
-  async $reveal(treeViewId: string, treeItemId: string, options?: ITreeViewRevealOptions) {
+  async $reveal(treeViewId: string, treeItemId?: string, options?: ITreeViewRevealOptions) {
     this.mainLayoutService.revealView(treeViewId);
     const treeModel = this.treeModels.get(treeViewId);
-    if (treeModel) {
+    if (treeModel && treeItemId) {
       treeModel.reveal(treeItemId, options);
     }
   }

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
@@ -1051,13 +1051,13 @@ export class ExtensionTreeViewModel {
         await this.refresh();
       }
 
-      if (options.nodeChain && options.nodeChain.length > 0) {
-        // 要把节点链上的所有节点都展开（因为在 main thread 上都没有这些结点链的信息，还要去获取）
-        for (let idx = options.nodeChain.length - 1; idx >= 0; idx--) {
-          const element = options.nodeChain[idx];
-          await this.reveal(element, options);
-        }
-      }
+      // if (options.nodeChain && options.nodeChain.length > 0) {
+      //   // 要把节点链上的所有节点都展开（因为在 main thread 上都没有这些结点链的信息，还要去获取）
+      //   for (let idx = options.nodeChain.length - 1; idx >= 0; idx--) {
+      //     const element = options.nodeChain[idx];
+      //     await this.reveal(element, options);
+      //   }
+      // }
 
       const id = this.treeViewDataProvider.getTreeNodeIdByTreeItemId(treeItemId);
       if (!id) {

--- a/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
+++ b/packages/extension/src/browser/vscode/api/tree-view/tree-view.model.service.ts
@@ -1051,14 +1051,6 @@ export class ExtensionTreeViewModel {
         await this.refresh();
       }
 
-      // if (options.nodeChain && options.nodeChain.length > 0) {
-      //   // 要把节点链上的所有节点都展开（因为在 main thread 上都没有这些结点链的信息，还要去获取）
-      //   for (let idx = options.nodeChain.length - 1; idx >= 0; idx--) {
-      //     const element = options.nodeChain[idx];
-      //     await this.reveal(element, options);
-      //   }
-      // }
-
       const id = this.treeViewDataProvider.getTreeNodeIdByTreeItemId(treeItemId);
       if (!id) {
         return;

--- a/packages/extension/src/common/vscode/treeview.ts
+++ b/packages/extension/src/common/vscode/treeview.ts
@@ -11,7 +11,7 @@ export interface ITreeViewRevealOptions {
   select?: boolean;
   focus?: boolean;
   expand?: boolean | number;
-  nodeChain?: string[];
+  // nodeChain?: string[];
 }
 
 export interface IMainThreadTreeView {

--- a/packages/extension/src/common/vscode/treeview.ts
+++ b/packages/extension/src/common/vscode/treeview.ts
@@ -11,7 +11,6 @@ export interface ITreeViewRevealOptions {
   select?: boolean;
   focus?: boolean;
   expand?: boolean | number;
-  // nodeChain?: string[];
 }
 
 export interface IMainThreadTreeView {

--- a/packages/extension/src/common/vscode/treeview.ts
+++ b/packages/extension/src/common/vscode/treeview.ts
@@ -11,6 +11,7 @@ export interface ITreeViewRevealOptions {
   select?: boolean;
   focus?: boolean;
   expand?: boolean | number;
+  nodeChain?: string[];
 }
 
 export interface IMainThreadTreeView {
@@ -18,7 +19,7 @@ export interface IMainThreadTreeView {
   $registerTreeDataProvider<T>(treeViewId: string, options: TreeViewBaseOptions): Promise<void>;
   $refresh<T>(treeViewId: string, itemsToRefresh?: T | null): Promise<void>;
   $refresh(treeViewId: string, itemsToRefresh?: TreeViewItem): Promise<void>;
-  $reveal(treeViewId: string, treeItemId: string, options?: ITreeViewRevealOptions): Promise<any>;
+  $reveal(treeViewId: string, treeItemId?: string, options?: ITreeViewRevealOptions): Promise<any>;
   $setTitle(treeViewId: string, message: string): Promise<void>;
   $setDescription(treeViewId: string, message: string): Promise<void>;
   $setMessage(treeViewId: string, message: string): Promise<void>;
@@ -102,7 +103,7 @@ export class TreeViewItem {
   accessibilityInformation?: IAccessibilityInformation;
 }
 
-export interface TreeView<T> extends IDisposable {
+export interface TreeView<T> extends vscode.TreeView<T> {
   /**
    * 当节点展开时触发的事件
    */
@@ -148,6 +149,8 @@ export interface TreeView<T> extends IDisposable {
    * **NOTE:** 需要在实现TreeDataProvider.getParent接口情况下该接口才可用.
    */
   reveal(element: T, options?: { select?: boolean; focus?: boolean; expand?: boolean | number }): PromiseLike<void>;
+
+  dispose(): void;
 }
 
 export interface TreeViewBaseOptions {

--- a/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
@@ -523,24 +523,24 @@ class ExtHostTreeView<T extends vscode.TreeItem> implements IDisposable {
       // if the parent of the given element is not revealed in the main thread, the element id will never be found in the main thread
       // so we need to reveal the parent first, here we collect all the parents of the given element, send them to the main thread
 
-      const parentChain = await this.resolveParentChain(element);
+      // const parentChain = await this.resolveParentChain(element);
 
-      const nodeIds = [] as string[];
-      for (let index = parentChain.length - 1; index >= 0; index--) {
-        const parent = parentChain[index];
-        let treeViewItem = this.element2TreeViewItem.get(parent);
-        if (!treeViewItem) {
-          treeViewItem = await this.cacheElement(parent);
-        }
+      // const nodeIds = [] as string[];
+      // for (let index = parentChain.length - 1; index >= 0; index--) {
+      //   const parent = parentChain[index];
+      //   let treeViewItem = this.element2TreeViewItem.get(parent);
+      //   if (!treeViewItem) {
+      //     treeViewItem = await this.cacheElement(parent);
+      //   }
 
-        nodeIds.push(treeViewItem.id);
-      }
+      //   nodeIds.push(treeViewItem.id);
+      // }
 
       const revealOptions = {
         expand: options?.expand,
         focus: options?.focus,
         select: options?.select,
-        nodeChain: nodeIds,
+        // nodeChain: nodeIds,
       } as ITreeViewRevealOptions;
 
       await this.proxy.$reveal(this.treeViewId, elementId, revealOptions);

--- a/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.treeview.ts
@@ -520,27 +520,10 @@ class ExtHostTreeView<T extends vscode.TreeItem> implements IDisposable {
     await this.refreshPromise;
 
     if (elementId) {
-      // if the parent of the given element is not revealed in the main thread, the element id will never be found in the main thread
-      // so we need to reveal the parent first, here we collect all the parents of the given element, send them to the main thread
-
-      // const parentChain = await this.resolveParentChain(element);
-
-      // const nodeIds = [] as string[];
-      // for (let index = parentChain.length - 1; index >= 0; index--) {
-      //   const parent = parentChain[index];
-      //   let treeViewItem = this.element2TreeViewItem.get(parent);
-      //   if (!treeViewItem) {
-      //     treeViewItem = await this.cacheElement(parent);
-      //   }
-
-      //   nodeIds.push(treeViewItem.id);
-      // }
-
       const revealOptions = {
         expand: options?.expand,
         focus: options?.focus,
         select: options?.select,
-        // nodeChain: nodeIds,
       } as ITreeViewRevealOptions;
 
       await this.proxy.$reveal(this.treeViewId, elementId, revealOptions);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

ExtensionTreeNode 那里有时序问题。如果 ExtTree 更新了，会通知前端刷新，但没有确保时序，插件进程以为树刷新好了，就执行后续操作，比如 reveal(treeItem), 但是这个 treeItem 还没被加载进来。

同时 reveal 没有确保能 reveal 到某个子节点。

### Changelog

ext tree view reveal an element is not work