### PR TITLE
fix: ai native left panel supports large size

### DIFF
--- a/packages/ai-native/src/browser/layout/ai-layout.tsx
+++ b/packages/ai-native/src/browser/layout/ai-layout.tsx
@@ -29,7 +29,6 @@ export const AILayout = () => {
             isTabbar={true}
             defaultSize={layout.left?.currentId ? layout.left?.size || 310 : 49}
             minResize={280}
-            maxResize={480}
             minSize={49}
           />
           <SplitPanel id='main-vertical' minResize={300} flexGrow={1} direction='top-to-bottom'>


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes
### Background or solution

### Changelog
Fix: AI Native Left面板在搜索内容比较长的情况下没办法拖拽到大尺寸