### PR TITLE
fix: improve handling extra menu nodes on left tabbar

### DIFF
--- a/packages/ai-native/src/browser/layout/tabbar.view.tsx
+++ b/packages/ai-native/src/browser/layout/tabbar.view.tsx
@@ -107,6 +107,7 @@ const AILeftTabbarRenderer: React.FC = () => {
             ? navMenu.map((menu) => (
                 <EnhanceIconWithCtxMenu
                   key={menu.id}
+                  id={menu.id}
                   wrapperClassName={styles.extra_bottom_icon}
                   iconClass={menu.icon}
                   menuNodes={menu.children}

--- a/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
+++ b/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
@@ -1,6 +1,8 @@
 import cls from 'classnames';
 import React, { useCallback } from 'react';
 
+import { CommandService } from '@opensumi/ide-core-common';
+
 import { Icon } from '../../../components';
 import { MenuNode } from '../../../menu/next/base';
 import { IBrowserCtxMenu } from '../../../menu/next/renderer/ctxmenu/browser';
@@ -40,6 +42,7 @@ export const EnhanceIcon = React.forwardRef<HTMLDivElement | null, IEnhanceIconP
 );
 
 interface IEnhanceIconWithCtxMenuProps extends IEnhanceIconProps {
+  id: string;
   menuNodes: MenuNode[];
   skew?: { x: number; y: number };
 }
@@ -48,7 +51,8 @@ interface IEnhanceIconWithCtxMenuProps extends IEnhanceIconProps {
  * 包含下拉菜单的 icon 组件，可以自定义下拉菜单位置
  */
 export const EnhanceIconWithCtxMenu = (props: IEnhanceIconWithCtxMenuProps) => {
-  const { children, menuNodes, skew, ...restProps } = props;
+  const { children, menuNodes, skew, id, ...restProps } = props;
+  const commandService = useInjectable<CommandService>(CommandService);
 
   const ctxMenuRenderer = useInjectable<IBrowserCtxMenu>(IBrowserCtxMenu);
   const [anchor, setAnchor] = React.useState<{ x: number; y: number } | undefined>(undefined);
@@ -89,14 +93,19 @@ export const EnhanceIconWithCtxMenu = (props: IEnhanceIconWithCtxMenuProps) => {
     if (!anchor) {
       return;
     }
-
-    handleRefRect((_anchor) => {
-      ctxMenuRenderer.show({
-        anchor: _anchor,
-        menuNodes,
+    if (menuNodes) {
+      handleRefRect((_anchor) => {
+        ctxMenuRenderer.show({
+          anchor: _anchor,
+          menuNodes,
+        });
       });
-    });
-  }, [iconRef.current, menuNodes, anchor]);
+    } else {
+      try {
+        commandService.executeCommand(id);
+      } catch {}
+    }
+  }, [iconRef.current, menuNodes, anchor, id]);
 
   return (
     <EnhanceIcon ref={iconRef} onClick={handleClick} {...restProps}>

--- a/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
+++ b/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
@@ -51,7 +51,7 @@ interface IEnhanceIconWithCtxMenuProps extends IEnhanceIconProps {
  * 包含下拉菜单的 icon 组件，可以自定义下拉菜单位置
  */
 export const EnhanceIconWithCtxMenu = (props: IEnhanceIconWithCtxMenuProps) => {
-  const { children, menuNodes, skew, id, ...restProps } = props;
+  const { children, menuNodes, skew, id: commandId, ...restProps } = props;
   const commandService = useInjectable<CommandService>(CommandService);
 
   const ctxMenuRenderer = useInjectable<IBrowserCtxMenu>(IBrowserCtxMenu);
@@ -102,10 +102,10 @@ export const EnhanceIconWithCtxMenu = (props: IEnhanceIconWithCtxMenuProps) => {
       });
     } else {
       try {
-        commandService.executeCommand(id);
+        commandService.executeCommand(commandId);
       } catch {}
     }
-  }, [iconRef.current, menuNodes, anchor, id]);
+  }, [iconRef.current, menuNodes, anchor, commandId]);
 
   return (
     <EnhanceIcon ref={iconRef} onClick={handleClick} {...restProps}>

--- a/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
+++ b/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
@@ -42,7 +42,7 @@ export const EnhanceIcon = React.forwardRef<HTMLDivElement | null, IEnhanceIconP
 );
 
 interface IEnhanceIconWithCtxMenuProps extends IEnhanceIconProps {
-  id: string;
+  id?: string;
   menuNodes: MenuNode[];
   skew?: { x: number; y: number };
 }
@@ -100,7 +100,7 @@ export const EnhanceIconWithCtxMenu = (props: IEnhanceIconWithCtxMenuProps) => {
           menuNodes,
         });
       });
-    } else {
+    } else if (commandId) {
       try {
         commandService.executeCommand(commandId);
       } catch {}

--- a/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
+++ b/packages/core-browser/src/components/ai-native/enhanceIcon/index.tsx
@@ -101,9 +101,7 @@ export const EnhanceIconWithCtxMenu = (props: IEnhanceIconWithCtxMenuProps) => {
         });
       });
     } else if (commandId) {
-      try {
-        commandService.executeCommand(commandId);
-      } catch {}
+      commandService.executeCommand(commandId);
     }
   }, [iconRef.current, menuNodes, anchor, commandId]);
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

支持仅注册了 command 命令的按钮展示及执行

### Changelog

improve handling extra menu nodes on left tabbar