### PR TITLE
fix: avoid multi ServerApp instance share one path handler

### DIFF
--- a/packages/connection/__test__/node/channel-handler.test.ts
+++ b/packages/connection/__test__/node/channel-handler.test.ts
@@ -1,6 +1,5 @@
 import net from 'net';
 
-import { commonChannelPathHandler } from '@opensumi/ide-connection/lib/node';
 import { NetSocketConnection } from '@opensumi/ide-connection/src/common/connection';
 import { ElectronChannelHandler } from '@opensumi/ide-connection/src/electron';
 import { Deferred } from '@opensumi/ide-core-common';
@@ -8,6 +7,9 @@ import { normalizedIpcHandlerPathAsync } from '@opensumi/ide-core-common/src/uti
 
 // eslint-disable-next-line import/no-restricted-paths
 import { WSChannelHandler } from '../../src/browser';
+import { CommonChannelPathHandler } from '../../src/common/server-handler';
+
+const commonChannelPathHandler = new CommonChannelPathHandler();
 
 const clientId = 'test-client-id';
 
@@ -19,7 +21,7 @@ describe('channel handler', () => {
     const ipcPath = await normalizedIpcHandlerPathAsync('test', true);
     server.listen(ipcPath);
 
-    const nodeChannelHandler = new ElectronChannelHandler(server);
+    const nodeChannelHandler = new ElectronChannelHandler(server, commonChannelPathHandler);
     nodeChannelHandler.listen();
 
     commonChannelPathHandler.register('test', {

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -9,8 +9,11 @@ import { Deferred } from '@opensumi/ide-core-common';
 
 import { RPCService } from '../../src';
 import { RPCServiceCenter, initRPCService } from '../../src/common';
+import { CommonChannelPathHandler } from '../../src/common/server-handler';
 import { WSChannel } from '../../src/common/ws-channel';
-import { CommonChannelHandler, WebSocketServerRoute, commonChannelPathHandler } from '../../src/node';
+import { CommonChannelHandler, WebSocketServerRoute } from '../../src/node';
+
+const commonChannelPathHandler = new CommonChannelPathHandler();
 
 const wssPort = 7788;
 
@@ -31,7 +34,7 @@ describe('connection', () => {
   it('websocket connection route', async () => {
     const server = http.createServer();
     const socketRoute = new WebSocketServerRoute(server, console);
-    const channelHandler = new CommonChannelHandler('/service', console);
+    const channelHandler = new CommonChannelHandler('/service', commonChannelPathHandler, console);
     socketRoute.registerHandler(channelHandler);
     socketRoute.init();
 
@@ -93,7 +96,7 @@ describe('connection', () => {
     const server = http.createServer();
     const deferred = new Deferred();
     const socketRoute = new WebSocketServerRoute(server, console);
-    const channelHandler = new CommonChannelHandler('/service', console, {
+    const channelHandler = new CommonChannelHandler('/service', commonChannelPathHandler, console, {
       wsServerOptions: {
         verifyClient: () => false,
       },

--- a/packages/connection/src/common/server-handler.ts
+++ b/packages/connection/src/common/server-handler.ts
@@ -98,8 +98,6 @@ export class CommonChannelPathHandler {
   }
 }
 
-export const commonChannelPathHandler = new CommonChannelPathHandler();
-
 export interface ChannelHandlerOptions {
   serializer?: ISerializer<ChannelMessage, any>;
 }
@@ -115,7 +113,12 @@ export abstract class BaseCommonChannelHandler {
   protected heartbeatTimer: NodeJS.Timeout | null = null;
 
   serializer: ISerializer<ChannelMessage, any> = furySerializer;
-  constructor(public handlerId: string, protected logger: ILogger = console, options: ChannelHandlerOptions = {}) {
+  constructor(
+    public handlerId: string,
+    protected commonChannelPathHandler: CommonChannelPathHandler,
+    protected logger: ILogger = console,
+    options: ChannelHandlerOptions = {},
+  ) {
     if (options.serializer) {
       this.serializer = options.serializer;
     }
@@ -156,7 +159,7 @@ export abstract class BaseCommonChannelHandler {
 
             channel = new WSServerChannel(wrappedConnection, { id, clientId, logger: this.logger });
             this.channelMap.set(id, channel);
-            commonChannelPathHandler.openChannel(path, channel, clientId);
+            this.commonChannelPathHandler.openChannel(path, channel, clientId);
             channel.serverReady(traceId);
             break;
           }
@@ -185,7 +188,7 @@ export abstract class BaseCommonChannelHandler {
 
     connection.onceClose(() => {
       this.logger.log(`connection ${clientId} is closed, dispose all channels`);
-      commonChannelPathHandler.disposeConnectionClientId(connection, clientId);
+      this.commonChannelPathHandler.disposeConnectionClientId(connection, clientId);
 
       Array.from(this.channelMap.values())
         .filter((channel) => channel.clientId === clientId)

--- a/packages/connection/src/common/server-handler.ts
+++ b/packages/connection/src/common/server-handler.ts
@@ -5,6 +5,8 @@ import { ISerializer } from './serializer/types';
 import { ILogger } from './types';
 import { WSChannel, WSServerChannel } from './ws-channel';
 
+import type { Injector } from '@opensumi/di';
+
 export interface IPathHandler {
   dispose: (channel: WSChannel, connectionId: string) => void;
   handler: (channel: WSChannel, connectionId: string, params?: Record<string, string>) => void;
@@ -209,3 +211,11 @@ export abstract class BaseCommonChannelHandler {
 }
 
 export const RPCServiceChannelPath = 'RPCService';
+
+export function injectConnectionProviders(injector: Injector) {
+  const commonChannelPathHandler = new CommonChannelPathHandler();
+  injector.addProviders({
+    token: CommonChannelPathHandler,
+    useValue: commonChannelPathHandler,
+  });
+}

--- a/packages/connection/src/electron/channel-handler.ts
+++ b/packages/connection/src/electron/channel-handler.ts
@@ -2,14 +2,18 @@ import net from 'net';
 
 import { ILogger } from '../common';
 import { NetSocketConnection } from '../common/connection';
-import { BaseCommonChannelHandler } from '../common/server-handler';
+import { BaseCommonChannelHandler, CommonChannelPathHandler } from '../common/server-handler';
 
 /**
  * Channel Handler for electron backend
  */
 export class ElectronChannelHandler extends BaseCommonChannelHandler {
-  constructor(private server: net.Server, logger: ILogger = console) {
-    super('electron-channel-handler', logger);
+  constructor(
+    private server: net.Server,
+    protected commonChannelPathHandler: CommonChannelPathHandler,
+    logger: ILogger = console,
+  ) {
+    super('electron-channel-handler', commonChannelPathHandler, logger);
   }
 
   doHeartbeat(connection: any): void {

--- a/packages/connection/src/node/common-channel-handler.ts
+++ b/packages/connection/src/node/common-channel-handler.ts
@@ -3,11 +3,9 @@ import WebSocket from 'ws';
 
 import { ILogger } from '../common';
 import { WSWebSocketConnection } from '../common/connection';
-import { BaseCommonChannelHandler, commonChannelPathHandler } from '../common/server-handler';
+import { BaseCommonChannelHandler, CommonChannelPathHandler } from '../common/server-handler';
 
 import { CommonChannelHandlerOptions, WebSocketHandler } from './ws';
-
-export { commonChannelPathHandler };
 
 export interface WebSocketConnection extends WebSocket {
   routeParam: {
@@ -22,8 +20,13 @@ export class CommonChannelHandler extends BaseCommonChannelHandler implements We
   private wsServer: WebSocket.Server;
   protected handlerRoute: MatchFunction;
 
-  constructor(routePath: string, logger: ILogger = console, private options: CommonChannelHandlerOptions = {}) {
-    super('node-channel-handler', logger);
+  constructor(
+    routePath: string,
+    protected commonChannelPathHandler: CommonChannelPathHandler,
+    logger: ILogger = console,
+    private options: CommonChannelHandlerOptions = {},
+  ) {
+    super('node-channel-handler', commonChannelPathHandler, logger);
     this.handlerRoute = match(routePath, options.pathMatchOptions);
     this.initWSServer();
   }

--- a/packages/core-node/src/bootstrap/app.ts
+++ b/packages/core-node/src/bootstrap/app.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import Koa from 'koa';
 
 import { Injector } from '@opensumi/di';
+import { injectConnectionProviders } from '@opensumi/ide-connection/lib/common/server-handler';
 import { WebSocketHandler } from '@opensumi/ide-connection/lib/node';
 import {
   ContributionProvider,
@@ -20,12 +21,7 @@ import {
 } from '@opensumi/ide-core-common';
 import { DEFAULT_ALIPAY_CLOUD_REGISTRY } from '@opensumi/ide-core-common/lib/const';
 
-import {
-  RPCServiceCenter,
-  createNetServerConnection,
-  createServerConnection2,
-  injectConnectionProviders,
-} from '../connection';
+import { RPCServiceCenter, createNetServerConnection, createServerConnection2 } from '../connection';
 import { NodeModule } from '../node-module';
 import { AppConfig, IServerApp, IServerAppOpts, ModuleConstructor, ServerAppContribution } from '../types';
 

--- a/packages/core-node/src/bootstrap/app.ts
+++ b/packages/core-node/src/bootstrap/app.ts
@@ -20,7 +20,12 @@ import {
 } from '@opensumi/ide-core-common';
 import { DEFAULT_ALIPAY_CLOUD_REGISTRY } from '@opensumi/ide-core-common/lib/const';
 
-import { RPCServiceCenter, createNetServerConnection, createServerConnection2 } from '../connection';
+import {
+  RPCServiceCenter,
+  createNetServerConnection,
+  createServerConnection2,
+  injectConnectionProviders,
+} from '../connection';
 import { NodeModule } from '../node-module';
 import { AppConfig, IServerApp, IServerAppOpts, ModuleConstructor, ServerAppContribution } from '../types';
 
@@ -114,6 +119,7 @@ export class ServerApp implements IServerApp {
       useValue: this.config,
     });
     injectInnerProviders(this.injector);
+    injectConnectionProviders(this.injector);
   }
 
   private async initializeContribution() {

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -13,14 +13,6 @@ import { IServerAppOpts } from './types';
 
 export { RPCServiceCenter };
 
-export function injectConnectionProviders(injector: Injector) {
-  const commonChannelPathHandler = new CommonChannelPathHandler();
-  injector.addProviders({
-    token: CommonChannelPathHandler,
-    useValue: commonChannelPathHandler,
-  });
-}
-
 function handleClientChannel(
   injector: Injector,
   modulesInstances: NodeModule[],

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -13,6 +13,14 @@ import { IServerAppOpts } from './types';
 
 export { RPCServiceCenter };
 
+export function injectConnectionProviders(injector: Injector) {
+  const commonChannelPathHandler = new CommonChannelPathHandler();
+  injector.addProviders({
+    token: CommonChannelPathHandler,
+    useValue: commonChannelPathHandler,
+  });
+}
+
 function handleClientChannel(
   injector: Injector,
   modulesInstances: NodeModule[],
@@ -44,12 +52,7 @@ export function createServerConnection2(
   serverAppOpts: IServerAppOpts,
 ) {
   const logger = injector.get(INodeLogger);
-  const commonChannelPathHandler = new CommonChannelPathHandler();
-  injector.addProviders({
-    token: CommonChannelPathHandler,
-    useValue: commonChannelPathHandler,
-  });
-
+  const commonChannelPathHandler = injector.get(CommonChannelPathHandler);
   const socketRoute = new WebSocketServerRoute(server, logger);
   const channelHandler = new CommonChannelHandler('/service', commonChannelPathHandler, logger, {
     pathMatchOptions: serverAppOpts.pathMatchOptions,
@@ -75,11 +78,7 @@ export function createServerConnection2(
 
 export function createNetServerConnection(server: net.Server, injector: Injector, modulesInstances: NodeModule[]) {
   const logger = injector.get(INodeLogger) as INodeLogger;
-  const commonChannelPathHandler = new CommonChannelPathHandler();
-  injector.addProviders({
-    token: CommonChannelPathHandler,
-    useValue: commonChannelPathHandler,
-  });
+  const commonChannelPathHandler = injector.get(CommonChannelPathHandler);
 
   const handler = new ElectronChannelHandler(server, commonChannelPathHandler, logger);
   // 事件由 connection 的时机来触发

--- a/packages/core-node/src/connection.ts
+++ b/packages/core-node/src/connection.ts
@@ -3,14 +3,9 @@ import net from 'net';
 
 import { ClassCreator, FactoryCreator, Injector, InstanceCreator } from '@opensumi/di';
 import { RPCServiceCenter, WSChannel, initRPCService } from '@opensumi/ide-connection';
-import { RPCServiceChannelPath } from '@opensumi/ide-connection/lib/common/server-handler';
+import { CommonChannelPathHandler, RPCServiceChannelPath } from '@opensumi/ide-connection/lib/common/server-handler';
 import { ElectronChannelHandler } from '@opensumi/ide-connection/lib/electron';
-import {
-  CommonChannelHandler,
-  WebSocketHandler,
-  WebSocketServerRoute,
-  commonChannelPathHandler,
-} from '@opensumi/ide-connection/lib/node';
+import { CommonChannelHandler, WebSocketHandler, WebSocketServerRoute } from '@opensumi/ide-connection/lib/node';
 
 import { INodeLogger } from './logger/node-logger';
 import { NodeModule } from './node-module';
@@ -49,8 +44,14 @@ export function createServerConnection2(
   serverAppOpts: IServerAppOpts,
 ) {
   const logger = injector.get(INodeLogger);
+  const commonChannelPathHandler = new CommonChannelPathHandler();
+  injector.addProviders({
+    token: CommonChannelPathHandler,
+    useValue: commonChannelPathHandler,
+  });
+
   const socketRoute = new WebSocketServerRoute(server, logger);
-  const channelHandler = new CommonChannelHandler('/service', logger, {
+  const channelHandler = new CommonChannelHandler('/service', commonChannelPathHandler, logger, {
     pathMatchOptions: serverAppOpts.pathMatchOptions,
     wsServerOptions: serverAppOpts.wsServerOptions,
   });
@@ -74,8 +75,13 @@ export function createServerConnection2(
 
 export function createNetServerConnection(server: net.Server, injector: Injector, modulesInstances: NodeModule[]) {
   const logger = injector.get(INodeLogger) as INodeLogger;
+  const commonChannelPathHandler = new CommonChannelPathHandler();
+  injector.addProviders({
+    token: CommonChannelPathHandler,
+    useValue: commonChannelPathHandler,
+  });
 
-  const handler = new ElectronChannelHandler(server, logger);
+  const handler = new ElectronChannelHandler(server, commonChannelPathHandler, logger);
   // 事件由 connection 的时机来触发
   commonChannelPathHandler.register(RPCServiceChannelPath, {
     handler: (channel: WSChannel, clientId: string) => {

--- a/packages/extension/src/node/extension.service.ts
+++ b/packages/extension/src/node/extension.service.ts
@@ -5,7 +5,7 @@ import util from 'util';
 import { Autowired, Injectable } from '@opensumi/di';
 import { WSServerChannel } from '@opensumi/ide-connection';
 import { NetSocketConnection } from '@opensumi/ide-connection/lib/common/connection';
-import { commonChannelPathHandler } from '@opensumi/ide-connection/lib/node';
+import { CommonChannelPathHandler } from '@opensumi/ide-connection/lib/common/server-handler';
 import {
   Emitter,
   Event,
@@ -95,6 +95,9 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
 
   @Autowired(IExtensionHostManager)
   private extensionHostManager: IExtensionHostManager;
+
+  @Autowired(CommonChannelPathHandler)
+  private commonChannelPathHandler: CommonChannelPathHandler;
 
   private clientExtProcessMap: Map<string, number> = new Map();
   private clientExtProcessInspectPortMap: Map<string, number> = new Map();
@@ -507,7 +510,7 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
   private async _setMainThreadConnection(
     handler: (connectionResult: { channel: WSServerChannel; clientId: string }) => void,
   ) {
-    commonChannelPathHandler.register(CONNECTION_HANDLE_BETWEEN_EXTENSION_AND_MAIN_THREAD, {
+    this.commonChannelPathHandler.register(CONNECTION_HANDLE_BETWEEN_EXTENSION_AND_MAIN_THREAD, {
       handler: (channel: WSServerChannel, clientId: string) => {
         handler({
           channel,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

应该是每个 ServerApp 实例创建一个 CommonChannelPathHandler 这个类。
原来是多个 ServerApp 共享一个 CommonChannelPathHandler 类了。

在 Codeblitz 上就会出现创建一次 ClientApp 时会触发后端所有的 ServerApp 的响应。

### Changelog

avoid multi ServerApp instance share one path handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入 `CommonChannelPathHandler` 以增强通道路径处理能力。
	- 更新 `ServerApp` 以支持依赖注入的连接提供者。
	
- **修复**
	- 改进 WebSocket 服务器的连接和消息路由逻辑。

- **文档**
	- 更新导入语句和类属性声明，以反映新结构和依赖关系。

- **重构**
	- 增强了对通道处理的模块化和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->