### PR TITLE
fix: file service will watch same folder multiple times

### DIFF
--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -57,7 +57,7 @@ export interface IRPCDiskFileSystemProvider {
 }
 
 export interface IWatcher {
-  id: number;
+  uri: string;
   options?: {
     excludes?: string[];
   };
@@ -73,7 +73,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   readonly onDidChangeFile: Event<FileChangeEvent> = this.fileChangeEmitter.event;
   protected watcherServerDisposeCollection: DisposableCollection;
 
-  protected readonly watcherCollection = new Map<string, IWatcher>();
+  protected readonly watcherCollection = new Map<number, IWatcher>();
   protected watchFileExcludes: string[] = [];
 
   private _whenReadyDeferred: Deferred<void> = new Deferred();
@@ -134,7 +134,8 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   async watch(uri: UriComponents, options?: { excludes?: string[] }): Promise<number> {
     await this.whenReady;
     const _uri = Uri.revive(uri);
-    const id = await this.watcherServer.watchFileChanges(_uri.toString(), {
+    const uriString = _uri.toString();
+    const id = await this.watcherServer.watchFileChanges(uriString, {
       excludes: options?.excludes ?? [],
     });
     const disposable = {
@@ -142,15 +143,15 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
         this.watcherServer.unwatchFileChanges(id);
       },
     };
-    this.watcherCollection.set(_uri.toString(), { id, options, disposable });
+    this.watcherCollection.set(id, { uri: uriString, options, disposable });
     return id;
   }
 
   unwatch(watcherId: number) {
-    for (const [_uri, { id, disposable }] of this.watcherCollection) {
-      if (watcherId === id) {
-        disposable.dispose();
-      }
+    const watcher = this.watcherCollection.get(watcherId);
+    if (watcher) {
+      watcher.disposable.dispose();
+      this.watcherCollection.delete(watcherId);
     }
   }
 
@@ -174,11 +175,12 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     try {
       const dirList = await fse.readdir(_uri.fsPath);
 
-      dirList.forEach((name) => {
-        const filePath = paths.join(_uri.fsPath, name);
-        // eslint-disable-next-line import/namespace
-        result.push([name, this.getFileStatType(fse.statSync(filePath))]);
-      });
+      await Promise.all(
+        dirList.map(async (name) => {
+          const filePath = paths.join(_uri.fsPath, name);
+          result.push([name, this.getFileStatType(await fse.stat(filePath))]);
+        }),
+      );
       return result;
     } catch (e) {
       return result;
@@ -264,7 +266,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
       await writeFileAtomic(FileUri.fsPath(new URI(_uri)), buffer);
     } catch (e) {
       await fse.writeFile(FileUri.fsPath(new URI(_uri)), buffer);
-      this.logger.warn('Error using writeFileAtomicSync, using fs instead.', e);
+      this.logger.warn('Error using writeFileAtomic, using fs instead.', e);
     } finally {
       this.ignoreNextChangesEvent.delete(_uri.toString());
     }
@@ -427,7 +429,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
       uri: string;
       options?: { excludes?: string[] };
     }[] = [];
-    for (const [uri, { id, options }] of this.watcherCollection) {
+    for (const [id, { uri, options }] of this.watcherCollection) {
       tasks.push({
         id,
         uri,

--- a/packages/file-service/src/node/shared/filter.ts
+++ b/packages/file-service/src/node/shared/filter.ts
@@ -1,0 +1,10 @@
+export function isTemporaryFile(path: string): boolean {
+  if (path) {
+    if (/\.\d{7}\d+$/.test(path)) {
+      // write-file-atomic 源文件xxx.xx 对应的临时文件为 xxx.xx.22243434
+      // 这类文件的更新应当完全隐藏掉
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/file-service/src/node/un-recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/un-recursive/file-service-watcher.ts
@@ -16,6 +16,7 @@ import {
 
 import { FileChangeType, FileSystemWatcherClient, IFileSystemWatcherServer } from '../../common/index';
 import { FileChangeCollection } from '../file-change-collection';
+import { isTemporaryFile } from '../shared/filter';
 const { join, basename, normalize } = path;
 @Injectable({ multiple: true })
 export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
@@ -70,15 +71,16 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
     try {
       const watcher = watch(basePath);
       this.logger.log('start watching', basePath);
-      const isDirectory = fs.lstatSync(basePath).isDirectory();
+      const isDirectory = (await fs.lstat(basePath)).isDirectory();
 
       const docChildren = new Set<string>();
       let signalDoc = '';
       if (isDirectory) {
         try {
-          for (const child of fs.readdirSync(basePath)) {
+          const children = await fs.readdir(basePath);
+          for (const child of children) {
             const base = join(basePath, String(child));
-            if (!fs.lstatSync(base).isDirectory()) {
+            if (!(await fs.lstat(base)).isDirectory()) {
               docChildren.add(child);
             }
           }
@@ -96,7 +98,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
       });
 
       watcher.on('change', (type: string, filename: string | Buffer) => {
-        if (this.isTemporaryFile(filename as string)) {
+        if (isTemporaryFile(filename as string)) {
           return;
         }
 
@@ -118,7 +120,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
             // 监听的目录如果是文件夹，那么只对其下面的文件改动做出响应
             if (docChildren.has(changeFileName)) {
               if ((type === 'rename' || type === 'change') && changeFileName === filename) {
-                const fileExists = fs.existsSync(changePath);
+                const fileExists = await fs.pathExists(changePath);
                 if (fileExists) {
                   this.pushUpdated(changePath);
                 } else {
@@ -126,8 +128,8 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
                   this.pushDeleted(changePath);
                 }
               }
-            } else if (fs.pathExistsSync(changePath)) {
-              if (!fs.lstatSync(changePath).isDirectory()) {
+            } else if (await fs.pathExists(changePath)) {
+              if (!(await fs.lstat(changePath)).isDirectory()) {
                 this.pushAdded(changePath);
                 docChildren.add(changeFileName);
               }
@@ -136,7 +138,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
         } else {
           setTimeout(async () => {
             if (changeFileName === signalDoc) {
-              if (fs.pathExistsSync(basePath)) {
+              if (await fs.pathExists(basePath)) {
                 this.pushUpdated(basePath);
               } else {
                 this.pushDeleted(basePath);
@@ -168,7 +170,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
     let watchPath = '';
 
     if (exist) {
-      const stat = await fs.lstatSync(basePath);
+      const stat = await fs.lstat(basePath);
       if (stat) {
         watchPath = basePath;
       }
@@ -247,16 +249,5 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
       return;
     }
     this.client = client;
-  }
-
-  protected isTemporaryFile(path: string): boolean {
-    if (path) {
-      if (/\.\d{7}\d+$/.test(path)) {
-        // write-file-atomic 源文件xxx.xx 对应的临时文件为 xxx.xx.22243434
-        // 这类文件的更新应当完全隐藏掉
-        return true;
-      }
-    }
-    return false;
   }
 }


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

之前的逻辑有判断要 watch 的路径是否已经被 watch 了，但是因为 async await 的原因，前端同时请求过来三四个一样的路径，后端会同时 watch 这些路径。

同时也优化了一些性能问题，原来的代码里检测文件夹是否存在时使用了 Sync 方法，这会导致处理文件监听时 Node 层会同步卡住进行的。

### Changelog

fix file service will watch same folder multiple times