### PR TITLE
feat: support partial edit widget

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -431,13 +431,14 @@ export class AINativeBrowserContribution
         command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
         keybinding: 'alt+y',
         args: true,
+        priority: 100,
         when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
       });
       keybindings.registerKeybinding({
         command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
         keybinding: 'alt+n',
         args: false,
-        priority: 1,
+        priority: 100,
         when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
       });
 

--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -31,8 +31,13 @@ import {
   AI_INLINE_CHAT_VISIBLE,
   AI_INLINE_COMPLETION_REPORTER,
   AI_INLINE_COMPLETION_VISIBLE,
+  AI_INLINE_DIFF_PARTIAL_EDIT,
 } from '@opensumi/ide-core-browser/lib/ai-native/command';
-import { InlineChatIsVisible, InlineInputWidgetIsVisible } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
+import {
+  InlineChatIsVisible,
+  InlineDiffPartialEditsIsVisible,
+  InlineInputWidgetIsVisible,
+} from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
 import { DesignLayoutConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
 import {
   AI_NATIVE_SETTING_GROUP_TITLE,
@@ -86,6 +91,7 @@ import {
 import { InlineChatFeatureRegistry } from './widget/inline-chat/inline-chat.feature.registry';
 import { AIInlineChatService } from './widget/inline-chat/inline-chat.service';
 import { InlineInputChatService } from './widget/inline-input/inline-input.service';
+import { InlineStreamDiffService } from './widget/inline-stream-diff/inline-stream-diff.service';
 import { SumiLightBulbWidget } from './widget/light-bulb';
 
 @Domain(
@@ -174,6 +180,9 @@ export class AINativeBrowserContribution
 
   @Autowired(InlineInputChatService)
   private readonly inlineInputChatService: InlineInputChatService;
+
+  @Autowired(InlineStreamDiffService)
+  private readonly inlineStreamDiffService: InlineStreamDiffService;
 
   constructor() {
     this.registerFeature();
@@ -363,6 +372,12 @@ export class AINativeBrowserContribution
       },
     });
 
+    commands.registerCommand(AI_INLINE_DIFF_PARTIAL_EDIT, {
+      execute: (isAccept: boolean) => {
+        this.inlineStreamDiffService.launchAcceptDiscardPartialEdit(isAccept);
+      },
+    });
+
     /**
      * 当 inline completion 消失时
      */
@@ -411,6 +426,19 @@ export class AINativeBrowserContribution
         keybinding: 'esc',
         args: false,
         when: `editorFocus && ${InlineChatIsVisible.raw}`,
+      });
+      keybindings.registerKeybinding({
+        command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
+        keybinding: 'alt+y',
+        args: true,
+        when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
+      });
+      keybindings.registerKeybinding({
+        command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
+        keybinding: 'alt+n',
+        args: false,
+        priority: 1,
+        when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
       });
 
       if (this.inlineChatFeatureRegistry.getInteractiveInputHandler()) {

--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -429,14 +429,14 @@ export class AINativeBrowserContribution
       });
       keybindings.registerKeybinding({
         command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
-        keybinding: 'alt+y',
+        keybinding: 'ctrl+y',
         args: true,
         priority: 100,
         when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
       });
       keybindings.registerKeybinding({
         command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
-        keybinding: 'alt+n',
+        keybinding: 'ctrl+n',
         args: false,
         priority: 100,
         when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,

--- a/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
+++ b/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
@@ -3,6 +3,7 @@ import { IContextKey, IContextKeyService, IScopedContextKeyService } from '@open
 import {
   InlineChatIsVisible,
   InlineCompletionIsTrigger,
+  InlineDiffPartialEditsIsVisible,
   InlineHintWidgetIsVisible,
   InlineInputWidgetIsVisible,
 } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
@@ -20,6 +21,7 @@ export class AINativeContextKey {
   public readonly inlineCompletionIsTrigger: IContextKey<boolean>;
   public readonly inlineHintWidgetIsVisible: IContextKey<boolean>;
   public readonly inlineInputWidgetIsVisible: IContextKey<boolean>;
+  public readonly inlineDiffPartialEditsIsVisible: IContextKey<boolean>;
 
   constructor(@Optional() dom?: HTMLElement | IContextKeyServiceTarget | ContextKeyService) {
     this._contextKeyService = this.globalContextKeyService.createScoped(dom);
@@ -27,5 +29,6 @@ export class AINativeContextKey {
     this.inlineCompletionIsTrigger = InlineCompletionIsTrigger.bind(this._contextKeyService);
     this.inlineHintWidgetIsVisible = InlineHintWidgetIsVisible.bind(this._contextKeyService);
     this.inlineInputWidgetIsVisible = InlineInputWidgetIsVisible.bind(this._contextKeyService);
+    this.inlineDiffPartialEditsIsVisible = InlineDiffPartialEditsIsVisible.bind(this._contextKeyService);
   }
 }

--- a/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
+++ b/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
@@ -1,14 +1,28 @@
-import { Disposable } from '@opensumi/ide-core-common';
-import { ICodeEditor, IModelDecorationsChangeAccessor, IModelDeltaDecoration } from '@opensumi/ide-monaco';
+import { Disposable, Emitter, Event, isUndefined } from '@opensumi/ide-core-common';
+import {
+  ICodeEditor,
+  IContentSizeChangedEvent,
+  IModelDecorationsChangeAccessor,
+  IModelDeltaDecoration,
+  ITextModel,
+} from '@opensumi/ide-monaco';
 
 interface IEnhanceModelDeltaDecoration {
   id: string;
   readonly editorDecoration: IModelDeltaDecoration;
   dispose(): void;
+  length: number;
 }
 
 export class EnhanceDecorationsCollection extends Disposable {
   private deltaDecorations: IEnhanceModelDeltaDecoration[] = [];
+
+  protected readonly _onDidDecorationsChange = new Emitter<IEnhanceModelDeltaDecoration[]>();
+  public readonly onDidDecorationsChange: Event<IEnhanceModelDeltaDecoration[]> = this._onDidDecorationsChange.event;
+
+  private get model(): ITextModel {
+    return this.codeEditor.getModel()!;
+  }
 
   constructor(private readonly codeEditor: ICodeEditor) {
     super();
@@ -18,6 +32,34 @@ export class EnhanceDecorationsCollection extends Disposable {
         this.clear();
       }),
     );
+
+    this.addDispose(
+      this.codeEditor.onDidContentSizeChange((event: IContentSizeChangedEvent) => {
+        const { contentHeightChanged } = event;
+        if (contentHeightChanged) {
+          this.flush();
+        }
+      }),
+    );
+  }
+
+  /**
+   * 每次在文档变更时获取新的 decoration 位置
+   */
+  private flush(): void {
+    this.deltaDecorations = this.deltaDecorations.map((d) => {
+      const {
+        id,
+        editorDecoration: { range },
+      } = d;
+
+      const newRange = this.model.getDecorationRange(id);
+      d.editorDecoration.range = newRange ?? range;
+
+      return d;
+    });
+
+    this._onDidDecorationsChange.fire(this.deltaDecorations);
   }
 
   private delete(id: string): void {
@@ -28,7 +70,7 @@ export class EnhanceDecorationsCollection extends Disposable {
     });
   }
 
-  set(decorations: IModelDeltaDecoration[]): void {
+  set(decorations: (IModelDeltaDecoration & { length?: number })[]): void {
     this.clear();
 
     this.codeEditor.changeDecorations((accessor: IModelDecorationsChangeAccessor) => {
@@ -40,6 +82,9 @@ export class EnhanceDecorationsCollection extends Disposable {
         newDecorations.push({
           id,
           editorDecoration: decoration,
+          length: isUndefined(decoration.length)
+            ? decoration.range.endLineNumber - decoration.range.startLineNumber
+            : decoration.length,
           dispose: () => {
             this.delete(id);
           },
@@ -52,6 +97,10 @@ export class EnhanceDecorationsCollection extends Disposable {
 
   getDecorations(): IEnhanceModelDeltaDecoration[] {
     return this.deltaDecorations;
+  }
+
+  getDecorationByLineNumber(lineNumber: number): IEnhanceModelDeltaDecoration | undefined {
+    return this.deltaDecorations.find((d) => d.editorDecoration.range.startLineNumber === lineNumber);
   }
 
   clear(): void {

--- a/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
+++ b/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
@@ -1,0 +1,66 @@
+import { Disposable } from '@opensumi/ide-core-common';
+import { ICodeEditor, IModelDecorationsChangeAccessor, IModelDeltaDecoration } from '@opensumi/ide-monaco';
+
+interface IEnhanceModelDeltaDecoration {
+  id: string;
+  readonly editorDecoration: IModelDeltaDecoration;
+  dispose(): void;
+}
+
+export class EnhanceDecorationsCollection extends Disposable {
+  private deltaDecorations: IEnhanceModelDeltaDecoration[] = [];
+
+  constructor(private readonly codeEditor: ICodeEditor) {
+    super();
+
+    this.addDispose(
+      Disposable.create(() => {
+        this.clear();
+      }),
+    );
+  }
+
+  private delete(id: string): void {
+    this.codeEditor.changeDecorations((accessor) => {
+      accessor.removeDecoration(id);
+
+      this.deltaDecorations = this.deltaDecorations.filter((d) => d.id !== id);
+    });
+  }
+
+  set(decorations: IModelDeltaDecoration[]): void {
+    this.clear();
+
+    this.codeEditor.changeDecorations((accessor: IModelDecorationsChangeAccessor) => {
+      const newDecorations: IEnhanceModelDeltaDecoration[] = [];
+
+      for (const decoration of decorations) {
+        const id = accessor.addDecoration(decoration.range, decoration.options);
+
+        newDecorations.push({
+          id,
+          editorDecoration: decoration,
+          dispose: () => {
+            this.delete(id);
+          },
+        });
+      }
+
+      this.deltaDecorations = newDecorations;
+    });
+  }
+
+  getDecorations(): IEnhanceModelDeltaDecoration[] {
+    return this.deltaDecorations;
+  }
+
+  clear(): void {
+    this.codeEditor.changeDecorations((accessor) => {
+      for (const decoration of this.deltaDecorations) {
+        accessor.removeDecoration(decoration.id);
+      }
+
+      this.deltaDecorations = [];
+    });
+  }
+}

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -192,5 +192,6 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
       return new LineRange(lineNumber, lineNumber + 1);
     });
     this.node.renderPartialEditWidgets(allAddRanges);
+    this.monacoEditor.focus();
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -184,6 +184,8 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
     this.node.addLinesToDiff(message);
   }
   onEnd(): void {
-    this.node.recompute(EComputerMode.legacy);
+    const { changes } = this.node.recompute(EComputerMode.legacy);
+    const allAddRanges = changes.map((c) => c.addedRange);
+    this.node.renderPartialEditWidgets(allAddRanges);
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -1,6 +1,7 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { Disposable, ErrorResponse, ReplyResponse } from '@opensumi/ide-core-common';
 import { EOL, ICodeEditor, IPosition, ITextModel, Position, Selection } from '@opensumi/ide-monaco';
+import { LineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/lineRange';
 import { DefaultEndOfLine } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { createTextBuffer } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model/textModel';
 import { ModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/services/modelService';
@@ -185,7 +186,11 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
   }
   onEnd(): void {
     const { changes } = this.node.recompute(EComputerMode.legacy);
-    const allAddRanges = changes.map((c) => c.addedRange);
+    const zone = this.node.getZone();
+    const allAddRanges = changes.map((c) => {
+      const lineNumber = zone.startLineNumber + c.addedRange.startLineNumber - 1;
+      return new LineRange(lineNumber, lineNumber + 1);
+    });
     this.node.renderPartialEditWidgets(allAddRanges);
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
@@ -3,14 +3,14 @@
 }
 
 .inline_diff_added_range {
-  background-color: var(--diffEditor-insertedLineBackground);
+  background-color: var(--aiNative-inlineDiffAddedRange);
 }
 
 .inline_diff_remove_zone_widget_container {
   width: calc(100% + 10px);
 
   .inline_diff_remove_zone {
-    background-color: var(--diffEditor-removedLineBackground);
+    background-color: var(--aiNative-inlineDiffRemovedRange);
     height: 100%;
     width: 100%;
   }
@@ -45,13 +45,13 @@
     padding: 2px;
 
     &.accept_btn {
-      background-color: rgba(0, 255, 0, 0.2);
-      color: rgba(255, 255, 255, 0.8);
+      background-color: var(--aiNative-inlineDiffAcceptPartialEdit);
+      color: #fff;
     }
 
     &.discard_btn {
-      background-color: rgba(255, 0, 0, 0.4);
-      color: rgba(255, 255, 255, 0.8);
+      background-color: var(--aiNative-inlineDiffDiscardPartialEdit);
+      color: #fff;
     }
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
@@ -4,6 +4,10 @@
 
 .inline_diff_added_range {
   background-color: var(--aiNative-inlineDiffAddedRange);
+
+  &.hide {
+    visibility: hidden;
+  }
 }
 
 .inline_diff_remove_zone_widget_container {

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
@@ -19,3 +19,39 @@
 .inline_diff_pending_range {
   background-color: var(--editorWidget-background);
 }
+
+.accept_partial_edit_widget_id {
+  pointer-events: none;
+  width: 1e6px;
+}
+
+.inline_diff_accept_partial_widget_container {
+  width: 100%;
+  visibility: visible;
+
+  .content {
+    float: right;
+    display: flex;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-right: 10px;
+  }
+
+  .btn {
+    pointer-events: auto;
+    border: none;
+    font-size: 12px;
+    cursor: pointer;
+    padding: 2px;
+
+    &.accept_btn {
+      background-color: rgba(0, 255, 0, 0.2);
+      color: rgba(255, 255, 255, 0.8);
+    }
+
+    &.discard_btn {
+      background-color: rgba(255, 0, 0, 0.4);
+      color: rgba(255, 255, 255, 0.8);
+    }
+  }
+}

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.service.ts
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@opensumi/di';
+import { Emitter, Event } from '@opensumi/ide-core-common';
+
+@Injectable()
+export class InlineStreamDiffService {
+  private readonly _onAcceptDiscardPartialEdit = new Emitter<boolean>();
+  public readonly onAcceptDiscardPartialEdit: Event<boolean> = this._onAcceptDiscardPartialEdit.event;
+
+  public launchAcceptDiscardPartialEdit(isAccept: boolean): void {
+    this._onAcceptDiscardPartialEdit.fire(isAccept);
+  }
+}

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -33,7 +33,10 @@ interface IPartialEditWidgetComponent {
   discardSequence: string;
 }
 
-type TPartialEdit = 'accept' | 'discard';
+enum EPartialEdit {
+  accept = 'accept',
+  discard = 'discard',
+}
 
 @Injectable({ multiple: true })
 class AcceptPartialEditWidget extends ReactInlineContentWidget {
@@ -194,7 +197,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
 
     this.addDispose(
       this.inlineStreamDiffService.onAcceptDiscardPartialEdit((isAccept) => {
-        // console.log('onAcceptDiscardPartialEdit:>>> ', this)
+        const firstWidget = this.partialEditWidgetList[0];
+        if (firstWidget) {
+          this.handlePartialEditAction(isAccept ? EPartialEdit.accept : EPartialEdit.discard, firstWidget);
+        }
       }),
     );
   }
@@ -308,7 +314,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     ]);
   }
 
-  private handlePartialEditAction(type: TPartialEdit, widget: AcceptPartialEditWidget) {
+  private handlePartialEditAction(type: EPartialEdit, widget: AcceptPartialEditWidget) {
     const position = widget.getPosition()!.position!;
     const model = this.monacoEditor.getModel()!;
     /**
@@ -318,14 +324,14 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     const findAddedDec = this.addedRangeDec.getDecorationByLineNumber(position.lineNumber);
 
     switch (type) {
-      case 'accept':
+      case EPartialEdit.accept:
         widget.dispose();
         findAddedDec?.dispose();
         findRemovedWidget?.dispose();
 
         break;
 
-      case 'discard':
+      case EPartialEdit.discard:
         widget.dispose();
 
         if (findAddedDec) {
@@ -372,10 +378,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
 
       acceptPartialEditWidget.addDispose([
         acceptPartialEditWidget.onAccept(() => {
-          this.handlePartialEditAction('accept', acceptPartialEditWidget);
+          this.handlePartialEditAction(EPartialEdit.accept, acceptPartialEditWidget);
         }),
         acceptPartialEditWidget.onDiscard(() => {
-          this.handlePartialEditAction('discard', acceptPartialEditWidget);
+          this.handlePartialEditAction(EPartialEdit.discard, acceptPartialEditWidget);
         }),
         acceptPartialEditWidget.onDispose(() => {
           const id = acceptPartialEditWidget.getId();

--- a/packages/core-browser/src/ai-native/command.ts
+++ b/packages/core-browser/src/ai-native/command.ts
@@ -10,6 +10,10 @@ export const AI_INLINE_COMPLETION_VISIBLE = {
   id: 'ai.inline.completion.visible',
 };
 
+export const AI_INLINE_DIFF_PARTIAL_EDIT = {
+  id: 'ai.inline.diff.partial.edit',
+};
+
 export const AI_INLINE_COMPLETION_REPORTER = {
   id: 'ai.inline.completion.reporter',
 };

--- a/packages/core-browser/src/contextkey/ai-native.ts
+++ b/packages/core-browser/src/contextkey/ai-native.ts
@@ -4,3 +4,4 @@ export const InlineChatIsVisible = new RawContextKey('ai.native.inlineChatIsVisi
 export const InlineCompletionIsTrigger = new RawContextKey('ai.native.inlineCompletionIsTrigger', false);
 export const InlineHintWidgetIsVisible = new RawContextKey('ai.native.inlineHintWidgetIsVisible', false);
 export const InlineInputWidgetIsVisible = new RawContextKey('ai.native.inlineInputWidgetIsVisible', false);
+export const InlineDiffPartialEditsIsVisible = new RawContextKey('ai.native.inlineDiffPartialEditsIsVisible', false);

--- a/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
+++ b/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
@@ -91,11 +91,15 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
     this.editor.layoutContentWidget(this);
   }
 
+  getClassName(): string {
+    return this.getId();
+  }
+
   getDomNode(): HTMLElement {
     if (!this.domNode) {
       this.domNode = document.createElement('div');
       requestAnimationFrame(() => {
-        this.domNode.classList.add(this.getId());
+        this.domNode.classList.add(this.getClassName());
         this.domNode.style.zIndex = StackingLevelStr.Overlay;
       });
     }

--- a/packages/theme/src/common/color-tokens/ai-native.ts
+++ b/packages/theme/src/common/color-tokens/ai-native.ts
@@ -1,0 +1,31 @@
+import { registerColor, transparent } from '../utils';
+
+import { defaultInsertColor, defaultRemoveColor } from './editor';
+
+export const designInlineDiffAddedRange = registerColor(
+  'aiNative.inlineDiffAddedRange',
+  { dark: defaultInsertColor, light: defaultInsertColor, hcDark: null, hcLight: null },
+  '',
+  true,
+);
+
+export const designInlineDiffRemovedRange = registerColor(
+  'aiNative.inlineDiffRemovedRange',
+  { dark: defaultRemoveColor, light: defaultRemoveColor, hcDark: null, hcLight: null },
+  '',
+  true,
+);
+
+export const designInlineDiffAcceptPartialEdit = registerColor(
+  'aiNative.inlineDiffAcceptPartialEdit',
+  { dark: transparent(defaultInsertColor, 3), light: transparent(defaultInsertColor, 3), hcDark: null, hcLight: null },
+  '',
+  true,
+);
+
+export const designInlineDiffDiscardPartialEdit = registerColor(
+  'aiNative.inlineDiffDiscardPartialEdit',
+  { dark: transparent(defaultRemoveColor, 3), light: transparent(defaultRemoveColor, 3), hcDark: null, hcLight: null },
+  '',
+  true,
+);

--- a/packages/theme/src/common/color-tokens/index.ts
+++ b/packages/theme/src/common/color-tokens/index.ts
@@ -34,5 +34,6 @@ export * from './charts';
 export * from './minimap';
 export * from './testing';
 export * from './design';
+export * from './ai-native';
 
 export * from './custom';


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

- [x] 流式渲染结束后会在每一个 diff 块的右侧显示 采纳/弃用 两个按钮
![image](https://github.com/opensumi/core/assets/20262815/09746f24-cb70-496b-9507-af695e300c82)
- [x] 支持点击或快捷键操作


https://github.com/opensumi/core/assets/20262815/8158b47b-2a26-4093-bd8a-534b6d8f07e3


### Changelog
live 模式的 inline diff 支持采纳或弃用部分变更