### PR TITLE
fix: inline diff widget layout

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
@@ -376,6 +376,7 @@ export class InlineChatHandler extends Disposable {
                 startTime,
                 isRetry,
               });
+              this.aiDiffWidget.layout();
             }),
             controller.onAbort(() => {
               this.convertInlineChatStatus(EInlineChatStatus.READY, {
@@ -385,6 +386,7 @@ export class InlineChatHandler extends Disposable {
                 isRetry,
                 isStop: true,
               });
+              this.aiDiffWidget.layout();
             }),
             controller.onEnd(() => {
               this.convertInlineChatStatus(EInlineChatStatus.DONE, {
@@ -393,6 +395,7 @@ export class InlineChatHandler extends Disposable {
                 startTime,
                 isRetry,
               });
+              this.aiDiffWidget.layout();
             }),
           ]);
         }),

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-widget.tsx
@@ -88,29 +88,21 @@ const DiffContentProvider = React.memo((props: IDiffContentProviderProps) => {
     const originalModel = modelService.createModel(codeValueInRange, languageSelection);
     const modifiedModel = modelService.createModel('', languageSelection);
 
-    const layout = () => {
-      if (onMaxLineCount) {
-        const originalEditor = diffEditor.getOriginalEditor();
-        const modifiedEditor = diffEditor.getModifiedEditor();
-
-        const originContentHeight = originalEditor.getContentHeight();
-        const originLineCount =
-          originContentHeight / originalEditor.getOption(monacoApi.editor.EditorOption.lineHeight);
-
-        const modifiedContentHeight = modifiedEditor.getContentHeight();
-        const modifiedLineCount =
-          modifiedContentHeight / modifiedEditor.getOption(monacoApi.editor.EditorOption.lineHeight);
-
-        onMaxLineCount(Math.max(originLineCount, modifiedLineCount) + 1);
-      }
-    };
-
     diffEditor.setModel({
       original: originalModel,
       modified: modifiedModel,
     });
 
     diffEditor.revealLine(range.startLineNumber, monaco.editor.ScrollType.Immediate);
+
+    const layout = () => {
+      if (onMaxLineCount) {
+        const originLineCount = originalModel.getLineCount();
+        const modifiedLineCount = modifiedModel.getLineCount();
+
+        onMaxLineCount(Math.max(originLineCount, modifiedLineCount) + 1);
+      }
+    };
 
     if (onReady) {
       onReady({


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

当流式输出过快的时候会偶现 inline diff widget 底部出现空白

### Changelog
修复 inline diff widget 偶现的底部空白问题