### PR TITLE
feat: add 'clear result' button to search panel

### DIFF
--- a/packages/search/src/browser/tree/search-tree.view.tsx
+++ b/packages/search/src/browser/tree/search-tree.view.tsx
@@ -30,6 +30,11 @@ export interface ISearchResultTotalContent {
 const ResultTotalContent = ({ total, state, model }: ISearchResultTotalContent) => {
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const searchModelService = useInjectable<SearchModelService>(SearchModelService);
+
+  const handleClear = useCallback(() => {
+    searchModelService.clearSearchResults();
+  }, [searchModelService]);
+
   const handleFold = useCallback(() => {
     const toCollapsed = !collapsed;
     setCollapsed(toCollapsed);
@@ -64,6 +69,13 @@ const ResultTotalContent = ({ total, state, model }: ISearchResultTotalContent) 
         <span className={styles.text}>
           {formatLocalize('search.files.result', String(total.resultNum), String(total.fileNum))}
         </span>
+        <Button
+          className={cls(styles.result_fold, { [styles.disabled]: state === SEARCH_STATE.doing })}
+          onClick={handleClear}
+          type='icon'
+          icon='clear'
+          title={localize('search.ClearSearchResultsAction.label')}
+        ></Button>
         <Button
           className={cls(styles.result_fresh, { [styles.disabled]: state === SEARCH_STATE.doing })}
           onClick={handleRefresh}

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -336,6 +336,11 @@ export class SearchModelService extends Disposable {
     return this.treeModel.root.expandedAll();
   }
 
+  clearSearchResults() {
+    this.searchService.clean();
+    this.searchService.search();
+  }
+
   private toReplaceResource(fileResource: URI) {
     const REPLACE_PREVIEW = 'replacePreview';
     return fileResource


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
### Background or solution
关联issuse https://github.com/opensumi/core/issues/3525
为搜索面板添加一个一键清除所有搜索结果的按钮，如下图：
![image](https://github.com/user-attachments/assets/f1ff9996-37ed-4ddf-b57b-a5a95914c3b4)

### Changelog
add 'clear result' button to search panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在搜索结果界面新增“清除搜索结果”按钮，用户可直接通过此按钮清除当前搜索结果。
	- 改进了国际化支持，添加了按钮标题的本地化文本。

- **用户体验改进**
	- 增强了组件的交互性，允许用户更有效地管理搜索结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->