### PR TITLE
feat(ai-native): improve accessibility support

### DIFF
--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -476,7 +476,14 @@ export const AIChatView = observer(() => {
             id={'ai-chat-header-clear'}
             title={localize('aiNative.operate.clear.title')}
           >
-            <EnhanceIcon wrapperClassName={styles.action_btn} className={getIcon('clear')} onClick={handleClear} />
+            <EnhanceIcon
+              wrapperClassName={styles.action_btn}
+              className={getIcon('clear')}
+              onClick={handleClear}
+              tabIndex={0}
+              role='button'
+              ariaLabel={localize('aiNative.operate.clear.title')}
+            />
           </Popover>
           <Popover
             overlayClassName={styles.popover_icon}
@@ -488,6 +495,9 @@ export const AIChatView = observer(() => {
               wrapperClassName={styles.action_btn}
               className={getIcon('window-close')}
               onClick={handleCloseChatView}
+              tabIndex={0}
+              role='button'
+              ariaLabel={localize('aiNative.operate.close.title')}
             />
           </Popover>
         </div>

--- a/packages/ai-native/src/browser/components/ChatEditor.tsx
+++ b/packages/ai-native/src/browser/components/ChatEditor.tsx
@@ -71,13 +71,25 @@ export const CodeEditorWithHighlight = ({ input, language, relationId }) => {
     <div className={styles.monaco_wrapper}>
       <div className={styles.action_toolbar}>
         <Popover id={`ai-chat-inser-${useUUID}`} title={localize('aiNative.chat.code.insert')}>
-          <EnhanceIcon className={getIcon('insert')} onClick={() => handleInsert()} />
+          <EnhanceIcon
+            className={getIcon('insert')}
+            onClick={() => handleInsert()}
+            tabIndex={0}
+            role='button'
+            ariaLabel={localize('aiNative.chat.code.insert')}
+          />
         </Popover>
         <Popover
           id={`ai-chat-copy-${useUUID}`}
           title={localize(isCoping ? 'aiNative.chat.code.copy.success' : 'aiNative.chat.code.copy')}
         >
-          <EnhanceIcon className={getIcon('copy')} onClick={() => handleCopy()} />
+          <EnhanceIcon
+            className={getIcon('copy')}
+            onClick={() => handleCopy()}
+            tabIndex={0}
+            role='button'
+            ariaLabel={localize('aiNative.chat.code.copy')}
+          />
         </Popover>
       </div>
       <Highlight language={language} ref={ref} className={styles.editor}>

--- a/packages/ai-native/src/browser/components/ChatMarkdown.tsx
+++ b/packages/ai-native/src/browser/components/ChatMarkdown.tsx
@@ -96,7 +96,7 @@ export const ChatMarkdown = (props: MarkdownProps) => {
     };
   }, [props.markdown]);
 
-  return <div className={cls(styles.markdown_container, props.className)} ref={ref} />;
+  return <div className={cls(styles.markdown_container, props.className)} ref={ref} tabIndex={0} />;
 };
 
 export function postProcessCodeBlockLanguageId(lang: string | undefined): string {

--- a/packages/ai-native/src/browser/components/ChatThinking.tsx
+++ b/packages/ai-native/src/browser/components/ChatThinking.tsx
@@ -62,7 +62,7 @@ export const ChatThinking = (props: ITinkingProps) => {
             </span>
           )}
           {showStop && (
-            <div className={styles.block} onClick={handlePause}>
+            <div className={styles.block} onClick={handlePause} tabIndex={0} role='button'>
               <Icon className={getIcon('circle-pause')}></Icon>
               <span>{localize('aiNative.operate.stop.title')}</span>
             </div>
@@ -136,6 +136,8 @@ export const ChatThinkingResult = ({
                 wrapperClassName={styles.text_btn}
                 className={styles.transform}
                 onClick={handleRegenerate}
+                tabIndex={0}
+                role='button'
               >
                 <span>{localize('aiNative.operate.afresh.title')}</span>
               </EnhanceIcon>

--- a/packages/core-browser/src/components/ai-native/interactive-input/index.tsx
+++ b/packages/core-browser/src/components/ai-native/interactive-input/index.tsx
@@ -172,6 +172,9 @@ export const InteractiveInput = React.forwardRef(
                   wrapperClassName={styles.send_icon}
                   className={getIcon('send-solid')}
                   onClick={handleSend}
+                  tabIndex={0}
+                  role='button'
+                  ariaLabel={localize('aiNative.chat.enter.send')}
                 />
               </Popover>
             )}

--- a/packages/core-browser/src/components/ai-native/thumbs/index.tsx
+++ b/packages/core-browser/src/components/ai-native/thumbs/index.tsx
@@ -70,6 +70,10 @@ export const Thumbs = (props: ThumbsProps) => {
             wrapperClassName={wrapperClassName}
             onClick={() => handleClick('up')}
             className={getExternalIcon(thumbsupIcon, KTICON_OWNER)}
+            tabIndex={0}
+            role='button'
+            ariaLabel={localize('aiNative.inline.chat.operate.thumbsup.title')}
+            ariaPressed={thumbsupIcon === 'thumbs-fill' ? 'true' : 'false'}
           />
         </Popover>
       )}
@@ -79,6 +83,10 @@ export const Thumbs = (props: ThumbsProps) => {
             wrapperClassName={wrapperClassName}
             onClick={() => handleClick('down')}
             className={getExternalIcon(thumbsdownIcon, KTICON_OWNER)}
+            tabIndex={0}
+            role='button'
+            ariaLabel={localize('aiNative.inline.chat.operate.thumbsdown.title')}
+            ariaPressed={thumbsdownIcon === 'thumbsdown-fill' ? 'true' : 'false'}
           />
         </Popover>
       )}


### PR DESCRIPTION
### Types

- [ ] Other Changes

### Background or solution
增强ai-native模块的无障碍能力，使键盘用户以及使用读屏软件的视障用户更容易使用AI功能：
- 为按钮添加tabindex、role以及aria-*属性。
- 为列表项添加tabindex属性支持使用键盘的用户聚焦。

支持的按钮包括：清空、关闭、插入、复制、刷新、停止、点赞、踩、发送等按钮。

![优化AI助理模块的可访问性](https://github.com/user-attachments/assets/44df8dd2-856a-40fb-be28-a1c675a90437)

优化后读屏软件演示视频：

https://github.com/user-attachments/assets/bfa2e1c7-8d27-443f-9091-7838d238a608


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增强了聊天界面的可访问性，添加了可聚焦的按钮属性（`tabIndex`、`role`、`ariaLabel`）以支持辅助技术。
	- 在代码编辑器和其他组件中引入了相似的可访问性功能，提升了键盘导航体验。

- **Bug 修复**
	- 无明显的 bug 修复内容。

- **文档**
	- 无更新。

- **重构**
	- 无重构内容。

- **样式**
	- 无样式更改。

- **测试**
	- 无测试相关更新。

- **杂事**
	- 无杂事相关内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->