### PR TITLE
fix: conditionally show HorizontalVertical component based on visible

### DIFF
--- a/packages/ai-native/src/browser/layout/tabbar.view.tsx
+++ b/packages/ai-native/src/browser/layout/tabbar.view.tsx
@@ -89,7 +89,7 @@ const AILeftTabbarRenderer: React.FC = () => {
 
       return (
         <>
-          <HorizontalVertical margin={'8px auto 0px'} width={'60%'} />
+          {visibleContainers.length > 0 && <HorizontalVertical margin={'8px auto 0px'} width={'60%'} />}
           {visibleContainers.map((component) => renderContainers(component, handleTabClick, currentContainerId))}
         </>
       );


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

当无注册的右侧面板时，隐藏分割线
![image](https://github.com/opensumi/core/assets/9823838/35a91ac3-eca6-4c40-9163-eafdce1c1615)

### Changelog

conditionally show HorizontalVertical component based on visible