### PR TITLE
feat: avoid send too many log request

### DIFF
--- a/packages/core-browser/__mocks__/logger.ts
+++ b/packages/core-browser/__mocks__/logger.ts
@@ -64,6 +64,10 @@ export class MockLoggerManageClient implements ILoggerManagerClient {
     return this.logger;
   }
 
+  getBrowserLogger(namespace: SupportLogNamespace): ILogServiceClient {
+    return this.logger;
+  }
+
   async getLogFolder() {
     return '';
   }

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -5,7 +5,6 @@
 import '@opensumi/monaco-editor-core/esm/vs/editor/editor.main';
 
 import { Injector } from '@opensumi/di';
-import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser';
 import {
   AppLifeCycleServiceToken,
   CommandRegistry,
@@ -19,14 +18,13 @@ import {
   IDisposable,
   IEventBus,
   ILogServiceClient,
-  ILoggerManagerClient,
+  ILogger,
   IReporterService,
   LifeCyclePhase,
   MaybePromise,
   REPORT_NAME,
   StorageProvider,
   StorageResolverContribution,
-  SupportLogNamespace,
   URI,
   asExtensionCandidate,
   createContributionProvider,
@@ -233,7 +231,7 @@ export class ClientApp implements IClientApp, IDisposable {
 
     measureReporter.timeEnd('ClientApp.createConnection');
 
-    this.logger = this.getLogger();
+    this.logger = this.injector.get(ILogger);
     this.stateService.state = 'client_connected';
     this.registerEventListeners();
     // 在 connect 之后立即初始化数据，保证其它 module 能同步获取数据
@@ -255,18 +253,6 @@ export class ClientApp implements IClientApp, IDisposable {
     channel.onReopen(() => {
       this.onReconnectContributions();
     });
-
-    // create logger after connection established
-    this.logger = this.getLogger();
-    this.injector.get(WSChannelHandler).replaceLogger(this.logger);
-  }
-
-  private getLogger() {
-    if (this.logger) {
-      return this.logger;
-    }
-    this.logger = this.injector.get(ILoggerManagerClient).getLogger(SupportLogNamespace.Browser);
-    return this.logger;
   }
 
   private onReconnectContributions() {

--- a/packages/core-browser/src/bootstrap/connection.ts
+++ b/packages/core-browser/src/bootstrap/connection.ts
@@ -9,11 +9,13 @@ import {
   BrowserConnectionErrorEvent,
   BrowserConnectionOpenEvent,
   IEventBus,
+  ILogger,
   IReporterService,
 } from '@opensumi/ide-core-common';
 import { BackService } from '@opensumi/ide-core-common/lib/module';
 
 import { ClientAppStateService } from '../application';
+import { Logger } from '../logger';
 import { AppConfig } from '../react-providers/config-provider';
 
 import { ModuleConstructor } from './app.interface';
@@ -77,6 +79,10 @@ export async function createConnectionService(
   }
 
   initConnectionService(injector, modules, clientCenter);
+
+  // report log to server after connection established
+  const logger = injector.get(ILogger) as Logger;
+  logger.reportToServer();
 
   return channel;
 }

--- a/packages/core-browser/src/bootstrap/inner-providers.ts
+++ b/packages/core-browser/src/bootstrap/inner-providers.ts
@@ -137,6 +137,10 @@ export function injectInnerProviders(injector: Injector) {
       useClass: Logger,
     },
     {
+      token: Logger,
+      useAlias: ILogger,
+    },
+    {
       token: ComponentRegistry,
       useClass: ComponentRegistryImpl,
     },

--- a/packages/core-browser/src/logger/browser-logger.ts
+++ b/packages/core-browser/src/logger/browser-logger.ts
@@ -60,39 +60,4 @@ export class Logger extends LoggerWrapper implements ILogServiceClient {
     this.logger.dispose();
     this.logger = this.loggerManager.getLogger(SupportLogNamespace.Browser);
   }
-
-  public getLevel() {
-    return this.logger.getLevel();
-  }
-
-  public setLevel(level: LogLevel) {
-    return this.logger.setLevel(level);
-  }
-
-  public error(...args) {
-    return this.logger.error(...args);
-  }
-
-  public warn(...args) {
-    return this.logger.warn(...args);
-  }
-
-  public log(...args) {
-    return this.logger.log(...args);
-  }
-  public debug(...args) {
-    return this.logger.debug(...args);
-  }
-
-  public verbose(...args) {
-    return this.logger.verbose(...args);
-  }
-
-  public critical(...args) {
-    return this.logger.critical(...args);
-  }
-
-  public dispose() {
-    return this.logger.dispose();
-  }
 }

--- a/packages/core-browser/src/logger/browser-logger.ts
+++ b/packages/core-browser/src/logger/browser-logger.ts
@@ -6,12 +6,12 @@ export { ILogger } from '@opensumi/ide-core-common';
 @Injectable()
 export class Logger implements ILogServiceClient {
   @Autowired(ILoggerManagerClient)
-  private LoggerManager: ILoggerManagerClient;
+  private loggerManager: ILoggerManagerClient;
 
   private logger: ILogServiceClient;
 
   constructor() {
-    this.logger = this.LoggerManager.getLogger(SupportLogNamespace.Browser);
+    this.logger = this.loggerManager.getLogger(SupportLogNamespace.Browser);
   }
 
   public getLevel() {

--- a/packages/core-browser/src/logger/browser-logger.ts
+++ b/packages/core-browser/src/logger/browser-logger.ts
@@ -3,19 +3,66 @@ import { ILogServiceClient, ILoggerManagerClient, LogLevel, SupportLogNamespace 
 
 export { ILogger } from '@opensumi/ide-core-common';
 
-@Injectable()
-export class Logger implements ILogServiceClient {
-  @Autowired(ILoggerManagerClient)
-  private loggerManager: ILoggerManagerClient;
+class LoggerWrapper implements ILogServiceClient {
+  protected logger: ILogServiceClient;
 
-  private logger: ILogServiceClient;
+  setup(logger: ILogServiceClient) {
+    this.logger = logger;
+  }
+
+  public getLevel() {
+    return this.logger.getLevel();
+  }
+
+  public setLevel(level: LogLevel) {
+    return this.logger.setLevel(level);
+  }
+
+  public error(...args) {
+    return this.logger.error(...args);
+  }
+
+  public warn(...args) {
+    return this.logger.warn(...args);
+  }
+
+  public log(...args) {
+    return this.logger.log(...args);
+  }
+  public debug(...args) {
+    return this.logger.debug(...args);
+  }
+
+  public verbose(...args) {
+    return this.logger.verbose(...args);
+  }
+
+  public critical(...args) {
+    return this.logger.critical(...args);
+  }
+
+  public dispose() {
+    return this.logger.dispose();
+  }
+}
+
+@Injectable()
+export class Logger extends LoggerWrapper implements ILogServiceClient {
+  @Autowired(ILoggerManagerClient)
+  protected loggerManager: ILoggerManagerClient;
 
   constructor() {
+    super();
+    this.logger = this.loggerManager.getBrowserLogger(SupportLogNamespace.Browser);
+  }
+
+  public reportToServer() {
+    this.logger.dispose();
     this.logger = this.loggerManager.getLogger(SupportLogNamespace.Browser);
   }
 
   public getLevel() {
-    return this.getLevel();
+    return this.logger.getLevel();
   }
 
   public setLevel(level: LogLevel) {

--- a/packages/core-common/src/log.ts
+++ b/packages/core-common/src/log.ts
@@ -174,6 +174,7 @@ export const ILoggerManagerClient = Symbol('ILoggerManagerClient');
 export interface ILoggerManagerClient {
   onDidChangeLogLevel: Event<LogLevel>;
   getLogger(namespace: SupportLogNamespace, pid?: number): ILogServiceClient;
+  getBrowserLogger(namespace: SupportLogNamespace): ILogServiceClient;
 
   setGlobalLogLevel(level: LogLevel): Promise<void>;
   getGlobalLogLevel(): Promise<LogLevel>;

--- a/packages/logs-core/__tests__/browser/log-manage.test.ts
+++ b/packages/logs-core/__tests__/browser/log-manage.test.ts
@@ -3,7 +3,7 @@ import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helpe
 import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 
 import { LogModule } from '../../src/browser';
-import { LoggerManagerClient } from '../../src/browser/log-manage';
+import { LoggerManagerClient } from '../../src/browser/log-manager';
 import { ILoggerManagerClient, LogLevel, LogServiceForClientPath, SupportLogNamespace } from '../../src/common';
 
 @Injectable()

--- a/packages/logs-core/__tests__/browser/log.service.test.ts
+++ b/packages/logs-core/__tests__/browser/log.service.test.ts
@@ -4,7 +4,6 @@ import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helpe
 import { LogModule } from '../../src/browser';
 import { LogServiceClient } from '../../src/browser/log.service';
 import {
-  ILogServiceClient,
   ILogServiceForClient,
   ILoggerManagerClient,
   LogLevel,
@@ -67,7 +66,7 @@ class MockLogServiceForClient implements ILogServiceForClient {
 describe('log-manager', () => {
   let injector: Injector;
   let logManager: ILoggerManagerClient;
-  let logServiceClient: ILogServiceClient;
+  let logServiceClient: LogServiceClient;
   let logServiceForClient: MockLogServiceForClient;
 
   beforeEach(() => {
@@ -78,7 +77,8 @@ describe('log-manager', () => {
     });
     logManager = injector.get(ILoggerManagerClient);
     logServiceForClient = injector.get(LogServiceForClientPath);
-    logServiceClient = new LogServiceClient(SupportLogNamespace.Browser, logServiceForClient);
+    logServiceClient = new LogServiceClient(SupportLogNamespace.Browser);
+    logServiceClient.setup(logServiceForClient);
   });
 
   test('setLevel', async () => {

--- a/packages/logs-core/__tests__/browser/log.service.test.ts
+++ b/packages/logs-core/__tests__/browser/log.service.test.ts
@@ -5,6 +5,7 @@ import { LogModule } from '../../src/browser';
 import { LogServiceClient } from '../../src/browser/log.service';
 import {
   ILogServiceClient,
+  ILogServiceForClient,
   ILoggerManagerClient,
   LogLevel,
   LogServiceForClientPath,
@@ -12,7 +13,18 @@ import {
 } from '../../src/common';
 
 @Injectable()
-class MockLogServiceForClient {
+class MockLogServiceForClient implements ILogServiceForClient {
+  dispose(namespace: SupportLogNamespace): void {}
+  async setGlobalLogLevel(level: LogLevel): Promise<void> {}
+  getGlobalLogLevel(): Promise<LogLevel> {
+    return Promise.resolve(LogLevel.Verbose);
+  }
+  async disposeAll(): Promise<void> {
+    this.dispose(this.namespace);
+  }
+  async getLogFolder(): Promise<string> {
+    return '';
+  }
   private level: LogLevel;
 
   catchLogArgs: any[];
@@ -23,7 +35,7 @@ class MockLogServiceForClient {
     this.namespace = namespace;
   }
 
-  async getLevel() {
+  getLevel() {
     return this.level;
   }
 

--- a/packages/logs-core/src/browser/index.ts
+++ b/packages/logs-core/src/browser/index.ts
@@ -3,7 +3,7 @@ import { BrowserModule } from '@opensumi/ide-core-browser';
 
 import { ILoggerManagerClient, LogServiceForClientPath } from '../common/';
 
-import { LoggerManagerClient } from './log-manage';
+import { LoggerManagerClient } from './log-manager';
 
 export * from '../common/';
 export { LogServiceClient } from './log.service';

--- a/packages/logs-core/src/browser/log-manager.ts
+++ b/packages/logs-core/src/browser/log-manager.ts
@@ -8,7 +8,7 @@ import {
   LogLevel,
   LogServiceForClientPath,
   SupportLogNamespace,
-} from '../common/';
+} from '../common';
 
 import { LogServiceClient } from './log.service';
 

--- a/packages/logs-core/src/browser/log-manager.ts
+++ b/packages/logs-core/src/browser/log-manager.ts
@@ -19,7 +19,16 @@ export class LoggerManagerClient implements ILoggerManagerClient {
   logServiceForClient: ILogServiceForClient;
 
   getLogger(namespace: SupportLogNamespace, pid?: number): ILogServiceClient {
-    return new LogServiceClient(namespace, this.logServiceForClient, pid);
+    const logger = new LogServiceClient(namespace);
+    logger.setup(this.logServiceForClient, pid);
+    return logger;
+  }
+
+  /**
+   * Logger that can used in non-server environment
+   */
+  getBrowserLogger(namespace: SupportLogNamespace): ILogServiceClient {
+    return new LogServiceClient(namespace);
   }
 
   async getLogFolder() {

--- a/packages/logs-core/src/browser/log.service.ts
+++ b/packages/logs-core/src/browser/log.service.ts
@@ -1,3 +1,5 @@
+import { Deferred } from '@opensumi/ide-core-common';
+
 import { DebugLog, ILogServiceClient, ILogServiceForClient, LogLevel, SupportLogNamespace, format } from '../common/';
 
 export class LogServiceClient implements ILogServiceClient {
@@ -6,11 +8,23 @@ export class LogServiceClient implements ILogServiceClient {
   private debugLog: DebugLog;
   private pid: number | undefined;
 
-  constructor(namespace: SupportLogNamespace, logServiceForClient, pid?: number) {
+  private level: LogLevel = LogLevel.Verbose;
+
+  protected ready = new Deferred<void>();
+
+  constructor(namespace: SupportLogNamespace, logServiceForClient: ILogServiceForClient, pid?: number) {
     this.namespace = namespace;
     this.logServiceForClient = logServiceForClient;
     this.debugLog = new DebugLog(namespace);
     this.pid = pid;
+
+    this.init();
+  }
+
+  protected async init() {
+    const level = await this.logServiceForClient.getGlobalLogLevel();
+    this.level = level;
+    this.ready.resolve();
   }
 
   async getLevel() {
@@ -18,36 +32,63 @@ export class LogServiceClient implements ILogServiceClient {
   }
 
   async setLevel(level: LogLevel) {
+    this.level = level;
     await this.logServiceForClient.setLevel(this.namespace, level);
   }
 
   async verbose(...args: any[]) {
     this.debugLog.verbose(...args);
+
     await this.logServiceForClient.verbose(this.namespace, format(args), this.pid);
   }
 
   async debug(...args: any[]) {
     this.debugLog.debug(...args);
+
+    await this.ready.promise;
+    if (this.level > LogLevel.Debug) {
+      return;
+    }
     await this.logServiceForClient.debug(this.namespace, format(args), this.pid);
   }
 
   async log(...args: any[]) {
     this.debugLog.log(...args);
+
+    await this.ready.promise;
+    if (this.level > LogLevel.Info) {
+      return;
+    }
     await this.logServiceForClient.log(this.namespace, format(args), this.pid);
   }
 
   async warn(...args: any[]) {
     this.debugLog.warn(...args);
+
+    await this.ready.promise;
+    if (this.level > LogLevel.Warning) {
+      return;
+    }
     await this.logServiceForClient.warn(this.namespace, format(args), this.pid);
   }
 
   async error(...args: any[]) {
     this.debugLog.error(...args);
+
+    await this.ready.promise;
+    if (this.level > LogLevel.Error) {
+      return;
+    }
     await this.logServiceForClient.error(this.namespace, format(args), this.pid);
   }
 
   async critical(...args: any[]) {
     this.debugLog.error(...args);
+
+    await this.ready.promise;
+    if (this.level > LogLevel.Critical) {
+      return;
+    }
     await this.logServiceForClient.critical(this.namespace, format(args), this.pid);
   }
 

--- a/packages/logs-core/src/common/log-core.ts
+++ b/packages/logs-core/src/common/log-core.ts
@@ -15,9 +15,9 @@ export interface ILogServiceForClient {
 
   dispose(namespace: SupportLogNamespace): void;
 
-  setGlobalLogLevel(level: LogLevel);
-  getGlobalLogLevel();
-  disposeAll();
+  setGlobalLogLevel(level: LogLevel): Promise<void>;
+  getGlobalLogLevel(): Promise<LogLevel>;
+  disposeAll(): Promise<void>;
 
   getLogFolder(): Promise<string>;
 }

--- a/packages/logs-core/src/node/log.service.ts
+++ b/packages/logs-core/src/node/log.service.ts
@@ -120,7 +120,7 @@ export class BaseLogService implements IBaseLogService {
     }
     if (this.logger) {
       this.doLog(this.logger, level, message);
-    } else if (this.getLevel() <= level) {
+    } else {
       this.buffer.push({ level, message });
     }
   }

--- a/packages/logs-core/src/node/log.service.ts
+++ b/packages/logs-core/src/node/log.service.ts
@@ -335,15 +335,15 @@ export class LogServiceForClient extends RPCService<IRPCLogService> implements I
     this.getLogger(namespace).dispose();
   }
 
-  setGlobalLogLevel(level: LogLevel) {
+  async setGlobalLogLevel(level: LogLevel) {
     this.loggerManager.setGlobalLogLevel(level);
   }
 
-  getGlobalLogLevel() {
-    this.loggerManager.getGlobalLogLevel();
+  async getGlobalLogLevel() {
+    return this.loggerManager.getGlobalLogLevel();
   }
 
-  disposeAll() {
+  async disposeAll() {
     this.loggerManager.dispose();
   }
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features


### Background or solution

从埋点来看，我们的 log debug 必定会上报给后端，实际上后端已经设置成了 info，会丢弃掉这次 log 请求，这个会带来通信成本

![CleanShot 2024-06-12 at 12 58 29@2x](https://github.com/opensumi/core/assets/13938334/75c42b56-8f49-4c22-95c7-5ab94023a38a)

### Changelog

avoid send too many log request
