### PR TITLE
feat: request completion support workspaceDir

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -289,6 +289,10 @@ export class AINativeBrowserContribution
         title: localize('preference.ai.native.inlineCompletions.title'),
         preferences: [
           {
+            id: AINativeSettingSectionsId.InlineCompletionsCacheEnabled,
+            localized: 'preference.ai.native.inlineCompletions.cache.enabled',
+          },
+          {
             id: AINativeSettingSectionsId.InlineCompletionsDebounceTime,
             localized: 'preference.ai.native.inlineCompletions.debounceTime',
           },

--- a/packages/ai-native/src/browser/contrib/inline-completions/completeProvider.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/completeProvider.ts
@@ -220,11 +220,8 @@ export class CompletionRequestTask {
       return [];
     }
 
-    if (rs && rs.codeModelList && rs.codeModelList.length > 0) {
-      this.promptCache.setCache(requestBean, { ...rs, relationId });
-    }
     // 返回补全结果为空直接返回
-    if (rs.codeModelList.length === 0) {
+    if (!rs || !rs.codeModelList || rs.codeModelList.length === 0) {
       this.aiCompletionsService.reporterEnd(relationId, {
         success: true,
         replytime: Date.now() - requestStartTime,
@@ -232,6 +229,10 @@ export class CompletionRequestTask {
       });
       this.aiCompletionsService.updateStatusBarItem('no result', false);
       return [];
+    }
+
+    if (rs.codeModelList.length > 0) {
+      this.promptCache.setCache(requestBean, { ...rs, relationId });
     }
 
     this.aiCompletionsService.updateStatusBarItem('completion result: ' + rs.codeModelList.length, false);

--- a/packages/ai-native/src/browser/contrib/inline-completions/completeProvider.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/completeProvider.ts
@@ -1,5 +1,5 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
-import { PreferenceService } from '@opensumi/ide-core-browser';
+import { AppConfig, PreferenceService } from '@opensumi/ide-core-browser';
 import { AI_INLINE_COMPLETION_REPORTER } from '@opensumi/ide-core-browser/lib/ai-native/command';
 import {
   AINativeSettingSectionsId,
@@ -10,13 +10,13 @@ import {
   sleep,
   uuid,
 } from '@opensumi/ide-core-common';
-import { IAICompletionResultModel } from '@opensumi/ide-core-common/lib/types/ai-native';
+import { IAICompletionOption, IAICompletionResultModel } from '@opensumi/ide-core-common/lib/types/ai-native';
 import { AISerivceType, IAIReporter } from '@opensumi/ide-core-common/lib/types/ai-native/reporter';
 import { IEditor } from '@opensumi/ide-editor';
 import * as monaco from '@opensumi/ide-monaco';
 
 import { DEFAULT_COMPLECTION_MODEL } from './constants';
-import { CompletionRequestBean, IInlineCompletionCache, InlineCompletionItem } from './model/competionModel';
+import { IInlineCompletionCache, InlineCompletionItem } from './model/competionModel';
 import { PromptCache } from './promptCache';
 import { getPrefixPrompt, getSuffixPrompt, lineBasedPromptProcessor } from './provider';
 import { AICompletionsService } from './service/ai-completions.service';
@@ -68,6 +68,9 @@ export class CompletionRequestTask {
   @Autowired(PreferenceService)
   private readonly preferenceService: PreferenceService;
 
+  @Autowired(AppConfig)
+  private appConfig: AppConfig;
+
   isCancelFlag: boolean;
 
   private isEnablePromptEngineering = true;
@@ -98,7 +101,7 @@ export class CompletionRequestTask {
   async constructRequestBean(
     context: ICompletionContext,
     token: monaco.CancellationToken,
-  ): Promise<CompletionRequestBean> {
+  ): Promise<IAICompletionOption> {
     if (this.isEnablePromptEngineering) {
       const prompt = await getPrefixPrompt(context, DEFAULT_COMPLECTION_MODEL, this.injector, token);
       const suffix = await getSuffixPrompt(context, DEFAULT_COMPLECTION_MODEL, this.injector, token);
@@ -109,6 +112,7 @@ export class CompletionRequestTask {
         sessionId: uuid(),
         language: context.language,
         fileUrl: context.fileUrl,
+        workspaceDir: context.workspaceDir,
       };
     }
 
@@ -120,6 +124,7 @@ export class CompletionRequestTask {
       sessionId: uuid(),
       language: context.language,
       fileUrl: context.fileUrl,
+      workspaceDir: context.workspaceDir,
     };
   }
 
@@ -154,17 +159,17 @@ export class CompletionRequestTask {
 
     const languageId = model.getLanguageId();
     const context: ICompletionContext = {
-      // todo: 改成相对工作空间的路径
-      fileUrl: model.uri.toString().split('/').pop()!,
+      fileUrl: model.uri.fsPath,
       filename: model.uri.toString().split('/').pop()!,
       language: languageId,
       prefix,
       suffix,
       uri: URI.from(model.uri),
+      workspaceDir: this.appConfig.workspaceDir,
     };
 
     // 组装请求参数,向远程发起请求
-    const completionRequestBean = await this.constructRequestBean(context, token);
+    const requestBean = await this.constructRequestBean(context, token);
     if (this.isCancelFlag) {
       return [];
     }
@@ -173,7 +178,7 @@ export class CompletionRequestTask {
     const requestStartTime = Date.now();
 
     let rs: IAICompletionResultModel | null;
-    const cacheData = this.promptCache.getCache(completionRequestBean.prompt);
+    const cacheData = this.promptCache.getCache(requestBean);
     const relationId =
       cacheData?.relationId || this.aiReporter.start(AISerivceType.Completion, { message: AISerivceType.Completion });
 
@@ -183,7 +188,7 @@ export class CompletionRequestTask {
       rs = cacheData;
     } else {
       try {
-        rs = await this.aiCompletionsService.complete(completionRequestBean, model, position, token);
+        rs = await this.aiCompletionsService.complete(requestBean, model, position, token);
       } catch (error) {
         this.aiCompletionsService.reporterEnd(relationId, {
           success: false,
@@ -216,7 +221,7 @@ export class CompletionRequestTask {
     }
 
     if (rs && rs.codeModelList && rs.codeModelList.length > 0) {
-      this.promptCache.setCache(completionRequestBean.prompt, { ...rs, relationId });
+      this.promptCache.setCache(requestBean, { ...rs, relationId });
     }
     // 返回补全结果为空直接返回
     if (rs.codeModelList.length === 0) {

--- a/packages/ai-native/src/browser/contrib/inline-completions/model/competionModel.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/model/competionModel.ts
@@ -22,28 +22,6 @@ export interface IInlineCompletionCache {
 }
 
 /**
- * 补全请求对象
- */
-export interface CompletionRequestBean {
-  /**
-   * 模型输入上文
-   */
-  prompt: string;
-  /**
-   * 代码语言类型
-   */
-  language: string;
-  sessionId: string;
-  /**
-   * 代码下文
-   */
-  suffix: string | null;
-  /**
-   * 文件路径
-   */
-  fileUrl: string | null;
-}
-/**
  * 补全结果缓存对象
  */
 export interface CompletionResultModelCache {

--- a/packages/ai-native/src/browser/contrib/inline-completions/promptCache.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/promptCache.ts
@@ -1,8 +1,14 @@
 import { Autowired, Injectable } from '@opensumi/di';
-import { IAICompletionOption, IAICompletionResultModel, StaleLRUMap } from '@opensumi/ide-core-browser';
+import {
+  AINativeSettingSectionsId,
+  DisposableStore,
+  IAICompletionOption,
+  IAICompletionResultModel,
+  IDisposable,
+  PreferenceService,
+  StaleLRUMap,
+} from '@opensumi/ide-core-browser';
 import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calculate/hash-calculate';
-
-const isCacheEnable = () => true;
 
 /**
  * 缓存服务
@@ -10,9 +16,14 @@ const isCacheEnable = () => true;
  * 2. 用 prompt 的 hash 值作为 key
  */
 @Injectable()
-export class PromptCache {
+export class PromptCache implements IDisposable {
+  protected _disposables = new DisposableStore();
+
   @Autowired(IHashCalculateService)
   private hashCalculateService: IHashCalculateService;
+
+  @Autowired(PreferenceService)
+  private preferenceService: PreferenceService;
 
   private cacheMap = new StaleLRUMap<string, IAICompletionResultModel & { relationId: string }>(15, 10, 60 * 1000);
 
@@ -21,8 +32,25 @@ export class PromptCache {
     return this.hashCalculateService.calculate(content);
   }
 
+  protected _isCacheEnabled = false;
+  constructor() {
+    this._isCacheEnabled = this.preferenceService.getValid(
+      AINativeSettingSectionsId.InlineCompletionsCacheEnabled,
+      true,
+    );
+
+    this._disposables.add(
+      this.preferenceService.onSpecificPreferenceChange(
+        AINativeSettingSectionsId.InlineCompletionsCacheEnabled,
+        (e) => {
+          this._isCacheEnabled = e.newValue;
+        },
+      ),
+    );
+  }
+
   getCache(requestBean: IAICompletionOption) {
-    if (!isCacheEnable()) {
+    if (!this._isCacheEnabled) {
       return null;
     }
     const hash = this.calculateCacheKey(requestBean);
@@ -33,7 +61,7 @@ export class PromptCache {
   }
 
   setCache(bean: IAICompletionOption, res: any) {
-    if (!isCacheEnable()) {
+    if (!this._isCacheEnabled) {
       return false;
     }
     if (!res) {
@@ -46,5 +74,9 @@ export class PromptCache {
       return true;
     }
     return false;
+  }
+
+  dispose(): void {
+    this._disposables.dispose();
   }
 }

--- a/packages/ai-native/src/browser/contrib/inline-completions/promptCache.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/promptCache.ts
@@ -28,7 +28,7 @@ export class PromptCache implements IDisposable {
   private cacheMap = new StaleLRUMap<string, IAICompletionResultModel & { relationId: string }>(15, 10, 60 * 1000);
 
   protected calculateCacheKey(requestBean: IAICompletionOption) {
-    const content = requestBean.prompt + (requestBean.suffix || '');
+    const content = requestBean.prompt;
     return this.hashCalculateService.calculate(content);
   }
 

--- a/packages/ai-native/src/browser/contrib/inline-completions/service/ai-completions.service.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/service/ai-completions.service.ts
@@ -46,6 +46,8 @@ export class AICompletionsService extends Disposable {
   // 中间件拓展 inlinecompletion
   private lastMiddlewareInlineCompletion?: IProvideInlineCompletionsSignature;
 
+  protected validCompletionThreshold = 750;
+
   private recordRenderTime(): void {
     this.lastRenderTime = Date.now();
   }
@@ -113,7 +115,7 @@ export class AICompletionsService extends Disposable {
   public async reporterEnd(relationId: string, data: CompletionRT) {
     const reportData = {
       ...data,
-      isValid: typeof data.renderingTime === 'number' ? data.renderingTime > 750 : false,
+      isValid: typeof data.renderingTime === 'number' ? data.renderingTime > this.validCompletionThreshold : false,
     };
     this.aiReporter.end(relationId, reportData);
   }

--- a/packages/ai-native/src/browser/contrib/inline-completions/service/ai-completions.service.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/service/ai-completions.service.ts
@@ -12,9 +12,9 @@ import {
   IAIReportCompletionOption,
 } from '@opensumi/ide-core-common';
 import { CompletionRT, IAIReporter } from '@opensumi/ide-core-common/lib/types/ai-native/reporter';
+import * as monaco from '@opensumi/ide-monaco';
 
 import { IProvideInlineCompletionsSignature } from '../../../types';
-import { CompletionRequestBean } from '../model/competionModel';
 
 @Injectable()
 export class AICompletionsService extends Disposable {
@@ -58,20 +58,25 @@ export class AICompletionsService extends Disposable {
     return this._isVisibleCompletion;
   }
 
-  public async complete(data: CompletionRequestBean, model, position, token): Promise<IAICompletionResultModel | null> {
-    const doCompletion = async (data: CompletionRequestBean) => {
+  public async complete(
+    data: IAICompletionOption,
+    model: monaco.editor.ITextModel,
+    position: monaco.Position,
+    token: monaco.CancellationToken,
+  ): Promise<IAICompletionResultModel | null> {
+    const doCompletion = async (data: IAICompletionOption) => {
       if (!this.aiBackService.requestCompletion) {
         return null;
       }
 
       try {
         this.isDefaultCompletionModel = true;
-        const now = Date.now();
+        const completionStart = Date.now();
         const result = (await this.aiBackService.requestCompletion(
-          data as IAICompletionOption,
+          data,
           this.cancelIndicator.token,
         )) as IAICompletionResultModel;
-        this.recordCompletionUseTime(now);
+        this.recordCompletionUseTime(completionStart);
         return result;
       } catch (error) {
         return null;

--- a/packages/ai-native/src/browser/contrib/inline-completions/types.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/types.ts
@@ -129,6 +129,7 @@ export interface ICompletionContext {
   suffix: string;
   fileUrl: string;
   filename: string;
+  workspaceDir: string;
   language: string;
   uri: URI;
 }

--- a/packages/ai-native/src/browser/preferences/schema.ts
+++ b/packages/ai-native/src/browser/preferences/schema.ts
@@ -42,5 +42,9 @@ export const aiNativePreferenceSchema: PreferenceSchema = {
       type: 'number',
       default: 150,
     },
+    [AINativeSettingSectionsId.InlineCompletionsCacheEnabled]: {
+      type: 'boolean',
+      default: true,
+    },
   },
 };

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -5,6 +5,7 @@ import {
   CancellationToken,
   ChatResponse,
   Deferred,
+  IAICompletionOption,
   IAICompletionResultModel,
   IDisposable,
   IResolveConflictHandler,
@@ -16,7 +17,6 @@ import { SumiReadableStream } from '@opensumi/ide-utils/lib/stream';
 
 import { IChatWelcomeMessageContent, ISampleQuestions, ITerminalCommandSuggestionDesc } from '../common';
 
-import { CompletionRequestBean } from './contrib/inline-completions/model/competionModel';
 import { BaseTerminalDetectionLineMatcher } from './contrib/terminal/matcher';
 import { InlineChatController } from './widget/inline-chat/inline-chat-controller';
 
@@ -250,8 +250,8 @@ export type IProvideInlineCompletionsSignature = (
   model: ITextModel,
   position: Position,
   token: CancellationToken,
-  next: (reqBean: CompletionRequestBean) => MaybePromise<IAICompletionResultModel | null>,
-  completionRequestBean: CompletionRequestBean,
+  next: (reqBean: IAICompletionOption) => MaybePromise<IAICompletionResultModel | null>,
+  requestOption: IAICompletionOption,
 ) => MaybePromise<IAICompletionResultModel | null>;
 
 export interface IAIMiddleware {

--- a/packages/core-common/src/settings/ai-native.ts
+++ b/packages/core-common/src/settings/ai-native.ts
@@ -14,6 +14,7 @@ export enum AINativeSettingSectionsId {
    */
   InlineCompletionsPromptEngineeringEnabled = 'ai.native.inlineCompletions.promptEngineering.enabled',
   InlineCompletionsDebounceTime = 'ai.native.inlineCompletions.debounceTime',
+  InlineCompletionsCacheEnabled = 'ai.native.inlineCompletions.cache.enabled',
 }
 export const AI_NATIVE_SETTING_GROUP_ID = 'AI-Native';
 export const AI_NATIVE_SETTING_GROUP_TITLE = 'AI Native';

--- a/packages/core-common/src/types/ai-native/index.ts
+++ b/packages/core-common/src/types/ai-native/index.ts
@@ -63,9 +63,39 @@ export interface IAINativeConfig {
   layout?: IDesignLayoutConfig;
 }
 
+export enum ECompletionType {
+  /**
+   * 行补全
+   */
+  Line = 0,
+  /**
+   * 片段补全
+   */
+  Snippet = 1,
+  /**
+   * 块补全
+   */
+  Block = 2,
+}
+
+/**
+ * 补全模型
+ */
+export interface CodeModel {
+  content: string;
+  displayName?: string;
+  id?: number;
+  score?: number;
+  /**
+   * 补全来源，当你的后端对接了多个 LLM 时，可以通过 source 来区分不同的模型
+   */
+  source?: string;
+  completionType?: ECompletionType;
+}
+
 export interface IAICompletionResultModel {
   sessionId: string;
-  codeModelList: Array<{ content: string }>;
+  codeModelList: Array<CodeModel>;
   isCancel?: boolean;
 }
 
@@ -85,12 +115,29 @@ export interface IAIBackServiceOption {
   history?: IHistoryChatMessage[];
 }
 
+/**
+ * 补全请求对象
+ */
 export interface IAICompletionOption {
+  sessionId: string;
+  /**
+   * 模型输入上文
+   */
   prompt: string;
-  suffix?: string;
-  language?: string;
-  fileUrl?: string;
-  sessionId?: string;
+  /**
+   * 代码下文
+   */
+  suffix?: string | null;
+
+  workspaceDir: string;
+  /**
+   * 文件路径
+   */
+  fileUrl: string;
+  /**
+   * 代码语言类型
+   */
+  language: string;
 }
 
 export interface IAIRenameSuggestionOption {

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1489,6 +1489,7 @@ export const localizationBundle = {
     'preference.ai.native.inlineDiff.preview.mode': 'Inline Diff preview mode',
     'preference.ai.native.inlineDiff.preview.mode.sideBySide': 'Displayed in the editor as left and right diff panels',
     'preference.ai.native.inlineDiff.preview.mode.inlineLive': 'Displayed in the editor through streaming rendering',
+    'preference.ai.native.inlineCompletions.cache.enabled': 'Whether to enable cache for inline completions',
     // #endregion AI Native
 
     // #endregion merge editor

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1253,6 +1253,7 @@ export const localizationBundle = {
     'preference.ai.native.inlineDiff.preview.mode': 'Inline Diff 的预览模式',
     'preference.ai.native.inlineDiff.preview.mode.sideBySide': '在编辑器当中以左右 diff 面板的方式展示',
     'preference.ai.native.inlineDiff.preview.mode.inlineLive': '在编辑器当中以流式渲染的方式展示',
+    'preference.ai.native.inlineCompletions.cache.enabled': '是否启用内联补全的缓存',
     // #endregion AI Native
 
     'webview.webviewTagUnavailable': '非 Electron 环境不支持 webview 标签，请使用 iframe 标签',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

补全 context 中加入文件完整路径，工作区路径

### Changelog

add `workspaceDir` and `fileUrl` into request completion option


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在 AI 本地设置部分添加了一个新的首选项，用于启用内联补全的缓存。
  - 在 `ICompletionContext` 接口中增加了 `workspaceDir` 属性。
  - 在 `AINativeBrowserContribution` 类中增加了 `InlineCompletionsCacheEnabled` 的偏好设置。

- **修复**
  - 更新了 `complete` 方法的参数类型和实现，以使用新的参数类型。
  - 更新了缓存逻辑以使用 `IAICompletionOption` 而不是字符串进行缓存键的计算和存储。

- **优化**
  - 改进了 `PromptCache` 类，增加了启用缓存的相关逻辑和 `dispose` 方法。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->