### PR TITLE
style: inline-hint line height

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-hint/inline-hint-line-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-hint/inline-hint-line-widget.tsx
@@ -6,6 +6,7 @@ import { AI_INLINE_CHAT_INTERACTIVE_INPUT_VISIBLE } from '@opensumi/ide-core-bro
 import { AIInlineHintLineContentWidgetId, formatLocalize } from '@opensumi/ide-core-common';
 import { ReactInlineContentWidget } from '@opensumi/ide-monaco/lib/browser/ai-native/BaseInlineContentWidget';
 import { ContentWidgetPositionPreference } from '@opensumi/ide-monaco/lib/browser/monaco-exports/editor';
+import { EditorOption } from '@opensumi/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 
 import styles from './inline-hint.module.less';
 
@@ -30,8 +31,9 @@ export class InlineHintLineWidget extends ReactInlineContentWidget {
   }
 
   override renderView(): ReactNode {
+    const lineHeight = this.editor.getOption(EditorOption.lineHeight);
     return (
-      <div className={styles.hint_line_widget}>
+      <div className={styles.hint_line_widget} style={{ height: lineHeight }}>
         <span className={styles.text}>
           {formatLocalize('aiNative.inline.hint.widget.placeholder', this.getSequenceKeyString())}
         </span>

--- a/packages/ai-native/src/browser/widget/inline-hint/inline-hint.module.less
+++ b/packages/ai-native/src/browser/widget/inline-hint/inline-hint.module.less
@@ -1,10 +1,11 @@
 .hint_line_widget {
   width: max-content;
-  height: 100%;
   padding-left: 12px;
   user-select: none;
   pointer-events: none;
   position: absolute;
+  display: flex;
+  align-items: center;
 
   .text {
     color: var(--input-placeholderForeground) !important;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

### Changelog
改进 inline-hint 的垂直居中问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了根据编辑器行高设置组件高度的功能。

- **样式**
  - 为 `.hint_line_widget` 类添加了 `display: flex;` 属性。
  - 为 `.hint_line_widget` 类添加了 `align-items: center;` 属性，优化布局和元素对齐方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->