### PR TITLE
chore: delete useless provideDiffPreviewStrategy API

### DIFF
--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -25,18 +25,24 @@ interface IBaseInlineChatHandler<T extends any[]> {
    * 直接执行 action 的操作，点击后 inline chat 立即消失
    */
   execute?: (...args: T) => MaybePromise<void>;
+}
+
+interface IDiffPreviewInlineChatHandler<T extends any[]> extends IBaseInlineChatHandler<T> {
   /**
    * 提供 diff editor 的预览策略
    */
   providerDiffPreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
+}
+
+interface IPreviewInlineChatHandler<T extends any[]> extends IBaseInlineChatHandler<T> {
   /**
    * 在 editor 里直接预览输出的结果
    */
   providerPreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
 }
 
-export type IEditorInlineChatHandler = IBaseInlineChatHandler<[editor: ICodeEditor, token: CancellationToken]>;
-export type IInteractiveInputHandler = IBaseInlineChatHandler<
+export type IEditorInlineChatHandler = IDiffPreviewInlineChatHandler<[editor: ICodeEditor, token: CancellationToken]>;
+export type IInteractiveInputHandler = IPreviewInlineChatHandler<
   [editor: ICodeEditor, value: string, token: CancellationToken]
 >;
 
@@ -45,10 +51,6 @@ export enum ERunStrategy {
    * 正常执行，执行后 input 直接消失
    */
   EXECUTE = 'EXECUTE',
-  /**
-   * 预览 diff，执行后 input 保留，显示 inline diff editor
-   */
-  DIFF_PREVIEW = 'DIFF_PREVIEW',
   /**
    * 预览输出结果，执行后 input 保留，并在 editor 里直接展示输出结果
    */

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -38,7 +38,7 @@ interface IPreviewInlineChatHandler<T extends any[]> extends IBaseInlineChatHand
   /**
    * 在 editor 里直接预览输出的结果
    */
-  providerPreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
+  providePreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
 }
 
 export type IEditorInlineChatHandler = IDiffPreviewInlineChatHandler<[editor: ICodeEditor, token: CancellationToken]>;

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -25,24 +25,18 @@ interface IBaseInlineChatHandler<T extends any[]> {
    * 直接执行 action 的操作，点击后 inline chat 立即消失
    */
   execute?: (...args: T) => MaybePromise<void>;
-}
-
-interface IDiffPreviewInlineChatHandler<T extends any[]> extends IBaseInlineChatHandler<T> {
   /**
-   * 提供 diff editor 的预览策略
+   * 在 editor 里预览输出的结果
+   */
+  providePreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
+  /**
+   * @deprecated use providePreviewStrategy api
    */
   providerDiffPreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
 }
 
-interface IPreviewInlineChatHandler<T extends any[]> extends IBaseInlineChatHandler<T> {
-  /**
-   * 在 editor 里直接预览输出的结果
-   */
-  providePreviewStrategy?: (...args: T) => MaybePromise<ChatResponse | InlineChatController>;
-}
-
-export type IEditorInlineChatHandler = IDiffPreviewInlineChatHandler<[editor: ICodeEditor, token: CancellationToken]>;
-export type IInteractiveInputHandler = IPreviewInlineChatHandler<
+export type IEditorInlineChatHandler = IBaseInlineChatHandler<[editor: ICodeEditor, token: CancellationToken]>;
+export type IInteractiveInputHandler = IBaseInlineChatHandler<
   [editor: ICodeEditor, value: string, token: CancellationToken]
 >;
 

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
@@ -268,8 +268,8 @@ export class InlineChatHandler extends Disposable {
           handler.execute && strategy === ERunStrategy.EXECUTE
             ? handler.execute!.bind(this, monacoEditor, value, this.cancelIndicator.token)
             : undefined,
-          handler.providerPreviewStrategy && strategy === ERunStrategy.PREVIEW
-            ? handler.providerPreviewStrategy.bind(this, monacoEditor, value, this.cancelIndicator.token)
+          handler.providePreviewStrategy && strategy === ERunStrategy.PREVIEW
+            ? handler.providePreviewStrategy.bind(this, monacoEditor, value, this.cancelIndicator.token)
             : undefined,
         );
       }),

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
@@ -268,8 +268,8 @@ export class InlineChatHandler extends Disposable {
           handler.execute && strategy === ERunStrategy.EXECUTE
             ? handler.execute!.bind(this, monacoEditor, value, this.cancelIndicator.token)
             : undefined,
-          handler.providerDiffPreviewStrategy && strategy === ERunStrategy.DIFF_PREVIEW
-            ? handler.providerDiffPreviewStrategy.bind(this, monacoEditor, value, this.cancelIndicator.token)
+          handler.providerPreviewStrategy && strategy === ERunStrategy.PREVIEW
+            ? handler.providerPreviewStrategy.bind(this, monacoEditor, value, this.cancelIndicator.token)
             : undefined,
         );
       }),

