### PR TITLE
fix: terminal not restore

### DIFF
--- a/packages/terminal-next/src/common/preference.ts
+++ b/packages/terminal-next/src/common/preference.ts
@@ -128,7 +128,6 @@ export const enum CodeTerminalSettingId {
   PersistentSessionReviveProcess = 'terminal.integrated.persistentSessionReviveProcess',
   CustomGlyphs = 'terminal.integrated.customGlyphs',
   PersistentSessionScrollback = 'terminal.integrated.persistentSessionScrollback',
-  PersistentSession = 'terminal.integrated.enablePersistentSession',
   InheritEnv = 'terminal.integrated.inheritEnv',
   ShowLinkHover = 'terminal.integrated.showLinkHover',
   IgnoreProcessNames = 'terminal.integrated.ignoreProcessNames',
@@ -344,7 +343,7 @@ export const terminalPreferenceSchema: PreferenceSchema = {
       enum: [RenderType.WebGL, RenderType.Canvas, RenderType.Dom],
       default: RenderType.WebGL,
     },
-    [CodeTerminalSettingId.PersistentSession]: {
+    [CodeTerminalSettingId.EnablePersistentSessions]: {
       type: 'boolean',
       description: '%preference.terminal.integrated.enablePersistentSessionDesc%',
       default: true,


### PR DESCRIPTION
### Types

修复了终端在页面刷新后无法恢复的问题 

- [x] 🐛 Bug Fixes


### Background or solution
Terminal Persistent 设置项不一致导致的问题。

### Changelog
- fix: terminal not restore
