### PR TITLE
fix: use ext message io for worker

### DIFF
--- a/packages/connection/src/common/rpc/message-io.ts
+++ b/packages/connection/src/common/rpc/message-io.ts
@@ -351,6 +351,11 @@ export class MessageIO extends IMessageIO<PlatformBuffer> {
   }
 }
 
+/**
+ * 请不要使用 RawMessageIO 作为与 Worker-Host 之间的通信协议
+ * 因为与插件层的通信需要正确的反序列化和序列化 Uri/URI/vscode-uri 这三种 uri
+ * TODO: 兼容 Uri/URI/vscode-uri 的序列化和反序列化
+ */
 export class RawMessageIO implements IMessageIO<RPCMessage> {
   Request(requestId: number, method: string, headers: IRequestHeaders, args: any[]): RPCRequestMessage {
     return {

--- a/packages/extension/src/browser/extension-worker.service.ts
+++ b/packages/extension/src/browser/extension-worker.service.ts
@@ -1,15 +1,15 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { warning } from '@opensumi/ide-components/lib/utils';
+import { IRPCProtocol, SumiConnectionMultiplexer, createExtMessageIO } from '@opensumi/ide-connection';
 import { BaseConnection } from '@opensumi/ide-connection/lib/common/connection';
 import { MessagePortConnection } from '@opensumi/ide-connection/lib/common/connection/drivers/message-port';
-import { RawMessageIO } from '@opensumi/ide-connection/lib/common/rpc';
-import { IRPCProtocol, SumiConnectionMultiplexer } from '@opensumi/ide-connection/lib/common/rpc/multiplexer';
 import { AppConfig, Deferred, IExtensionProps, ILogger, URI } from '@opensumi/ide-core-browser';
 import { Disposable, DisposableStore, path, toDisposable } from '@opensumi/ide-core-common';
 
 import { IExtension, IExtensionWorkerHost, WorkerHostAPIIdentifier } from '../common';
 import { ActivatedExtensionJSON } from '../common/activator';
 import { AbstractWorkerExtProcessService } from '../common/extension.service';
+import { knownProtocols } from '../common/vscode/protocols';
 
 import { getWorkerBootstrapUrl } from './loader';
 import { createSumiAPIFactory } from './sumi/main.thread.api.impl';
@@ -206,7 +206,7 @@ export class WorkerExtProcessService
     const protocol = new SumiConnectionMultiplexer(this.connection, {
       timeout: this.appConfig.rpcMessageTimeout,
       name: 'worker-ext-host',
-      io: new RawMessageIO(),
+      io: createExtMessageIO(knownProtocols),
     });
 
     this.logger.log('[Worker Host] web worker extension host ready');

--- a/packages/extension/src/hosted/worker.host.ts
+++ b/packages/extension/src/hosted/worker.host.ts
@@ -1,7 +1,6 @@
 import { Injector } from '@opensumi/di';
-import { ProxyIdentifier, SumiConnectionMultiplexer } from '@opensumi/ide-connection';
+import { ProxyIdentifier, SumiConnectionMultiplexer, createExtMessageIO } from '@opensumi/ide-connection';
 import { MessagePortConnection } from '@opensumi/ide-connection/lib/common/connection/drivers/message-port';
-import { RawMessageIO } from '@opensumi/ide-connection/lib/common/rpc';
 import {
   Deferred,
   Emitter,
@@ -22,6 +21,7 @@ import {
   MainThreadAPIIdentifier,
   SumiWorkerExtensionService,
 } from '../common/vscode';
+import { knownProtocols } from '../common/vscode/protocols';
 
 import { ExtensionContext } from './api/vscode/ext.host.extensions';
 import { ExtHostSecret } from './api/vscode/ext.host.secrets';
@@ -38,7 +38,7 @@ export function initRPCProtocol() {
   const msgPortConnection = new MessagePortConnection(channel.port1);
 
   const extProtocol = new SumiConnectionMultiplexer(msgPortConnection, {
-    io: new RawMessageIO(),
+    io: createExtMessageIO(knownProtocols),
   });
 
   return extProtocol;


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

3.1 把 worker host 弄挂了，应该是只会导致一些 api 挂掉（provideDocumentSymbols， provideDocumentHighlights）

-  https://github.com/opensumi/core/pull/3729

原因是，与 worker-host 的通信改成不进行序列化之后，Uri、URI 发过去会变成纯对象，纯对象 toString 后就变成 [Object object] 了

我们的序列化方案处理了 Uri、URI 发到对端后还是 Uri、URI

![CleanShot 2024-06-14 at 16 34 09@2x](https://github.com/opensumi/core/assets/13938334/a41e4d74-fbe9-43af-aa3a-3495ce62af2d)

### Changelog

use ext message io for worker
