### PR TITLE
fix: hide bottom tab panel if no container

### DIFF
--- a/packages/ai-native/src/browser/layout/ai-layout.tsx
+++ b/packages/ai-native/src/browser/layout/ai-layout.tsx
@@ -33,7 +33,13 @@ export const AILayout = () => {
           />
           <SplitPanel id='main-vertical' minResize={300} flexGrow={1} direction='top-to-bottom'>
             <SlotRenderer flex={2} flexGrow={1} minResize={200} slot='main' />
-            <SlotRenderer flex={1} defaultSize={layout.bottom?.size} minResize={160} slot='bottom' isTabbar={true} />
+            <SlotRenderer
+              flex={1}
+              defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 0}
+              minResize={160}
+              slot='bottom'
+              isTabbar={true}
+            />
           </SplitPanel>
           <SlotRenderer
             slot='right'

--- a/packages/ai-native/src/browser/layout/ai-layout.tsx
+++ b/packages/ai-native/src/browser/layout/ai-layout.tsx
@@ -35,7 +35,7 @@ export const AILayout = () => {
             <SlotRenderer flex={2} flexGrow={1} minResize={200} slot='main' />
             <SlotRenderer
               flex={1}
-              defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 0}
+              defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 24}
               minResize={160}
               slot='bottom'
               isTabbar={true}

--- a/packages/core-browser/src/components/layout/default-layout.tsx
+++ b/packages/core-browser/src/components/layout/default-layout.tsx
@@ -56,7 +56,7 @@ export function ToolbarActionBasedLayout(
           <SlotRenderer flex={2} flexGrow={1} minResize={200} slot='main' />
           <SlotRenderer
             flex={1}
-            defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 0}
+            defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 24}
             minResize={160}
             slot='bottom'
             isTabbar={true}

--- a/packages/core-browser/src/components/layout/default-layout.tsx
+++ b/packages/core-browser/src/components/layout/default-layout.tsx
@@ -5,14 +5,26 @@ import { SlotRenderer } from '../../react-providers/slot';
 import { BoxPanel } from './box-panel';
 import { SplitPanel } from './split-panel';
 
