### PR TITLE
fix: inline live diff zone range

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -168,16 +168,7 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
 
       case EResultKind.DISCARD:
       case EResultKind.REGENERATE:
-        this.model.pushEditOperations(
-          null,
-          [
-            {
-              range: this.node.getZone(),
-              text: this.node.getRawOriginalTextLines().join(this.model.getEOL()),
-            },
-          ],
-          () => null,
-        );
+        this.node.discard();
         break;
 
       default:

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
@@ -1,5 +1,5 @@
 .inline_diff_current {
-  background-color: var(--editorWhitespace-foreground);
+  background-color: var(--editorIndentGuide-activeBackground);
 }
 
 .inline_diff_added_range {
@@ -14,4 +14,8 @@
     height: 100%;
     width: 100%;
   }
+}
+
+.inline_diff_pending_range {
+  background-color: var(--editorWidget-background);
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
@@ -6,11 +6,12 @@
   background-color: var(--diffEditor-insertedLineBackground);
 }
 
-.inline_diff_remove_zone {
-  background-color: var(--diffEditor-removedLineBackground);
-  height: 100%;
-  width: 100%;
-  display: inline-block;
-  margin-left: 80px;
-  white-space: pre-wrap;
+.inline_diff_remove_zone_widget_container {
+  width: calc(100% + 10px);
+
+  .inline_diff_remove_zone {
+    background-color: var(--diffEditor-removedLineBackground);
+    height: 100%;
+    width: 100%;
+  }
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -13,7 +13,7 @@ import { renderLines } from '../ghost-text-widget/index';
 
 import styles from './inline-stream-diff.module.less';
 
-const RemovedWidgetComponent = ({ dom }) => {
+const RemovedWidgetComponent = ({ dom, marginWidth }) => {
   const ref = React.useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -22,18 +22,19 @@ const RemovedWidgetComponent = ({ dom }) => {
     }
   }, [dom, ref]);
 
-  return <div className={styles.inline_diff_remove_zone} ref={ref}></div>;
+  return <div className={styles.inline_diff_remove_zone} ref={ref} style={{ marginLeft: marginWidth + 'px' }}></div>;
 };
 
 class RemovedZoneWidget extends ZoneWidget {
   private root: ReactDOMClient.Root;
 
   _fillContainer(container: HTMLElement): void {
+    container.classList.add(styles.inline_diff_remove_zone_widget_container);
     this.root = ReactDOMClient.createRoot(container);
   }
 
-  renderDom(dom: HTMLElement): void {
-    this.root.render(<RemovedWidgetComponent dom={dom} />);
+  renderDom(dom: HTMLElement, options: { marginWidth: number }): void {
+    this.root.render(<RemovedWidgetComponent dom={dom} marginWidth={options.marginWidth} />);
   }
 
   override revealRange(): void {}
@@ -132,7 +133,11 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       })),
       this.monacoEditor.getOptions(),
     );
-    widget.renderDom(dom);
+
+    const layoutInfo = this.monacoEditor.getOption(EditorOption.layoutInfo);
+    const marginWidth = layoutInfo.contentLeft;
+
+    widget.renderDom(dom, { marginWidth });
     widget.show(position, heightInLines);
 
     this.removedZoneWidgets.push(widget);

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import ReactDOMClient from 'react-dom/client';
 
+import { StackingLevel } from '@opensumi/ide-core-browser';
 import { Disposable } from '@opensumi/ide-core-common';
 import { ICodeEditor, IEditorDecorationsCollection, Position, Range, Selection } from '@opensumi/ide-monaco';
 import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
@@ -12,6 +13,11 @@ import { ZoneWidget } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/z
 import { renderLines } from '../ghost-text-widget/index';
 
 import styles from './inline-stream-diff.module.less';
