### PR TITLE
style: adjust find-widget close button position in monaco editor

### DIFF
--- a/packages/core-browser/src/style/monaco-override.less
+++ b/packages/core-browser/src/style/monaco-override.less
@@ -16,6 +16,9 @@
     }
     .find-widget .button {
       outline: none;
+      &.codicon-widget-close {
+        top: 8px;
+      }
     }
     .rename-box {
       .preview {


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

Before:
<img width="456" alt="截屏2024-06-04 14 21 08" src="https://github.com/opensumi/core/assets/9823838/59fe009d-4292-46bc-bdc8-e2596b4f72cd">

After:
<img width="442" alt="image" src="https://github.com/opensumi/core/assets/9823838/07f5333a-0880-4800-bc4a-883394dd5a95">

### Changelog

adjust find-widget close button position in monaco editor