### PR TITLE
feat: support live inline diff undo/redo edit

### DIFF
--- a/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
+++ b/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
@@ -13,7 +13,6 @@ import { space } from '@opensumi/ide-utils/lib/strings';
 
 import styles from './styles.module.less';
 
-// @internal
 interface IDeltaData extends IModelDeltaDecoration {
   length: number;
   dispose(): void;
@@ -28,7 +27,6 @@ export interface IEnhanceModelDeltaDecoration extends IDeltaData {
   setRange(newRange: IRange): void;
 }
 
-// @internal
 class DeltaDecorations implements IEnhanceModelDeltaDecoration {
   length: number;
   range: IRange;

--- a/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
+++ b/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
@@ -52,7 +52,10 @@ class DeltaDecorations implements IEnhanceModelDeltaDecoration {
       return;
     }
 
-    const classList = this.options.className.split(space).filter((s) => s !== styles.hidden || s !== styles.visible);
+    const classList = this.options.className
+      .split(space)
+      .filter((s) => s !== styles.hidden && s !== styles.visible)
+      .filter(Boolean);
     classList.push(newClassName);
 
     this.options.className = classList.join(space);

--- a/packages/ai-native/src/browser/model/styles.module.less
+++ b/packages/ai-native/src/browser/model/styles.module.less
@@ -1,0 +1,7 @@
+.hidden {
+  visibility: hidden;
+}
+
+.visible {
+  visibility: visible;
+}

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
@@ -447,6 +447,12 @@ export class InlineChatHandler extends Disposable {
         doLayoutContentWidget();
       }),
     );
+
+    this.aiInlineChatOperationDisposed.addDispose(
+      this.diffPreviewer.onDispose(() => {
+        this.aiInlineContentWidget.dispose();
+      }),
+    );
   }
 
   private async handleDiffPreviewStrategy(

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -150,11 +150,8 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
   }
   createNode(): InlineStreamDiffHandler {
     const node = this.injector.get(InlineStreamDiffHandler, [this.monacoEditor, this.selection]);
-    this.addDispose(
-      Disposable.create(() => {
-        node.dispose();
-      }),
-    );
+    this.addDispose(node.onDispose(() => this.dispose()));
+    this.addDispose(node);
     return node;
   }
   getPosition(): IPosition | undefined {
@@ -164,7 +161,7 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
   handleAction(action: EResultKind): void {
     switch (action) {
       case EResultKind.ACCEPT:
-        this.node.clearAllDecorations();
+        this.node.dispose();
         break;
 
       case EResultKind.DISCARD:
@@ -192,6 +189,7 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
       return new LineRange(lineNumber, lineNumber + 1);
     });
     this.node.renderPartialEditWidgets(allAddRanges);
+    this.node.pushStackElement();
     this.monacoEditor.focus();
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -378,21 +378,23 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     addedDec?: IEnhanceModelDeltaDecoration,
     removedWidget?: RemovedZoneWidget,
   ): void {
-    partialWidget.hide();
-    addedDec?.hide();
-    removedWidget?.hide();
+    const hide = () => {
+      partialWidget.hide();
+      addedDec?.hide();
+      removedWidget?.hide();
+    };
+
+    const resume = () => {
+      partialWidget.resume();
+      addedDec?.resume();
+      removedWidget?.resume();
+    };
+
+    hide();
 
     this.pushUndoElement({
-      undo: () => {
-        partialWidget.resume();
-        addedDec?.resume();
-        removedWidget?.resume();
-      },
-      redo: () => {
-        partialWidget.hide();
-        addedDec?.hide();
-        removedWidget?.hide();
-      },
+      undo: () => resume(),
+      redo: () => hide(),
     });
   }
 

--- a/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
+++ b/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
@@ -44,18 +44,26 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
         this.layoutContentWidget();
       }),
     );
+
+    this.addDispose(
+      Disposable.create(() => {
+        this.hide();
+        if (this.root) {
+          this.root.unmount();
+        }
+      }),
+    );
   }
 
   public abstract renderView(): React.ReactNode;
   public abstract id(): string;
 
-  override dispose(): void {
-    this.hide();
-    super.dispose();
-  }
-
   setPositionPreference(preferences: ContentWidgetPositionPreference[]): void {
     this.positionPreference = preferences;
+  }
+
+  setOptions(options?: ShowAIContentOptions | undefined): void {
+    this.options = options;
   }
 
   show(options?: ShowAIContentOptions | undefined): void {
@@ -71,16 +79,16 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
       return;
     }
 
-    this.options = options;
+    this.setOptions(options);
     this.editor.addContentWidget(this);
   }
 
   hide() {
-    this.options = undefined;
     this.editor.removeContentWidget(this);
-    if (this.root) {
-      this.root.unmount();
-    }
+  }
+
+  resume(): void {
+    this.editor.addContentWidget(this);
   }
 
   getId(): string {

--- a/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
+++ b/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
@@ -30,6 +30,11 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
   suppressMouseDown = false;
   positionPreference: ContentWidgetPositionPreference[] = [ContentWidgetPositionPreference.BELOW];
 
+  private _isHidden: boolean;
+  public get isHidden(): boolean {
+    return this._isHidden;
+  }
+
   protected domNode: HTMLElement;
   protected options: ShowAIContentOptions | undefined;
   private root?: ReactDOMClient.Root | null = null;
@@ -80,14 +85,17 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
     }
 
     this.setOptions(options);
+    this._isHidden = false;
     this.editor.addContentWidget(this);
   }
 
   hide() {
+    this._isHidden = true;
     this.editor.removeContentWidget(this);
   }
 
   resume(): void {
+    this._isHidden = false;
     this.editor.addContentWidget(this);
   }
 

--- a/packages/utils/src/strings.ts
+++ b/packages/utils/src/strings.ts
@@ -5,6 +5,7 @@ import { Constants } from './uint';
  * The empty string.
  */
 export const empty = '';
+export const space = ' ';
 
 const hasTextEncoder = typeof TextEncoder !== 'undefined';
 const hasTextDecoder = typeof TextDecoder !== 'undefined';


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

- [x] 支持在流式渲染完成之后按 undo 撤销当前 inline diff 模式
- [x] 采纳或丢弃 部分变更时也支持 undo/redo 操作


https://github.com/opensumi/core/assets/20262815/7c547bd8-69dd-4380-a4b8-a16456c12b37



### Changelog
live 模式的 inline diff 支持 undo/redo 操作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了撤销/重做功能以支持实时预览装饰模型中的部分编辑。

- **改进**
  - 在 `InlineChatHandler` 中新增了对 `aiInlineContentWidget` 进行处置的操作。
  - 优化了 `LiveInlineDiffPreviewer` 类中的节点处置和方法调用。

- **样式**
  - 新增了用于隐藏和显示元素的样式。

- **重构**
  - 更新了多个类的方法签名和属性以支持新的功能和优化。

- **常规**
  - 在 `strings.ts` 文件中添加了一个新的导出常量 `space`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->