### PR TITLE
fix: enable multi-root workspace support

### DIFF
--- a/configs/vscode-extensions.json
+++ b/configs/vscode-extensions.json
@@ -143,6 +143,16 @@
         "version": "1.55.2"
       }
     ],
+    "ms-python": [
+      {
+        "name": "python",
+        "version": "2024.4.1"
+      },
+      {
+        "name": "debugpy",
+        "version": "2024.6.0"
+      }
+    ],
     "ms-vscode": [
       {
         "name": "js-debug",

--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -824,6 +824,7 @@ export namespace WORKSPACE_COMMANDS {
 
   export const REMOVE_WORKSPACE_FOLDER: Command = {
     id: 'workspace.removeFolderFromWorkspace',
+    label: '%workspace.removeFolderFromWorkspace%',
     category: CATEGORY,
   };
 

--- a/packages/core-browser/src/common/common.contribution.ts
+++ b/packages/core-browser/src/common/common.contribution.ts
@@ -21,7 +21,13 @@ import { MenuId } from '../menu/next/menu-id';
 import { PreferenceContribution } from '../preferences';
 import { AppConfig } from '../react-providers/config-provider';
 
-import { COMMON_COMMANDS, EDITOR_COMMANDS, FILE_COMMANDS, TERMINAL_COMMANDS } from './common.command';
+import {
+  COMMON_COMMANDS,
+  EDITOR_COMMANDS,
+  FILE_COMMANDS,
+  TERMINAL_COMMANDS,
+  WORKSPACE_COMMANDS,
+} from './common.command';
 import { ClientAppContribution } from './common.define';
 
 export const inputFocusedContextKey = 'inputFocus';
@@ -154,6 +160,16 @@ export class ClientCommonContribution
         command: FILE_COMMANDS.OPEN_WORKSPACE.id,
         group: '1_open',
         when: 'config.application.supportsOpenWorkspace',
+      },
+      {
+        command: WORKSPACE_COMMANDS.ADD_WORKSPACE_FOLDER.id,
+        group: '1_open',
+        when: 'config.workspace.supportMultiRootWorkspace',
+      },
+      {
+        command: WORKSPACE_COMMANDS.SAVE_WORKSPACE_AS_FILE.id,
+        group: '1_open',
+        when: 'config.workspace.supportMultiRootWorkspace',
       },
       {
         command: EDITOR_COMMANDS.NEW_UNTITLED_FILE.id,

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
@@ -10,7 +10,7 @@ import {
   Select,
   TreeNodeType,
 } from '@opensumi/ide-components';
-import { isMacintosh, localize, path, useInjectable } from '@opensumi/ide-core-browser';
+import { URI, isMacintosh, localize, path, useInjectable } from '@opensumi/ide-core-browser';
 import { Progress } from '@opensumi/ide-core-browser/lib/progress/progress-bar';
 import { IDialogService, IOpenDialogOptions, ISaveDialogOptions } from '@opensumi/ide-overlay';
 
@@ -153,7 +153,19 @@ export const FileDialog = ({ options, model, isOpenDialog }: React.PropsWithChil
           }
         } else {
           if ((options as IOpenDialogOptions).canSelectFiles && type === TreeNodeType.TreeNode) {
-            handleItemClick(item, type);
+            const filterExts = new Set(
+              Object.values((options as IOpenDialogOptions).filters ?? {})
+                .flat()
+                .map((item) => `.${item}`),
+            );
+            if (filterExts.size > 0) {
+              const ext = URI.parse(item.filestat.uri).path.ext;
+              if (filterExts.has(ext)) {
+                handleItemClick(item, type);
+              }
+            } else {
+              handleItemClick(item, type);
+            }
           } else if ((options as IOpenDialogOptions).canSelectFolders && type === TreeNodeType.CompositeTreeNode) {
             handleItemClick(item, type);
           }

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -49,7 +49,7 @@ export const localizationBundle = {
     'file.action.new.folder': 'New Folder',
     'file.action.refresh': 'Refresh',
     'file.open.folder': 'Open Folder',
-    'file.open.workspace': 'Open Workspace',
+    'file.open.workspace': 'Open Workspace from File ...',
     'file.action.collapse': 'Collapse',
     'file.confirm.delete': 'Are you sure you want to delete the following files?\n{0}',
     'file.confirm.delete.ok': 'Move to trash',
@@ -1062,6 +1062,7 @@ export const localizationBundle = {
     'terminal.killProcess': 'Kill Process',
     'terminal.process.unHealthy':
       '*This terminal session has been timed out and killed by the system. Please open a new terminal session to proceed with operations.',
+    'terminal.selectCWDForNewTerminal': 'Select current working directory for new terminal',
 
     'terminal.focusNext.inTerminalGroup': 'Terminal: Focus Next Terminal in Terminal Group',
     'terminal.focusPrevious.inTerminalGroup': 'Terminal: Focus Previous Terminal in Terminal Group',
@@ -1215,7 +1216,7 @@ export const localizationBundle = {
     'editor.compareAndSave.title': '{0} (on Disk) <=> {1} (Editing) ',
 
     'workspace.openDirectory': 'Open Directory',
-    'workspace.addFolderToWorkspace': 'Add Folder Into Workspace ...',
+    'workspace.addFolderToWorkspace': 'Add Folder to Workspace ...',
     'workspace.removeFolderFromWorkspace': 'Remove Folder From Workspace',
     'workspace.saveWorkspaceAsFile': 'Save Workspace As ...',
     'workspace.openWorkspace': 'Open Workspace',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -51,7 +51,7 @@ export const localizationBundle = {
     'file.action.collapse': '全部折叠',
     'file.location': '在文件树中定位',
     'file.open.folder': '打开文件夹',
-    'file.open.workspace': '打开工作区',
+    'file.open.workspace': '从文件打开工作区',
     'file.confirm.delete': '确定删除下面列的文件?\n{0}',
     'file.confirm.delete.ok': '移入回收站',
     'file.confirm.delete.cancel': '取消',
@@ -719,6 +719,7 @@ export const localizationBundle = {
     'terminal.toggleTerminal': '切换终端面板',
     'terminal.killProcess': '结束进程',
     'terminal.process.unHealthy': '*此终端会话已被系统超时回收，请打开新的终端会话来进行操作',
+    'terminal.selectCWDForNewTerminal': '为新 terminal 选择当前工作路径',
 
     'view.command.show': '打开 {0}',
 

--- a/packages/overlay/src/common/index.ts
+++ b/packages/overlay/src/common/index.ts
@@ -103,7 +103,7 @@ export interface IDialogOptions {
   title?: string;
   defaultUri?: URI;
   filters?: {
-    [name: string]: string;
+    [name: string]: string[];
   };
 }
 

--- a/packages/terminal-next/src/browser/terminal.client.ts
+++ b/packages/terminal-next/src/browser/terminal.client.ts
@@ -510,7 +510,10 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     if (this.workspace.isMultiRootWorkspaceOpened) {
       // 工作区模式下每次新建终端都需要用户手动进行一次路径选择
       const roots = this.workspace.tryGetRoots();
-      const choose = await this.quickPick.show(roots.map((file) => new URI(file.uri).codeUri.fsPath));
+      const choose = await this.quickPick.show(
+        roots.map((file) => new URI(file.uri).codeUri.fsPath),
+        { placeholder: localize('terminal.selectCWDForNewTerminal') },
+      );
       return choose;
     } else if (this.workspace.workspace) {
       return new URI(this.workspace.workspace?.uri).codeUri.fsPath;
@@ -530,7 +533,7 @@ export class TerminalClient extends Disposable implements ITerminalClient {
     const widget = this._widget;
     if (TerminalClient.WORKSPACE_PATH_CACHED.has(widget.group.id)) {
       this._workspacePath = TerminalClient.WORKSPACE_PATH_CACHED.get(widget.group.id)!;
-    } else {
+    } else if (!widget.recovery) {
       const choose = await this._pickWorkspace();
       if (choose) {
         this._workspacePath = choose;

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -355,6 +355,8 @@ export class TerminalController extends WithEventBus implements ITerminalControl
               group,
               typeof session === 'string' ? session : session.client,
               !!session.task,
+              false,
+              true,
             );
             const client = await this.clientFactory(widget);
 

--- a/packages/terminal-next/src/browser/terminal.view.ts
+++ b/packages/terminal-next/src/browser/terminal.view.ts
@@ -31,7 +31,7 @@ export class Widget extends Disposable implements IWidget {
   @observable
   processName: string | undefined;
 
-  constructor(id: string, public reuse: boolean = false) {
+  constructor(id: string, public reuse: boolean = false, public recovery: boolean = false) {
     super();
     makeObservable(this);
     this._id = id;
@@ -372,8 +372,8 @@ export class TerminalGroupViewService implements ITerminalGroupViewService {
     this.selectGroup(index);
   }
 
-  createWidget(group: WidgetGroup, id?: string, reuse?: boolean, isSimpleWidget = false) {
-    const widget = new Widget(id || this.service.generateSessionId(), reuse);
+  createWidget(group: WidgetGroup, id?: string, reuse?: boolean, isSimpleWidget = false, recovery = false) {
+    const widget = new Widget(id || this.service.generateSessionId(), reuse, recovery);
     this._widgets.set(widget.id, widget);
     widget.group = group;
     if (!isSimpleWidget) {

--- a/packages/terminal-next/src/common/resize.ts
+++ b/packages/terminal-next/src/common/resize.ts
@@ -11,6 +11,7 @@ export interface IWidget extends Disposable {
   element: HTMLDivElement;
   group: IWidgetGroup;
   reuse: boolean;
+  recovery: boolean;
   show: boolean;
   error: boolean;
   resize: (dynamic?: number) => void;

--- a/packages/workspace/src/browser/workspace-preferences.ts
+++ b/packages/workspace/src/browser/workspace-preferences.ts
@@ -15,7 +15,7 @@ export const workspacePreferenceSchema: PreferenceSchema = {
       default: false,
     },
     'workspace.supportMultiRootWorkspace': {
-      description: 'Enable the multi-root workspace support to test this feature internally',
+      description: 'Enable multi-root workspace support',
       type: 'boolean',
       default: false,
     },

--- a/packages/workspace/src/common/mocks/workspace-service.ts
+++ b/packages/workspace/src/common/mocks/workspace-service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@opensumi/di';
 import { Deferred, Emitter, URI } from '@opensumi/ide-core-common';
 import { FileStat } from '@opensumi/ide-file-service';
 
-import { IWorkspaceService } from '../../common';
+import { IWorkspaceService, WorkspaceInput } from '../../common';
 
 @Injectable()
 export class MockWorkspaceService implements IWorkspaceService {
@@ -14,10 +14,16 @@ export class MockWorkspaceService implements IWorkspaceService {
 
   whenReady: Promise<void>;
 
+  workspaceSuffixName: string;
+
   private deferredRoots = new Deferred<FileStat[]>();
 
   constructor() {
     this.whenReady = this.init();
+  }
+
+  open(uri: URI, options?: WorkspaceInput): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   async init() {

--- a/packages/workspace/src/common/workspace.interface.ts
+++ b/packages/workspace/src/common/workspace.interface.ts
@@ -12,6 +12,8 @@ export interface WorkspaceInput {
 export const IWorkspaceService = Symbol('IWorkspaceService');
 
 export interface IWorkspaceService {
+  // 工作区文件后缀，默认后缀为 `sumi-workspace`
+  workspaceSuffixName: string;
   // 获取当前的根节点
   roots: Promise<FileStat[]>;
   // 获取workspace
@@ -68,6 +70,8 @@ export interface IWorkspaceService {
   setWorkspace(workspaceStat: FileStat | undefined): Promise<void>;
   // 初始化文件服务中 `files.exclude` 和 `watche.exclude` 配置
   initFileServiceExclude(): Promise<void>;
+  // 打开工作区
+  open(uri: URI, options?: WorkspaceInput): Promise<void>;
 }
 
 export const IWorkspaceStorageService = Symbol('IWorkspaceStorageService');


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

开启以下配置的情况下
```js
  opts.defaultPreferences = {
    'workspace.supportMultiRootWorkspace': true,
    'application.supportsOpenFolder': true,
    'application.supportsOpenWorkspace': true,
  };
```

- 支持打开文件夹和打开.sumi-workspace工作区
![image](https://github.com/user-attachments/assets/146481c8-2e08-4eb0-a7ba-89d86e274205)

- 支持添加文件夹和删除文件夹
![image](https://github.com/user-attachments/assets/54be28e9-204d-48ae-ad1c-81131a39a029)

![image](https://github.com/user-attachments/assets/72de2236-6b95-428e-bcf8-0dfa31df5e9b)



### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了工作区文件和文件夹相关的新命令。
  - 增加了终端选择当前工作目录的新功能。

- **错误修复**
  - 修复了文件选择对话框的文件过滤逻辑问题。

- **改进**
  - 更新了“多根工作区支持”偏好的描述。
  - 改进了终端和文件操作的本地化字符串。

- **本地化**
  - 更新了简体中文和英语的本地化字符串，以提高文本的清晰度和功能性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->