### PR TITLE
fix: not restore diff editor state

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -9,7 +9,6 @@ import {
   Emitter as EventEmitter,
   ILineChange,
   ISelection,
-  LRUCache,
   OnEvent,
   URI,
   WithEventBus,
@@ -690,8 +689,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
           currentEditor.revealRangeInCenter(range);
         });
       });
-    } else {
-      this.restoreState();
     }
     this._onRefOpen.fire(originalDocModelRef);
     this._onRefOpen.fire(modifiedDocModelRef);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

当前 Diff 编辑器的状态恢复存在问题，来回切换会导致光标位置乱跳问题，临时处理一下，后续仍是一个需要解决的问题

### Changelog

not restore diff editor state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 移除了不必要的 `LRUCache` 导入和 `this.restoreState()` 调用，以优化代码性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->