--- a/packages/ai-native/src/browser/widget/inline-input/inline-input.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input.handler.ts
@@ -74,8 +74,8 @@ export class InlineInputHandler extends Disposable {
       return;
     }
 
-    if (strategy === ERunStrategy.PREVIEW && handler.providerPreviewStrategy) {
-      const previewResponse = await handler.providerPreviewStrategy(monacoEditor, value, this.cancelIndicator.token);
+    if (strategy === ERunStrategy.PREVIEW && handler.providePreviewStrategy) {
+      const previewResponse = await handler.providePreviewStrategy(monacoEditor, value, this.cancelIndicator.token);
 
       if (CancelResponse.is(previewResponse)) {
         widget.launchChatStatus(EInlineChatStatus.READY);

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -121,7 +121,7 @@ export class AINativeContribution implements AINativeCoreContribution {
         },
       },
       {
-        providerDiffPreviewStrategy: async (editor: ICodeEditor, token) => {
+        providePreviewStrategy: async (editor: ICodeEditor, token) => {
           const crossCode = this.getCrossCode(editor);
           const prompt = `Add Chinese comments to the code: \`\`\`\n ${crossCode}\`\`\`.`;
 
@@ -145,7 +145,7 @@ export class AINativeContribution implements AINativeCoreContribution {
         },
       },
       {
-        providerDiffPreviewStrategy: async (editor: ICodeEditor, token) => {
+        providePreviewStrategy: async (editor: ICodeEditor, token) => {
           const crossCode = this.getCrossCode(editor);
           const prompt = `Optimize the code:\n\`\`\`\n ${crossCode}\`\`\``;
 

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -97,7 +97,7 @@ export class AINativeContribution implements AINativeCoreContribution {
       },
       {
         execute: async (editor, value, token) => {},
-        providerPreviewStrategy: async (editor, value, token) => {
+        providePreviewStrategy: async (editor, value, token) => {
           const crossCode = this.getCrossCode(editor);
           const prompt = `Comment the code: \`\`\`\n ${crossCode}\`\`\`. It is required to return only the code results without explanation.`;
           const controller = new InlineChatController({ enableCodeblockRender: true });

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -85,31 +85,27 @@ export class AINativeContribution implements AINativeCoreContribution {
   }
 
   registerInlineChatFeature(registry: IInlineChatFeatureRegistry) {
-    const doPreview = async (editor, value, token) => {
-      const crossCode = this.getCrossCode(editor);
-      const prompt = `Comment the code: \`\`\`\n ${crossCode}\`\`\`. It is required to return only the code results without explanation.`;
-      const controller = new InlineChatController({ enableCodeblockRender: true });
-      const stream = await this.aiBackService.requestStream(prompt, {}, token);
-      controller.mountReadable(stream);
-
-      return controller;
-    };
-
     registry.registerInteractiveInput(
       {
         handleStrategy: (editor, value) => {
-          const isEmptySelection = editor.getSelection()?.isEmpty();
-          if (isEmptySelection) {
-            return ERunStrategy.PREVIEW;
+          if (value.includes('execute')) {
+            return ERunStrategy.EXECUTE;
           }
 
-          return ERunStrategy.DIFF_PREVIEW;
+          return ERunStrategy.PREVIEW;
         },
       },
       {
         execute: async (editor, value, token) => {},
-        providerPreviewStrategy: doPreview,
-        providerDiffPreviewStrategy: doPreview,
+        providerPreviewStrategy: async (editor, value, token) => {
+          const crossCode = this.getCrossCode(editor);
+          const prompt = `Comment the code: \`\`\`\n ${crossCode}\`\`\`. It is required to return only the code results without explanation.`;
+          const controller = new InlineChatController({ enableCodeblockRender: true });
+          const stream = await this.aiBackService.requestStream(prompt, {}, token);
+          controller.mountReadable(stream);
+
+          return controller;
+        },
       },
     );
 


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

providerDiffPreviewStrategy 函数的功能可以由 providerPreviewStrategy 提供

### Changelog
registerInteractiveInput API 删除 providerDiffPreviewStrategy 函数

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入了新的接口 `IDiffPreviewInlineChatHandler` 和 `IPreviewInlineChatHandler`，以增强内联聊天处理能力。
  - 更新了 `registerInlineChatFeature` 方法的逻辑，使执行策略的判断更加灵活。

- **Bug 修复**
  - 修正了内联输入处理器中的方法名，以确保预览策略的调用一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->