### PR TITLE
feat: prevent accidentally opening binary file

### DIFF
--- a/packages/ai-native/src/browser/widget/light-bulb/index.ts
+++ b/packages/ai-native/src/browser/widget/light-bulb/index.ts
@@ -1,6 +1,5 @@
 import { asClassNameArrayWrapper } from '@opensumi/ide-core-browser';
-import { Sumicon } from '@opensumi/ide-core-common/lib/codicons';
-import { Codicon } from '@opensumi/monaco-editor-core/esm/vs/base/common/codicons';
+import { Codicon, Sumicon } from '@opensumi/ide-core-common/lib/codicons';
 import { ThemeIcon } from '@opensumi/monaco-editor-core/esm/vs/base/common/themables';
 import {
   LightBulbState,

--- a/packages/debug/__tests__/browser/view/configuration/debug-configuration.service.test.ts
+++ b/packages/debug/__tests__/browser/view/configuration/debug-configuration.service.test.ts
@@ -1,7 +1,6 @@
 import { PreferenceService } from '@opensumi/ide-core-browser';
 import { Disposable, EventBusImpl, IEventBus, StorageProvider, URI } from '@opensumi/ide-core-common';
-import { IDebugSessionManager } from '@opensumi/ide-debug';
-import { DEFAULT_CONFIGURATION_NAME_SEPARATOR } from '@opensumi/ide-debug';
+import { DEFAULT_CONFIGURATION_NAME_SEPARATOR, IDebugSessionManager } from '@opensumi/ide-debug';
 import { DebugConfigurationManager } from '@opensumi/ide-debug/lib/browser/debug-configuration-manager';
 import { DebugConfigurationService } from '@opensumi/ide-debug/lib/browser/view/configuration/debug-configuration.service';
 import { DebugConsoleService } from '@opensumi/ide-debug/lib/browser/view/console/debug-console.service';
@@ -64,6 +63,7 @@ describe('Debug Configuration Service', () => {
   const mockPreferenceService = {
     onPreferenceChanged: jest.fn(),
     get: jest.fn(() => true),
+    getValid: jest.fn(() => true),
   };
 
   const mockDebugConsoleService = {

--- a/packages/editor/src/browser/component.ts
+++ b/packages/editor/src/browser/component.ts
@@ -108,7 +108,7 @@ export class EditorComponentRegistryImpl implements EditorComponentRegistry {
     let results: IEditorOpenType[] = [];
     const resolvers = this.getResolvers(resource.uri.scheme).slice(); // 防止异步操作时数组被改变
     let shouldBreak = false;
-    const resolve = (res) => {
+    const resolve = (res: IEditorOpenType[]) => {
       results = res;
       shouldBreak = true;
     };

--- a/packages/editor/src/browser/fs-resource/fs-editor-doc.ts
+++ b/packages/editor/src/browser/fs-resource/fs-editor-doc.ts
@@ -110,7 +110,10 @@ export class BaseFileSystemEditorDocumentProvider implements IEditorDocumentMode
         uri.toString(),
         getLanguageIdFromMonaco(uri)!,
       );
+
+    // TODO: 应该挪到后端去做
     const detected = await detectEncodingFromBuffer(buffer, guessEncoding);
+
     detected.encoding = await this.getReadEncoding(uri, options, detected.encoding);
 
     const content = buffer.toString(detected.encoding);
@@ -132,6 +135,7 @@ export class BaseFileSystemEditorDocumentProvider implements IEditorDocumentMode
     // TODO: 这部分要优化成buffer获取（长期来看是stream获取，encoding在哪一层做？）
     // 暂时还是使用 resolveContent 内提供的 decode 功能
     // 之后 encoding 做了分层之后和其他的需要 decode 的地方一起改
+
     return (await this.read(uri, { encoding })).content;
   }
 

--- a/packages/editor/src/browser/fs-resource/fs-resource.ts
+++ b/packages/editor/src/browser/fs-resource/fs-resource.ts
@@ -129,7 +129,6 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
   }
 
   async provideResource(uri: URI): Promise<IResource<any>> {
-    // 获取文件类型 getFileType: (path: string) => string
     await this.ready;
     this.involvedFiles.add(uri.codeUri.fsPath);
     return Promise.all([

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1631,7 +1631,7 @@ const customEditorSchema: PreferenceSchemaProperties = {
   },
   'editor.largeFile': {
     type: 'number',
-    default: 4 * 1024 * 1024 * 1024,
+    default: 4 * 1024 * 1024 * 1024, // 4096 MB
     description: '%editor.configuration.largeFileSize%',
   },
   'editor.quickSuggestionsDelay': {

--- a/packages/editor/src/browser/types.ts
+++ b/packages/editor/src/browser/types.ts
@@ -114,13 +114,10 @@ export class RegisterEditorComponentEvent extends BasicEvent<string> {}
 export abstract class EditorComponentRegistry {
   abstract registerEditorComponent<T>(component: IEditorComponent<T>, initialProps?: any): IDisposable;
 
-  // 等同于 handlesScheme => 10
-  abstract registerEditorComponentResolver<T>(scheme: string, resolver: IEditorComponentResolver<T>): IDisposable;
-
-  // handlesScheme 返回权重， 小于 0 表示不处理
   abstract registerEditorComponentResolver<T>(
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
-    handlesScheme: (scheme: string) => number,
+    handlesScheme:
+      | string // 等同于 handlesScheme => 10
+      | ((scheme: string) => number), // handlesScheme 返回权重， 小于 0 表示不处理
     resolver: IEditorComponentResolver<T>,
   ): IDisposable;
 

--- a/packages/extension/src/browser/vscode/api/main.thread.doc.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.doc.ts
@@ -116,7 +116,7 @@ export class MainThreadExtensionDocumentData extends WithEventBus implements IMa
         this.docSyncEnabled.set(
           uriString,
           docRef.instance.getMonacoModel().getValueLength() <
-            (this.preference.get<number>('editor.docExtHostSyncMaxSize') || 4 * 1024 * 1024 * 1024),
+            this.preference.getValid<number>('editor.docExtHostSyncMaxSize', 4 * 1024 * 1024 * 1024),
         );
         docRef.dispose();
       }

--- a/packages/file-scheme/__tests__/browser/contribution.test.ts
+++ b/packages/file-scheme/__tests__/browser/contribution.test.ts
@@ -1,4 +1,6 @@
 import { PreferenceService, URI } from '@opensumi/ide-core-browser';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import {
   BrowserEditorContribution,
   EditorComponentRegistry,
@@ -12,9 +14,6 @@ import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { ILanguageService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
 import { StandaloneServices } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
-
 const createMockResource = (uriString: string) => ({ uri: new URI(uriString) } as any as IResource);
 
 const mockFileService = {
@@ -27,6 +26,7 @@ const mockFileService = {
 const mockPreferenceService = {
   onPreferenceChanged: jest.fn(),
   get: jest.fn(() => undefined),
+  getValid: jest.fn(() => undefined),
   ready: Promise.resolve(),
 };
 

--- a/packages/file-scheme/__tests__/browser/contribution.test.ts
+++ b/packages/file-scheme/__tests__/browser/contribution.test.ts
@@ -26,7 +26,7 @@ const mockFileService = {
 const mockPreferenceService = {
   onPreferenceChanged: jest.fn(),
   get: jest.fn(() => undefined),
-  getValid: jest.fn(() => undefined),
+  getValid: jest.fn((_, defaultValue) => defaultValue),
   ready: Promise.resolve(),
 };
 

--- a/packages/file-scheme/src/browser/external.view.tsx
+++ b/packages/file-scheme/src/browser/external.view.tsx
@@ -9,7 +9,7 @@ import {
   WorkbenchEditorService,
 } from '@opensumi/ide-editor/lib/browser';
 
-import styles from './style.module.less';
+import { PreventComponent } from './prevent.view';
 
 export const BinaryEditorComponent: ReactEditorComponent<null> = (props) => {
   const srcPath = props.resource.uri.codeUri.fsPath;
@@ -29,14 +29,19 @@ export const BinaryEditorComponent: ReactEditorComponent<null> = (props) => {
     eventBus.fire(new ResourceOpenTypeChangedEvent(current.uri));
   };
 
-  return (
-    <div className={styles.external}>
-      {localize('editor.cannotOpenBinary')}
-      <a onClick={() => handleClick()}>{localize('editor.file.prevent.stillOpen')}</a>
+  const actions = [
+    {
+      label: localize('editor.file.prevent.stillOpen'),
+      onClick: () => handleClick(),
+    },
+  ];
 
-      {appConfig.isElectronRenderer ? (
-        <a onClick={() => injector.get(IElectronMainUIService).openPath(srcPath)}>{localize('editor.openExternal')}</a>
-      ) : null}
-    </div>
-  );
+  if (appConfig.isElectronRenderer) {
+    actions.push({
+      label: localize('editor.openExternal'),
+      onClick: () => injector.get(IElectronMainUIService).openPath(srcPath),
+    });
+  }
+
+  return <PreventComponent description={localize('editor.cannotOpenBinary')} actions={actions} />;
 };

--- a/packages/file-scheme/src/browser/external.view.tsx
+++ b/packages/file-scheme/src/browser/external.view.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
 import { INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import { AppConfig, localize, useInjectable } from '@opensumi/ide-core-browser';
+import { AppConfig, IEventBus, localize, useInjectable } from '@opensumi/ide-core-browser';
 import { IElectronMainUIService } from '@opensumi/ide-core-common/lib/electron';
-import { ReactEditorComponent } from '@opensumi/ide-editor/lib/browser';
+import {
+  ReactEditorComponent,
+  ResourceOpenTypeChangedEvent,
+  WorkbenchEditorService,
+} from '@opensumi/ide-editor/lib/browser';
 
 import styles from './style.module.less';
 
@@ -11,10 +15,25 @@ export const BinaryEditorComponent: ReactEditorComponent<null> = (props) => {
   const srcPath = props.resource.uri.codeUri.fsPath;
   const injector: Injector = useInjectable(INJECTOR_TOKEN);
   const appConfig: AppConfig = useInjectable(AppConfig);
+  const editorService = useInjectable<WorkbenchEditorService>(WorkbenchEditorService);
+  const eventBus = useInjectable<IEventBus>(IEventBus);
+
+  const handleClick = () => {
+    const current = editorService.currentResource;
+
+    if (!current) {
+      return;
+    }
+
+    current.metadata = { ...current.metadata, skipPreventBinary: true };
+    eventBus.fire(new ResourceOpenTypeChangedEvent(current.uri));
+  };
 
   return (
     <div className={styles.external}>
       {localize('editor.cannotOpenBinary')}
+      <a onClick={() => handleClick()}>{localize('editor.file.prevent.stillOpen')}</a>
+
       {appConfig.isElectronRenderer ? (
         <a onClick={() => injector.get(IElectronMainUIService).openPath(srcPath)}>{localize('editor.openExternal')}</a>
       ) : null}

--- a/packages/file-scheme/src/browser/file-scheme.contribution.ts
+++ b/packages/file-scheme/src/browser/file-scheme.contribution.ts
@@ -106,6 +106,8 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
     editorComponentRegistry.registerEditorComponentResolver(
       (scheme: string) => (scheme === Schemes.file || this.fileServiceClient.handlesScheme(scheme) ? 10 : -1),
       (resource: IResource<any>, results: IEditorOpenType[]) => {
+        const { metadata, uri } = resource as { uri: URI; metadata: any };
+
         if (results.length === 0) {
           results.push({
             type: EditorOpenType.component,
@@ -120,36 +122,50 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
       async (resource: IResource<any>, results: IEditorOpenType[]) => {
         const type = await this.getFileType(resource.uri.toString());
 
-        if (type === 'image') {
-          results.push({
-            type: EditorOpenType.component,
-            componentId: IMAGE_PREVIEW_COMPONENT_ID,
-          });
-        }
-
-        if (type === 'video') {
-          results.push({
-            type: EditorOpenType.component,
-            componentId: VIDEO_PREVIEW_COMPONENT_ID,
-          });
-        }
-
-        if (type === 'text') {
-          const { metadata, uri } = resource as { uri: URI; metadata: any };
-          const stat = await this.fileServiceClient.getFileStat(uri.toString());
-          await this.preference.ready;
-          const maxSize = this.preference.get<number>('editor.largeFile') || 4 * 1024 * 1024 * 1024;
-
-          if (stat && (stat.size || 0) > maxSize && !(metadata || {}).noPrevent) {
+        switch (type) {
+          case 'image': {
             results.push({
               type: EditorOpenType.component,
-              componentId: LARGE_FILE_PREVENT_COMPONENT_ID,
+              componentId: IMAGE_PREVIEW_COMPONENT_ID,
             });
-          } else {
+            break;
+          }
+          case 'video': {
             results.push({
-              type: EditorOpenType.code,
-              title: localize('editorOpenType.code'),
+              type: EditorOpenType.component,
+              componentId: VIDEO_PREVIEW_COMPONENT_ID,
             });
+            break;
+          }
+          case 'binary':
+          case 'text': {
+            const { metadata: _metadata, uri } = resource as { uri: URI; metadata: any };
+            const metadata = _metadata || {};
+
+            const skipPreventTooLarge = metadata.skipPreventTooLarge;
+            const skipPreventBinary = metadata.skipPreventBinary;
+
+            // 二进制文件不支持打开
+            if (type === 'binary' && !skipPreventBinary) {
+              break;
+            }
+
+            const stat = await this.fileServiceClient.getFileStat(uri.toString());
+            await this.preference.ready;
+            const maxSize = this.preference.getValid<number>('editor.largeFile', 4 * 1024 * 1024 * 1024);
+
+            if (stat && (stat.size || 0) > maxSize && !skipPreventTooLarge) {
+              results.push({
+                type: EditorOpenType.component,
+                componentId: LARGE_FILE_PREVENT_COMPONENT_ID,
+              });
+            } else {
+              results.push({
+                type: EditorOpenType.code,
+                title: localize('editorOpenType.code'),
+              });
+            }
+            break;
           }
         }
       },

--- a/packages/file-scheme/src/browser/file-scheme.contribution.ts
+++ b/packages/file-scheme/src/browser/file-scheme.contribution.ts
@@ -106,8 +106,6 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
     editorComponentRegistry.registerEditorComponentResolver(
       (scheme: string) => (scheme === Schemes.file || this.fileServiceClient.handlesScheme(scheme) ? 10 : -1),
       (resource: IResource<any>, results: IEditorOpenType[]) => {
-        const { metadata, uri } = resource as { uri: URI; metadata: any };
-
         if (results.length === 0) {
           results.push({
             type: EditorOpenType.component,
@@ -139,14 +137,11 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
           }
           case 'binary':
           case 'text': {
-            const { metadata: _metadata, uri } = resource as { uri: URI; metadata: any };
+            const { metadata: _metadata, uri } = resource;
             const metadata = _metadata || {};
 
-            const skipPreventTooLarge = metadata.skipPreventTooLarge;
-            const skipPreventBinary = metadata.skipPreventBinary;
-
             // 二进制文件不支持打开
-            if (type === 'binary' && !skipPreventBinary) {
+            if (type === 'binary' && !metadata.skipPreventBinary) {
               break;
             }
 
@@ -154,7 +149,7 @@ export class FileSystemEditorComponentContribution implements BrowserEditorContr
             await this.preference.ready;
             const maxSize = this.preference.getValid<number>('editor.largeFile', 4 * 1024 * 1024 * 1024);
 
-            if (stat && (stat.size || 0) > maxSize && !skipPreventTooLarge) {
+            if (stat && (stat.size || 0) > maxSize && !metadata.skipPreventTooLarge) {
               results.push({
                 type: EditorOpenType.component,
                 componentId: LARGE_FILE_PREVENT_COMPONENT_ID,

--- a/packages/file-scheme/src/browser/prevent.view.tsx
+++ b/packages/file-scheme/src/browser/prevent.view.tsx
@@ -1,10 +1,35 @@
+import cls from 'classnames';
 import React from 'react';
 
-import { IEventBus, localize, useInjectable } from '@opensumi/ide-core-browser';
+import { IEventBus, getExternalIcon, localize, useInjectable } from '@opensumi/ide-core-browser';
+import { Button } from '@opensumi/ide-core-browser/lib/components';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { ResourceOpenTypeChangedEvent } from '@opensumi/ide-editor/lib/browser/types';
 
 import styles from './style.module.less';
+
+interface PreventComponentProps {
+  description: string;
+
+  actions: {
+    label: string;
+    onClick: () => void;
+  }[];
+}
+export const PreventComponent: React.FC<PreventComponentProps> = (props: PreventComponentProps) => (
+  <div className={styles['error-page']}>
+    <div className={cls(styles.icon, getExternalIcon('warning'))}></div>
+    <div className={styles['description']}>{props.description}</div>
+
+    <div className={styles['actions-wrapper']}>
+      {props.actions.map((action, index) => (
+        <Button key={index} onClick={() => action.onClick()} className={styles['action-button']}>
+          {action.label}
+        </Button>
+      ))}
+    </div>
+  </div>
+);
 
 export const LargeFilePrevent = () => {
   const editorService = useInjectable<WorkbenchEditorService>(WorkbenchEditorService);
@@ -22,9 +47,14 @@ export const LargeFilePrevent = () => {
   };
 
   return (
-    <div className={styles.font}>
-      {localize('editor.largeFile.prevent')}
-      <a onClick={() => handleClick()}>{localize('editor.file.prevent.stillOpen')}</a>
-    </div>
+    <PreventComponent
+      description={localize('editor.largeFile.prevent')}
+      actions={[
+        {
+          label: localize('editor.file.prevent.stillOpen'),
+          onClick: () => handleClick(),
+        },
+      ]}
+    />
   );
 };

--- a/packages/file-scheme/src/browser/prevent.view.tsx
+++ b/packages/file-scheme/src/browser/prevent.view.tsx
@@ -17,14 +17,14 @@ export const LargeFilePrevent = () => {
       return;
     }
 
-    current.metadata = { noPrevent: true };
+    current.metadata = { ...current.metadata, skipPreventTooLarge: true };
     eventBus.fire(new ResourceOpenTypeChangedEvent(current.uri));
   };
 
   return (
     <div className={styles.font}>
       {localize('editor.largeFile.prevent')}
-      <a onClick={() => handleClick()}>{localize('editor.largeFile.prevent.stillOpen')}</a>
+      <a onClick={() => handleClick()}>{localize('editor.file.prevent.stillOpen')}</a>
     </div>
   );
 };

--- a/packages/file-scheme/src/browser/style.module.less
+++ b/packages/file-scheme/src/browser/style.module.less
@@ -50,11 +50,42 @@
   height: 100%;
 }
 
-.external {
-  padding: 10px;
-}
+.error-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-.font {
-  padding: 4px;
+  flex-direction: column;
+
   font-size: 12px;
+  padding: 10px;
+
+  height: 100%;
+  width: 100%;
+
+  user-select: none;
+
+  & .icon {
+    font-size: 40px !important;
+    color: var(--kt-modalWarningIcon-foreground);
+  }
+
+  .description {
+    width: 100%;
+    margin-top: 4px;
+
+    text-align: center;
+
+    font-size: 14px;
+  }
+
+  & .action-wrapper {
+    display: flex;
+    width: 100%;
+  }
+
+  & .action-button {
+    margin-top: 20px;
+    font-size: 13px;
+  }
 }

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -22,7 +22,7 @@
     "@opensumi/ide-core-node": "workspace:*",
     "@opensumi/ide-logs": "workspace:*",
     "@parcel/watcher": "2.1.0",
-    "file-type": "^12.0.0",
+    "file-type": "16.5.3",
     "nsfw": "2.2.0",
     "trash": "^5.2.0",
     "vscode-languageserver-types": "^3.16.0",

--- a/packages/file-service/src/common/file-ext.ts
+++ b/packages/file-service/src/common/file-ext.ts
@@ -29,6 +29,7 @@ export const EXT_LIST_IMAGE = new Set([
 export const EXT_LIST_TEXT = new Set(['xml']);
 
 export const enum EditorFileType {
+  Directory = 'directory',
   Text = 'text',
   Image = 'image',
   Video = 'video',

--- a/packages/file-service/src/common/file-ext.ts
+++ b/packages/file-service/src/common/file-ext.ts
@@ -1,6 +1,6 @@
-export const EXT_LIST_VIDEO = ['mp4', 'webm', 'mkv', 'mov', 'mts', 'flv', 'avi', 'wmv'];
+export const EXT_LIST_VIDEO = new Set(['mp4', 'webm', 'mkv', 'mov', 'mts', 'flv', 'avi', 'wmv']);
 
-export const EXT_LIST_IMAGE = [
+export const EXT_LIST_IMAGE = new Set([
   'png',
   'gif',
   'jpg',
@@ -24,7 +24,9 @@ export const EXT_LIST_IMAGE = [
   'orf',
   'webp',
   'apng',
-];
+]);
+
+export const EXT_LIST_TEXT = new Set(['xml']);
 
 export const enum EditorFileType {
   Text = 'text',
@@ -39,11 +41,13 @@ export function getFileTypeByExt(ext?: string) {
     return type;
   }
 
-  if (EXT_LIST_IMAGE.indexOf(ext) !== -1) {
+  if (EXT_LIST_IMAGE.has(ext)) {
     type = EditorFileType.Image;
-  } else if (EXT_LIST_VIDEO.indexOf(ext) !== -1) {
+  } else if (EXT_LIST_VIDEO.has(ext)) {
     type = EditorFileType.Video;
-  } else if (ext && ['xml'].indexOf(ext) === -1) {
+  } else if (EXT_LIST_TEXT.has(ext)) {
+    type = EditorFileType.Text;
+  } else {
     type = EditorFileType.Binary;
   }
 

--- a/packages/file-service/src/node/shared/file-type.ts
+++ b/packages/file-service/src/node/shared/file-type.ts
@@ -19,7 +19,7 @@ export async function getFileType(uri: string): Promise<string | undefined> {
     const stat = await fse.stat(fsPath);
 
     if (stat.isDirectory()) {
-      return 'directory';
+      return EditorFileType.Directory;
     } else {
       let ext: string | undefined;
       if (stat.size) {

--- a/packages/file-service/src/node/shared/file-type.ts
+++ b/packages/file-service/src/node/shared/file-type.ts
@@ -1,9 +1,12 @@
 import fileType from 'file-type';
 import * as fse from 'fs-extra';
 
-import { FileUri } from '@opensumi/ide-core-common';
+import { BinaryBuffer, Deferred, FileUri, detectEncodingFromBuffer } from '@opensumi/ide-core-common';
+import { listenReadable } from '@opensumi/ide-utils/lib/stream';
 
 import { EditorFileType, getFileTypeByExt, isErrnoException } from '../../common';
+
+const NO_ENCODING_GUESS_MIN_BYTES = 512; // when not auto guessing the encoding, small number of bytes are enough
 
 export async function getFileType(uri: string): Promise<string | undefined> {
   try {
@@ -11,25 +14,73 @@ export async function getFileType(uri: string): Promise<string | undefined> {
     if (!uri.startsWith('file:/')) {
       return getFileTypeByExt();
     }
-    const stat = await fse.stat(FileUri.fsPath(uri));
+
+    const fsPath = FileUri.fsPath(uri);
+    const stat = await fse.stat(fsPath);
 
     if (stat.isDirectory()) {
       return 'directory';
     } else {
       let ext: string | undefined;
       if (stat.size) {
-        const type = await fileType.stream(fse.createReadStream(FileUri.fsPath(uri)));
+        const readStream = fse.createReadStream(fsPath);
+        const streamWithType = await fileType.stream(readStream);
+
         // 可以拿到 type.fileType 说明为二进制文件
-        if (type.fileType) {
-          if (type.fileType.mime) {
-            if (type.fileType.mime.startsWith('image/')) {
+        if (streamWithType.fileType) {
+          if (streamWithType.fileType.mime) {
+            if (streamWithType.fileType.mime.startsWith('image/')) {
               return EditorFileType.Image;
             }
-            if (type.fileType.mime.startsWith('video/')) {
+            if (streamWithType.fileType.mime.startsWith('video/')) {
               return EditorFileType.Video;
             }
           }
-          ext = type.fileType.ext;
+          ext = streamWithType.fileType.ext;
+        }
+
+        if (!ext) {
+          const bufferedChunks: Uint8Array[] = [];
+          let bytesBuffered = 0;
+
+          const deferred = new Deferred<boolean | undefined>();
+
+          let decoded = false;
+
+          const decodeStream = async () => {
+            decoded = true;
+            const detected = await detectEncodingFromBuffer(BinaryBuffer.concat(bufferedChunks), false);
+
+            deferred.resolve(detected.seemsBinary);
+          };
+
+          // read file stream
+          listenReadable(readStream, {
+            onData: async (chunk) => {
+              bufferedChunks.push(chunk);
+              bytesBuffered += chunk.byteLength;
+
+              // buffered enough data for encoding detection, create stream
+              if (bytesBuffered >= NO_ENCODING_GUESS_MIN_BYTES) {
+                readStream.pause();
+
+                await decodeStream();
+                setTimeout(() => readStream.destroy());
+              }
+            },
+            onEnd: async () => {
+              if (!decoded) {
+                await decodeStream();
+              }
+            },
+          });
+          const isBinary = await deferred.promise;
+
+          readStream.destroy();
+          streamWithType.destroy();
+          if (isBinary) {
+            return EditorFileType.Binary;
+          }
         }
       }
       return getFileTypeByExt(ext);

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -970,7 +970,7 @@ export const localizationBundle = {
       'Controls whether the diff editor shows changes in leading or trailing whitespace as diffs.',
     'diffEditor.action.toggleCollapseUnchangedRegions': 'Toggle Collapse Unchanged Regions',
 
-    'editor.largeFile.prevent': 'The file is too large, continuing to open it may cause it to jam or crash.',
+    'editor.largeFile.prevent': 'The file is too large, continuing to open it may cause lag or crash.',
     'editor.autoSave.enum.off': 'OFF',
     'editor.autoSave.enum.editorFocusChange': 'When editor focus changed',
     'editor.autoSave.enum.afterDelay': 'Save after delay',

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -113,7 +113,7 @@ export const localizationBundle = {
     'editor.closeTab.title': 'Close ({0})',
     'editor.closeCurrent': 'Close Current Editor',
     'editor.openExternal': 'Open Externally',
-    'editor.cannotOpenBinary': 'Cannot open binary file in this editor.',
+    'editor.cannotOpenBinary': 'The file is not displayed in the text editor because it is binary.',
     'editor.splitToLeft': 'Split To Left',
     'editor.splitToRight': 'Split To Right',
     'editor.splitToTop': 'Split To Top',
@@ -604,7 +604,7 @@ export const localizationBundle = {
     'editor.configuration.autoSaveDelay':
       "Controls the delay in ms after which a dirty file is saved automatically. Only applies when `#editor.formatOnSave#` is set to 'Save After Delay'.",
     'editor.configuration.forceReadOnly': 'If Enable readOnly',
-    'editor.configuration.largeFileSize': 'Custom size of the large file',
+    'editor.configuration.largeFileSize': 'Custom size of the large file (B)',
     'editor.configuration.fontFamily': 'Controls the font family.',
     'editor.configuration.fontWeight':
       'Controls the font weight. Accepts "normal" and "bold" keywords or numbers between 1 and 1000.',
@@ -975,7 +975,7 @@ export const localizationBundle = {
     'editor.autoSave.enum.editorFocusChange': 'When editor focus changed',
     'editor.autoSave.enum.afterDelay': 'Save after delay',
     'editor.autoSave.enum.windowLostFocus': 'When window lost focus',
-    'editor.largeFile.prevent.stillOpen': 'Still open it.',
+    'editor.file.prevent.stillOpen': 'Open Anyway',
 
     'editor.workspaceSymbol.quickopen': 'Search Workspace Symbol',
     'editor.workspaceSymbolClass.quickopen': 'Search Workspace Class Symbol',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -109,7 +109,7 @@ export const localizationBundle = {
     'editor.closeTab.title': '关闭 ({0})',
     'editor.closeCurrent': '关闭当前编辑窗口',
     'editor.openExternal': '使用外部软件打开',
-    'editor.cannotOpenBinary': '我们无法在编辑器中展示这个文件。',
+    'editor.cannotOpenBinary': '无法在编辑器中展示二进制文件。',
     'editor.splitToLeft': '向左拆分',
     'editor.splitToRight': '向右拆分',
     'editor.splitToTop': '向上拆分',
@@ -552,7 +552,7 @@ export const localizationBundle = {
     'editor.tokenize.test': '获取选中字符串的Tokenize结果(console)',
 
     'editor.largeFile.prevent': '文件过大，继续打开可能会导致卡顿或者崩溃。',
-    'editor.largeFile.prevent.stillOpen': '仍要打开',
+    'editor.file.prevent.stillOpen': '仍要打开',
     'editor.closeEditorsInOtherGroups': '关闭其他组中的编辑器',
     'editor.resetEditorGroups': '重置编辑器组大小',
     'editor.revert': '还原文档',
@@ -1096,7 +1096,7 @@ export const localizationBundle = {
     'editor.configuration.tabSize':
       '控制 Tab 缩进等于的空格数。若启用 `#editor.detectIndentation#`，该设置可能会被覆盖',
     'editor.configuration.fontWeight': '控制字体粗细，接收 "normal" 和 "bold" 关键词或者 1 到 1000 数值。',
-    'editor.configuration.largeFileSize': '控制超大文件的自定义体积。',
+    'editor.configuration.largeFileSize': '控制超大文件的自定义体积。(单位：B)',
     'editor.configuration.preferredFormatter': '配置优先使用的格式化器。',
     'editor.configuration.wrapTab': '控制当编辑器 Tab 超过可用空间时，是否使用换行来代替滚动模式。',
     'editor.configuration.enablePreviewFromCodeNavigation': '控制当代码导航从其出发时，编辑器是否仍处于预览模式。',

--- a/packages/preferences/__tests__/browser/preference-settings.test.ts
+++ b/packages/preferences/__tests__/browser/preference-settings.test.ts
@@ -7,6 +7,8 @@ import {
   PreferenceService,
   URI,
 } from '@opensumi/ide-core-browser';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { PreferenceSettingId } from '@opensumi/ide-preferences';
 import { PREFERENCE_COMMANDS } from '@opensumi/ide-preferences/lib/browser/preference-contribution';
@@ -15,9 +17,6 @@ import {
   defaultSettingGroup,
   defaultSettingSections,
 } from '@opensumi/ide-preferences/lib/browser/preference-settings.service';
-
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 
 describe('PreferenceSettingService should be work', () => {
   let injector: MockInjector;
@@ -41,6 +40,11 @@ describe('PreferenceSettingService should be work', () => {
     mockPreferenceService = {
       set: jest.fn(),
       get: (key) => {
+        if (key === 'settings.userBeforeWorkspace') {
+          return true;
+        }
+      },
+      getValid: (key) => {
         if (key === 'settings.userBeforeWorkspace') {
           return true;
         }

--- a/packages/preferences/__tests__/browser/preference-settings.test.ts
+++ b/packages/preferences/__tests__/browser/preference-settings.test.ts
@@ -44,10 +44,12 @@ describe('PreferenceSettingService should be work', () => {
           return true;
         }
       },
-      getValid: (key) => {
+      getValid: (key, defaultValue) => {
         if (key === 'settings.userBeforeWorkspace') {
           return true;
         }
+
+        return defaultValue;
       },
       onSpecificPreferenceChange: () => Disposable.NULL,
       resolve: jest.fn(() => ({

--- a/packages/utils/src/buffer.ts
+++ b/packages/utils/src/buffer.ts
@@ -52,7 +52,7 @@ export class BinaryBuffer {
     }
   }
 
-  static concat(buffers: BinaryBuffer[], totalLength?: number): BinaryBuffer {
+  static concat(buffers: (BinaryBuffer | Uint8Array)[], totalLength?: number): BinaryBuffer {
     if (typeof totalLength === 'undefined') {
       totalLength = 0;
       for (let i = 0, len = buffers.length; i < len; i++) {

--- a/packages/workspace/__tests__/browser/workspace-service.test.ts
+++ b/packages/workspace/__tests__/browser/workspace-service.test.ts
@@ -52,12 +52,14 @@ describe('WorkspaceService should be work while workspace was a single directory
         return FILES_DEFAULTS.filesExclude;
       }
     },
-    getValid: (preferenceName: string) => {
+    getValid: (preferenceName: string, defaultValue) => {
       if (preferenceName === 'files.watcherExclude') {
         return FILES_DEFAULTS.filesWatcherExclude;
       } else if (preferenceName === 'files.exclude') {
         return FILES_DEFAULTS.filesExclude;
       }
+
+      return defaultValue;
     },
     inspect: jest.fn(),
   };

--- a/packages/workspace/__tests__/browser/workspace-service.test.ts
+++ b/packages/workspace/__tests__/browser/workspace-service.test.ts
@@ -1,14 +1,14 @@
 import { FILES_DEFAULTS, IClientApp, IWindowService, PreferenceService } from '@opensumi/ide-core-browser';
 import { MockedStorageProvider } from '@opensumi/ide-core-browser/__mocks__/storage';
 import { Disposable, StorageProvider, URI } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { DiskFileServicePath, FileStat } from '@opensumi/ide-file-service';
 import { MockFsProvider } from '@opensumi/ide-file-service/__mocks__/file-system-provider';
 import { IFileServiceClient } from '@opensumi/ide-file-service/lib/common';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { WorkspaceService } from '@opensumi/ide-workspace/lib/browser/workspace-service';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 import { WorkspaceModule } from '../../src/browser';
 import { WorkspacePreferences } from '../../src/browser/workspace-preferences';
 
@@ -46,6 +46,13 @@ describe('WorkspaceService should be work while workspace was a single directory
   const mockPreferenceService = {
     onPreferenceChanged: jest.fn(() => Disposable.create(() => {})),
     get: (preferenceName: string) => {
+      if (preferenceName === 'files.watcherExclude') {
+        return FILES_DEFAULTS.filesWatcherExclude;
+      } else if (preferenceName === 'files.exclude') {
+        return FILES_DEFAULTS.filesExclude;
+      }
+    },
+    getValid: (preferenceName: string) => {
       if (preferenceName === 'files.watcherExclude') {
         return FILES_DEFAULTS.filesWatcherExclude;
       } else if (preferenceName === 'files.exclude') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,7 +2515,7 @@ __metadata:
     "@opensumi/ide-dev-tool": "workspace:*"
     "@opensumi/ide-logs": "workspace:*"
     "@parcel/watcher": "npm:2.1.0"
-    file-type: "npm:^12.0.0"
+    file-type: "npm:16.5.3"
     nsfw: "npm:2.2.0"
     trash: "npm:^5.2.0"
     vscode-languageserver-types: "npm:^3.16.0"
@@ -3457,6 +3457,13 @@ __metadata:
   dependencies:
     defer-to-connect: "npm:^2.0.0"
   checksum: 10/c29df3bcec6fc3bdec2b17981d89d9c9fc9bd7d0c9bcfe92821dc533f4440bc890ccde79971838b4ceed1921d456973c4180d7175ee1d0023ad0562240a58d95
+  languageName: node
+  linkType: hard
+
+"@tokenizer/token@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@tokenizer/token@npm:0.3.0"
+  checksum: 10/889c1f1e63ac7c92c0ea22d4a2861142f1b43c3d92eb70ec42aa9e9851fab2e9952211d50f541b287781280df2f979bf5600a9c1f91fbc61b7fcf9994e9376a5
   languageName: node
   linkType: hard
 
@@ -9187,10 +9194,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:^12.0.0":
-  version: 12.4.2
-  resolution: "file-type@npm:12.4.2"
-  checksum: 10/92866cf59f87da2b35b6054478ca88ed07f324a834e5dabefea21ef54aba77fce20a5677523a09efe7934423ca74660838c19e940ee8683fe3d8e082493b8d99
+"file-type@npm:16.5.3":
+  version: 16.5.3
+  resolution: "file-type@npm:16.5.3"
+  dependencies:
+    readable-web-to-node-stream: "npm:^3.0.0"
+    strtok3: "npm:^6.2.4"
+    token-types: "npm:^4.1.1"
+  checksum: 10/2f2580539ac339fc02a8e2073325b91d4487a510e92925dc536c429f4c80097ad7707656853ebdda6b27382478d2f121bcbed005455e431c5c46d7b8198cf854
   languageName: node
   linkType: hard
 
@@ -15567,6 +15578,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"peek-readable@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "peek-readable@npm:4.1.0"
+  checksum: 10/97373215dcf382748645c3d22ac5e8dbd31759f7bd0c539d9fdbaaa7d22021838be3e55110ad0ed8f241c489342304b14a50dfee7ef3bcee2987d003b24ecc41
+  languageName: node
+  linkType: hard
+
 "pend@npm:^1.2.0, pend@npm:~1.2.0":
   version: 1.2.0
   resolution: "pend@npm:1.2.0"
@@ -16996,6 +17014,15 @@ __metadata:
     process: "npm:^0.11.10"
     string_decoder: "npm:^1.3.0"
   checksum: 10/01b128a559c5fd76a898495f858cf0a8839f135e6a69e3409f986e88460134791657eb46a2ff16826f331682a3c4d0c5a75cef5e52ef259711021ba52b1c2e82
+  languageName: node
+  linkType: hard
+
+"readable-web-to-node-stream@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "readable-web-to-node-stream@npm:3.0.2"
+  dependencies:
+    readable-stream: "npm:^3.6.0"
+  checksum: 10/d3a5bf9d707c01183d546a64864aa63df4d9cb835dfd2bf89ac8305e17389feef2170c4c14415a10d38f9b9bfddf829a57aaef7c53c8b40f11d499844bf8f1a4
   languageName: node
   linkType: hard
 
@@ -18496,6 +18523,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strtok3@npm:^6.2.4":
+  version: 6.3.0
+  resolution: "strtok3@npm:6.3.0"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    peek-readable: "npm:^4.1.0"
+  checksum: 10/98fba564d3830202aa3a6bcd5ccaf2cbd849bd87ae79ece91d337e1913916705a8e633c9577138d030a984f8ec987dea51807e01252f995cf5e183fdea35eb2b
+  languageName: node
+  linkType: hard
+
 "style-loader@npm:^3.3.4":
   version: 3.3.4
   resolution: "style-loader@npm:3.3.4"
@@ -18897,6 +18934,16 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10/952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
+"token-types@npm:^4.1.1":
+  version: 4.2.1
+  resolution: "token-types@npm:4.2.1"
+  dependencies:
+    "@tokenizer/token": "npm:^0.3.0"
+    ieee754: "npm:^1.2.1"
+  checksum: 10/2995257d246387e773758c3c92a3cc99d0c0bf13cbafe0de5d712e4c35ed298da6704e21545cb123fa1f1b42ad62936c35bbd0611018b735e78c30b8b22b42d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

如果用户不小心点击了 node 的 binary 文件，我们原来的识别无法识别到它是一个二进制文件。

现在复用了检测二进制的逻辑（和 vscode 保持一致）

![CleanShot 2024-06-13 at 14 05 53@2x](https://github.com/opensumi/core/assets/13938334/c433db8a-37a1-4677-92d9-aba6d290c5dd)

![CleanShot 2024-06-13 at 14 11 10@2x](https://github.com/opensumi/core/assets/13938334/e656446b-2d4f-435a-af01-155c133425a9)



### Changelog

prevent accidentally opening binary file
