### PR TITLE
feat: support disable restore editor group state

### DIFF
--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -292,6 +292,12 @@ export interface AppConfig {
    * 是否启用 Diff 协议文件自动恢复
    */
   enableDiffRevive?: boolean;
+  /**
+   * Disable restore editor group state
+   *
+   * This is useful when your scenario is one-time use, and you can control the opening of the editor tab yourself.
+   */
+  disableRestoreEditorGroupState?: boolean;
 }
 
 export interface ICollaborationClientOpts {

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -126,6 +126,9 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
   @Autowired(ResourceService)
   private resourceService: ResourceService;
 
+  @Autowired(AppConfig)
+  private appConfig: AppConfig;
+
   private readonly _onActiveResourceChange = new EventEmitter<MaybeNull<IResource>>();
   public readonly onActiveResourceChange: Event<MaybeNull<IResource>> = this._onActiveResourceChange.event;
 
@@ -484,7 +487,9 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
 
   public async restoreState() {
     let state: IEditorGridState = { editorGroup: { uris: [], previewIndex: -1 } };
-    state = this.openedResourceState.get<IEditorGridState>('grid', state);
+    if (!this.appConfig.disableRestoreEditorGroupState) {
+      state = this.openedResourceState.get<IEditorGridState>('grid', state);
+    }
     this.topGrid = new EditorGrid();
     this.topGrid.onDidGridAndDesendantStateChange(() => {
       this._sortedEditorGroups = undefined;

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -12,7 +12,6 @@ renderApp(
       layoutViewSize: {
         menubarHeight: 48,
       },
-      disableRestoreEditorGroupState: true,
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {
           modules: [MENU_BAR_FEATURE_TIP],

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -12,6 +12,7 @@ renderApp(
       layoutViewSize: {
         menubarHeight: 48,
       },
+      disableRestoreEditorGroupState: true,
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {
           modules: [MENU_BAR_FEATURE_TIP],


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

在某些事务性的场景下，是不需要恢复标签页的，因为要恢复的文件可能已经不存在了。

### Changelog

support disable restore editor group state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `disableRestoreEditorGroupState` 属性，用于控制是否恢复编辑器组状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->