### PR TITLE
fix: sync dirty state when will save document

### DIFF
--- a/packages/editor/src/browser/doc-model/editor-document-model.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model.ts
@@ -369,6 +369,7 @@ export class EditorDocumentModel extends Disposable implements IEditorDocumentMo
           uri: this.uri,
           reason,
           language: this.languageId,
+          dirty: this.dirty,
         }),
       );
       if (!this.editorPreferences['editor.askIfDiff']) {

--- a/packages/editor/src/browser/doc-model/types.ts
+++ b/packages/editor/src/browser/doc-model/types.ts
@@ -14,8 +14,6 @@ import { EOL, EndOfLineSequence } from '@opensumi/ide-monaco/lib/browser/monaco-
 import { IEditorDocumentModelContentChange, SaveReason } from '../../common';
 import { IEditorDocumentModel, IEditorDocumentModelRef } from '../../common/editor';
 
-import { EditorDocumentModel } from './editor-document-model';
-
 export interface IDocModelUpdateOptions extends monaco.editor.ITextModelUpdateOptions {
   detectIndentation?: boolean;
 }
@@ -217,6 +215,7 @@ export class EditorDocumentModelWillSaveEvent extends BasicEvent<{
   uri: URI;
   reason: SaveReason;
   language: string;
+  dirty: boolean;
 }> {}
 export interface IStackElement {
   readonly beforeVersionId: number;

--- a/packages/extension/src/browser/vscode/api/main.thread.doc.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.doc.ts
@@ -171,6 +171,7 @@ export class MainThreadExtensionDocumentData extends WithEventBus implements IMa
     await this.proxy.$fireModelWillSaveEvent({
       uri: e.payload.uri.toString(),
       reason: e.payload.reason,
+      dirty: e.payload.dirty,
     });
   }
 

--- a/packages/extension/src/common/vscode/doc.ts
+++ b/packages/extension/src/common/vscode/doc.ts
@@ -92,6 +92,7 @@ export interface IExtensionDocumentModelSavedEvent {
 export interface IExtensionDocumentModelWillSaveEvent {
   uri: string;
   reason: SaveReason;
+  dirty: boolean;
 }
 
 export const ExtensionDocumentManagerProxy = Symbol('ExtensionDocumentManagerProxy');

--- a/packages/extension/src/hosted/api/vscode/doc/doc-manager.host.ts
+++ b/packages/extension/src/hosted/api/vscode/doc/doc-manager.host.ts
@@ -90,7 +90,7 @@ export class ExtensionDocumentDataManagerImpl implements ExtensionDocumentDataMa
     } else if (!options || typeof options === 'object') {
       uri = Uri.parse(await this._proxy.$tryCreateDocument(options));
     } else {
-      throw new Error('illegal argument -  uriOrFileNameOrOptions');
+      throw new Error('illegal argument - uriOrFileNameOrOptions');
     }
 
     const docUrl = normalizeFileUrl(uri.toString());
@@ -253,6 +253,8 @@ export class ExtensionDocumentDataManagerImpl implements ExtensionDocumentDataMa
     const document = this._documents.get(uri);
 
     if (document) {
+      document._acceptIsDirty(e.dirty);
+
       const promises: Promise<any>[] = [];
       const event: vscode.TextDocumentWillSaveEvent = {
         document: document.document,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

现状是 ext 层 document 的 dirty 状态会和 browser 层不同步。

如果此时 browser 层的文本是非 dirty 的，也就意味着它不会向插件层发送 Save 事件，这里我们在 onWillSave 的时候发一个事件去同步当前的状态。

这样至少保证了用户按 ctrl+s 的时候，状态能同步到 ext host

### Changelog

fix extesnion document state may not sync from main thread