### PR TITLE
fix: add pty socket timeout

### DIFF
--- a/packages/terminal-next/__tests__/node/pty.proxy.test.ts
+++ b/packages/terminal-next/__tests__/node/pty.proxy.test.ts
@@ -34,7 +34,7 @@ describe('PtyService function should be valid', () => {
     proxyProvider.initServer();
     injector.overrideProviders({
       token: PtyServiceManagerToken,
-      useValue: injector.get(PtyServiceManagerRemote, [{ path: ipcPath }]),
+      useValue: injector.get(PtyServiceManagerRemote, [{ socketConnectOpts: { path: ipcPath } }]),
     });
     await delay(2000);
   });

--- a/packages/terminal-next/src/node/pty.manager.remote.ts
+++ b/packages/terminal-next/src/node/pty.manager.remote.ts
@@ -3,7 +3,7 @@ import net, { SocketConnectOpts } from 'net';
 import { Injectable, Optional } from '@opensumi/di';
 import { RPCServiceCenter, initRPCService } from '@opensumi/ide-connection';
 import { SumiConnection } from '@opensumi/ide-connection/lib/common/rpc/connection';
-import { Disposable, IDisposable } from '@opensumi/ide-core-common';
+import { DebugLog, Disposable, IDisposable } from '@opensumi/ide-core-common';
 
 import {
   IPtyProxyRPCService,
@@ -32,6 +32,7 @@ interface PtyServiceOptions {
 export class PtyServiceManagerRemote extends PtyServiceManager {
   private disposer: Disposable;
   private options: PtyServiceOptions;
+  private debugLog: DebugLog;
 
   // Pty运行在单独的容器上，通过Socket连接，可以自定义Socket连接参数
   constructor(
@@ -43,6 +44,7 @@ export class PtyServiceManagerRemote extends PtyServiceManager {
       reconnectInterval: 2000,
       ...options,
     };
+    this.debugLog = new DebugLog('PtyServiceManagerRemote');
     this.initRemoteConnectionMode(connectOpts);
   }
 
@@ -139,11 +141,11 @@ export class PtyServiceManagerRemote extends PtyServiceManager {
     });
 
     try {
-      this.logger.log('PtyServiceManagerRemote socket start connect');
+      this.debugLog.log('PtyServiceManagerRemote socket start connect');
       socket.connect(connectOpts);
     } catch (e) {
       // 连接错误的时候会抛出异常，此时自动重连，同时需要 catch 错误
-      this.logger.warn('PtyServiceManagerRemote socket connect error', e);
+      this.debugLog.warn('PtyServiceManagerRemote socket connect error', e);
     }
   }
 

--- a/packages/terminal-next/src/node/pty.manager.remote.ts
+++ b/packages/terminal-next/src/node/pty.manager.remote.ts
@@ -14,14 +14,31 @@ import {
 
 import { PtyServiceManager } from './pty.manager';
 
+interface PtyServiceOptions {
+  /**
+   * 重连时间间隔
+   */
+  reconnectInterval?: number;
+}
+
 // 双容器架构 - 在IDE容器中远程运行，与DEV Server上的PtyService通信
 // 继承自PtyServiceManager，覆写了创建PtyProxyService连接的方法，用于需要远程连接PtyService的场景
 // 具体需要根据应用场景，通过DI注入覆盖PtyServiceManager使用
 @Injectable()
 export class PtyServiceManagerRemote extends PtyServiceManager {
+  private disposer: Disposable;
+  private options: PtyServiceOptions;
+
   // Pty运行在单独的容器上，通过Socket连接，可以自定义Socket连接参数
-  constructor(@Optional() connectOpts: SocketConnectOpts = { port: PTY_SERVICE_PROXY_SERVER_PORT }) {
+  constructor(
+    @Optional() connectOpts: SocketConnectOpts = { port: PTY_SERVICE_PROXY_SERVER_PORT },
+    @Optional() options?: PtyServiceOptions,
+  ) {
     super();
+    this.options = {
+      reconnectInterval: 2000,
+      ...options,
+    };
     this.initRemoteConnectionMode(connectOpts);
   }
 
@@ -62,35 +79,60 @@ export class PtyServiceManagerRemote extends PtyServiceManager {
   }
 
   private initRemoteConnectionMode(connectOpts: SocketConnectOpts) {
+    if (this.disposer) {
+      this.disposer.dispose();
+    }
+    this.disposer = new Disposable();
+
     const socket = new net.Socket();
-    let rpcServiceDisposable: IDisposable | undefined;
+
+    let reconnectTimer: NodeJS.Timeout | null = null;
+    const reconnect = () => {
+      if (reconnectTimer) {return;}
+      reconnectTimer = global.setTimeout(() => {
+        this.logger.log('PtyServiceManagerRemote reconnect');
+        socket.destroy();
+        this.initRemoteConnectionMode(connectOpts);
+      }, this.options.reconnectInterval);
+    };
 
     // UNIX Socket 连接监听，成功连接后再创建RPC服务
-    socket.on('connect', () => {
+    socket.once('connect', () => {
       this.logger.log('PtyServiceManagerRemote connected');
-      rpcServiceDisposable?.dispose();
-      rpcServiceDisposable = this.initRPCService(socket);
+      socket.setTimeout(0);
+      if (reconnectTimer) {
+        global.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      this.disposer.addDispose(this.initRPCService(socket));
     });
 
     // UNIX Socket 连接失败或者断开，此时需要等待 1.5s 后重新连接
-    socket.on('close', () => {
-      this.logger.log('PtyServiceManagerRemote connect failed, will reconnect after 2s');
-      rpcServiceDisposable?.dispose();
-      global.setTimeout(() => {
-        this.initRemoteConnectionMode(connectOpts);
-      }, 2000);
+    socket.on('close', (hadError) => {
+      this.logger.log('PtyServiceManagerRemote socket close, hadError:', hadError);
+      reconnect();
     });
 
     // 处理 Socket 异常
     socket.on('error', (e) => {
-      this.logger.warn('pty unix domain socket error ', e);
+      this.logger.warn('PtyServiceManagerRemote socket error ', e);
+    });
+
+    socket.on('end', () => {
+      this.logger.log('PtyServiceManagerRemote socket end');
+    });
+
+    socket.on('timeout', () => {
+      this.logger.log('PtyServiceManagerRemote socket timeout');
+      reconnect();
     });
 
     try {
+      this.logger.log('PtyServiceManagerRemote socket start connect');
       socket.connect(connectOpts);
     } catch (e) {
       // 连接错误的时候会抛出异常，此时自动重连，同时需要 catch 错误
-      this.logger.warn(e);
+      this.logger.warn('PtyServiceManagerRemote socket connect error', e);
     }
   }
 


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution
pty 双容器下 socket 有概率即没有出发 connnect，也没有触发 close，导致终端一致无法 ready，增加一个 timeout 事件

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了配置选项以自定义重新连接间隔和套接字超时处理。
  - 实现了在套接字关闭时以可配置间隔重新连接的逻辑。
- **测试**
  - 修改了测试文件以确保新配置选项的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->