### PR TITLE
fix: skip locked panels during resize check

### DIFF
--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -64,6 +64,7 @@ export interface SplitPanelProps extends SplitChildProps {
   className?: string;
   style?: React.CSSProperties;
   direction?: Layout.direction;
+  headerSize?: number;
   id: string;
   // setAbsoluteSize 时保证相邻节点总宽度不变
   resizeKeep?: boolean;
@@ -95,6 +96,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = (props) => {
   const {
     id,
     className,
+    headerSize,
     resizeHandleClassName,
     style,
     children = [],
@@ -298,7 +300,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = (props) => {
                     splitPanelService.panels.push(ele);
                   }
                 }}
-                className={hides[index] ? RESIZE_LOCK : ''}
+                className={getElementSize(element, totalFlexNum) === `${headerSize}px` ? RESIZE_LOCK : ''}
                 id={getProp(element, 'id') /* @deprecated: query by data-view-id */}
                 style={{
                   // 手风琴场景，固定尺寸和 flex 尺寸混合布局；需要在 Resize Flex 模式下禁用

--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -5,7 +5,7 @@ import { IEventBus } from '@opensumi/ide-core-common';
 
 import { ResizeEvent } from '../../layout';
 import { useInjectable } from '../../react-hooks';
-import { IResizeHandleDelegate, ResizeFlexMode } from '../resize/resize';
+import { IResizeHandleDelegate, RESIZE_LOCK, ResizeFlexMode } from '../resize/resize';
 
 import { Layout } from './layout';
 import { SplitPanelManager } from './split-panel.service';
@@ -298,6 +298,7 @@ export const SplitPanel: React.FC<SplitPanelProps> = (props) => {
                     splitPanelService.panels.push(ele);
                   }
                 }}
+                className={hides[index] ? RESIZE_LOCK : ''}
                 id={getProp(element, 'id') /* @deprecated: query by data-view-id */}
                 style={{
                   // 手风琴场景，固定尺寸和 flex 尺寸混合布局；需要在 Resize Flex 模式下禁用

--- a/packages/main-layout/src/browser/accordion/accordion.view.tsx
+++ b/packages/main-layout/src/browser/accordion/accordion.view.tsx
@@ -54,6 +54,7 @@ export const AccordionContainer = observer(
       <SplitPanel
         className={className}
         style={style}
+        headerSize={headerSize}
         dynamicTarget={true}
         id={containerId}
         resizeKeep={false}

--- a/packages/main-layout/src/browser/accordion/section.view.tsx
+++ b/packages/main-layout/src/browser/accordion/section.view.tsx
@@ -159,13 +159,12 @@ export const AccordionSection = ({
   }, [expanded, headerSize, alignment]);
 
   return (
-    <div className={styles_kt_split_panel} data-view-id={viewId}>
+    <div className={styles_kt_split_panel} data-view-id={viewId} draggable={false}>
       {!noHeader && (
         <div
           {...attrs}
           className={cls(styles_kt_split_panel_header, headerClass)}
           onClick={clickHandler}
-          draggable={false}
           onContextMenu={(e) => onContextMenuHandler(e, viewId)}
           style={{ height: computedHeaderSize, lineHeight: computedHeaderSize }}
         >


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

ref #7499

### Changelog

skip locked panels during resize check