### PR TITLE
fix: will watch same folder multiple times

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.file-system-event.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.file-system-event.ts
@@ -9,6 +9,7 @@ import {
   ILogger,
   ProgressLocation,
   URI,
+  Uri,
   formatLocalize,
   localize,
   raceCancellation,
@@ -77,15 +78,15 @@ export class MainThreadFileSystemEvent extends Disposable {
         for (const change of changes) {
           switch (change.type) {
             case FileChangeType.ADDED:
-              events.created.push(new URI(change.uri).codeUri);
+              events.created.push(Uri.parse(change.uri));
               hasResult = true;
               break;
             case FileChangeType.UPDATED:
-              events.changed.push(new URI(change.uri).codeUri);
+              events.changed.push(Uri.parse(change.uri));
               hasResult = true;
               break;
             case FileChangeType.DELETED:
-              events.deleted.push(new URI(change.uri).codeUri);
+              events.deleted.push(Uri.parse(change.uri));
               hasResult = true;
               break;
           }

--- a/packages/file-service/__tests__/node/file-change-collection.test.ts
+++ b/packages/file-service/__tests__/node/file-change-collection.test.ts
@@ -3,6 +3,8 @@ import { FileUri } from '@opensumi/ide-core-node';
 import { FileChangeType } from '../../src/common';
 import { FileChangeCollection } from '../../src/node/file-change-collection';
 
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
 describe('FileChangeCollection', () => {
   assertChanges({
     first: FileChangeType.ADDED,

--- a/packages/file-service/__tests__/node/file-node-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-node-watcher.test.ts
@@ -1,7 +1,7 @@
 import * as fse from 'fs-extra';
 import temp from 'temp';
 
-import { Deferred, FileUri } from '@opensumi/ide-core-node';
+import { Deferred, FileUri, sleep } from '@opensumi/ide-core-node';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 
 import { DidFilesChangedParams, FileChangeType } from '../../src/common/index';
@@ -16,6 +16,7 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
     await fse.mkdirp(FileUri.fsPath(root.resolve('for_rename_folder')));
     await fse.writeFile(FileUri.fsPath(root.resolve('for_rename')), 'rename');
     await watcherServer.watchFileChanges(root.toString());
+    await sleep(1000);
     return { root, watcherServer };
   }
   const watcherServerList: UnRecursiveFileSystemWatcher[] = [];

--- a/packages/file-service/__tests__/node/file-node-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-node-watcher.test.ts
@@ -7,6 +7,8 @@ import { createNodeInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { DidFilesChangedParams, FileChangeType } from '../../src/common/index';
 import { UnRecursiveFileSystemWatcher } from '../../src/node/un-recursive/file-service-watcher';
 
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
 describe('unRecursively watch for folder additions, deletions, rename,and updates', () => {
   const track = temp.track();
   async function generateWatcher() {

--- a/packages/file-service/__tests__/node/file-service-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-service-watcher.test.ts
@@ -8,6 +8,8 @@ import { createNodeInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { DidFilesChangedParams, FileChangeType } from '../../src/common';
 import { FileSystemWatcherServer } from '../../src/node/recursive/file-service-watcher';
 
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
 const sleepTime = 1000;
 
 describe('ParceWatcher Test', () => {

--- a/packages/file-service/__tests__/node/file-service-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-service-watcher.test.ts
@@ -10,7 +10,7 @@ import { FileSystemWatcherServer } from '../../src/node/recursive/file-service-w
 
 const sleepTime = 1000;
 
-(isMacintosh ? describe.skip : describe)('ParceWatcher Test', () => {
+describe('ParceWatcher Test', () => {
   const track = temp.track();
   const watcherServerList: FileSystemWatcherServer[] = [];
   let seed = 1;
@@ -22,7 +22,7 @@ const sleepTime = 1000;
     injector.mock(FileSystemWatcherServer, 'isEnableNSFW', () => false);
     const watcherServer = injector.get(FileSystemWatcherServer);
     const watcherId = await watcherServer.watchFileChanges(root.toString());
-
+    await sleep(sleepTime);
     return { root, watcherServer, watcherId };
   }
 

--- a/packages/file-service/__tests__/node/index.test.ts
+++ b/packages/file-service/__tests__/node/index.test.ts
@@ -13,6 +13,8 @@ import { FileSystemWatcherServer } from '../../lib/node/recursive/file-service-w
 import { FileChangeType, IFileService } from '../../src/common';
 import { FileService, FileServiceModule } from '../../src/node';
 
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
 describe('FileService', () => {
   let root: URI;
   let fileService: IFileService;

--- a/packages/file-service/src/browser/watcher.ts
+++ b/packages/file-service/src/browser/watcher.ts
@@ -25,12 +25,14 @@ export class FileSystemWatcher implements IFileServiceWatcher {
     this.watchId = options.watchId;
     this.uri = options.uri;
 
-    this.fileServiceClient.onFilesChanged((fileChangeList: FileChange[]) => {
-      const result = filterChange(fileChangeList, this.uri.toString());
-      if (result && result.length > 0) {
-        this.changeEmitter.fire(result);
-      }
-    });
+    this.toDispose.push(
+      this.fileServiceClient.onFilesChanged((fileChangeList: FileChange[]) => {
+        const result = filterChange(fileChangeList, this.uri.toString());
+        if (result && result.length > 0) {
+          this.changeEmitter.fire(result);
+        }
+      }),
+    );
   }
 
   get onFilesChanged(): Event<FileChange[]> {

--- a/packages/file-service/src/node/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/recursive/file-service-watcher.ts
@@ -419,14 +419,18 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
   };
 
   protected async fileInWatching(watcherId: number, directory: string, file: string): Promise<string | undefined> {
-    const realPath = await this.resolvePath(directory, file);
+    const tempPath = paths.join(directory, file);
+    if (this.isIgnored(watcherId, tempPath)) {
+      return;
+    }
+    const realPath = await this.resolveRealPathIfNeeded(directory, file);
     if (this.isIgnored(watcherId, realPath)) {
       return;
     }
     return realPath;
   }
 
-  protected async resolvePath(directory: string, file: string): Promise<string> {
+  protected async resolveRealPathIfNeeded(directory: string, file: string): Promise<string> {
     const path = paths.join(directory, file);
     // 如果是 linux 则获取一下真实 path，以防返回的是软连路径被过滤
     if (isLinux) {

--- a/packages/file-service/src/node/shared/filter.ts
+++ b/packages/file-service/src/node/shared/filter.ts
@@ -1,0 +1,10 @@
+export function isTemporaryFile(path: string): boolean {
+  if (path) {
+    if (/\.\d{7}\d+$/.test(path)) {
+      // write-file-atomic 源文件xxx.xx 对应的临时文件为 xxx.xx.22243434
+      // 这类文件的更新应当完全隐藏掉
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/file-service/src/node/un-recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/un-recursive/file-service-watcher.ts
@@ -16,6 +16,7 @@ import {
 
 import { FileChangeType, FileSystemWatcherClient, IFileSystemWatcherServer } from '../../common/index';
 import { FileChangeCollection } from '../file-change-collection';
+import { isTemporaryFile } from '../shared/filter';
 const { join, basename, normalize } = path;
 @Injectable({ multiple: true })
 export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
@@ -70,15 +71,16 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
     try {
       const watcher = watch(basePath);
       this.logger.log('start watching', basePath);
-      const isDirectory = fs.lstatSync(basePath).isDirectory();
+      const isDirectory = (await fs.lstat(basePath)).isDirectory();
 
       const docChildren = new Set<string>();
       let signalDoc = '';
       if (isDirectory) {
         try {
-          for (const child of fs.readdirSync(basePath)) {
+          const children = await fs.readdir(basePath);
+          for (const child of children) {
             const base = join(basePath, String(child));
-            if (!fs.lstatSync(base).isDirectory()) {
+            if (!(await fs.lstat(base)).isDirectory()) {
               docChildren.add(child);
             }
           }
@@ -96,7 +98,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
       });
 
       watcher.on('change', (type: string, filename: string | Buffer) => {
-        if (this.isTemporaryFile(filename as string)) {
+        if (isTemporaryFile(filename as string)) {
           return;
         }
 
@@ -118,7 +120,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
             // 监听的目录如果是文件夹，那么只对其下面的文件改动做出响应
             if (docChildren.has(changeFileName)) {
               if ((type === 'rename' || type === 'change') && changeFileName === filename) {
-                const fileExists = fs.existsSync(changePath);
+                const fileExists = await fs.pathExists(changePath);
                 if (fileExists) {
                   this.pushUpdated(changePath);
                 } else {
@@ -126,8 +128,8 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
                   this.pushDeleted(changePath);
                 }
               }
-            } else if (fs.pathExistsSync(changePath)) {
-              if (!fs.lstatSync(changePath).isDirectory()) {
+            } else if (await fs.pathExists(changePath)) {
+              if (!(await fs.lstat(changePath)).isDirectory()) {
                 this.pushAdded(changePath);
                 docChildren.add(changeFileName);
               }
@@ -136,7 +138,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
         } else {
           setTimeout(async () => {
             if (changeFileName === signalDoc) {
-              if (fs.pathExistsSync(basePath)) {
+              if (await fs.pathExists(basePath)) {
                 this.pushUpdated(basePath);
               } else {
                 this.pushDeleted(basePath);
@@ -168,7 +170,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
     let watchPath = '';
 
     if (exist) {
-      const stat = await fs.lstatSync(basePath);
+      const stat = await fs.lstat(basePath);
       if (stat) {
         watchPath = basePath;
       }
@@ -247,16 +249,5 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
       return;
     }
     this.client = client;
-  }
-
-  protected isTemporaryFile(path: string): boolean {
-    if (path) {
-      if (/\.\d{7}\d+$/.test(path)) {
-        // write-file-atomic 源文件xxx.xx 对应的临时文件为 xxx.xx.22243434
-        // 这类文件的更新应当完全隐藏掉
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/packages/utils/src/uri.ts
+++ b/packages/utils/src/uri.ts
@@ -294,6 +294,10 @@ export class URI {
     return query;
   }
 
+  get fsPath(): string {
+    return this.codeUri.fsPath;
+  }
+
   static stringifyQuery(query: { [key: string]: any }): string {
     const values: string[] = [];
     Object.keys(query).forEach((key) => {


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution
之前的逻辑有判断要 watch 的路径是否已经被 watch 了，但是因为 async await 的原因，前端同时请求过来三四个一样的路径，后端会同时 watch 这些路径。

同时也优化了一些性能问题，原来的代码里检测文件夹是否存在时使用了 Sync 方法，这会导致处理文件监听时 Node 层会同步卡住进行的。
### Changelog

fix file service will watch same folder multiple times