### PR TITLE
fix(inline-diff): remove-widget at first line cannot be dismissed

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -610,7 +610,9 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     /**
      * added widget 通常是在 removed widget 的下面一行的位置
      */
-    const removedWidget = this.removedZoneWidgets.find((w) => w.position?.lineNumber === position.lineNumber - 1);
+    const removedWidget = this.removedZoneWidgets.find(
+      (w) => w.position?.lineNumber === Math.max(1, position.lineNumber - 1),
+    );
     const addedDec = this.addedRangeDec.getDecorationByLineNumber(position.lineNumber);
 
     const addedLinesCount = addedDec?.length || 0;

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -51,6 +51,9 @@
   }
   .kt_editor_tabs {
     display: flex;
+    .editor_actions_no_actions {
+      padding: 0 !important;
+    }
     .editor_actions {
       flex-shrink: 0;
       height: 100%;

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -540,6 +540,8 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
     const [hasFocus, setHasFocus] = useState<boolean>(editorService.currentEditorGroup === group);
     const [args, setArgs] = useState<[URI, IEditorGroup, MaybeNull<URI>] | undefined>(acquireArgs());
 
+    const noActions = menu.getMergedMenuNodes().length === 0;
+
     useEffect(() => {
       const disposableCollection = new DisposableCollection();
       disposableCollection.push(
@@ -566,7 +568,9 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
     return (
       <div
         ref={ref}
-        className={cls(styles_editor_actions, className)}
+        className={cls(styles_editor_actions, className, {
+          [styles.editor_actions_no_actions]: noActions,
+        })}
         style={{ height: layoutViewSize.editorTabsHeight }}
       >
         <InlineMenuBar<URI, IEditorGroup, MaybeNull<URI>>


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

第一行的 removed widget 采纳后不会消失

### Changelog

removed widget at first line cannot be dismissed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了小部件移除逻辑，确保在第一行时也能稳定查找已移除的小部件。
  - 添加了新的CSS类`.editor_actions_no_actions`，用于在没有可用操作时增强编辑器的布局一致性和可视清晰度。

- **样式**
  - 为编辑器中的无操作场景应用新的CSS样式，以改善用户界面的视觉呈现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->