### PR TITLE
fix: skip locked panels during resize check

### DIFF
--- a/packages/core-browser/src/components/layout/split-panel.service.ts
+++ b/packages/core-browser/src/components/layout/split-panel.service.ts
@@ -25,7 +25,6 @@ export interface ISplitPanelService extends IDisposable {
 
 @Injectable({ multiple: true })
 export class SplitPanelService extends Disposable implements ISplitPanelService {
-  private static MIN_SIZE = 120;
   constructor(protected readonly panelId: string) {
     super();
   }
@@ -52,10 +51,15 @@ export class SplitPanelService extends Disposable implements ISplitPanelService 
   getFirstResizablePanel(index: number, direction: boolean, isPrev?: boolean): HTMLElement | undefined {
     if (isPrev) {
       if (direction) {
-        return this.panels[index];
+        for (let i = index; i >= 0; i--) {
+          if (!this.panels[i].classList.contains(RESIZE_LOCK)) {
+            // 跳过无法调整的面板
+            return this.panels[i];
+          }
+        }
       } else {
         for (let i = index; i >= 0; i--) {
-          if (this.panels[i].clientHeight > SplitPanelService.MIN_SIZE) {
+          if (!this.panels[i].classList.contains(RESIZE_LOCK)) {
             return this.panels[i];
           }
         }
@@ -70,10 +74,7 @@ export class SplitPanelService extends Disposable implements ISplitPanelService 
         }
       } else {
         for (let i = index + 1; i < this.panels.length; i++) {
-          if (
-            this.panels[i].clientHeight > SplitPanelService.MIN_SIZE &&
-            !this.panels[i].classList.contains(RESIZE_LOCK)
-          ) {
+          if (!this.panels[i].classList.contains(RESIZE_LOCK)) {
             return this.panels[i];
           }
         }

--- a/packages/core-browser/src/components/layout/split-panel.service.ts
+++ b/packages/core-browser/src/components/layout/split-panel.service.ts
@@ -3,6 +3,8 @@ import React from 'react';
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { Deferred, Disposable, IDisposable } from '@opensumi/ide-core-common';
 
+import { RESIZE_LOCK } from '../resize/resize';
+
 import { SplitPanelProps } from './split-panel';
 
 export const ISplitPanelService = Symbol('ISplitPanelService');
@@ -60,10 +62,18 @@ export class SplitPanelService extends Disposable implements ISplitPanelService 
       }
     } else {
       if (!direction) {
-        return this.panels[index + 1];
+        for (let i = index + 1; i < this.panels.length; i++) {
+          if (!this.panels[i].classList.contains(RESIZE_LOCK)) {
+            // 跳过无法调整的面板
+            return this.panels[i];
+          }
+        }
       } else {
         for (let i = index + 1; i < this.panels.length; i++) {
-          if (this.panels[i].clientHeight > SplitPanelService.MIN_SIZE) {
+          if (
+            this.panels[i].clientHeight > SplitPanelService.MIN_SIZE &&
+            !this.panels[i].classList.contains(RESIZE_LOCK)
+          ) {
             return this.panels[i];
           }
         }

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -391,6 +391,7 @@ export const Tabs = ({ group }: ITabsProps) => {
     const curTabIndex = group.resources.findIndex((resource) => group.currentResource === resource);
     return (
       <div
+        draggable={false}
         className={cls({
           [styles_kt_editor_tabs_content]: true,
           [styles_kt_editor_tabs_current_last]: curTabIndex === group.resources.length - 1,

--- a/packages/main-layout/src/browser/accordion/section.view.tsx
+++ b/packages/main-layout/src/browser/accordion/section.view.tsx
@@ -165,6 +165,7 @@ export const AccordionSection = ({
           {...attrs}
           className={cls(styles_kt_split_panel_header, headerClass)}
           onClick={clickHandler}
+          draggable={false}
           onContextMenu={(e) => onContextMenuHandler(e, viewId)}
           style={{ height: computedHeaderSize, lineHeight: computedHeaderSize }}
         >


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

支持在在折叠的面板上下均可拖拽 Resize 的能力

https://github.com/opensumi/core/assets/9823838/2b78ee2a-8d90-42d1-afda-6b9476355587

### Changelog

skip locked panels during resize check
