### PR TITLE
fix: server's incorrect dispose of service center

### DIFF
--- a/packages/connection/__test__/browser/index.test.ts
+++ b/packages/connection/__test__/browser/index.test.ts
@@ -28,7 +28,7 @@ describe('connection browser', () => {
               furySerializer.serialize({
                 id: msgObj.id,
                 kind: 'server-ready',
-                token: '',
+                traceId: '',
               }),
             );
           } else if (msgObj.kind === 'data') {
@@ -66,7 +66,7 @@ describe('connection browser', () => {
       channel.dispatch({
         kind: 'server-ready',
         id: 'test',
-        token: '',
+        traceId: '',
       });
       await sleep(500);
       // message queue flushed

--- a/packages/connection/__test__/common/fury-extends/one-of.test.ts
+++ b/packages/connection/__test__/common/fury-extends/one-of.test.ts
@@ -36,7 +36,6 @@ describe('oneOf', () => {
       clientId: '123',
       id: '456',
       path: '/test',
-      connectionToken: 'abc',
     };
 
     testIt(obj3);

--- a/packages/connection/__test__/common/fury-extends/one-of.test.ts
+++ b/packages/connection/__test__/common/fury-extends/one-of.test.ts
@@ -43,7 +43,7 @@ describe('oneOf', () => {
     const obj4: ServerReadyMessage = {
       kind: 'server-ready',
       id: '456',
-      token: '',
+      traceId: '',
     };
 
     testIt(obj4);

--- a/packages/connection/__test__/common/fury-extends/one-of.test.ts
+++ b/packages/connection/__test__/common/fury-extends/one-of.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable no-console */
-
-import { OpenMessage, PingMessage, PongMessage, ServerReadyMessage, furySerializer } from '@opensumi/ide-connection';
+import { OpenMessage, PingMessage, PongMessage, ServerReadyMessage } from '../../../src/common/channel/types';
+import { furySerializer } from '../../../src/common/serializer';
 
 const parse = furySerializer.deserialize;
 const stringify = furySerializer.serialize;
@@ -9,11 +8,12 @@ describe('oneOf', () => {
   function testIt(obj: any) {
     const bytes = stringify(obj);
     const obj2 = parse(bytes);
-    expect(obj2).toEqual(obj);
-    const str = JSON.stringify(obj);
 
-    console.log('bytes.length', bytes.byteLength);
-    console.log('json length', str.length);
+    // 确保 obj 里的所有字段都在 obj2 里
+    // eslint-disable-next-line guard-for-in
+    for (const key in Object.keys(obj)) {
+      expect(obj2[key]).toEqual(obj[key]);
+    }
   }
 
   it('should serialize and deserialize', () => {
@@ -36,6 +36,7 @@ describe('oneOf', () => {
       clientId: '123',
       id: '456',
       path: '/test',
+      traceId: '',
     };
 
     testIt(obj3);

--- a/packages/connection/__test__/common/fury-extends/one-of.test.ts
+++ b/packages/connection/__test__/common/fury-extends/one-of.test.ts
@@ -36,7 +36,7 @@ describe('oneOf', () => {
       clientId: '123',
       id: '456',
       path: '/test',
-      traceId: '',
+      traceId: '12312312',
     };
 
     testIt(obj3);
@@ -44,7 +44,7 @@ describe('oneOf', () => {
     const obj4: ServerReadyMessage = {
       kind: 'server-ready',
       id: '456',
-      traceId: '',
+      traceId: '123123',
     };
 
     testIt(obj4);

--- a/packages/connection/src/common/channel/types.ts
+++ b/packages/connection/src/common/channel/types.ts
@@ -8,41 +8,43 @@ export type ChannelMessage =
   | CloseMessage
   | ErrorMessage;
 
+export interface BaseMessage {
+  kind: string;
+  id: string;
+  needAck?: boolean;
+  traceId?: string;
+}
+
 /**
  * `ping` and `pong` are used to detect whether the connection is alive.
  */
-export interface PingMessage {
+export interface PingMessage extends BaseMessage {
   kind: 'ping';
-  id: string;
 }
 
 /**
  * when server receive a `ping` message, it should reply a `pong` message, vice versa.
  */
-export interface PongMessage {
+export interface PongMessage extends BaseMessage {
   kind: 'pong';
-  id: string;
 }
 
 /**
  * `data` message indicate that the channel has received some data.
  * the `content` field is the data, it should be a string.
  */
-export interface DataMessage {
+export interface DataMessage extends BaseMessage {
   kind: 'data';
-  id: string;
   content: string;
 }
 
-export interface BinaryMessage {
+export interface BinaryMessage extends BaseMessage {
   kind: 'binary';
-  id: string;
   binary: Uint8Array;
 }
 
-export interface CloseMessage {
+export interface CloseMessage extends BaseMessage {
   kind: 'close';
-  id: string;
   code: number;
   reason: string;
 }
@@ -52,19 +54,17 @@ export interface CloseMessage {
  * `path` is used to identify which handler should be used to handle the channel.
  * `clientId` is used to identify the client.
  */
-export interface OpenMessage {
+export interface OpenMessage extends BaseMessage {
   kind: 'open';
-  id: string;
   path: string;
   clientId: string;
-  connectionToken: string;
 }
 
 export enum ErrorMessageCode {
   ChannelNotFound = 1,
 }
 
-export interface ErrorMessage {
+export interface ErrorMessage extends BaseMessage {
   kind: 'error';
   id: string;
   code: ErrorMessageCode;
@@ -75,7 +75,7 @@ export interface ErrorMessage {
  * when server receive a `open` message, it should reply a `server-ready` message.
  * this is indicate that the channel is ready to use.
  */
-export interface ServerReadyMessage {
+export interface ServerReadyMessage extends BaseMessage {
   kind: 'server-ready';
   id: string;
   token: string;

--- a/packages/connection/src/common/channel/types.ts
+++ b/packages/connection/src/common/channel/types.ts
@@ -78,5 +78,5 @@ export interface ErrorMessage extends BaseMessage {
 export interface ServerReadyMessage extends BaseMessage {
   kind: 'server-ready';
   id: string;
-  token: string;
+  traceId: string;
 }

--- a/packages/connection/src/common/channel/types.ts
+++ b/packages/connection/src/common/channel/types.ts
@@ -11,7 +11,6 @@ export type ChannelMessage =
 export interface BaseMessage {
   kind: string;
   id: string;
-  needAck?: boolean;
   traceId?: string;
 }
 
@@ -58,6 +57,7 @@ export interface OpenMessage extends BaseMessage {
   kind: 'open';
   path: string;
   clientId: string;
+  traceId: string;
 }
 
 export enum ErrorMessageCode {

--- a/packages/connection/src/common/rpc-service/center.ts
+++ b/packages/connection/src/common/rpc-service/center.ts
@@ -177,6 +177,7 @@ export class RPCServiceCenter implements IDisposable {
 
   dispose(): void {
     this._disposables.dispose();
+    this.proxies.forEach((proxy) => proxy.dispose());
   }
 }
 

--- a/packages/connection/src/common/rpc-service/center.ts
+++ b/packages/connection/src/common/rpc-service/center.ts
@@ -178,6 +178,7 @@ export class RPCServiceCenter implements IDisposable {
   dispose(): void {
     this._disposables.dispose();
     this.proxies.forEach((proxy) => proxy.dispose());
+    this.proxies = [];
   }
 }
 

--- a/packages/connection/src/common/serializer/fury.ts
+++ b/packages/connection/src/common/serializer/fury.ts
@@ -5,6 +5,14 @@ import { oneOf } from '../fury-extends/one-of';
 
 import { ISerializer } from './types';
 
+function baseFields() {
+  return {
+    id: Type.string(),
+    needAck: Type.bool(),
+    traceId: Type.string(),
+  };
+}
+
 export const PingProtocol = Type.object('ping', {
   id: Type.string(),
 });
@@ -14,35 +22,34 @@ export const PongProtocol = Type.object('pong', {
 });
 
 export const OpenProtocol = Type.object('open', {
+  ...baseFields(),
   clientId: Type.string(),
-  id: Type.string(),
   path: Type.string(),
-  connectionToken: Type.string(),
 });
 
 export const ServerReadyProtocol = Type.object('server-ready', {
-  id: Type.string(),
+  ...baseFields(),
   token: Type.string(),
 });
 
 export const ErrorProtocol = Type.object('error', {
-  id: Type.string(),
+  ...baseFields(),
   code: Type.uint16(),
   message: Type.string(),
 });
 
 export const DataProtocol = Type.object('data', {
-  id: Type.string(),
+  ...baseFields(),
   content: Type.string(),
 });
 
 export const BinaryProtocol = Type.object('binary', {
-  id: Type.string(),
+  ...baseFields(),
   binary: Type.binary(),
 });
 
 export const CloseProtocol = Type.object('close', {
-  id: Type.string(),
+  ...baseFields(),
   code: Type.uint32(),
   reason: Type.string(),
 });

--- a/packages/connection/src/common/serializer/fury.ts
+++ b/packages/connection/src/common/serializer/fury.ts
@@ -28,7 +28,7 @@ export const OpenProtocol = Type.object('open', {
 
 export const ServerReadyProtocol = Type.object('server-ready', {
   ...baseFields(),
-  token: Type.string(),
+  traceId: Type.string(),
 });
 
 export const ErrorProtocol = Type.object('error', {

--- a/packages/connection/src/common/serializer/fury.ts
+++ b/packages/connection/src/common/serializer/fury.ts
@@ -8,23 +8,22 @@ import { ISerializer } from './types';
 function baseFields() {
   return {
     id: Type.string(),
-    needAck: Type.bool(),
-    traceId: Type.string(),
   };
 }
 
 export const PingProtocol = Type.object('ping', {
-  id: Type.string(),
+  ...baseFields(),
 });
 
 export const PongProtocol = Type.object('pong', {
-  id: Type.string(),
+  ...baseFields(),
 });
 
 export const OpenProtocol = Type.object('open', {
   ...baseFields(),
   clientId: Type.string(),
   path: Type.string(),
+  traceId: Type.string(),
 });
 
 export const ServerReadyProtocol = Type.object('server-ready', {

--- a/packages/connection/src/common/server-handler.ts
+++ b/packages/connection/src/common/server-handler.ts
@@ -157,7 +157,7 @@ export abstract class BaseCommonChannelHandler {
             channel = new WSServerChannel(wrappedConnection, { id, clientId, logger: this.logger });
             this.channelMap.set(id, channel);
             commonChannelPathHandler.openChannel(path, channel, clientId);
-            channel.serverReady(traceId!);
+            channel.serverReady(traceId);
             break;
           }
           default: {

--- a/packages/connection/src/common/ws-channel.ts
+++ b/packages/connection/src/common/ws-channel.ts
@@ -160,7 +160,6 @@ export class WSChannel {
     }
 
     data.traceId = traceId;
-    data.needAck = true;
     this.connection.send(data);
 
     this.stateTracer.send(traceId, {

--- a/packages/connection/src/common/ws-channel.ts
+++ b/packages/connection/src/common/ws-channel.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '@opensumi/events';
-import { DisposableStore, EventQueue, StateTracer, randomString } from '@opensumi/ide-core-common';
+import { DisposableStore, EventQueue, randomString } from '@opensumi/ide-core-common';
 
 import { ChannelMessage, ErrorMessageCode } from './channel/types';
 import { IConnectionShape } from './connection/types';
@@ -15,6 +15,82 @@ export interface IWSChannelCreateOptions {
   logger?: ILogger;
 
   ensureServerReady?: boolean;
+  deliveryTimeout?: number;
+}
+
+enum MessageDeliveryState {
+  ReSend,
+  Sended,
+  Success,
+  Failed,
+}
+
+class StateTracer {
+  private map = new Map<string, MessageDeliveryState>();
+
+  protected deliveryTimeout = 500;
+  protected timerMap = new Map<string, NodeJS.Timeout>();
+
+  setDeliveryTimeout(timeout: number) {
+    this.deliveryTimeout = timeout;
+  }
+
+  protected set(traceId: string, state: MessageDeliveryState) {
+    this.map.set(traceId, state);
+  }
+
+  get(traceId: string) {
+    return this.map.get(traceId);
+  }
+
+  success(traceId: string) {
+    this.map.set(traceId, MessageDeliveryState.Success);
+    const timer = this.timerMap.get(traceId);
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  dispose() {
+    this.timerMap.forEach((timer) => {
+      clearTimeout(timer);
+    });
+  }
+
+  stop(traceId: string) {
+    const timer = this.timerMap.get(traceId);
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  send(
+    traceId: string,
+    options: {
+      whenRetry: () => void;
+    },
+  ) {
+    this.set(traceId, MessageDeliveryState.Sended);
+    this.guard(traceId, options);
+  }
+
+  guard(
+    traceId: string,
+    options: {
+      whenRetry: () => void;
+    },
+  ) {
+    const timer = this.timerMap.get(traceId);
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    const newTimer = setTimeout(() => {
+      this.set(traceId, MessageDeliveryState.ReSend);
+      options.whenRetry();
+    }, this.deliveryTimeout);
+    this.timerMap.set(traceId, newTimer);
+  }
 }
 
 export class WSChannel {
@@ -35,6 +111,8 @@ export class WSChannel {
   protected _isServerReady = false;
   protected _ensureServerReady: boolean | undefined;
 
+  protected stateTracer = new StateTracer();
+
   public id: string;
 
   public channelPath: string;
@@ -53,6 +131,9 @@ export class WSChannel {
     }
 
     this._ensureServerReady = Boolean(ensureServerReady);
+    if (options.deliveryTimeout) {
+      this.stateTracer.setDeliveryTimeout(options.deliveryTimeout);
+    }
 
     this._disposables.add(this.emitter.on('binary', (data) => this.onBinaryQueue.push(data)));
   }
@@ -66,6 +147,31 @@ export class WSChannel {
       return;
     }
     this.connection.send(data);
+  }
+
+  /**
+   * @param traceId 一个 connection token 用于在全链路中追踪一个消息的生命周期，防止消息未发送或者重复发送
+   */
+  protected ensureMessageDeliveried(data: ChannelMessage, traceId = randomString(16)) {
+    const state = this.stateTracer.get(traceId);
+    if (state && state >= MessageDeliveryState.Sended) {
+      this.logger.error(`message already send already success or in progress, traceId: ${traceId}, state: ${state}`);
+      return;
+    }
+
+    data.traceId = traceId;
+    data.needAck = true;
+    this.connection.send(data);
+
+    this.stateTracer.send(traceId, {
+      whenRetry: () => {
+        if (this._isServerReady) {
+          this.stateTracer.stop(traceId);
+          return;
+        }
+        this.ensureMessageDeliveried(data, traceId);
+      },
+    });
   }
 
   onMessage(cb: (data: string) => any) {
@@ -106,11 +212,11 @@ export class WSChannel {
   dispatch(msg: ChannelMessage) {
     switch (msg.kind) {
       case 'server-ready':
-        this.stateTracer.fulfill(msg.token);
-        this.resume();
-        if (this.timer) {
-          clearTimeout(this.timer);
+        if (msg.traceId) {
+          this.stateTracer.success(msg.traceId);
         }
+
+        this.resume();
         this.emitter.emit('open', msg.id);
         break;
       case 'data':
@@ -136,56 +242,24 @@ export class WSChannel {
     }
   }
 
-  stateTracer = this._disposables.add(new StateTracer());
-
-  /**
-   * @param connectionToken 一个 connection token 用于在全链路中追踪一个 channel 的生命周期，防止 channel 被重复打开
-   */
-  open(path: string, clientId: string, connectionToken = randomString(16)) {
+  open(path: string, clientId: string) {
     this.channelPath = path;
     this.clientId = clientId;
 
     this.LOG_TAG = `[WSChannel id=${this.id} path=${path}]`;
 
-    if (this.stateTracer.has(connectionToken)) {
-      this.logger.warn(
-        `channel already opened or in progress, path: ${path}, clientId: ${clientId}, connectionToken: ${connectionToken}`,
-      );
-      return;
-    }
-
-    this.stateTracer.record(connectionToken);
-
-    this.connection.send({
+    const msg = {
       kind: 'open',
       id: this.id,
       path,
       clientId,
-      connectionToken,
-    });
+    } as ChannelMessage;
 
     if (this._ensureServerReady) {
-      this.ensureOpenSend(path, clientId, connectionToken);
+      this.ensureMessageDeliveried(msg);
+    } else {
+      this.connection.send(msg);
     }
-
-    return connectionToken;
-  }
-
-  protected timer: NodeJS.Timeout;
-  /**
-   * 启动定时器，确保 server-ready 消息在一定时间内到达
-   */
-  protected ensureOpenSend(path: string, clientId: string, connectionToken: string) {
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
-    this.timer = setTimeout(() => {
-      if (this._isServerReady) {
-        return;
-      }
-      this.stateTracer.delete(connectionToken);
-      this.open(path, clientId, connectionToken);
-    }, 500);
   }
 
   send(content: string) {
@@ -235,9 +309,7 @@ export class WSChannel {
   }
 
   dispose() {
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
+    this.stateTracer.dispose();
     this.sendQueue = [];
     this._disposables.dispose();
   }

--- a/packages/connection/src/common/ws-channel.ts
+++ b/packages/connection/src/common/ws-channel.ts
@@ -338,11 +338,11 @@ export class WSServerChannel extends WSChannel {
     this.clientId = options.clientId;
   }
 
-  serverReady(token: string) {
+  serverReady(traceId: string) {
     this.connection.send({
       kind: 'server-ready',
       id: this.id,
-      token,
+      traceId,
     });
   }
 

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -35,6 +35,7 @@ function handleClientChannel(
   channel.onceClose(() => {
     remove.dispose();
     serviceChildInjector.disposeAll();
+    serviceCenter.dispose();
 
     logger.log(`Remove RPC connection ${clientId}`);
   });

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -52,7 +52,7 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
 
   clientMessage(id: string, data: string) {
     if (this.client) {
-      this.client.onMessage(id, data);
+      return this.client.onMessage(id, data);
     } else {
       this.logger.warn(`clientMessage ${id} rpcClient not found`);
     }

--- a/packages/terminal-next/src/node/terminal.service.ts
+++ b/packages/terminal-next/src/node/terminal.service.ts
@@ -145,9 +145,9 @@ export class TerminalServiceImpl implements ITerminalNodeService {
             this.batchedPtyDataMap.set(sessionId, '');
           }
 
-          this.batchedPtyDataMap.set(sessionId, this.batchedPtyDataMap.get(sessionId) + chunk);
+          const ptyData = this.batchedPtyDataMap.get(sessionId)!;
 
-          const ptyData = this.batchedPtyDataMap.get(sessionId) || '';
+          this.batchedPtyDataMap.set(sessionId, ptyData + chunk);
 
           if (ptyData?.length + chunk.length >= BATCH_MAX_SIZE) {
             this.flushPtyData(clientId, sessionId);

--- a/packages/utils/__tests__/event.test.ts
+++ b/packages/utils/__tests__/event.test.ts
@@ -17,6 +17,7 @@ import {
   Event,
   EventBufferer,
   EventMultiplexer,
+  EventQueue,
   PauseableEmitter,
   WaitUntilEvent,
 } from '../src/event';
@@ -931,5 +932,36 @@ describe('Dispatcher', () => {
     expect(listener2).toHaveBeenCalledWith('bar');
 
     dispatcher.dispose();
+  });
+});
+
+describe('EventQueue', () => {
+  it('should queue events', async () => {
+    const queue = new EventQueue<string>();
+    const emitter = new Emitter<string>();
+
+    emitter.event(queue.push);
+
+    const listener = jest.fn();
+    const listener2 = jest.fn();
+
+    emitter.fire('foo');
+    emitter.fire('bar');
+
+    const dispose1 = queue.on(listener);
+    const dispose2 = queue.on(listener2);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    dispose1.dispose();
+
+    emitter.fire('baz');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener2).toHaveBeenCalledTimes(1);
+
+    dispose2.dispose();
+    emitter.fire('qux');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener2).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/utils/src/linked-list.ts
+++ b/packages/utils/src/linked-list.ts
@@ -1,3 +1,4 @@
+import { onUnexpectedError } from './errors';
 import { FIN, Iterator, IteratorResult } from './iterator';
 
 class Node<E> {
@@ -132,6 +133,16 @@ export class LinkedList<E> {
         return element;
       },
     };
+  }
+
+  forEach(callback: (element: E) => void): void {
+    for (let node = this._first; node !== Node.Undefined; node = node.next) {
+      try {
+        callback(node.element);
+      } catch (error) {
+        onUnexpectedError(error);
+      }
+    }
   }
 
   toArray(): E[] {

--- a/packages/utils/src/strings.ts
+++ b/packages/utils/src/strings.ts
@@ -1010,3 +1010,18 @@ const _format2Regexp = /{([^}]+)}/g;
 export function format2(template: string, values: Record<string, unknown>): string {
   return template.replace(_format2Regexp, (match, group) => (values[group] ?? match) as string);
 }
+
+export function getChunks(str: string, size: number): string[] {
+  const strLength: number = str.length;
+  const numChunks: number = Math.ceil(strLength / size);
+  const chunks: string[] = new Array(numChunks);
+
+  let i = 0;
+  let o = 0;
+
+  for (; i < numChunks; ++i, o += size) {
+    chunks[i] = str.substr(o, size);
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

又梳理了一下重连会带来的一些问题

1. rpc service center 和 channel 的 dispose 没有完全清理干净
2. 新建 channel 没有删掉旧的, 旧 channel 仍然可以收到消息
3. 重连会多次创建 Worker，导致通信很多报错
4. EventQueue 逻辑有问题，当没有接收方的时候，没有存消息到队列中

### Changelog

fix server's incorrect dispose of service center