### PR TITLE
feat(editor): add a preference prevent scroll after get focused

### DIFF
--- a/packages/core-browser/src/dom/index.ts
+++ b/packages/core-browser/src/dom/index.ts
@@ -175,3 +175,14 @@ export class FocusTracker extends Disposable {
 export function trackFocus(element: HTMLElement | Window): IFocusTracker {
   return new FocusTracker(element);
 }
+
+/**
+ * https://developer.mozilla.org/zh-CN/docs/Web/API/MouseEvent/button
+ */
+export const MouseEventButton = {
+  Left: 0,
+  Middle: 1,
+  Right: 2,
+  Back: 3,
+  Forward: 4,
+};

--- a/packages/core-browser/src/services/clipboard.service.ts
+++ b/packages/core-browser/src/services/clipboard.service.ts
@@ -35,13 +35,17 @@ export class BrowserClipboardService implements IClipboardService {
     textArea.style.position = 'absolute';
 
     textArea.value = text;
-    textArea.focus();
+    textArea.focus({
+      preventScroll: true,
+    });
     textArea.select();
 
     document.execCommand('copy');
 
     if (activeElement instanceof HTMLElement) {
-      activeElement.focus();
+      activeElement.focus({
+        preventScroll: true,
+      });
     }
 
     document.body.removeChild(textArea);

--- a/packages/core-common/src/settings/general.ts
+++ b/packages/core-common/src/settings/general.ts
@@ -1,4 +1,4 @@
-export const enum GeneralSettingsId {
+export enum GeneralSettingsId {
   Icon = 'general.icon',
   Theme = 'general.theme',
   Language = 'general.language',

--- a/packages/editor/src/browser/monaco-contrib/command/command.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/command/command.service.ts
@@ -191,7 +191,6 @@ export class MonacoCommandRegistry implements IMonacoCommandsRegistry {
   protected execute(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): any {
     const editor = this.getActiveCodeEditor();
     if (editor) {
-      // editor.focus();
       return Promise.resolve(monacoHandler.execute(editor, ...args));
     }
     return Promise.resolve();

--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -1498,6 +1498,11 @@ const customEditorSchema: PreferenceSchemaProperties = {
     default: true,
     description: '%editor.configuration.previewMode%',
   },
+  'editor.preventScrollAfterFocused': {
+    type: 'boolean',
+    default: false,
+    description: '%editor.configuration.preventScrollAfterFocused%',
+  },
   'editor.wrapTab': {
     type: 'boolean',
     default: false,

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -22,6 +22,7 @@ import {
   Event,
   IEventBus,
   MaybeNull,
+  MouseEventButton,
   PreferenceService,
   ResizeEvent,
   URI,
@@ -172,7 +173,10 @@ export const Tabs = ({ group }: ITabsProps) => {
             '.' + styles.kt_editor_tab + "[data-uri='" + group.currentResource.uri.toString() + "']",
           );
           if (currentTab) {
-            currentTab.scrollIntoView();
+            currentTab.scrollIntoView({
+              block: 'nearest',
+              inline: 'nearest',
+            });
           }
         } catch (e) {
           // noop
@@ -425,14 +429,14 @@ export const Tabs = ({ group }: ITabsProps) => {
               }}
               key={resource.uri.toString()}
               onMouseUp={(e) => {
-                if (e.nativeEvent.which === 2) {
+                if (e.nativeEvent.button === MouseEventButton.Middle) {
                   e.preventDefault();
                   e.stopPropagation();
                   group.close(resource.uri);
                 }
               }}
               onMouseDown={(e) => {
-                if (e.nativeEvent.which === 1) {
+                if (e.nativeEvent.button === MouseEventButton.Left) {
                   group.open(resource.uri, { focus: true });
                 }
               }}

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -587,6 +587,11 @@ export interface IResourceOpenOptions {
   focus?: boolean;
 
   /**
+   * If set `focus`, the editor's dom will be focused, This option prevents the element from being scrolled after getting the focus.
+   */
+  preventScroll?: boolean;
+
+  /**
    * 强制使用指定的打开方式
    */
   forceOpenType?: IEditorOpenType;

--- a/packages/terminal-next/src/browser/component/tab.item.tsx
+++ b/packages/terminal-next/src/browser/component/tab.item.tsx
@@ -26,7 +26,6 @@ export const renderInfoItem = observer((props: ItemProps) => {
   const iconService = useInjectable<IIconService>(IconService);
   const handleSelect = debounce(() => props.onClick && props.onClick(), 20);
   const handleClose = debounce(() => props.onClose && props.onClose(), 20);
-  const appConfig = useInjectable<AppConfig>(AppConfig);
   const styles_item_container = useDesignStyles(styles.item_container, 'item_container');
   const styles_tab_item_selected = useDesignStyles(styles.tab_item_selected, 'tab_item_selected');
   const styles_item_info_name = useDesignStyles(styles.item_info_name, 'item_info_name');

--- a/packages/theme/src/browser/icon.service.ts
+++ b/packages/theme/src/browser/icon.service.ts
@@ -95,11 +95,13 @@ export class IconService extends WithEventBus implements IIconService {
   }
 
   private listen() {
-    this.preferenceService.onPreferenceChanged(async (e) => {
-      if (e.preferenceName === GeneralSettingsId.Icon && this.iconContributionRegistry.has(e.newValue)) {
-        await this.applyTheme(this.preferenceService.get<string>(GeneralSettingsId.Icon)!);
-      }
-    });
+    this.addDispose(
+      this.preferenceService.onSpecificPreferenceChange(GeneralSettingsId.Icon, async (e) => {
+        if (this.iconContributionRegistry.has(e.newValue)) {
+          await this.applyTheme(e.newValue);
+        }
+      }),
+    );
   }
 
   private styleSheetCollection = '';


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

点击 tab 的时候，会调用 `group.open(uri, {focus: true})`，该方法内部调用了 Element.prototype.focus， 这个方法会使得元素被滚动到视图
![image](https://github.com/user-attachments/assets/865fd79e-41a7-4566-8247-93b0ffcaf7dc)

![image](https://github.com/user-attachments/assets/077c422d-de90-4bc4-ac98-723f6821f366)


### Changelog

add a preference that can prevent scroll after editor get focus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了 `MouseEventButton` 常量，用于表示不同的鼠标按键。
  - 在 `IResourceOpenOptions` 接口中新增了 `preventScroll` 属性。
  - 在 `customEditorSchema` 中新增了 `editor.preventScrollAfterFocused` 属性。

- **改进**
  - `BrowserClipboardService` 类中的 `focus()` 方法现在包含 `preventScroll: true` 参数。
  - `MonacoCommandRegistry` 类中的 `execute` 方法现在直接返回 `monacoHandler.execute` 的结果。
  - `IconService` 类中的 `listen` 方法改用 `onSpecificPreferenceChange` 进行事件处理。

- **修复**
  - 调整了 `tab.view.tsx` 中的滚动行为处理，以及鼠标事件处理的逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->