### PR TITLE
feat: support register tabbar right component

### DIFF
--- a/packages/core-browser/src/layout/index.ts
+++ b/packages/core-browser/src/layout/index.ts
@@ -3,3 +3,4 @@ export * from './layout-hooks';
 export * from './layout.interface';
 export * from './accordion/view-context-key.registry';
 export * from './accordion/tab-bar-toolbar';
+export * from './render';

--- a/packages/core-browser/src/layout/render.tsx
+++ b/packages/core-browser/src/layout/render.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactIs from 'react-is';
+
+import { ErrorBoundary } from '../react-providers';
+
+import { View } from './layout.interface';
+
+export const renderView = (view?: View) => (
+    <>
+      {view && ReactIs.isValidElementType(view.component) ? (
+        <ErrorBoundary>{view.component && React.createElement(view.component, view.initialProps)}</ErrorBoundary>
+      ) : null}
+    </>
+  );

--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -17,6 +17,7 @@ import {
   PreferenceService,
   URI,
   View,
+  renderView,
   useDesignStyles,
   useDisposable,
 } from '@opensumi/ide-core-browser';
@@ -314,12 +315,7 @@ export const EditorGroupView = observer(({ group }: { group: EditorGroup }) => {
             backgroundImage: !EmptyEditorViewConfig && editorBackgroundImage ? `url(${editorBackgroundImage})` : 'none',
           }}
         >
-          {EmptyEditorViewConfig && ReactIs.isValidElementType(EmptyEditorViewConfig.component) ? (
-            <ErrorBoundary>
-              {EmptyEditorViewConfig.component &&
-                React.createElement(EmptyEditorViewConfig.component, EmptyEditorViewConfig.initialProps)}
-            </ErrorBoundary>
-          ) : null}
+          {renderView(EmptyEditorViewConfig)}
         </div>
       )}
     </div>