+
+const ZoneDescription = 'zone-description';
+const ActiveLineDecoration = 'activeLine-decoration';
+const AddedRangeDecoration = 'added-range-decoration';
+const PendingRangeDecoration = 'pending-range-decoration';
 
 const RemovedWidgetComponent = ({ dom, marginWidth }) => {
   const ref = React.useRef<HTMLDivElement>(null);
@@ -50,41 +56,42 @@ interface ITextLinesTokens {
 }
 
 export class LivePreviewDiffDecorationModel extends Disposable {
-  private selectionDec: IEditorDecorationsCollection;
+  private zoneDec: IEditorDecorationsCollection;
 
   private activeLineDec: IEditorDecorationsCollection;
+  private pendingRangeDec: IEditorDecorationsCollection;
   private addedRangeDec: IEditorDecorationsCollection;
 
   private removedZoneWidgets: Array<RemovedZoneWidget> = [];
   private rawOriginalTextLinesTokens: ITextLinesTokens[] = [];
 
+  private zone: LineRange;
+
   constructor(private readonly monacoEditor: ICodeEditor, private readonly selection: Selection) {
     super();
 
-    this.selectionDec = this.monacoEditor.createDecorationsCollection();
+    this.zoneDec = this.monacoEditor.createDecorationsCollection();
 
     this.activeLineDec = this.monacoEditor.createDecorationsCollection();
     this.addedRangeDec = this.monacoEditor.createDecorationsCollection();
+    this.pendingRangeDec = this.monacoEditor.createDecorationsCollection();
 
-    this.selectionDec.set([
-      {
-        range: Range.fromPositions(
+    this.updateZone(
+      LineRange.fromRangeInclusive(
+        Range.fromPositions(
           { lineNumber: this.selection.startLineNumber, column: 1 },
           { lineNumber: this.selection.endLineNumber, column: Number.MAX_SAFE_INTEGER },
         ),
-        options: ModelDecorationOptions.register({
-          description: 'zone-decoration',
-          className: styles.inline_diff_zone,
-          isWholeLine: true,
-        }),
-      },
-    ]);
+      ),
+    );
   }
 
   override dispose(): void {
     super.dispose();
 
-    this.selectionDec.clear();
+    this.zoneDec.clear();
+
+    this.clearPendingLine();
     this.clearActiveLine();
     this.clearAddedLine();
     this.clearRemovedWidgets();
@@ -143,20 +150,23 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     this.removedZoneWidgets.push(widget);
   }
 
-  public getZone(): Range {
-    const selectionRange = this.selectionDec.getRange(0)!;
+  public updateZone(newZone: LineRange): void {
+    this.zone = newZone;
 
-    const addedIndex = this.addedRangeDec.getRanges().length - 1;
-    const latestAddedRange = this.addedRangeDec.getRange(Math.max(0, addedIndex));
+    this.zoneDec.set([
+      {
+        range: newZone.toInclusiveRange()!,
+        options: ModelDecorationOptions.register({
+          description: ZoneDescription,
+          className: styles.inline_diff_zone,
+          isWholeLine: true,
+        }),
+      },
+    ]);
+  }
 
-    if (!latestAddedRange) {
-      return selectionRange;
-    }
-
-    return selectionRange.setEndPosition(
-      Math.max(selectionRange.endLineNumber, latestAddedRange.endLineNumber),
-      Math.max(selectionRange.endColumn, latestAddedRange.endColumn),
-    );
+  public getZone(): LineRange {
+    return this.zone;
   }
 
   public touchActiveLine(lineNumber: number) {
@@ -175,9 +185,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
           },
         ),
         options: ModelDecorationOptions.register({
-          description: 'activeLine-decoration',
+          description: ActiveLineDecoration,
           isWholeLine: true,
           className: styles.inline_diff_current,
+          zIndex: StackingLevel.WorkbenchEditor,
         }),
       },
     ]);
@@ -191,6 +202,30 @@ export class LivePreviewDiffDecorationModel extends Disposable {
         range: Range.fromPositions(
           {
             lineNumber: zone.startLineNumber + range.startLineNumber - 1,
+            column: 1,
+          },
+          {
+            lineNumber: zone.startLineNumber + range.endLineNumberExclusive - 2,
+            column: Number.MAX_SAFE_INTEGER,
+          },
+        ),
+        options: ModelDecorationOptions.register({
+          description: AddedRangeDecoration,
+          isWholeLine: true,
+          className: styles.inline_diff_added_range,
+        }),
+      })),
+    );
+  }
+
+  public touchPendingRange(range: LineRange) {
+    const zone = this.getZone();
+
+    this.pendingRangeDec.set([
+      {
+        range: Range.fromPositions(
+          {
+            lineNumber: zone.startLineNumber + range.startLineNumber - 1,
             column: 0,
           },
           {
@@ -199,12 +234,16 @@ export class LivePreviewDiffDecorationModel extends Disposable {
           },
         ),
         options: ModelDecorationOptions.register({
-          description: 'added-range-decoration',
+          description: PendingRangeDecoration,
           isWholeLine: true,
-          className: styles.inline_diff_added_range,
+          className: styles.inline_diff_pending_range,
         }),
-      })),
-    );
+      },
+    ]);
+  }
+
+  public clearPendingLine() {
+    this.pendingRangeDec.clear();
   }
 
   public clearActiveLine() {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

zone 表示用户选中的代码区域，我们会在这个区域范围内进行流式 diff 渲染

之前的处理方式是采用 monaco 的 decoration 来进行 rang 范围计算，但这种方式偶尔会有问题，会导致流式渲染的区域超过这个 zone 的范围，不仅 diff 的对比不正确，更会导致未选中的代码部分被覆写

现在重新调整了 zone 的计算方式，在每次要 handleEdits 时实时的根据 newFullRangeTextLines 内容长度重新计算 zone

### Changelog
修复 inline live 模式下流式 diff 渲染时会出现溢出覆写的情况