### PR TITLE
fix: debug console readonly status

### DIFF
--- a/packages/debug/src/browser/view/console/debug-console.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console.service.ts
@@ -44,7 +44,6 @@ const consoleInputMonacoOptions: monaco.editor.IEditorOptions = {
     handleMouseWheel: true,
   },
   acceptSuggestionOnEnter: 'on',
-  readOnly: true,
 };
 
 @Injectable()
@@ -149,11 +148,10 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
     this._consoleInputElement = e;
     this.inputEditor = this.editorService.createCodeEditor(this._consoleInputElement!, {
       ...consoleInputMonacoOptions,
+      readOnly: !this.contextKeyService.getContextValue(CONTEXT_IN_DEBUG_MODE_KEY),
     });
 
-    this.debugContextKey = this.injector.get(DebugContextKey, [
-      (this.inputEditor.monacoEditor as any)._contextKeyService,
-    ]);
+    this.debugContextKey = this.injector.get(DebugContextKey, [this.inputEditor.monacoEditor.contextKeyService]);
 
     this.contextKeyService.onDidChangeContext((e) => {
       if (e.payload.affectsSome(DebugConsoleService.keySet)) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

在不打开调试控制台的情况下开启调试，此时再打开调试控制台就会必现这个问题

### Changelog
修复 debug 模式下调试控制台一直显示只读状态的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 根据上下文值动态设置调试控制台输入框的只读属性，以便在调试模式下进行编辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->