### PR TITLE
fix: update default editor background color to #181818

### DIFF
--- a/packages/design/src/browser/style/design.module.less
+++ b/packages/design/src/browser/style/design.module.less
@@ -427,6 +427,7 @@
       height: 22px;
       color: var(--design-text-foreground);
       border-radius: 4px;
+      box-sizing: border-box;
 
       &:not(.disabled):hover {
         color: var(--design-text-hoverForeground);
@@ -639,6 +640,8 @@
       margin-left: 0;
       box-sizing: border-box;
       color: var(--design-text-foreground);
+      box-sizing: border-box;
+      border-radius: 4px;
 
       &::before {
         font-size: 14px;

--- a/packages/design/src/browser/style/design.module.less
+++ b/packages/design/src/browser/style/design.module.less
@@ -423,8 +423,8 @@
       align-items: center;
       justify-content: center;
       font-size: 14px;
-      width: 22px;
-      height: 22px;
+      width: 20px;
+      height: 20px;
       color: var(--design-text-foreground);
       border-radius: 4px;
       box-sizing: border-box;

--- a/packages/design/src/browser/theme/default-theme.ts
+++ b/packages/design/src/browser/theme/default-theme.ts
@@ -782,7 +782,7 @@ export default {
     'editorInlayHint.parameterBackground': '#00000000',
     'button.background': '#ffffff14',
     'scrollbarSlider.background': '#ffffff14',
-    'editor.background': '#00000026',
+    'editor.background': '#181818',
     'quickInput.background': '#222830',
     'list.focusBackground': '#ffffff1f',
     'textLink.foreground': '#3c8dff',


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

由于 editor.background 设置了 0.15 透明度，导致刷新后出现白色闪烁，使用不带透明度色值解决这一问题

### Changelog

update default editor background color to #181818