### PR TITLE
fix: textmate service is not compatible with monaco 0.47

### DIFF
--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -913,6 +913,16 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 
   dispose() {
     super.dispose();
-    this.monacoLanguageService['_encounteredLanguages'].clear();
+    if (this.monacoLanguageService['_requestedRichLanguages']) {
+      this.monacoLanguageService['_requestedRichLanguages'].clear();
+    } else {
+      this.logger.warn('monaco language service not found _requestedRichLanguages');
+    }
+
+    if (this.monacoLanguageService['_requestedBasicLanguages']) {
+      this.monacoLanguageService['_requestedBasicLanguages'].clear();
+    } else {
+      this.logger.warn('monaco language service not found _requestedBasicLanguages');
+    }
   }
 }


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

dispose textmate service 的时候会报错

![image](https://github.com/user-attachments/assets/b01e12b6-9a43-42fe-a666-84dd3e92fb1b)


0.35.x 中 ILanguageService 中的 _encounteredLanguages 在 0.47.x 中已经被移除
等价的是 _requestedBasicLanguages 和 _requestedRichLanguages

### Changelog

fix textmate service is not compatible with monaco 0.47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了 `TextmateService` 类的 `dispose` 方法，现在在清除 `_requestedRichLanguages` 和 `_requestedBasicLanguages` 时添加了条件处理，并在未找到服务时记录警告日志。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->