### PR TITLE
fix: add intersection observer for resize detection

### DIFF
--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -1,5 +1,6 @@
 require('./jest.setup.base');
 require('jest-canvas-mock');
+require('intersection-observer');
 require('jest-fetch-mock').enableMocks();
 const { Buffer } = require('buffer');
 const timer = require('timers');

--- a/jest.setup.node.js
+++ b/jest.setup.node.js
@@ -42,6 +42,7 @@ global.getComputedStyle = jsdom.window.getComputedStyle;
 global.window = jsdom.window;
 global.DOMParser = jsdom.window.DOMParser;
 global.MutationObserver = jsdom.window.MutationObserver;
+global.IntersectionObserver = jsdom.window.IntersectionObserver;
 global.KeyboardEvent = jsdom.window.KeyboardEvent;
 global.requestAnimationFrame = (fn) => setTimeout(fn, 16);
 global.cancelAnimationFrame = (timer) => {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "glob": "^8.0.1",
     "handlebars": "^4.7.3",
     "husky": "^7.0.4",
+    "intersection-observer": "^0.12.2",
     "is-git-clean": "^1.1.0",
     "jest": "^29.7.0",
     "jest-canvas-mock": "^2.4.0",

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -459,6 +459,13 @@ export abstract class ResizeZoneWidget extends ZoneWidget {
 
   protected observeContainer(dom: HTMLDivElement): IDisposable {
     this.wrap = dom;
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          this.resizeZoneWidget();
+        }
+      }
+    });
     const mutationObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === 'childList') {
@@ -482,9 +489,11 @@ export abstract class ResizeZoneWidget extends ZoneWidget {
       });
       this.resizeZoneWidget();
     });
+    intersectionObserver.observe(this.wrap);
     mutationObserver.observe(this.wrap, { childList: true, subtree: true });
     return {
       dispose() {
+        intersectionObserver.disconnect();
         mutationObserver.disconnect();
       },
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,6 +1992,7 @@ __metadata:
     glob: "npm:^8.0.1"
     handlebars: "npm:^4.7.3"
     husky: "npm:^7.0.4"
+    intersection-observer: "npm:^0.12.2"
     is-git-clean: "npm:^1.1.0"
     jest: "npm:^29.7.0"
     jest-canvas-mock: "npm:^2.4.0"
@@ -10901,6 +10902,13 @@ __metadata:
   version: 3.1.1
   resolution: "interpret@npm:3.1.1"
   checksum: 10/bc9e11126949c4e6ff49b0b819e923a9adc8e8bf3f9d4f2d782de6d5f592774f6fee4457c10bd08c6a2146b4baee460ccb242c99e5397defa9c846af0d00505a
+  languageName: node
+  linkType: hard
+
+"intersection-observer@npm:^0.12.2":
+  version: 0.12.2
+  resolution: "intersection-observer@npm:0.12.2"
+  checksum: 10/cb1a6369bd1636b3f227d7cb7fec22f5a35b9d8ba9e26303b405d50c54c3ef02c5a547107b1d951e7eb421e192a564222faf4660a21fad69c34dcb9f926c159c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

解决评论组件不可见初始化异常问题

### Changelog

add intersection observer for resize detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了 `IntersectionObserver` 来监控元素的交叉情况，并在交叉时触发 `resizeZoneWidget()` 方法。
  
- **依赖更新**
  - 在 `package.json` 中添加了 `"intersection-observer": "^0.12.2"` 依赖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->