### PR TITLE
fix: will watch same folder multiple times

### DIFF
--- a/packages/file-service/src/node/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/recursive/file-service-watcher.ts
@@ -28,6 +28,14 @@ export interface WatcherOptions {
   excludes: string[];
 }
 
+const watcherPlaceHolder = {
+  path: '',
+  disposable: {
+    dispose: () => {},
+  },
+  handlers: [],
+};
+
 /**
  * @deprecated
  */
@@ -88,7 +96,6 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
    */
   async watchFileChanges(uri: string, options?: WatchOptions): Promise<number> {
     const basePath = FileUri.fsPath(uri);
-    const exist = await fs.pathExists(basePath);
 
     let watcherId = this.checkIsAlreadyWatched(basePath);
     if (watcherId) {
@@ -96,10 +103,14 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
     }
 
     watcherId = FileSystemWatcherServer.WATCHER_SEQUENCE++;
+    this.WATCHER_HANDLERS.set(watcherId, watcherPlaceHolder);
+
     const toDisposeWatcher = new DisposableCollection();
-    let watchPath;
+    let watchPath: string;
+
+    const exist = await fs.pathExists(basePath);
     if (exist) {
-      const stat = await fs.lstatSync(basePath);
+      const stat = await fs.lstat(basePath);
       if (stat && stat.isDirectory()) {
         watchPath = basePath;
       } else {
@@ -116,14 +127,16 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
       }
       events = this.trimChangeEvent(events);
       for (const event of events) {
-        if (event.type === 'create') {
-          this.pushAdded(event.path);
-        }
-        if (event.type === 'delete') {
-          this.pushDeleted(event.path);
-        }
-        if (event.type === 'update') {
-          this.pushUpdated(event.path);
+        switch (event.type) {
+          case 'create':
+            this.pushAdded(event.path);
+            break;
+          case 'delete':
+            this.pushDeleted(event.path);
+            break;
+          case 'update':
+            this.pushUpdated(event.path);
+            break;
         }
       }
     };

--- a/packages/file-service/src/node/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/recursive/file-service-watcher.ts
@@ -29,7 +29,6 @@ export interface WatcherOptions {
 }
 
 const watcherPlaceHolder = {
-  path: '',
   disposable: {
     dispose: () => {},
   },
@@ -103,7 +102,10 @@ export class FileSystemWatcherServer implements IFileSystemWatcherServer {
     }
 
     watcherId = FileSystemWatcherServer.WATCHER_SEQUENCE++;
-    this.WATCHER_HANDLERS.set(watcherId, watcherPlaceHolder);
+    this.WATCHER_HANDLERS.set(watcherId, {
+      ...watcherPlaceHolder,
+      path: basePath,
+    });
 
     const toDisposeWatcher = new DisposableCollection();
     let watchPath: string;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

之前的逻辑有判断要 watch 的路径是否已经被 watch 了，但是因为 async await 的原因，前端同时请求过来三四个一样的路径，后端会同时 watch 这些路径。

### Changelog
fix file service will watch same folder multiple times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 改进了文件系统监视器的初始化和事件处理功能，提升了文件变更监视的效率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->