### PR TITLE
fix: design theme preload

### DIFF
--- a/packages/design/src/browser/index.ts
+++ b/packages/design/src/browser/index.ts
@@ -21,8 +21,9 @@ import { DesignEditorTabService } from './override/editor-tab.service';
 import { DesignBrowserCtxMenuService } from './override/menu.service';
 import { DesignSplitPanelService } from './override/split-panel.service';
 import designStyles from './style/design.module.less';
-import defaultTheme from './theme/default-theme';
+import darkTheme from './theme/default-theme';
 import lightTheme from './theme/light-theme';
+import { doOverrideColorToken } from './theme/override.token';
 
 @Injectable()
 export class DesignModule extends BrowserModule {
@@ -34,13 +35,15 @@ export class DesignModule extends BrowserModule {
     const designStyleService: IDesignStyleService = injector.get(IDesignStyleService);
     designStyleService.setStyles(designStyles);
 
+    doOverrideColorToken();
+
     const appLifeCycleService: IAppLifeCycleService = injector.get(AppLifeCycleServiceToken);
 
     Event.once(Event.filter(appLifeCycleService.onDidLifeCyclePhaseChange, (phase) => phase === LifeCyclePhase.Ready))(
       () => {
         const themeService: IThemeService = injector.get(IThemeService);
 
-        [defaultTheme, lightTheme].forEach((theme) => {
+        [darkTheme, lightTheme].forEach((theme) => {
           themeService.registerThemes(
             [
               {
@@ -64,17 +67,14 @@ export class DesignModule extends BrowserModule {
           override async getThemeData(contribution?: IThemeContribution, basePath?: URI) {
             const newTheme = await super.getThemeData(contribution, basePath);
             document.body.classList.remove(lightTheme.designThemeType);
-            document.body.classList.remove(defaultTheme.designThemeType);
+            document.body.classList.remove(darkTheme.designThemeType);
 
-            if (defaultTheme.id === contribution?.id) {
-              document.body.classList.add(defaultTheme.designThemeType);
+            if (darkTheme.id === contribution?.id) {
+              document.body.classList.add(darkTheme.designThemeType);
             } else if (lightTheme.id === contribution?.id) {
               document.body.classList.add(lightTheme.designThemeType);
             }
             return newTheme;
-          }
-          override getDefaultThemeID(): string {
-            return defaultTheme.id;
           }
         },
         override: true,
@@ -84,7 +84,7 @@ export class DesignModule extends BrowserModule {
         token: IThemeService,
         useClass: class extends WorkbenchThemeService {
           override async ensureValidTheme(): Promise<string> {
-            return super.ensureValidTheme(defaultTheme.id);
+            return super.ensureValidTheme(darkTheme.id);
           }
         },
         override: true,

--- a/packages/design/src/browser/theme/override.token.ts
+++ b/packages/design/src/browser/theme/override.token.ts
@@ -1,0 +1,24 @@
+import { getColorRegistry, registerColor } from '@opensumi/ide-theme';
+
+import darkTheme from './default-theme';
+import lightTheme from './light-theme';
+
+export const doOverrideColorToken = () => {
+  const colorRegistry = getColorRegistry();
+
+  colorRegistry.getColors().forEach(({ id }) => {
+    if (darkTheme.colors[id] && lightTheme.colors[id]) {
+      const preColor = colorRegistry.getColor(id);
+      registerColor(
+        id,
+        {
+          dark: darkTheme.colors[id],
+          light: lightTheme.colors[id],
+          hcDark: preColor.defaults!.hcDark || null,
+          hcLight: preColor.defaults!.hcLight || null,
+        },
+        preColor.description,
+      );
+    }
+  });
+};

--- a/packages/theme/src/browser/theme.contribution.ts
+++ b/packages/theme/src/browser/theme.contribution.ts
@@ -96,9 +96,7 @@ export class ThemeContribution implements MenuContribution, CommandContribution,
     }
 
     this.themeService.ensureValidTheme().then((validTheme) => {
-      if (themeId !== validTheme) {
-        this.themeService.applyTheme(validTheme);
-      }
+      this.themeService.applyTheme(validTheme);
     });
   }
 

--- a/packages/theme/src/common/utils.ts
+++ b/packages/theme/src/common/utils.ts
@@ -28,6 +28,11 @@ export interface IColorRegistry {
   getColors(): ColorContribution[];
 
   /**
+   * Get color contributions by id
+   */
+  getColor(id: string): ColorContribution;
+
+  /**
    * Gets the default color of the given id
    */
   resolveDefaultColor(id: ColorIdentifier, theme: ITheme): Color | undefined;
@@ -65,6 +70,10 @@ class ColorRegistry implements IColorRegistry {
 
   public getColors(): ColorContribution[] {
     return Object.keys(this.colorsById).map((id) => this.colorsById[id]);
+  }
+
+  public getColor(id: string): ColorContribution {
+    return this.colorsById[id];
   }
 
   public resolveDefaultColor(id: ColorIdentifier, theme: ITheme): Color | undefined {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

由于主题加载的时机存在时序问题，无法在生命周期的最开始设置 design 主题。
所以改成了当引入 design module 之后会将默认的 dark 和 light 主题的 colorRegistry 设置成对应的 design 主题的 color 色值

### Changelog
引入 design 模块之后使用 design 主题进行预渲染
