### PR TITLE
fix(merge-editor): some scm provider cannot switch to text editor

### DIFF
--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1432,7 +1432,7 @@ export const localizationBundle = {
     'mergeEditor.conflict.next': 'Next Conflict',
     'mergeEditor.conflict.ai.resolve.all': 'AI Resolution',
     'mergeEditor.conflict.ai.resolve.all.stop': 'Stop All',
-    'mergeEditor.open.tradition': 'Tradition Editor',
+    'mergeEditor.open.tradition': 'Text Editor',
 
     // #region AI Native
     'aiNative.chat.ai.assistant.name': 'AI Assistant',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1199,7 +1199,7 @@ export const localizationBundle = {
     'mergeEditor.conflict.next': '下一处冲突',
     'mergeEditor.conflict.ai.resolve.all': 'AI 解决',
     'mergeEditor.conflict.ai.resolve.all.stop': '全部停止',
-    'mergeEditor.open.tradition': '传统编辑器',
+    'mergeEditor.open.tradition': '文本编辑器',
     'workbench.quickOpen.preserveInput': '是否在 QuickOpen 的输入框（包括命令面板）中保留上次输入的内容',
 
     // #region AI Native

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -192,19 +192,13 @@ const BottomBar: React.FC = () => {
           return;
         }
 
-        if (uri.scheme === 'git') {
-          // replace git:// with file://
+        if (uri.scheme !== 'file') {
+          // replace git:// or any other scheme with file://
           uri = uri.with({
             scheme: 'file',
             path: uri.path,
             query: '',
           });
-        }
-
-        if (uri.scheme !== 'file') {
-          // ignore other scheme
-          logger.warn('Unsupported scheme', uri.scheme);
-          return;
         }
 
         commandService.executeCommand(EDITOR_COMMANDS.API_OPEN_EDITOR_COMMAND_ID, uri);

--- a/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
+++ b/packages/monaco/src/browser/contrib/merge-editor/view/grid.tsx
@@ -193,7 +193,7 @@ const BottomBar: React.FC = () => {
         }
 
         if (uri.scheme !== 'file') {
-          // replace git:// or any other scheme with file://
+          // replace git:// or any other scheme to file://
           uri = uri.with({
             scheme: 'file',
             path: uri.path,


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

我们在 web 端加载代码的插件是 webscm，切换到 merge editor 后切换不回 text editor 了

### Changelog

some scm provider cannot switch merge editor to text editor