--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -20,6 +20,7 @@ import {
   renderView,
   useDesignStyles,
   useDisposable,
+  usePreference,
 } from '@opensumi/ide-core-browser';
 import {
   IResizeHandleDelegate,
@@ -242,7 +243,6 @@ const EditorEmptyComponent: React.FC<{
 export const EditorGroupView = observer(({ group }: { group: EditorGroup }) => {
   const groupWrapperRef = React.useRef<HTMLElement | null>();
 
-  const preferenceService = useInjectable(PreferenceService) as PreferenceService;
   const [isEmpty, setIsEmpty] = React.useState(group.resources.length === 0);
   const styles_kt_editor_group = useDesignStyles(styles.kt_editor_group, 'kt_editor_group');
 
@@ -264,20 +264,7 @@ export const EditorGroupView = observer(({ group }: { group: EditorGroup }) => {
     };
   }, []);
 
-  const [showActionWhenGroupEmpty, setShowActionWhenGroupEmpty] = React.useState(
-    () => !!preferenceService.get<boolean>('editor.showActionWhenGroupEmpty'),
-  );
-
-  useDisposable(
-    () => [
-      preferenceService.onPreferenceChanged((change) => {
-        if (change.preferenceName === 'editor.showActionWhenGroupEmpty') {
-          setShowActionWhenGroupEmpty(!!change.newValue);
-        }
-      }),
-    ],
-    [],
-  );
+  const showActionWhenGroupEmpty = usePreference('editor.showActionWhenGroupEmpty', false);
 
   const componentRegistry = useInjectable<ComponentRegistry>(ComponentRegistry);
 

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -116,7 +116,7 @@ export const Tabs = ({ group }: ITabsProps) => {
 
   const slotLocation = useMemo(() => getSlotLocation(pkgName, configContext.layoutConfig), []);
 
-  const RightExtraComponent = React.useMemo(() => {
+  const RightExtraContentViewConfig = React.useMemo(() => {
     const firstView = componentRegistry.getComponentRegistryInfo(TabbarRightExtraContentId)?.views?.[0];
     if (firstView) {
       return firstView;
@@ -523,7 +523,7 @@ export const Tabs = ({ group }: ITabsProps) => {
       </div>
       {!wrapMode && <EditorActions ref={editorActionRef} group={group} />}
 
-      {renderView(RightExtraComponent)}
+      {renderView(RightExtraContentViewConfig)}
     </div>
   );
 };

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -117,12 +117,7 @@ export const Tabs = ({ group }: ITabsProps) => {
   const slotLocation = useMemo(() => getSlotLocation(pkgName, configContext.layoutConfig), []);
 
   const RightExtraComponent = React.useMemo(() => {
-    const emptyComponentInfo = componentRegistry.getComponentRegistryInfo(TabbarRightExtraContentId);
-    if (!emptyComponentInfo || !emptyComponentInfo.views) {
-      return undefined;
-    }
-
-    const firstView = emptyComponentInfo && emptyComponentInfo.views[0];
+    const firstView = componentRegistry.getComponentRegistryInfo(TabbarRightExtraContentId)?.views?.[0];
     if (firstView) {
       return firstView;
     }

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -15,6 +15,7 @@ import React, {
 
 import { Scrollbars } from '@opensumi/ide-components';
 import {
+  ComponentRegistry,
   ConfigContext,
   Disposable,
   DisposableCollection,
@@ -26,18 +27,27 @@ import {
   PreferenceService,
   ResizeEvent,
   URI,
+  View,
   getExternalIcon,
   getIcon,
   getSlotLocation,
   useDesignStyles,
 } from '@opensumi/ide-core-browser';
+import { renderView } from '@opensumi/ide-core-browser';
 import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions';
 import { LayoutViewSizeConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
 import { IMenuRegistry, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { useInjectable, useUpdateOnEventBusEvent } from '@opensumi/ide-core-browser/lib/react-hooks';
 
-import { IEditorGroup, IResource, ResourceDidUpdateEvent, ResourceService, WorkbenchEditorService } from '../common';
+import {
+  IEditorGroup,
+  IResource,
+  ResourceDidUpdateEvent,
+  ResourceService,
+  TabbarRightExtraContentId,
+  WorkbenchEditorService,
+} from '../common';
 
 import styles from './editor.module.less';
 import { TabTitleMenuService } from './menu/title-context.menu';
@@ -72,6 +82,7 @@ export const Tabs = ({ group }: ITabsProps) => {
   const menuRegistry = useInjectable<IMenuRegistry>(IMenuRegistry);
   const editorTabService = useInjectable<IEditorTabService>(IEditorTabService);
   const layoutViewSize = useInjectable<LayoutViewSizeConfig>(LayoutViewSizeConfig);
+  const componentRegistry = useInjectable<ComponentRegistry>(ComponentRegistry);
 
   const styles_tab_right = useDesignStyles(styles.tab_right, 'tab_right');
   const styles_close_tab = useDesignStyles(styles.close_tab, 'close_tab');
@@ -104,6 +115,18 @@ export const Tabs = ({ group }: ITabsProps) => {
   const [lastMarginRight, setLastMarginRight] = useState<number | undefined>();
 
   const slotLocation = useMemo(() => getSlotLocation(pkgName, configContext.layoutConfig), []);
+
+  const RightExtraComponent = React.useMemo(() => {
+    const emptyComponentInfo = componentRegistry.getComponentRegistryInfo(TabbarRightExtraContentId);
+    if (!emptyComponentInfo || !emptyComponentInfo.views) {
+      return undefined;
+    }
+
+    const firstView = emptyComponentInfo && emptyComponentInfo.views[0];
+    if (firstView) {
+      return firstView;
+    }
+  }, []);
 
   useUpdateOnGroupTabChange(group);
   useUpdateOnEventBusEvent(
@@ -504,6 +527,8 @@ export const Tabs = ({ group }: ITabsProps) => {
         )}
       </div>
       {!wrapMode && <EditorActions ref={editorActionRef} group={group} />}
+
+      {renderView(RightExtraComponent)}
     </div>
   );
 };

--- a/packages/editor/src/common/components.ts
+++ b/packages/editor/src/common/components.ts
@@ -1,0 +1,2 @@
+export const TabbarRightExtraContentId = 'tabbar-right-extra-content';
+export const TabbarLeftExtraContentId = 'tabbar-left-extra-content';

--- a/packages/editor/src/common/index.ts
+++ b/packages/editor/src/common/index.ts
@@ -4,3 +4,4 @@ export * from './resource';
 export * from './language';
 export * from './utils';
 export * from './language-status';
+export * from './components';

--- a/packages/startup/entry/sample-modules/editor-empty-component.contribution.tsx
+++ b/packages/startup/entry/sample-modules/editor-empty-component.contribution.tsx
@@ -13,6 +13,7 @@ import { KeybindingRegistry } from '@opensumi/ide-core-browser/lib/keybinding/ke
 import { useInjectable } from '@opensumi/ide-core-browser/lib/react-hooks';
 import { localize, registerLocalizationBundle } from '@opensumi/ide-core-common';
 import { LOCALE_TYPES } from '@opensumi/ide-core-common/lib/const';
+import { TabbarRightExtraContentId } from '@opensumi/ide-editor';
 import { IKeymapService } from '@opensumi/ide-keymaps/lib/common/keymaps';
 import { KeybindingView } from '@opensumi/ide-quick-open/lib/browser/components/keybinding';
 
@@ -143,5 +144,11 @@ export class EditorEmptyComponentContribution implements ComponentContribution {
       component: EditorEmptyComponent,
       initialProps: {},
     });
+
+    // registry.register(TabbarRightExtraContentId, {
+    //   id: TabbarRightExtraContentId,
+    //   component: () => <button>buttonbuttonbuttonbutton</button>,
+    //   initialProps: {},
+    // });
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

支持在 tabbar 右侧注册组件，在一些集成场景可以在这放置一些组件，比如关闭，运行等。

### Changelog

support register component in editor tabbar right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入一个新的渲染工具组件 `renderView`，增强了错误处理能力。
  - 在选项卡组件中集成动态 UI 组件，改善用户界面交互，允许根据组件注册状态动态渲染额外内容。
  - 添加了两个常量，用于标识选项卡条的额外内容区域，提升了可扩展性。

- **文档**
  - 更新了导出声明，简化了模块导入方式，提升了可用性。

- **修复**
  - 通过封装渲染逻辑，简化了 `EditorGroupView` 组件的实现，提高了代码可读性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->