### PR TITLE
fix: lazy get layout modules

### DIFF
--- a/packages/core-browser/src/react-providers/slot.tsx
+++ b/packages/core-browser/src/react-providers/slot.tsx
@@ -198,16 +198,18 @@ export function SlotRenderer({ slot, isTabbar, id, ...props }: SlotProps) {
   const componentRegistry = useInjectable<ComponentRegistry>(ComponentRegistry);
   const appConfig = React.useContext(ConfigContext);
   const clientApp = useInjectable<IClientApp>(IClientApp);
-  const componentKeys = appConfig.layoutConfig[slot]?.modules ?? [];
   if (isTabbar) {
     slotRendererRegistry.addTabbar(slot);
   }
-  if (!componentKeys || !componentKeys.length) {
-    logger.warn(`No ${slot} view declared by location.`);
-  }
+
   const [componentInfos, setInfos] = React.useState<ComponentRegistryInfo[]>([]);
-  const updateComponentInfos = React.useCallback(() => {
+
+  const prepareComponentInfos = () => {
+    const componentKeys = appConfig.layoutConfig[slot]?.modules ?? [];
     const infos: ComponentRegistryInfo[] = [];
+    if (!componentKeys || !componentKeys.length) {
+      logger.warn(`No ${slot} view declared by location.`);
+    }
     componentKeys.forEach((token) => {
       const info = componentRegistry.getComponentRegistryInfo(token);
       if (!info) {
@@ -217,11 +219,11 @@ export function SlotRenderer({ slot, isTabbar, id, ...props }: SlotProps) {
       }
     });
     setInfos(infos);
-  }, []);
+  };
 
   React.useEffect(() => {
     // 对于嵌套在模块视图的SlotRenderer，渲染时应用已启动
-    clientApp.appInitialized.promise.then(updateComponentInfos);
+    clientApp.appInitialized.promise.then(prepareComponentInfos);
   }, []);
 
   const Renderer = slotRendererRegistry.getSlotRenderer(slot);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

我们的 AINativeModule 会在 initialize 阶段注入 Chat 面板，渲染也会保证在 appInitialized 后渲染面板。
但是有哪些面板的获取是在渲染过程中获取的，应该改为在 appInitialized 后获取。

### Changelog

lazy get layout modules