### PR TITLE
chore: improve inline diff indent

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-actions/result-items/index.tsx
+++ b/packages/ai-native/src/browser/widget/inline-actions/result-items/index.tsx
@@ -1,7 +1,10 @@
 import React, { useMemo } from 'react';
 
 import { ContentWidgetContainerPanel } from '@opensumi/ide-core-browser/lib/components/ai-native/content-widget/containerPanel';
-import { AIInlineResult } from '@opensumi/ide-core-browser/lib/components/ai-native/index';
+import {
+  AIInlineResult,
+  IAIInlineResultIconItemsProps,
+} from '@opensumi/ide-core-browser/lib/components/ai-native/index';
 import { localize } from '@opensumi/ide-core-common';
 
 import { EResultKind } from '../../inline-chat/inline-chat.service';
@@ -12,23 +15,25 @@ export interface IInlineResultActionProps {
 
 export const InlineResultAction = ({ onResultClick }: IInlineResultActionProps) => {
   const iconResultItems = useMemo(
-    () => [
-      {
-        icon: 'check',
-        text: localize('aiNative.inline.chat.operate.check.title'),
-        onClick: () => onResultClick(EResultKind.ACCEPT),
-      },
-      {
-        icon: 'discard',
-        text: localize('aiNative.operate.discard.title'),
-        onClick: () => onResultClick(EResultKind.DISCARD),
-      },
-      {
-        icon: 'afresh',
-        text: localize('aiNative.operate.afresh.title'),
-        onClick: () => onResultClick(EResultKind.REGENERATE),
-      },
-    ],
+    () =>
+      [
+        {
+          icon: 'check',
+          text: localize('aiNative.inline.chat.operate.check.title'),
+          btnType: 'default',
+          onClick: () => onResultClick(EResultKind.ACCEPT),
+        },
+        {
+          icon: 'discard',
+          text: localize('aiNative.operate.discard.title'),
+          onClick: () => onResultClick(EResultKind.DISCARD),
+        },
+        {
+          icon: 'afresh',
+          text: localize('aiNative.operate.afresh.title'),
+          onClick: () => onResultClick(EResultKind.REGENERATE),
+        },
+      ] as IAIInlineResultIconItemsProps[],
     [onResultClick],
   );
 

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff.handler.ts
@@ -27,7 +27,7 @@ import {
 } from '../inline-diff/inline-diff-previewer';
 import { InlineDiffWidget } from '../inline-diff/inline-diff-widget';
 import { InlineStreamDiffHandler } from '../inline-stream-diff/inline-stream-diff.handler';
-import { IPartialEditEvent, SerializableState } from '../inline-stream-diff/live-preview.decoration';
+import { IPartialEditEvent } from '../inline-stream-diff/live-preview.decoration';
 
 @Injectable()
 export class InlineDiffHandler extends IAIMonacoContribHandler {
@@ -158,11 +158,10 @@ export class InlineDiffHandler extends IAIMonacoContribHandler {
       disposable.dispose();
     };
 
-    if (InlineChatController.is(chatResponse)) {
-      const controller = chatResponse as InlineChatController;
-
-      disposable.addDispose(
-        previewer.onReady(() => {
+    disposable.addDispose(
+      previewer.onReady(() => {
+        if (InlineChatController.is(chatResponse)) {
+          const controller = chatResponse as InlineChatController;
           controller.listen();
 
           disposable.addDispose([
@@ -184,21 +183,12 @@ export class InlineDiffHandler extends IAIMonacoContribHandler {
               onFinish();
             }),
           ]);
-        }),
-      );
-    } else {
-      const model = monacoEditor.getModel();
-      const crossCode = model!.getValueInRange(crossSelection);
-
-      const answer = this.formatAnswer((chatResponse as ReplyResponse).message, crossCode);
-
-      disposable.addDispose(
-        previewer.onReady(() => {
-          previewer.setValue(answer);
+        } else {
+          previewer.setValue((chatResponse as ReplyResponse).message);
           onFinish();
-        }),
-      );
-    }
+        }
+      }),
+    );
 
     previewer.layout();
     return previewer;

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -1,18 +1,13 @@
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
-import { Disposable, Emitter, Event, IPosition, RunOnceScheduler } from '@opensumi/ide-core-browser';
+import { Disposable, Emitter, Event, RunOnceScheduler, sleep } from '@opensumi/ide-core-browser';
 import { ISingleEditOperation } from '@opensumi/ide-editor';
-import { ICodeEditor, IRange, ITextModel, Range, Selection } from '@opensumi/ide-monaco';
+import { ICodeEditor, ITextModel, Range, Selection } from '@opensumi/ide-monaco';
 import { StandaloneServices } from '@opensumi/ide-monaco/lib/browser/monaco-api/services';
-import { getLeadingWhitespace } from '@opensumi/ide-utils/lib/strings';
 import { LineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/lineRange';
 import { linesDiffComputers } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputers';
 import { DetailedLineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/rangeMapping';
 import { IModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/services/model';
 import { LineTokens } from '@opensumi/monaco-editor-core/esm/vs/editor/common/tokens/lineTokens';
-import {
-  generateIndent,
-  getSpaceCnt,
-} from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/indentation/browser/indentUtils';
 import { UndoRedoGroup } from '@opensumi/monaco-editor-core/esm/vs/platform/undoRedo/common/undoRedo';
 
 import { IDecorationSerializableState } from '../../model/enhanceDecorationsCollection';
@@ -402,16 +397,7 @@ export class InlineStreamDiffHandler extends Disposable {
       this.virtualModel.setValue(newContent);
     }
 
-    // 控制缩进
-    const startLineNumber = this.selection.startLineNumber;
-    const oldIndentation = getLeadingWhitespace(this.originalModel.getLineContent(startLineNumber));
-
-    const { tabSize, insertSpaces } = this.originalModel.getOptions();
-    const originalSpacesCnt = getSpaceCnt(oldIndentation, tabSize);
-    const newIndentation = generateIndent(originalSpacesCnt, tabSize, insertSpaces);
-
-    const newTextLines = this.virtualModel.getLinesContent().map((content) => newIndentation + content);
-
+    const newTextLines = this.virtualModel.getLinesContent();
     this.currentDiffModel = this.computeDiff(this.rawOriginalTextLines, newTextLines, computerMode);
     return this.currentDiffModel;
   }

--- a/packages/core-browser/src/components/ai-native/inline-chat/result.tsx
+++ b/packages/core-browser/src/components/ai-native/inline-chat/result.tsx
@@ -1,4 +1,7 @@
+import cls from 'classnames';
 import React from 'react';
+
+import { Button, ButtonType } from '@opensumi/ide-components';
 
 import { EnhanceIcon } from '../enhanceIcon';
 import { LineVertical } from '../line-vertical';
@@ -9,6 +12,7 @@ import styles from './styles.module.less';
 export interface IAIInlineResultIconItemsProps {
   text: string | React.ReactNode;
   onClick: () => void;
+  btnType?: ButtonType;
   icon?: string;
 }
 
@@ -25,8 +29,13 @@ export const AIInlineResult = (props: IAIInlineResultProps) => {
   return (
     <div className={styles.ai_inline_result_panel}>
       <div className={styles.side}>
-        {iconItems.map(({ icon, text, onClick }, idx) => (
-          <EnhanceIcon wrapperClassName={styles.operate_btn} icon={icon} onClick={onClick} key={idx}>
+        {iconItems.map(({ icon, text, onClick, btnType }, idx) => (
+          <EnhanceIcon
+            wrapperClassName={cls(styles.operate_btn, btnType === 'default' ? styles.default : '')}
+            icon={icon}
+            onClick={onClick}
+            key={idx}
+          >
             <span>{text}</span>
           </EnhanceIcon>
         ))}

--- a/packages/core-browser/src/components/ai-native/inline-chat/styles.module.less
+++ b/packages/core-browser/src/components/ai-native/inline-chat/styles.module.less
@@ -1,4 +1,5 @@
 @default_height: 24px;
+@default_line_height: 22px;
 
 .ai_inline_result_panel {
   display: flex;
@@ -11,14 +12,19 @@
     display: flex;
     align-items: center;
     .operate_btn {
-      height: 22px;
-      line-height: 22px;
+      height: @default_line_height;
+      line-height: @default_line_height;
       padding: 0 6px;
+      margin: 0 2px;
+
+      &.default {
+        background-color: var(--kt-primaryButton-hoverBackground);
+      }
     }
     .operate_icon {
-      width: 22px;
-      height: 22px;
-      line-height: 22px;
+      width: @default_line_height;
+      height: @default_line_height;
+      line-height: @default_line_height;
       border-radius: 4px;
     }
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

- [x] 采纳按钮采用 default button 主按钮颜色渲染
- [x] 改进 inline diff 所生成结果的缩进，根据选中区域的第一行缩进大小进行计算

### Changelog
优化 inline diff 所生成结果的缩进

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 增强了 `InlineResultAction` 组件的图标项目，通过新接口提升类型安全。
  - `InlineStreamDiffHandler` 现在更好地处理文本格式，保持缩进和空格，使显示更清晰。
  - `AIInlineResult` 组件支持新的可选属性 `btnType`，允许动态应用不同的按钮样式。
  - `BaseInlineDiffPreviewer` 类新增了格式化缩进的方法，提升内容插入时的视觉一致性。

- **样式改进**
  - 引入变量 `@default_line_height`，提高样式维护性和可调整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->