### PR TITLE
feat: support inline chat proposed extension api

### DIFF
--- a/packages/extension/src/browser/sumi/main.thread.chat-agents.ts
+++ b/packages/extension/src/browser/sumi/main.thread.chat-agents.ts
@@ -1,4 +1,7 @@
 import { Injectable, Injector } from '@opensumi/di';
+import { ChatInternalService } from '@opensumi/ide-ai-native/lib/browser/chat/chat.internal.service';
+import { ERunStrategy, IInlineChatFeatureRegistry } from '@opensumi/ide-ai-native/lib/browser/types';
+import { InlineChatController } from '@opensumi/ide-ai-native/lib/browser/widget/inline-chat/inline-chat-controller';
 import {
   IChatAgentService,
   IChatAgentWelcomeMessage,
@@ -6,13 +9,21 @@ import {
   IChatReplyFollowup,
 } from '@opensumi/ide-ai-native/lib/common';
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { Deferred, IChatContent, IChatProgress, IChatTreeData, IMarkdownString } from '@opensumi/ide-core-common';
+import {
+  Deferred,
+  IChatProgress,
+  IChatTreeData,
+  IMarkdownString,
+  InlineChatFeatureRegistryToken,
+} from '@opensumi/ide-core-common';
+import { SumiReadableStream } from '@opensumi/ide-utils/lib/stream';
 
 import { ExtHostSumiAPIIdentifier } from '../../common/sumi';
 import {
   IChatInputParam,
   IExtHostChatAgents,
   IExtensionChatAgentMetadata,
+  IInlineChatPreviewProviderMetadata,
   IMainThreadChatAgents,
 } from '../../common/sumi/chat-agents';
 
@@ -46,8 +57,86 @@ export class MainThreadChatAgents implements IMainThreadChatAgents {
     }
   }
 
+  get inlineChatFeatureRegistry(): IInlineChatFeatureRegistry | null {
+    try {
+      return this.injector.get(InlineChatFeatureRegistryToken);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  get chatInternalService(): ChatInternalService | null {
+    try {
+      return this.injector.get(ChatInternalService);
+    } catch (err) {
+      return null;
+    }
+  }
+
   constructor(rpcProtocol: IRPCProtocol, private injector: Injector) {
     this.#proxy = rpcProtocol.getProxy(ExtHostSumiAPIIdentifier.ExtHostChatAgents);
+  }
+  $registerInlineChatProvider(handle: number, name: string, metadata: IInlineChatPreviewProviderMetadata): void {
+    if (!this.inlineChatFeatureRegistry || !this.chatInternalService) {
+      return;
+    }
+
+    const d = this.inlineChatFeatureRegistry.registerInteractiveInput(
+      { handleStrategy: () => ERunStrategy.PREVIEW },
+      {
+        providerPreviewStrategy: async (editor, value, token) => {
+          const controller = new InlineChatController({ enableCodeblockRender: !!metadata.enableCodeblockRender });
+          const request = this.chatInternalService!.createRequest(value, name)!;
+
+          const stream = new SumiReadableStream<IChatProgress>();
+          controller.mountReadable(stream);
+
+          const progressCallback = (progress: IChatProgress) => {
+            if (token.isCancellationRequested) {
+              stream.abort();
+              return;
+            }
+
+            stream.emitData(progress);
+          };
+
+          this.pendingProgress.set(request.requestId, progressCallback);
+          const requestProps = {
+            sessionId: this.chatInternalService?.sessionModel.sessionId!,
+            requestId: request.requestId,
+            message: request.message.prompt,
+            command: request.message.command,
+          };
+          this.#proxy
+            .$invokeAgent(handle, requestProps, { history: [] }, token)
+            .then((result) => {
+              if (!result) {
+                stream.end();
+                return;
+              }
+
+              if (!token.isCancellationRequested) {
+                if (result.errorDetails) {
+                  request.response.setErrorDetails(result.errorDetails);
+                }
+                stream.end();
+              } else {
+                stream.abort();
+              }
+            })
+            .finally(() => {
+              this.pendingProgress.delete(request.requestId);
+            });
+
+          return controller;
+        },
+      },
+    );
+
+    this.agents.set(handle, {
+      name,
+      dispose: d.dispose,
+    });
   }
 
   $registerAgent(handle: number, name: string, metadata: IExtensionChatAgentMetadata) {

--- a/packages/extension/src/browser/sumi/main.thread.chat-agents.ts
+++ b/packages/extension/src/browser/sumi/main.thread.chat-agents.ts
@@ -84,7 +84,7 @@ export class MainThreadChatAgents implements IMainThreadChatAgents {
     const d = this.inlineChatFeatureRegistry.registerInteractiveInput(
       { handleStrategy: () => ERunStrategy.PREVIEW },
       {
-        providerPreviewStrategy: async (editor, value, token) => {
+        providePreviewStrategy: async (editor, value, token) => {
           const controller = new InlineChatController({ enableCodeblockRender: !!metadata.enableCodeblockRender });
           const request = this.chatInternalService!.createRequest(value, name)!;
 

--- a/packages/extension/src/common/sumi/chat-agents.ts
+++ b/packages/extension/src/common/sumi/chat-agents.ts
@@ -27,6 +27,13 @@ export interface IChatInputParam {
   prompt: string;
 }
 
+/**
+ * proposed api
+ */
+export interface IInlineChatPreviewProviderMetadata {
+  enableCodeblockRender?: boolean;
+}
+
 export interface IMainThreadChatAgents {
   $registerAgent(handle: number, name: string, metadata: IExtensionChatAgentMetadata): void;
   $updateAgent(handle: number, metadataUpdate: IExtensionChatAgentMetadata): void;
@@ -38,6 +45,11 @@ export interface IMainThreadChatAgents {
   ): Promise<number | void>;
   $populateChatInput: (handle: number, param: IChatInputParam) => void;
   $sendMessage: (chunk: IChatProgress) => void;
+
+  /**
+   * proposed api，会随时更改
+   */
+  $registerInlineChatProvider(handle: number, name: string, metadata: IInlineChatPreviewProviderMetadata): void;
 }
 
 export interface IExtHostChatAgents {

--- a/packages/types/sumi.d.ts
+++ b/packages/types/sumi.d.ts
@@ -893,6 +893,11 @@ declare module 'sumi' {
     token: CancellationToken,
   ) => ProviderResult<ChatAgentResult2>;
 
+  // proposed api
+  export interface InlineChatAgent {
+    dispose(): void;
+  }
+
   export interface ChatAgent extends ChatAgent2 {
     sampleQuestionProvider?: ChatAgentSampleQuestionProvider;
     chatWelcomMessageProvider?: ChatAgentWelcomeMessageProvider;
@@ -909,5 +914,8 @@ declare module 'sumi' {
     export function createChatAgent(name: string, handler: ChatAgentHandler): ChatAgent;
 
     export function sendMessage(chunk: ChatAgentCustomReplyMessage): void;
+
+    // proposed api
+    export function createInlineChatAgent(name: string, handler: ChatAgentHandler): InlineChatAgent;
   }
 }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution


### Changelog
插件 API 支持注册 inline chat 的对话功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 增强了聊天代理的功能，支持内联聊天代理的创建和注册。
	- 新增了内联聊天预览提供者的接口，允许更灵活的渲染选项（如代码块渲染）。
	- 引入了内联聊天代理的清理机制，确保资源管理更加高效。

- **错误修复**
	- 改进了错误处理机制，确保服务不可用时返回 `null`，提升了系统的健壮性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->