+interface ILayoutConfigCache {
+  [key: string]: { size: number; currentId: string };
+}
+
 export const getStorageValue = () => {
   // 启动时渲染的颜色和尺寸，弱依赖
-  let savedLayout: { [key: string]: { size: number; currentId: string } } = {};
+  let savedLayout: ILayoutConfigCache = {};
   let savedColors: { [colorKey: string]: string } = {};
   try {
-    savedLayout = JSON.parse(localStorage.getItem('layout') || '{}');
-    savedColors = JSON.parse(localStorage.getItem('theme') || '{}');
+    const layoutConfigStr = localStorage.getItem('layout');
+    if (layoutConfigStr) {
+      savedLayout = JSON.parse(layoutConfigStr);
+    }
+
+    const themeConfigStr = localStorage.getItem('theme');
+    if (themeConfigStr) {
+      savedColors = JSON.parse(themeConfigStr);
+    }
   } catch (err) {}
+
   return {
     layout: savedLayout,
     colors: savedColors,
@@ -42,7 +54,13 @@ export function ToolbarActionBasedLayout(
         />
         <SplitPanel id='main-vertical' minResize={300} flexGrow={1} direction='top-to-bottom'>
           <SlotRenderer flex={2} flexGrow={1} minResize={200} slot='main' />
-          <SlotRenderer flex={1} defaultSize={layout.bottom?.size} minResize={160} slot='bottom' isTabbar={true} />
+          <SlotRenderer
+            flex={1}
+            defaultSize={layout.bottom?.currentId ? layout.bottom?.size : 0}
+            minResize={160}
+            slot='bottom'
+            isTabbar={true}
+          />
         </SplitPanel>
         <SlotRenderer
           slot='right'

--- a/packages/core-browser/src/components/layout/default-layout.tsx
+++ b/packages/core-browser/src/components/layout/default-layout.tsx
@@ -5,7 +5,7 @@ import { SlotRenderer } from '../../react-providers/slot';
 import { BoxPanel } from './box-panel';
 import { SplitPanel } from './split-panel';
 
-interface ILayoutConfigCache {
+export interface ILayoutConfigCache {
   [key: string]: { size: number; currentId: string };
 }
 

--- a/packages/editor/src/browser/grid/grid.service.ts
+++ b/packages/editor/src/browser/grid/grid.service.ts
@@ -1,5 +1,5 @@
 import { Emitter, IDisposable, IEventBus, MaybeNull } from '@opensumi/ide-core-browser';
-import { makeRandomHexString } from '@opensumi/ide-core-common';
+import { DisposableStore, makeRandomHexString } from '@opensumi/ide-core-common';
 
 import { Direction, IEditorGroup, IEditorGroupState } from '../../common';
 import { GridResizeEvent } from '../types';
@@ -7,17 +7,19 @@ import { GridResizeEvent } from '../types';
 export const editorGridUid = new Set();
 
 export class EditorGrid implements IDisposable {
+  private _disposables = new DisposableStore();
+
   public editorGroup: IGridEditorGroup | null = null;
 
   public children: EditorGrid[] = [];
 
   public splitDirection: SplitDirection | undefined;
 
-  protected readonly _onDidGridStateChange = new Emitter<void>();
+  protected readonly _onDidGridStateChange = this._disposables.add(new Emitter<void>());
 
   public readonly onDidGridStateChange = this._onDidGridStateChange.event;
 
-  protected readonly _onDidGridAndDesendantStateChange = new Emitter<void>();
+  protected readonly _onDidGridAndDesendantStateChange = this._disposables.add(new Emitter<void>());
 
   public readonly onDidGridAndDesendantStateChange = this._onDidGridAndDesendantStateChange.event;
 
@@ -30,10 +32,12 @@ export class EditorGrid implements IDisposable {
     }
     this.uid = uid;
     editorGridUid.add(uid);
-    this.onDidGridStateChange(() => {
-      this._onDidGridAndDesendantStateChange.fire();
-      this.parent?._onDidGridAndDesendantStateChange.fire();
-    });
+    this._disposables.add(
+      this.onDidGridStateChange(() => {
+        this._onDidGridAndDesendantStateChange.fire();
+        this.parent?._onDidGridAndDesendantStateChange.fire();
+      }),
+    );
   }
 
   setEditorGroup(editorGroup: IGridEditorGroup) {
@@ -106,6 +110,8 @@ export class EditorGrid implements IDisposable {
     } else {
       // 应该不会落入这里
     }
+
+    this._disposables.dispose();
   }
 
   public replaceBy(target: EditorGrid) {

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -491,10 +491,13 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
       state = this.openedResourceState.get<IEditorGridState>('grid', state);
     }
     this.topGrid = new EditorGrid();
-    this.topGrid.onDidGridAndDesendantStateChange(() => {
-      this._sortedEditorGroups = undefined;
-      this._onDidEditorGroupsChanged.fire();
-    });
+    this.addDispose(this.topGrid);
+    this.addDispose(
+      this.topGrid.onDidGridAndDesendantStateChange(() => {
+        this._sortedEditorGroups = undefined;
+        this._onDidEditorGroupsChanged.fire();
+      }),
+    );
     const editorRestorePromises = [];
     const promise = this.topGrid
       .deserialize(state, () => this.createEditorGroup(), editorRestorePromises)


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

![CleanShot 2024-08-09 at 11 31 58@2x](https://github.com/user-attachments/assets/6c227063-bf1a-4fb9-8c2a-945f30086d4a)

如果缓存中有设置高度，但是没有 container，不应该展示底部 tab panel

### Changelog

hidden bottom tab panel if no container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了新的接口 `ILayoutConfigCache`，提升布局配置的类型安全性和清晰度。
  - 更新了底部插槽的 `SlotRenderer` 组件，使其 `defaultSize` 属性能够根据当前 ID 的存在与否动态设置。

- **改进**
  - 优化了从 `localStorage` 获取布局和主题设置的逻辑，增强了错误处理并提高了代码的健壮性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->