### PR TITLE
feat: add autoApplyNonConflictChanges configuration

### DIFF
--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -300,6 +300,10 @@ export const corePreferenceSchema: PreferenceSchema = {
       type: 'boolean',
       default: true,
     },
+    'mergeEditor.autoApplyNoConflictChanges': {
+      type: 'boolean',
+      default: false,
+    },
   },
 };
 

--- a/packages/core-browser/src/core-preferences.ts
+++ b/packages/core-browser/src/core-preferences.ts
@@ -300,7 +300,7 @@ export const corePreferenceSchema: PreferenceSchema = {
       type: 'boolean',
       default: true,
     },
-    'mergeEditor.autoApplyNoConflictChanges': {
+    'mergeEditor.autoApplyNonConflictChanges': {
       type: 'boolean',
       default: false,
     },

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -987,6 +987,9 @@ export const localizationBundle = {
 
     'preference.diffEditor.renderSideBySide': 'Render Side By Side',
     'preference.diffEditor.ignoreTrimWhitespace': 'Ignore Trim Whitespace',
+
+    'preference.mergeEditor.autoApplyNoConflictChanges': 'Automatically apply non-conflicting changes',
+
     'validate.tree.emptyFileNameError': 'Please provide a file or folder name',
     'validate.tree.fileNameStartsWithSlashError': 'File or folder name cannot start with /',
     'validate.tree.fileNameFollowOrStartWithSpaceWarning': 'Leading or trailing spaces detected in file or folder name',

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -988,7 +988,7 @@ export const localizationBundle = {
     'preference.diffEditor.renderSideBySide': 'Render Side By Side',
     'preference.diffEditor.ignoreTrimWhitespace': 'Ignore Trim Whitespace',
 
-    'preference.mergeEditor.autoApplyNoConflictChanges': 'Automatically apply non-conflicting changes',
+    'preference.mergeEditor.autoApplyNonConflictChanges': 'Automatically apply non-conflicting changes',
 
     'validate.tree.emptyFileNameError': 'Please provide a file or folder name',
     'validate.tree.fileNameStartsWithSlashError': 'File or folder name cannot start with /',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -560,7 +560,7 @@ export const localizationBundle = {
     'preference.diffEditor.renderSideBySide': '显示并排差异编辑器',
     'preference.diffEditor.ignoreTrimWhitespace': '忽略差异编辑器的前导和尾随空白字符',
 
-    'preference.mergeEditor.autoApplyNoConflictChanges': '自动合并非冲突变更',
+    'preference.mergeEditor.autoApplyNonConflictChanges': '自动合并非冲突变更',
 
     'status.editor.chooseLanguage': '选择语言模式',
     'status.editor.goToLineCol': '转到行/列',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -560,6 +560,8 @@ export const localizationBundle = {
     'preference.diffEditor.renderSideBySide': '显示并排差异编辑器',
     'preference.diffEditor.ignoreTrimWhitespace': '忽略差异编辑器的前导和尾随空白字符',
 
+    'preference.mergeEditor.autoApplyNoConflictChanges': '自动合并非冲突变更',
+
     'status.editor.chooseLanguage': '选择语言模式',
     'status.editor.goToLineCol': '转到行/列',
     'status.editor.chooseEncoding': '选择编码',

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -6,6 +6,7 @@ import {
   Emitter,
   Event,
   MonacoService,
+  PreferenceService,
   SCM_COMMANDS,
   localize,
 } from '@opensumi/ide-core-browser';
@@ -54,6 +55,9 @@ export class MergeEditorService extends Disposable {
 
   @Autowired(MergeConflictReportService)
   private readonly mergeConflictReportService: MergeConflictReportService;
+
+  @Autowired(PreferenceService)
+  protected readonly preferenceService: PreferenceService;
 
   public resultView: ResultCodeEditor;
 
@@ -426,8 +430,11 @@ export class MergeEditorService extends Disposable {
     this.resultView.inputDiffComputingResult();
 
     // resolve non conflict ranges
-    this.acceptLeft(true, ECompleteReason.AutoResolvedNonConflict);
-    this.acceptRight(true, ECompleteReason.AutoResolvedNonConflict);
+    const isAutoApply = this.preferenceService.getValid('mergeEditor.autoApplyNoConflictChanges', false);
+    if (isAutoApply) {
+      this.acceptLeft(true, ECompleteReason.AutoResolvedNonConflict);
+      this.acceptRight(true, ECompleteReason.AutoResolvedNonConflict);
+    }
 
     this.currentView.updateDecorations().updateActions();
     this.incomingView.updateDecorations().updateActions();

--- a/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
+++ b/packages/monaco/src/browser/contrib/merge-editor/merge-editor.service.ts
@@ -430,7 +430,7 @@ export class MergeEditorService extends Disposable {
     this.resultView.inputDiffComputingResult();
 
     // resolve non conflict ranges
-    const isAutoApply = this.preferenceService.getValid('mergeEditor.autoApplyNoConflictChanges', false);
+    const isAutoApply = this.preferenceService.getValid('mergeEditor.autoApplyNonConflictChanges', false);
     if (isAutoApply) {
       this.acceptLeft(true, ECompleteReason.AutoResolvedNonConflict);
       this.acceptRight(true, ECompleteReason.AutoResolvedNonConflict);

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -745,8 +745,8 @@ export const defaultSettingSections: {
       preferences: [
         // merge 编辑器
         {
-          id: 'mergeEditor.autoApplyNoConflictChanges',
-          localized: 'preference.mergeEditor.autoApplyNoConflictChanges',
+          id: 'mergeEditor.autoApplyNonConflictChanges',
+          localized: 'preference.mergeEditor.autoApplyNonConflictChanges',
         },
       ],
     },

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -741,6 +741,16 @@ export const defaultSettingSections: {
       ],
     },
     {
+      title: 'Merge Editor',
+      preferences: [
+        // merge 编辑器
+        {
+          id: 'mergeEditor.autoApplyNoConflictChanges',
+          localized: 'preference.mergeEditor.autoApplyNoConflictChanges',
+        },
+      ],
+    },
+    {
       title: 'Files',
       preferences: [
         { id: 'files.autoGuessEncoding', localized: 'preference.files.autoGuessEncoding.title' },


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

### Changelog
merge editor 新增 “自动合并非冲突变更” 配置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了一个新偏好设置 `mergeEditor.autoApplyNoConflictChanges`，默认值为`false`。
  - 在合并编辑器新增自动应用无冲突更改的功能。

- **本地化**
  - 增加了新的本地化键 `'preference.mergeEditor.autoApplyNoConflictChanges'`，值为“自动应用无冲突的更改”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->