### PR TITLE
style: remove unnecessary overflow:hidden from menubar in global style

### DIFF
--- a/packages/design/src/browser/style/global.less
+++ b/packages/design/src/browser/style/global.less
@@ -19,7 +19,6 @@
   margin-bottom: 1px;
   #opensumi-menubar {
     border-radius: 12px;
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

### Changelog

remove unnecessary overflow:hidden from menubar in global style