### PR TITLE
fix: diff editor display error model content

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -562,8 +562,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
 
   private modifiedDocModelRef: IEditorDocumentModelRef | null;
 
-  private diffEditorModelCache = new LRUCache<string, monaco.editor.IDiffEditorViewModel>(100);
-
   get originalDocModel() {
     if (this.originalDocModelRef && !this.originalDocModelRef.disposed) {
       return this.originalDocModelRef.instance;
@@ -647,13 +645,7 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     }
     const original = this.originalDocModel.getMonacoModel();
     const modified = this.modifiedDocModel.getMonacoModel();
-    const key = `${original.uri.toString()}-${modified.uri.toString()}`;
-    let model = this.diffEditorModelCache.get(key);
-    if (!model || (model as any)._store.isDisposed) {
-      model = this.monacoDiffEditor.createViewModel({ original, modified });
-      this.diffEditorModelCache.set(key, model);
-    }
-
+    const model = this.monacoDiffEditor.createViewModel({ original, modified });
     this.monacoDiffEditor.setModel(model);
 
     if (rawUri) {
@@ -662,7 +654,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
       this.currentUri = URI.from({
         scheme: DIFF_SCHEME,
         query: URI.stringifyQuery({
-          name,
           original: this.originalDocModel!.uri.toString(),
           modified: this.modifiedDocModel!.uri.toString(),
         }),
@@ -672,6 +663,7 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     if (options.range || options.originalRange) {
       const range = (options.range || options.originalRange) as monaco.IRange;
       const currentEditor = options.range ? this.modifiedEditor.monacoEditor : this.originalEditor.monacoEditor;
+      await model?.waitForDiff();
       // 必须使用 setTimeout, 因为两边的 editor 出现时机问题，diffEditor 是异步显示和渲染
       setTimeout(() => {
         currentEditor.revealRangeInCenter(range);
@@ -746,7 +738,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
   }
 
   updateDiffOptions() {
-    this.diffEditorModelCache.clear();
     this.doUpdateDiffOptions();
   }
 
@@ -816,7 +807,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     super.dispose();
     this.collectionService.removeEditors([this.originalEditor, this.modifiedEditor]);
     this.collectionService.removeDiffEditors([this]);
-    this.diffEditorModelCache.clear();
     this.monacoDiffEditor.dispose();
     this._disposed = true;
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution


![image](https://github.com/opensumi/core/assets/13938334/0d405e93-fadd-46f9-a165-57ca357eda1f)

这行代码会导致 diff 状态下，git 插件读取的数据不是最新的本地文件，因为它会命中缓存，不会去获取 provideEditorDocumentModelContent 了

原因是之前为了缓存 diff 编辑器的状态，每次不会 dispose 这个 editor ref，下次进来就命中缓存。
![image](https://github.com/opensumi/core/assets/13938334/08b256d1-714f-42c6-8d35-a9389ed8e6c7)
![image](https://github.com/opensumi/core/assets/13938334/d1b5418e-d682-442e-ab06-2c5084e050f7)


monaco saveState 和 restoreState 都没保存已经展开的那些数据，感觉只能先搁置 restore 这个状态了，先把 bug 修复吧


### Changelog

fix diff editor cannot should latest file content