### PR TITLE
fix: left tabbar item cannot drag

### DIFF
--- a/packages/core-browser/src/dom/index.ts
+++ b/packages/core-browser/src/dom/index.ts
@@ -186,3 +186,12 @@ export const MouseEventButton = {
   Back: 3,
   Forward: 4,
 };
+
+export function createClassNameTokens(className: string): string[] {
+  return className.split(' ').filter(Boolean);
+}
+
+export function addClassName(node: HTMLElement, className: string): void {
+  const tokens = createClassNameTokens(className);
+  node.classList.add(...tokens);
+}

--- a/packages/core-browser/src/dom/index.ts
+++ b/packages/core-browser/src/dom/index.ts
@@ -1,4 +1,5 @@
 import { Event as BaseEvent, Disposable, Emitter, IDisposable, isWebKit } from '@opensumi/ide-core-common';
+import { space } from '@opensumi/ide-utils/lib/strings';
 
 export * from './event';
 
@@ -188,7 +189,7 @@ export const MouseEventButton = {
 };
 
 export function createClassNameTokens(className: string): string[] {
-  return className.split(' ').filter(Boolean);
+  return className.split(space).filter(Boolean);
 }
 
 export function addClassName(node: HTMLElement, className: string): void {

--- a/packages/core-browser/src/toolbar/toolbar.tsx
+++ b/packages/core-browser/src/toolbar/toolbar.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom/client';
 
 import { Disposable, Emitter, IEventBus } from '@opensumi/ide-core-common';
 
-import { DomListener } from '../dom';
+import { DomListener, addClassName, createClassNameTokens } from '../dom';
 import { AbstractMenuService, ICtxMenuRenderer, MenuId, generateCtxMenu } from '../menu/next';
 import { PreferenceService } from '../preferences';
 import { useInjectable } from '../react-hooks';
@@ -417,7 +417,7 @@ function renderToolbarLocation(
     const moreElement = document.createElement('div');
     moreElement.classList.add('kt-toolbar-more');
     const moreLink = document.createElement('div');
-    moreLink.classList.add(...getIcon('more').split(' '));
+    addClassName(moreLink, getIcon('more'));
     moreElement.append(moreLink);
     locationContainer.append(moreElement);
     moreLink.addEventListener('mousedown', () => {

--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -1,7 +1,14 @@
 import debounce from 'lodash/debounce';
 
 import { Autowired, Injectable, Injector } from '@opensumi/di';
-import { DomListener, IContextKeyService, IReporterService, PreferenceService } from '@opensumi/ide-core-browser';
+import {
+  DomListener,
+  IContextKeyService,
+  IReporterService,
+  PreferenceService,
+  addClassName,
+  createClassNameTokens,
+} from '@opensumi/ide-core-browser';
 import {
   AbstractMenuService,
   ICtxMenuRenderer,
@@ -848,7 +855,7 @@ class InlineBreakpointWidget extends Disposable implements monaco.editor.IConten
     const domNode = document.createElement('div');
     domNode.className = 'inline-breakpoint-widget';
     if (cssClass) {
-      domNode.classList.add(...cssClass.split(' '));
+      addClassName(domNode, cssClass);
     }
     this.domNode = domNode;
 

--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -7,6 +7,8 @@ import {
   ComponentRegistryInfo,
   ComponentRegistryProvider,
   KeybindingRegistry,
+  addClassName,
+  createClassNameTokens,
   getIcon,
   useDesignStyles,
   useInjectable,
@@ -130,7 +132,7 @@ export const TabbarViewBase: React.FC<ITabbarViewProps> = observer((props) => {
               const dragImage = ref.cloneNode(true) as HTMLLIElement;
               dragImage.classList.add(styles.dragging);
               if (tabClassName) {
-                dragImage.classList.add(tabClassName);
+                addClassName(dragImage, tabClassName);
               }
               document.body.appendChild(dragImage);
               e.persist();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

左侧的 tabbar 拖动图标无法交换位置

### Changelog
fix left tabbar item cannot drag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 引入了 `createClassNameTokens` 和 `addClassName` 两个新函数，以简化和提升DOM元素类名管理的功能。
	- 更新了工具栏、调试模型和标签栏视图组件，以更模块化的方式处理类名，提升可维护性和可读性。

- **修复**
	- 优化了类名添加过程，替换了直接的DOM操作为新的实用函数，增强了代码的一致性和清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->