### PR TITLE
fix: capturer not work in web worker

### DIFF
--- a/packages/connection/src/common/capturer.ts
+++ b/packages/connection/src/common/capturer.ts
@@ -39,9 +39,14 @@ export interface ICapturedMessage {
   source?: string;
 }
 
-const _global = (typeof window !== 'undefined' ? window : global) || {
-  __OPENSUMI_DEVTOOLS_GLOBAL_HOOK__: undefined,
-};
+const _global: any =
+  typeof global === 'undefined'
+    ? typeof window === 'undefined'
+      ? {
+          __OPENSUMI_DEVTOOLS_GLOBAL_HOOK__: undefined,
+        }
+      : window
+    : global;
 
 export function getCapturer() {
   const hook = _global.__OPENSUMI_DEVTOOLS_GLOBAL_HOOK__;

--- a/packages/extension/src/common/utils.ts
+++ b/packages/extension/src/common/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * 对 extension-host 使用 webpack bundle 后，require 方法会被覆盖为 webpack 内部的 require
+ * 这里是一个 webpack 提供的 workaround，用于获取原始的 require
+ */
+declare let __webpack_require__: any;
+declare let __non_webpack_require__: any;
+
+// https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
+export function getNodeRequire() {
+  return typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
+}

--- a/packages/extension/src/hosted/ext.host.ts
+++ b/packages/extension/src/hosted/ext.host.ts
@@ -18,6 +18,7 @@ import { join } from '@opensumi/ide-utils/lib/path';
 
 import { EXTENSION_EXTEND_SERVICE_PREFIX, IExtendProxy, IExtensionHostService, getExtensionId } from '../common';
 import { ActivatedExtension, ActivatedExtensionJSON, ExtensionsActivator } from '../common/activator';
+import { getNodeRequire } from '../common/utils';
 import {
   ExtHostAPIIdentifier,
   ExtensionIdentifier,
@@ -36,18 +37,6 @@ import { ExtHostStorage } from './api/vscode/ext.host.storage';
 import { KTExtension } from './vscode.extension';
 
 const { enumValueToArray } = arrays;
-
-/**
- * 对 extension-host 使用 webpack bundle 后，require 方法会被覆盖为 webpack 内部的 require
- * 这里是一个 webpack 提供的 workaround，用于获取原始的 require
- */
-declare let __webpack_require__: any;
-declare let __non_webpack_require__: any;
-
-// https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
-export function getNodeRequire() {
-  return typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
-}
 
 enum EInternalModule {
   VSCODE = 'vscode',

--- a/packages/extension/src/hosted/extension-log2.ts
+++ b/packages/extension/src/hosted/extension-log2.ts
@@ -1,13 +1,9 @@
 import { Injector } from '@opensumi/di';
-import {
-  IExtensionLogger,
-  ILogService,
-  LogLevel,
-  SupportLogNamespace,
-  getNodeRequire,
-} from '@opensumi/ide-core-common';
+import { IExtensionLogger, ILogService, LogLevel, SupportLogNamespace } from '@opensumi/ide-core-common';
 import { AppConfig } from '@opensumi/ide-core-node/lib/types';
 import { LogServiceManager } from '@opensumi/ide-logs/lib/node/log-manager';
+
+import { getNodeRequire } from '../common/utils';
 
 export class ExtensionLogger2 implements IExtensionLogger {
   private injector: Injector;

--- a/packages/extension/src/node/extension.scanner.ts
+++ b/packages/extension/src/node/extension.scanner.ts
@@ -4,9 +4,10 @@ import path from 'path';
 import * as fs from 'fs-extra';
 import semver from 'semver';
 
-import { Uri, getDebugLogger, getNodeRequire } from '@opensumi/ide-core-node';
+import { Uri, getDebugLogger } from '@opensumi/ide-core-node';
 
 import { IExtensionMetaData, IExtraMetaData } from '../common';
+import { getNodeRequire } from '../common/utils';
 
 import { mergeContributes } from './merge-contributes';
 

--- a/packages/utils/src/os.ts
+++ b/packages/utils/src/os.ts
@@ -52,14 +52,3 @@ export function isElectronNode() {
 export function isDevelopment() {
   return safeGlobal.isDev || (typeof process !== 'undefined' && process.env.IS_DEV);
 }
-
-/**
- * 在 Electron 中，会将 opensumi 中的 extension-host 使用 webpack 打成一个，所以需要其他方法来获取原始的 require
- */
-declare let __webpack_require__: any;
-declare let __non_webpack_require__: any;
-
-// https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
-export function getNodeRequire() {
-  return typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
-}


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

WebWorker 里没有 global

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了一个新的实用程序函数 `getNodeRequire`，以便在 Webpack 环境中获取 Node.js 的 `require` 方法，增强了与 Node.js 模块的兼容性。

- **Bug 修复**
  - 移除了过时的 `getNodeRequire` 实现，简化了在扩展主机中的模块加载逻辑。

- **文档**
  - 更新了导入语句，以改进代码组织和可读性，未引入新功能或更改现有功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->