### PR TITLE
fix: render tabbar correctly on initial load

### DIFF
--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -154,8 +154,6 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
   }
 
   restoreTabbarService = async (service: TabbarService) => {
-    await service.viewReady.promise;
-
     this.state = this.layoutState.getState(LAYOUT_STATE.MAIN, {
       [SlotLocation.left]: {
         currentId: undefined,

--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -195,12 +195,29 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
         defaultContainer = '';
       }
     }
+    /**
+     * ContainerId 存在三种值类型，对应的处理模式如下：
+     * 1. undefined: 采用首个注册的容器作为当前 containerId
+     * 2. string: 直接使用该 containerId 作为当前 containerId
+     * 3. '': 直接清空当前 containerId，不展开相应的 viewContainer
+     */
     if (isUndefined(currentId)) {
-      service.updateCurrentContainerId(defaultContainer);
-    } else {
-      service.updateCurrentContainerId(
-        currentId ? (service.containersMap.has(currentId) ? currentId : defaultContainer) : '',
-      );
+      if (isUndefined(defaultContainer)) {
+        // 默认采用首个注册的容器作为当前 containerId
+        service.updateNextContainerId();
+      } else {
+        service.updateCurrentContainerId(defaultContainer);
+      }
+    } else if (currentId) {
+      if (service.containersMap.has(currentId)) {
+        service.updateCurrentContainerId(currentId);
+      } else {
+        service.updateCurrentContainerId(defaultContainer);
+        // 等待后续新容器注册时，更新当前的 containerId
+        service.updateNextContainerId(currentId);
+      }
+    } else if (currentId === '') {
+      service.updateCurrentContainerId('');
     }
   };
 

--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -198,7 +198,9 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
     if (isUndefined(currentId)) {
       service.updateCurrentContainerId(defaultContainer);
     } else {
-      service.updateCurrentContainerId(currentId);
+      service.updateCurrentContainerId(
+        currentId ? (service.containersMap.has(currentId) ? currentId : defaultContainer) : '',
+      );
     }
   };
 

--- a/packages/main-layout/src/browser/layout.service.ts
+++ b/packages/main-layout/src/browser/layout.service.ts
@@ -200,9 +200,7 @@ export class LayoutService extends WithEventBus implements IMainLayoutService {
     if (isUndefined(currentId)) {
       service.updateCurrentContainerId(defaultContainer);
     } else {
-      service.updateCurrentContainerId(
-        currentId ? (service.containersMap.has(currentId) ? currentId : defaultContainer) : '',
-      );
+      service.updateCurrentContainerId(currentId);
     }
   };
 

--- a/packages/main-layout/src/browser/tabbar/renderer.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/renderer.view.tsx
@@ -53,15 +53,8 @@ export const TabRendererBase: FC<{
   const resizeHandle = useContext(PanelContext);
   const rootRef = useRef<HTMLDivElement>(null);
   const [fullSize, setFullSize] = useState(0);
-  const skipFirstRender = useRef(true);
 
   useLayoutEffect(() => {
-    // 由于当前 Tabbar 组件渲染首次默认传入空的 components 数组初始化
-    // 为了避免后续存在时序问题，这里做一个简单的判断，跳过首次渲染场景
-    if (skipFirstRender.current) {
-      skipFirstRender.current = false;
-      return;
-    }
     tabbarService.registerResizeHandle(resizeHandle);
     components.forEach((component) => {
       tabbarService.registerContainer(component.options!.containerId, component);

--- a/packages/main-layout/src/browser/tabbar/renderer.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/renderer.view.tsx
@@ -53,8 +53,15 @@ export const TabRendererBase: FC<{
   const resizeHandle = useContext(PanelContext);
   const rootRef = useRef<HTMLDivElement>(null);
   const [fullSize, setFullSize] = useState(0);
+  const skipFirstRender = useRef(true);
 
   useLayoutEffect(() => {
+    // 由于当前 Tabbar 组件渲染首次默认传入空的 components 数组初始化
+    // 为了避免后续存在时序问题，这里做一个简单的判断，跳过首次渲染场景
+    if (skipFirstRender.current) {
+      skipFirstRender.current = false;
+      return;
+    }
     tabbarService.registerResizeHandle(resizeHandle);
     components.forEach((component) => {
       tabbarService.registerContainer(component.options!.containerId, component);

--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -23,6 +23,7 @@ import {
   formatLocalize,
   getTabbarCtxKey,
   isDefined,
+  isUndefined,
   localize,
   toDisposable,
 } from '@opensumi/ide-core-browser';
@@ -64,6 +65,9 @@ export class TabbarService extends WithEventBus {
   @observable
   // currentContainerId 默认值应该为一个非空且唯一的字符串，避免在切换容器时触发 MobX 不变错误
   currentContainerId?: string = NONE_CONTAINER_ID;
+
+  private nextContainerId = '';
+  private useFirstContainerId = false;
 
   previousContainerId = '';
 
@@ -172,6 +176,14 @@ export class TabbarService extends WithEventBus {
 
   public setIsLatter(v: boolean) {
     this.isLatter = v;
+  }
+
+  updateNextContainerId(nextContainerId?: string) {
+    if (isUndefined(nextContainerId)) {
+      this.useFirstContainerId = true;
+    } else {
+      this.nextContainerId = nextContainerId;
+    }
   }
 
   @action
@@ -320,6 +332,15 @@ export class TabbarService extends WithEventBus {
   registerContainer(containerId: string, componentInfo: ComponentRegistryInfo) {
     if (this.containersMap.has(containerId)) {
       return;
+    }
+
+    if (this.useFirstContainerId) {
+      this.useFirstContainerId = false;
+      this.updateCurrentContainerId(containerId);
+    }
+
+    if (this.nextContainerId === containerId) {
+      this.updateCurrentContainerId(containerId);
     }
 
     const disposables = new DisposableCollection();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

由于当前 Tabbar 组件渲染首次默认传入空的 components 数组初始化，为了避免后续存在时序问题，这里做一个简单的判断，跳过首次渲染场景，这样能保证 `TabbarService` 的初始化过程中存在可用的 container 进行情况判断。

https://github.com/opensumi/core/blob/d2fd46dfa5fa1c1e475696fe7da41b68cc4d7664/packages/core-browser/src/react-providers/slot.tsx#L229-L237

### Changelog

render tabbar correctly on initial load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 修改了服务的状态恢复逻辑，使其在不等待服务就绪的情况下进行。
	- 简化了当前容器ID的更新逻辑。

- **性能改进**
	- 移除了一些不必要的异步检查，以提高性能。

- **用户界面**
	- 添加了一个机制，以跳过标签栏的首次渲染，避免潜在的时间问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->