### PR TITLE
feat: support test results panel, icons in test view

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1379,6 +1379,8 @@ export const localizationBundle = {
     'test.title': 'Testing',
     'test.result.runFinished': 'Test run at {0}',
     'test.task.unnamed': 'Unnamed Task',
+    'test.results': 'Test Results',
+
     // #endregion
     'menu.missing.command': 'menuId {0} register command not exist: {1}',
     'menu.missing.altCommand': 'menuId {0} register altCommand not exist: {1}',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1151,6 +1151,7 @@ export const localizationBundle = {
     'test.title': '测试管理器',
     'test.result.runFinished': '测试运行完成于 {0}',
     'test.task.unnamed': '未命名任务',
+    'test.results': '测试结果',
 
     // Menu
     'menu.missing.command': '菜单{0} 要执行的命令不存在：{1}',

--- a/packages/testing/src/browser/components/testing.explorer.tree.tsx
+++ b/packages/testing/src/browser/components/testing.explorer.tree.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useState } from 'react';
 
 import { BasicRecycleTree, IRecycleTreeHandle } from '@opensumi/ide-components/lib/recycle-tree';
 import { BasicCompositeTreeNode } from '@opensumi/ide-components/lib/recycle-tree/basic/tree-node.define';
-import { CommandService, Event, map, useInjectable } from '@opensumi/ide-core-browser';
+import { CommandService, Event, map, transformLabelWithCodicon, useInjectable } from '@opensumi/ide-core-browser';
+import { IIconService } from '@opensumi/ide-theme';
 
 import { ITestService, TestServiceToken } from '../../common';
 import { DebugTestCommand, GoToTestCommand, RuntTestCommand } from '../../common/commands';
@@ -19,6 +20,7 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
   const testViewModel = useInjectable<TestTreeViewModelImpl>(TestTreeViewModelToken);
   const testService = useInjectable<ITestService>(TestServiceToken);
   const commandService = useInjectable<CommandService>(CommandService);
+  const iconService = useInjectable<IIconService>(IIconService);
 
   const [treeData, setTreeData] = useState<ITestTreeData[]>([]);
 
@@ -27,6 +29,15 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
   const asTreeData = React.useCallback(
     (item: TestTreeItem): ITestTreeData => ({
       label: item.label,
+      renderLabel: transformLabelWithCodicon(
+        item.label,
+        {
+          verticalAlign: 'middle',
+          marginRight: '4px',
+          marginLeft: '4px',
+        },
+        iconService.fromString.bind(iconService),
+      ),
       icon: '',
       get iconClassName() {
         return getItemIcon(item);
@@ -112,7 +123,7 @@ export const TestingExplorerTree: React.FC<{}> = observer(() => {
   };
 
   return (
-    <div>
+    <div className='monaco-workbench monaco-component'>
       {treeData.length > 0 && (
         <BasicRecycleTree
           treeData={treeData}

--- a/packages/testing/src/browser/components/testing.module.less
+++ b/packages/testing/src/browser/components/testing.module.less
@@ -21,6 +21,6 @@
 .preview_markdown {
   position: relative;
   overflow: hidden;
-  padding: 8px 12px 8px 20px;
+  padding: 0;
   height: calc(100% - 16px);
 }

--- a/packages/testing/src/browser/outputPeek/test-message-container.tsx
+++ b/packages/testing/src/browser/outputPeek/test-message-container.tsx
@@ -71,7 +71,10 @@ const MarkdownContentProvider = (props: { dto: TestDto | undefined }) => {
   React.useEffect(() => {
     if (shadowRootRef.current) {
       const { dto } = props;
-      const shadowRootElement = shadowRootRef.current.attachShadow({ mode: 'open' });
+      let shadowRootElement = shadowRootRef.current.shadowRoot;
+      if (!shadowRootElement) {
+        shadowRootElement = shadowRootRef.current.attachShadow({ mode: 'open' });
+      }
       if (!shadowRoot) {
         setShadowRoot(shadowRootElement);
       }
@@ -81,7 +84,7 @@ const MarkdownContentProvider = (props: { dto: TestDto | undefined }) => {
       const message = mdStr ? (mdStr as IMarkdownString).value.replace(/\t/g, '') : '';
       useMessage(message);
     }
-  }, []);
+  }, [props.dto]);
 
   return (
     <div ref={shadowRootRef} className={styles.preview_markdown}>
@@ -170,6 +173,9 @@ export const TestMessageContainer = () => {
   }, []);
 
   const renderTestMessage = React.useCallback(() => {
+    if (!dto) {
+      return null;
+    }
     if (type === EContainerType.DIFF) {
       return <DiffContentProvider dto={dto} />;
     } else if (type === EContainerType.MARKDOWN) {
@@ -178,7 +184,8 @@ export const TestMessageContainer = () => {
       const msg = getMessage(dto).message;
       return <div className={styles.preview_text}>{typeof msg === 'string' ? msg : msg.value}</div>;
     }
-  }, []);
+  }, [dto]);
+
   return (
     <div className={styles.test_output_peek_message_container} style={{ height: '100%' }}>
       {renderTestMessage()}

--- a/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
+++ b/packages/testing/src/browser/outputPeek/test-peek-widget.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { FC } from 'react';
 import ReactDOM from 'react-dom';
 import ReactDOMClient from 'react-dom/client';
 
 import { Autowired, Injectable } from '@opensumi/di';
-import { AppConfig, ConfigProvider, IContextKeyService } from '@opensumi/ide-core-browser';
+import { AppConfig, ConfigProvider, IContextKeyService, ViewState } from '@opensumi/ide-core-browser';
 import { SplitPanel } from '@opensumi/ide-core-browser/lib/components';
 import { InlineActionBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { AbstractMenuService, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
@@ -22,6 +22,17 @@ import { TestTreeContainer } from './test-tree-container';
 import type { ICodeEditor } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
 import './test-peek-widget.less';
+
+// 注册在底部 Component 的话，可以拿到 ViewState，进而拿到动态宽高
+// eslint-disable-next-line arrow-body-style
+export const TestResultPanel: FC<{ viewState?: ViewState }> = ({ viewState }) => {
+  return (
+    <SplitPanel overflow='hidden' id='testing-message-horizontal' flex={1} style={{ height: '100%' }}>
+      <TestMessageContainer />
+      <TestTreeContainer viewState={viewState} />
+    </SplitPanel>
+  );
+};
 
 @Injectable({ multiple: true })
 export class TestingOutputPeek extends PeekViewWidget {

--- a/packages/testing/src/common/test-result.ts
+++ b/packages/testing/src/common/test-result.ts
@@ -111,7 +111,7 @@ export interface ITestResult {
 
   getStateById(testExtId: string): TestResultItem | undefined;
 
-  getOutput(): Promise<string>;
+  getOutput(): string;
 
   toJSON(): ISerializedTestResults | undefined;
 
@@ -140,6 +140,7 @@ export class TestResultImpl implements ITestResult {
   public readonly onChange = this.changeEmitter.event;
   public readonly onComplete = this.completeEmitter.event;
   public readonly counts: { [K in TestResultState]: number } = makeEmptyCounts();
+  public readonly outputs: string[] = [];
 
   public get completedAt() {
     return this._completedAt;
@@ -241,8 +242,8 @@ export class TestResultImpl implements ITestResult {
     return this.testById.get(testExtId);
   }
 
-  getOutput(): Promise<string> {
-    throw new Error('Method not implemented.');
+  getOutput(): string {
+    return this.outputs.join('');
   }
   toJSON(): ISerializedTestResults | undefined {
     throw new Error('Method not implemented.');
@@ -276,7 +277,8 @@ export class TestResultImpl implements ITestResult {
     });
   }
   appendOutput(output: string, taskId: string, location?: IRichLocation, testId?: string): void {
-    throw new Error('Method not implemented.');
+    // 其他参数暂时没有完全实现，先满足顺序输出
+    this.outputs.push(output);
   }
   addTestChainToRun(controllerId: string, chain: readonly ITestItem[]): void {
     let parent = this.testById.get(chain[0].extId);


### PR DESCRIPTION
### Types

适配了新版的 Java Test 插件，全面升级了 IDE 测试能力。
- 支持了 IDE 底部区域展示单独的 Test Results 视图（默认隐藏，运行测试样例后出现）
- 支持了点击测试展示测试输出，支持了 appendOutput API
- 支持了点击测试结果展示错误信息 / diff 对比
- 支持了测试列表中展示 codicon
- 修复了某些情况下测试结果无法预览的问题

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

![image](https://github.com/opensumi/core/assets/12879047/742a390f-1f7e-4a6e-ae77-4fd58dc2add5)


### Background or solution
OpenSumi Java 开发支持，需要对 Java 语言服务，Java Debug 和 Java Test 做一次全面升级，前两者最近两年改动相对较少，但是 Test API 以及上层交互设计这两年改动较多，所以需要做一次全面升级。

### Changelog
- feat: support test results panel, icons in test view