### PR TITLE
fix: design module no register top layout

### DIFF
--- a/packages/core-browser/src/layout/constants.ts
+++ b/packages/core-browser/src/layout/constants.ts
@@ -135,10 +135,6 @@ export class DesignLayoutConfig implements IDesignLayoutConfig {
     return this.internalLayout.useMergeRightWithLeftPanel;
   }
 
-  get useMenubarView(): boolean {
-    return this.internalLayout.useMenubarView;
-  }
-
   get menubarLogo(): string {
     return this.internalLayout.menubarLogo;
   }

--- a/packages/core-browser/src/layout/constants.ts
+++ b/packages/core-browser/src/layout/constants.ts
@@ -123,7 +123,7 @@ export class LayoutViewSizeConfig implements ILayoutViewSize {
 export class DesignLayoutConfig implements IDesignLayoutConfig {
   private internalLayout: Required<IDesignLayoutConfig> = {
     useMergeRightWithLeftPanel: false,
-    useMenubarView: true,
+    useMenubarView: false,
     menubarLogo: '',
   };
 

--- a/packages/core-common/src/types/ai-native/index.ts
+++ b/packages/core-common/src/types/ai-native/index.ts
@@ -49,6 +49,7 @@ export interface IDesignLayoutConfig {
   useMergeRightWithLeftPanel?: boolean;
   /**
    * use new manubar view
+   * @deprecated Please use layoutConfig
    */
   useMenubarView?: boolean;
   /**

--- a/packages/design/src/browser/design.contribution.ts
+++ b/packages/design/src/browser/design.contribution.ts
@@ -1,19 +1,15 @@
 import { Autowired, Injectable } from '@opensumi/di';
 import {
-  AppConfig,
   ClientAppContribution,
-  ComponentRegistryImpl,
   Domain,
   SlotLocation,
   SlotRendererContribution,
   SlotRendererRegistry,
 } from '@opensumi/ide-core-browser';
-import { DesignLayoutConfig, LayoutViewSizeConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
+import { LayoutViewSizeConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
 import { Schemes } from '@opensumi/ide-core-common';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { FileServiceClient } from '@opensumi/ide-file-service/lib/browser/file-service-client';
-
-import { DESIGN_MENUBAR_CONTAINER_VIEW_ID } from '../common/constants';
 
 import { DesignBottomTabRenderer, DesignLeftTabRenderer, DesignRightTabRenderer } from './layout/tabbar.view';
 import { DesignThemeFileSystemProvider } from './theme/file-system.provider';
@@ -30,17 +26,8 @@ export class DesignCoreContribution implements ClientAppContribution, SlotRender
   @Autowired(LayoutViewSizeConfig)
   private layoutViewSize: LayoutViewSizeConfig;
 
-  @Autowired(DesignLayoutConfig)
-  private designLayoutConfig: DesignLayoutConfig;
-
   initialize() {
-    const { useMenubarView } = this.designLayoutConfig;
-
     this.fileSystem.registerProvider(Schemes.design, this.designThemeFileSystemProvider);
-
-    if (useMenubarView) {
-      this.layoutViewSize.setMenubarHeight(48);
-    }
 
     this.layoutViewSize.setEditorTabsHeight(36);
     this.layoutViewSize.setStatusBarHeight(36);

--- a/packages/design/src/browser/design.contribution.ts
+++ b/packages/design/src/browser/design.contribution.ts
@@ -27,9 +27,6 @@ export class DesignCoreContribution implements ClientAppContribution, SlotRender
   @Autowired()
   private readonly designThemeFileSystemProvider: DesignThemeFileSystemProvider;
 
-  @Autowired(AppConfig)
-  private appConfig: AppConfig;
-
   @Autowired(LayoutViewSizeConfig)
   private layoutViewSize: LayoutViewSizeConfig;
 
@@ -43,12 +40,6 @@ export class DesignCoreContribution implements ClientAppContribution, SlotRender
 
     if (useMenubarView) {
       this.layoutViewSize.setMenubarHeight(48);
-
-      ComponentRegistryImpl.replaceLayoutModule(
-        this.appConfig.layoutConfig,
-        SlotLocation.top,
-        DESIGN_MENUBAR_CONTAINER_VIEW_ID,
-      );
     }
 
     this.layoutViewSize.setEditorTabsHeight(36);

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -9,6 +9,9 @@ renderApp(
   getDefaultClientAppOpts({
     modules: [...AIModules],
     opts: {
+      layoutViewSize: {
+        menubarHeight: 48,
+      },
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {
           modules: [MENU_BAR_FEATURE_TIP],

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,4 +1,5 @@
-import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
+import { SlotLocation } from '@opensumi/ide-core-browser';
+import { DESIGN_MENUBAR_CONTAINER_VIEW_ID, DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
 import { MENU_BAR_FEATURE_TIP } from '@opensumi/ide-startup/lib/browser/menu-bar-help-icon';
 
@@ -11,6 +12,9 @@ renderApp(
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {
           modules: [MENU_BAR_FEATURE_TIP],
+        },
+        [SlotLocation.top]: {
+          modules: [DESIGN_MENUBAR_CONTAINER_VIEW_ID],
         },
       },
     },


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

layout 视图只允许通过 layoutConfig 去配置，design 模块不允许去修改

### Changelog
design 模块的 useMenubarView 配置不注册 top layout 视图