### PR TITLE
fix: should not change user defined ai capabilities

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -73,7 +73,6 @@ import {
   AINativeCoreContribution,
   IChatFeatureRegistry,
   IChatRenderRegistry,
-  IInlineChatFeatureRegistry,
   IRenameCandidatesProviderRegistry,
   IResolveConflictRegistry,
   ITerminalProviderRegistry,
@@ -162,8 +161,6 @@ export class AINativeBrowserContribution
   }
 
   initialize() {
-    this.aiNativeConfigService.enableCapabilities();
-
     const { supportsChatAssistant } = this.aiNativeConfigService.capabilities;
 
     if (supportsChatAssistant) {

--- a/packages/ai-native/src/browser/index.ts
+++ b/packages/ai-native/src/browser/index.ts
@@ -1,7 +1,8 @@
-import { Injectable, Provider } from '@opensumi/di';
+import { Autowired, Injectable, Provider } from '@opensumi/di';
 import {
   AIBackSerivcePath,
   AIBackSerivceToken,
+  AINativeConfigService,
   BrowserModule,
   ChatAgentViewServiceToken,
   ChatFeatureRegistryToken,
@@ -39,6 +40,14 @@ import { AIInlineChatService } from './widget/inline-chat/inline-chat.service';
 
 @Injectable()
 export class AINativeModule extends BrowserModule {
+  @Autowired(AINativeConfigService)
+  protected readonly aiNativeConfig: AINativeConfigService;
+
+  constructor() {
+    super();
+    this.aiNativeConfig.setAINativeModuleLoaded(true);
+  }
+
   contributionProvider = AINativeCoreContribution;
   providers: Provider[] = [
     AINativeBrowserContribution,

--- a/packages/core-browser/src/ai-native/ai-config.service.ts
+++ b/packages/core-browser/src/ai-native/ai-config.service.ts
@@ -13,14 +13,14 @@ export class AINativeConfigService {
   public layoutViewSize: LayoutViewSizeConfig;
 
   private internalCapabilities: Required<IAINativeCapabilities> = {
-    supportsMarkers: false,
-    supportsChatAssistant: false,
-    supportsInlineChat: false,
-    supportsInlineCompletion: false,
-    supportsConflictResolve: false,
-    supportsRenameSuggestions: false,
-    supportsTerminalDetection: false,
-    supportsTerminalCommandSuggest: false,
+    supportsMarkers: true,
+    supportsChatAssistant: true,
+    supportsInlineChat: true,
+    supportsInlineCompletion: true,
+    supportsConflictResolve: true,
+    supportsRenameSuggestions: true,
+    supportsTerminalDetection: true,
+    supportsTerminalCommandSuggest: true,
   };
 
   private setDefaultCapabilities(value: boolean): void {

--- a/packages/core-browser/src/ai-native/ai-config.service.ts
+++ b/packages/core-browser/src/ai-native/ai-config.service.ts
@@ -4,6 +4,22 @@ import { IAINativeCapabilities } from '@opensumi/ide-core-common';
 import { LayoutViewSizeConfig } from '../layout/constants';
 import { AppConfig } from '../react-providers/config-provider';
 
+const DEFAULT_CAPABILITIES: Required<IAINativeCapabilities> = {
+  supportsMarkers: true,
+  supportsChatAssistant: true,
+  supportsInlineChat: true,
+  supportsInlineCompletion: true,
+  supportsConflictResolve: true,
+  supportsRenameSuggestions: true,
+  supportsTerminalDetection: true,
+  supportsTerminalCommandSuggest: true,
+};
+
+const DISABLED_ALL_CAPABILITIES = {} as Required<IAINativeCapabilities>;
+Object.keys(DEFAULT_CAPABILITIES).forEach((key) => {
+  DISABLED_ALL_CAPABILITIES[key] = false;
+});
+
 @Injectable()
 export class AINativeConfigService {
   @Autowired(AppConfig)
@@ -12,16 +28,9 @@ export class AINativeConfigService {
   @Autowired(LayoutViewSizeConfig)
   public layoutViewSize: LayoutViewSizeConfig;
 
-  private internalCapabilities: Required<IAINativeCapabilities> = {
-    supportsMarkers: true,
-    supportsChatAssistant: true,
-    supportsInlineChat: true,
-    supportsInlineCompletion: true,
-    supportsConflictResolve: true,
-    supportsRenameSuggestions: true,
-    supportsTerminalDetection: true,
-    supportsTerminalCommandSuggest: true,
-  };
+  private aiModuleLoaded = false;
+
+  private internalCapabilities = DEFAULT_CAPABILITIES;
 
   private setDefaultCapabilities(value: boolean): void {
     for (const key in this.internalCapabilities) {
@@ -40,6 +49,10 @@ export class AINativeConfigService {
   }
 
   public get capabilities(): Required<IAINativeCapabilities> {
+    if (!this.aiModuleLoaded) {
+      return DISABLED_ALL_CAPABILITIES;
+    }
+
     const { AINativeConfig } = this.appConfig;
 
     if (AINativeConfig?.capabilities) {
@@ -47,5 +60,9 @@ export class AINativeConfigService {
     }
 
     return this.internalCapabilities;
+  }
+
+  setAINativeModuleLoaded(value: boolean): void {
+    this.aiModuleLoaded = value;
   }
 }

--- a/packages/core-browser/src/browser-module.ts
+++ b/packages/core-browser/src/browser-module.ts
@@ -17,7 +17,7 @@ export interface IClientApp {
 export abstract class BrowserModule<T = any> extends BasicModule {
   @Autowired(IClientApp)
   protected app: IClientApp;
-  public preferences?: (inject: Injector) => void;
+  public preferences?: (injector: Injector) => void;
   public component?: React.ComponentType<T>;
 
   // 脱离于文档流的模块


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

现在 ai 模块会在 initialize 阶段开启所有 ai 功能，用户传入到 ClientApp 的参数 AINativeConfig.capabilities 是不生效的。

### Changelog
should not change user defined ai capabilities