### PR TITLE
style:  adjust tabbar close popover styles

### DIFF
--- a/packages/design/src/browser/override/editor-tab.service.tsx
+++ b/packages/design/src/browser/override/editor-tab.service.tsx
@@ -1,14 +1,30 @@
 import cls from 'classnames';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useCallback, useMemo } from 'react';
 
 import { Injectable } from '@opensumi/di';
+import { Popover } from '@opensumi/ide-core-browser/lib/components';
+import { formatLocalize, isMacintosh, uuid } from '@opensumi/ide-core-common';
 import { EditorTabService } from '@opensumi/ide-editor/lib/browser/editor.tab.service';
 
 import styles from '../style/design.module.less';
 
 const EditorTabCloseComponent = (props) => {
   const { children } = props;
-  return children;
+  const [display, setDisplay] = React.useState(false);
+
+  const uid = useMemo(() => 'editor-tab-close-' + uuid(6), []);
+
+  const handleClick = useCallback(() => {
+    setDisplay(false);
+  }, []);
+
+  const title = useMemo(() => formatLocalize('editor.closeTab.title', isMacintosh ? '⌘W' : 'Ctrl+W'), []);
+
+  return (
+    <Popover delay={1000} id={uid} title={title} onClickAction={handleClick} display={display}>
+      {children}
+    </Popover>
+  );
 };
 
 @Injectable()

--- a/packages/design/src/browser/override/editor-tab.service.tsx
+++ b/packages/design/src/browser/override/editor-tab.service.tsx
@@ -2,7 +2,7 @@ import cls from 'classnames';
 import React, { ReactNode, useCallback, useMemo } from 'react';
 
 import { Injectable } from '@opensumi/di';
-import { Popover } from '@opensumi/ide-core-browser/lib/components';
+import { Popover, PopoverPosition } from '@opensumi/ide-core-browser/lib/components';
 import { formatLocalize, isMacintosh, uuid } from '@opensumi/ide-core-common';
 import { EditorTabService } from '@opensumi/ide-editor/lib/browser/editor.tab.service';
 
@@ -21,8 +21,15 @@ const EditorTabCloseComponent = (props) => {
   const title = useMemo(() => formatLocalize('editor.closeTab.title', isMacintosh ? '⌘W' : 'Ctrl+W'), []);
 
   return (
-    <Popover delay={1000} id={uid} title={title} onClickAction={handleClick} display={display}>
-      {children}
+    <Popover
+      delay={1000}
+      position={PopoverPosition.bottom}
+      id={uid}
+      title={title}
+      onClickAction={handleClick}
+      display={display}
+    >
+      <span title=''>{children}</span>
     </Popover>
   );
 };

--- a/packages/design/src/browser/override/editor-tab.service.tsx
+++ b/packages/design/src/browser/override/editor-tab.service.tsx
@@ -1,28 +1,14 @@
 import cls from 'classnames';
-import React, { ReactNode, useCallback, useMemo } from 'react';
+import React, { ReactNode } from 'react';
 
 import { Injectable } from '@opensumi/di';
-import { Popover } from '@opensumi/ide-core-browser/lib/components';
-import { localize, uuid } from '@opensumi/ide-core-common';
 import { EditorTabService } from '@opensumi/ide-editor/lib/browser/editor.tab.service';
 
 import styles from '../style/design.module.less';
 
 const EditorTabCloseComponent = (props) => {
   const { children } = props;
-  const [display, setDisplay] = React.useState(false);
-
-  const uid = useMemo(() => 'editor-tab-close-' + uuid(6), []);
-
-  const handleClick = useCallback(() => {
-    setDisplay(false);
-  }, []);
-
-  return (
-    <Popover id={uid} title={localize('editor.title.context.close')} onClickAction={handleClick} display={display}>
-      {children}
-    </Popover>
-  );
+  return children;
 };
 
 @Injectable()

--- a/packages/design/src/browser/style/design.module.less
+++ b/packages/design/src/browser/style/design.module.less
@@ -232,6 +232,7 @@
         font-size: 14px;
         color: var(--design-text-foreground);
         margin-left: 2px;
+        border-radius: 4px;
 
         &:not(.disabled):hover {
           color: var(--design-text-hoverForeground);
@@ -257,7 +258,6 @@
       }
 
       button.design-btnAction {
-        border-radius: 4px;
         color: var(--design-text-foreground);
 
         &:hover {
@@ -426,6 +426,7 @@
       width: 22px;
       height: 22px;
       color: var(--design-text-foreground);
+      border-radius: 4px;
 
       &:not(.disabled):hover {
         color: var(--design-text-hoverForeground);
@@ -437,7 +438,6 @@
       font-size: 14px;
 
       &:hover {
-        border-radius: 4px;
         background-color: var(--kt-icon-hoverBackground);
         color: var(--design-text-hoverForeground);
       }

--- a/packages/design/src/browser/style/global.less
+++ b/packages/design/src/browser/style/global.less
@@ -105,6 +105,7 @@
     0px 6px 16px 0px var(--design-boxShadow-tertiary);
   border-radius: 6px;
   line-height: 18px;
+  padding: 4px 6px;
 
   .kt-popover-title {
     margin-bottom: 0;

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -110,6 +110,7 @@ export const localizationBundle = {
     'editor.saveCodeActions.getting': 'Getting code actions from {0}.',
     'editor.saveCodeActions.saving': 'Saving "{0}"',
     'editor.title.context.close': 'Close',
+    'editor.closeTab.title': 'Close ({0})',
     'editor.closeCurrent': 'Close Current Editor',
     'editor.openExternal': 'Open Externally',
     'editor.cannotOpenBinary': 'Cannot open binary file in this editor.',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -106,6 +106,7 @@ export const localizationBundle = {
     'editor.redo': '重做',
     'editor.saveCurrent': '保存当前文件',
     'editor.title.context.close': '关闭',
+    'editor.closeTab.title': '关闭 ({0})',
     'editor.closeCurrent': '关闭当前编辑窗口',
     'editor.openExternal': '使用外部软件打开',
     'editor.cannotOpenBinary': '我们无法在编辑器中展示这个文件。',


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

<img width="223" alt="image" src="https://github.com/opensumi/core/assets/9823838/219506e2-abb5-4314-ae14-5ba57792bbf5">
<img width="157" alt="image" src="https://github.com/opensumi/core/assets/9823838/5d7cf44b-5209-487d-a054-7e74cb70f4d8">

### Changelog

simplify EditorTabCloseComponent and adjust button styles
