### PR TITLE
feat(inline-diff-previewer): support serialize state and restore state

### DIFF
--- a/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
+++ b/packages/ai-native/src/browser/model/enhanceDecorationsCollection.ts
@@ -180,6 +180,10 @@ export class EnhanceDecorationsCollection extends Disposable {
     return this.deltaDecorations.find((d) => d.getRange().startLineNumber === lineNumber);
   }
 
+  getRanges() {
+    return this.deltaDecorations.map((d) => d.getRange());
+  }
+
   clear(): void {
     this.codeEditor.changeDecorations((accessor) => {
       for (const decoration of this.deltaDecorations) {

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -9,6 +9,7 @@ import { ModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/
 import { EResultKind } from '../inline-chat/inline-chat.service';
 import { AIInlineContentWidget } from '../inline-chat/inline-content-widget';
 import { EComputerMode, InlineStreamDiffHandler } from '../inline-stream-diff/inline-stream-diff.handler';
+import { SerializableState } from '../inline-stream-diff/live-preview.decoration';
 
 import { InlineDiffWidget } from './inline-diff-widget';
 
@@ -213,5 +214,8 @@ export class LiveInlineDiffPreviewer extends BaseInlineDiffPreviewer<InlineStrea
   }
   get onPartialEditEvent() {
     return this.node.onPartialEditEvent;
+  }
+  serializeState(): SerializableState {
+    return this.node.serializeState();
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -10,7 +10,7 @@ import { IModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common
 import { LineTokens } from '@opensumi/monaco-editor-core/esm/vs/editor/common/tokens/lineTokens';
 import { UndoRedoGroup } from '@opensumi/monaco-editor-core/esm/vs/platform/undoRedo/common/undoRedo';
 
-import { AcceptPartialEditWidget, LivePreviewDiffDecorationModel } from './live-preview.decoration';
+import { AcceptPartialEditWidget, LivePreviewDiffDecorationModel, SerializableState } from './live-preview.decoration';
 
 interface IRangeChangeData {
   removedTextLines: string[];
@@ -203,17 +203,6 @@ export class InlineStreamDiffHandler extends Disposable {
     return this.livePreviewDiffDecorationModel.getZone();
   }
 
-  private renderPartialEditWidgets(diffModel: IComputeDiffData): void {
-    const { changes } = diffModel;
-    const zone = this.getZone();
-    const allAddRanges = changes.map((c) => {
-      const lineNumber = zone.startLineNumber + c.addedRange.startLineNumber - 1;
-      return new LineRange(lineNumber, lineNumber + 1);
-    });
-
-    this.livePreviewDiffDecorationModel.touchPartialEditWidgets(allAddRanges);
-  }
-
   private renderAddedRangeDecoration(diffModel: IComputeDiffData): void {
     const allAddRanges = diffModel.changes.map((c) => c.addedRange);
     this.livePreviewDiffDecorationModel.touchAddedRange(allAddRanges);
@@ -392,12 +381,18 @@ export class InlineStreamDiffHandler extends Disposable {
   public readyRender(diffModel: IComputeDiffData): void {
     this.doSchedulerEdits();
 
-    this.renderPartialEditWidgets(diffModel);
     this.pushStackElement();
     this.monacoEditor.focus();
   }
 
   get onPartialEditEvent() {
     return this.livePreviewDiffDecorationModel.onPartialEditEvent;
+  }
+
+  serializeState(): SerializableState {
+    return this.livePreviewDiffDecorationModel.serializeState();
+  }
+  restoreSerializedState(state: SerializableState): void {
+    this.livePreviewDiffDecorationModel.restoreSerializedState(state);
   }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features


### Background or solution

在创建内联 Diff 预览之后，如果用户想切换 Tab, 此时内联 Diff 进度会丢失

### Changelog

support serialize state and restore state for inline diff previewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
   - 增加了状态序列化功能，现在可以序列化和恢复组件状态。
- **改进**
   - 增加了 `getRanges()` 方法用于更方便地获取装饰范围。
   - 修改了 `LiveInlineDiffPreviewer` 类，添加了 `serializeState()` 方法。
   - 删除了 `InlineStreamDiffHandler` 类中的 `renderPartialEditWidgets` 方法，增加了 `serializeState` 和 `restoreSerializedState` 方法。
   - 更新了 `live-preview.decoration.tsx` 中的方法参数类型和逻辑，实现了更好的小部件管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->