### PR TITLE
fix: inline chat shortcut  display

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.feature.registry.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.feature.registry.ts
@@ -155,16 +155,21 @@ export class InlineChatFeatureRegistry extends Disposable implements IInlineChat
       this.interactiveInputModel.setStrategyHandler(() => runStrategy.strategy || ERunStrategy.EXECUTE);
     }
 
-    const keybindingStr = String(this.getSequenceKeyString());
-
-    if (keybindingStr) {
-      this.collectActions({
-        id: InteractiveInputModel.ID,
-        name: `Chat(${keybindingStr.toLocaleUpperCase()})`,
-        renderType: 'button',
-        order: Number.MAX_SAFE_INTEGER,
-      });
-    }
+    this.addDispose(
+      Event.filter(this.keybindingRegistry.onKeybindingsChanged, ({ affectsCommands }) =>
+        affectsCommands.includes(AI_INLINE_CHAT_INTERACTIVE_INPUT_VISIBLE.id),
+      )(() => {
+        const keybindingStr = String(this.getSequenceKeyString());
+        if (keybindingStr) {
+          this.collectActions({
+            id: InteractiveInputModel.ID,
+            name: `Chat(${keybindingStr.toLocaleUpperCase()})`,
+            renderType: 'button',
+            order: Number.MAX_SAFE_INTEGER,
+          });
+        }
+      }),
+    );
 
     return {
       dispose: () => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

![image](https://github.com/user-attachments/assets/49859f57-0eb2-4285-a8c4-e7c86502fe3d)


### Changelog
修复 inline chat 的对话快捷键按钮不显示的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 改进了在线聊天功能的键绑定处理逻辑，使其能根据实际的键绑定状态动态响应，提高了用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->