### PR TITLE
fix: improve inline chat position calculate

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
@@ -351,39 +351,42 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
     };
   }
 
-  private recheckPosition(lineNumber: number, column: number): monaco.editor.IContentWidgetPosition {
-    const preNonWhitespaceColumn = this.safeGetLineLastNonWhitespaceColumn(lineNumber - 1);
-    const curNonWhitespaceColumn = this.safeGetLineLastNonWhitespaceColumn(lineNumber);
-    const nextNonWhitespaceColumn = this.safeGetLineLastNonWhitespaceColumn(lineNumber + 1);
+  /**
+   * 以当前 selection 为中心取上下各 1 行重新计算
+   */
+  private recheckSelection(selection: monaco.Selection): monaco.editor.IContentWidgetPosition {
+    const preStartPosition = selection.getStartPosition();
+    const preEndPosition = selection.getEndPosition();
 
-    let newPreference = [monacoBrowser.editor.ContentWidgetPositionPreference.ABOVE];
-    let newLineNumber = lineNumber;
-    let newColumn = column;
+    const model = this.editor.getModel()!;
+    const maxCount = model.getLineCount();
 
-    if (curNonWhitespaceColumn >= nextNonWhitespaceColumn) {
-      newPreference = [monacoBrowser.editor.ContentWidgetPositionPreference.BELOW];
-    } else if (curNonWhitespaceColumn >= preNonWhitespaceColumn) {
-      newPreference = [monacoBrowser.editor.ContentWidgetPositionPreference.ABOVE];
-    } else {
-      newColumn = Math.min(preNonWhitespaceColumn, nextNonWhitespaceColumn);
+    const safeAboveStartLine = Math.max(1, preEndPosition.lineNumber - 1);
+    const safeBelowEndLine = Math.min(maxCount, preEndPosition.lineNumber + 1);
 
-      if (preNonWhitespaceColumn >= nextNonWhitespaceColumn) {
-        newPreference = [monacoBrowser.editor.ContentWidgetPositionPreference.BELOW];
-        newLineNumber = lineNumber - 1;
-      } else {
-        newPreference = [monacoBrowser.editor.ContentWidgetPositionPreference.ABOVE];
-        newLineNumber = lineNumber + 1;
-      }
+    const newStartPosition = preStartPosition.with(safeAboveStartLine, 1);
+    const newEndPosition = preEndPosition.with(
+      safeBelowEndLine,
+      this.safeGetLineLastNonWhitespaceColumn(safeBelowEndLine),
+    );
+
+    // 如果整个文档只有 1 行，则直接显示在右下角
+    if (maxCount === 1) {
+      return this.toBelowPosition(safeBelowEndLine, this.safeGetLineLastNonWhitespaceColumn(safeBelowEndLine));
     }
 
-    if (lineNumber === 1 || lineNumber === 2) {
-      newPreference = [monacoBrowser.editor.ContentWidgetPositionPreference.BELOW];
+    if (newEndPosition.lineNumber === 1 && preEndPosition.lineNumber !== preStartPosition.lineNumber) {
+      return this.computePosition(monaco.Selection.fromPositions(newStartPosition, newEndPosition));
     }
 
-    return {
-      position: new monaco.Position(newLineNumber, newColumn),
-      preference: newPreference,
-    };
+    const aboveMaxColumn = this.safeGetLineLastNonWhitespaceColumn(safeAboveStartLine);
+    const belowMaxColumn = this.safeGetLineLastNonWhitespaceColumn(safeBelowEndLine);
+    const currentMaxColumn = this.safeGetLineLastNonWhitespaceColumn(preEndPosition.lineNumber);
+    if (belowMaxColumn > currentMaxColumn && belowMaxColumn > aboveMaxColumn) {
+      return this.computePosition(monaco.Selection.fromPositions(newEndPosition, newStartPosition));
+    }
+
+    return this.computePosition(monaco.Selection.fromPositions(newStartPosition, newEndPosition));
   }
 
   private isProtrudeAbove(line: number) {
@@ -408,25 +411,27 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
    * 2. 靠近光标处周围没有字符的空白区域作为要显示的区域
    * 3. 显示的区域方向在右侧，左侧不考虑
    */
-  protected computePosition(selection: monaco.Selection): monaco.editor.IContentWidgetPosition | null {
-    const startPosition = selection.getStartPosition();
-    const endPosition = selection.getEndPosition();
-    const model = this.editor.getModel();
+  protected computePosition(selection: monaco.Selection): monaco.editor.IContentWidgetPosition {
+    let startPosition = selection.getStartPosition();
+    let endPosition = selection.getEndPosition();
+    let cursorPosition = selection.getPosition();
 
-    if (!model) {
-      return null;
+    const model = this.editor.getModel()!;
+    const maxCount = model.getLineCount();
+
+    // 只选中了一行
+    if (startPosition.lineNumber === endPosition.lineNumber) {
+      return this.recheckSelection(selection);
     }
 
-    const cursorPosition = selection.getPosition();
+    if (endPosition.lineNumber - startPosition.lineNumber === 1) {
+      cursorPosition = endPosition;
+    }
+
     const getCursorLastNonWhitespaceColumn = this.safeGetLineLastNonWhitespaceColumn(cursorPosition.lineNumber);
 
-    let targetLine: number | null = null;
-    let direction: 'above' | 'below' | null = null;
-
-    // 用户只选中了一行
-    if (startPosition.lineNumber === endPosition.lineNumber) {
-      return this.recheckPosition(cursorPosition.lineNumber, cursorPosition.column);
-    }
+    let targetLine: number = cursorPosition.lineNumber;
+    let direction: 'above' | 'below' = 'below';
 
     // 用户选中了多行，光标在选中的开始位置
     if (cursorPosition.equals(startPosition)) {
@@ -435,10 +440,9 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
         this.safeGetLineLastNonWhitespaceColumn(cursorPosition.lineNumber - 2),
       );
 
-      // 如果上面两行的最后一个非空白字符的列数小于当前行的最后一个非空白字符的列数 + 10
-      // 则直接显示在上面
-      if (getMaxLastWhitespaceColumn < getCursorLastNonWhitespaceColumn + 10) {
-        return this.toAbovePosition(cursorPosition.lineNumber, getMaxLastWhitespaceColumn + 1);
+      // 如果上面两行的最后一个非空白字符的列数小于当前行的最后一个非空白字符的列数, 则直接显示在上面
+      if (getMaxLastWhitespaceColumn <= getCursorLastNonWhitespaceColumn) {
+        return this.toAbovePosition(cursorPosition.lineNumber, getCursorLastNonWhitespaceColumn);
       }
 
       for (let i = startPosition.lineNumber; i <= endPosition.lineNumber; i++) {
@@ -459,11 +463,11 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
         this.safeGetLineLastNonWhitespaceColumn(cursorPosition.lineNumber + 2),
       );
 
-      if (getMaxLastWhitespaceColumn < getCursorLastNonWhitespaceColumn + 10) {
-        return this.toBelowPosition(cursorPosition.lineNumber, getMaxLastWhitespaceColumn + 1);
+      if (getMaxLastWhitespaceColumn <= getCursorLastNonWhitespaceColumn) {
+        return this.toBelowPosition(cursorPosition.lineNumber, getCursorLastNonWhitespaceColumn);
       }
 
-      for (let i = endPosition.lineNumber; i >= startPosition.lineNumber; i--) {
+      for (let i = Math.min(maxCount, endPosition.lineNumber + 1); i >= startPosition.lineNumber; i--) {
         if (this.isProtrudeBelow(i)) {
           targetLine = i;
           direction = 'below';
@@ -477,18 +481,11 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
       }
     }
 
-    if (targetLine && direction) {
-      const column = this.safeGetLineLastNonWhitespaceColumn(targetLine) + 1;
+    const column = this.safeGetLineLastNonWhitespaceColumn(targetLine) + 1;
 
-      if (direction === 'below') {
-        return this.toBelowPosition(targetLine, column);
-      }
-      return this.toAbovePosition(targetLine, column);
+    if (direction === 'below') {
+      return this.toBelowPosition(targetLine, column);
     }
-
-    return this.recheckPosition(
-      cursorPosition.lineNumber,
-      this.safeGetLineLastNonWhitespaceColumn(cursorPosition.lineNumber),
-    );
+    return this.toAbovePosition(targetLine, column);
   }
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before
![image](https://github.com/user-attachments/assets/326308f9-e2a3-46fe-a5e3-3bc2c3152617)

after
![image](https://github.com/user-attachments/assets/59f2eeef-c2ef-477e-8728-bd47ff1703c3)


### Changelog
优化 inline chat 的定位计算公式，避免遮挡代码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了内联内容小部件的定位方法，使其能够根据用户选择的文本动态调整位置。
	- 引入新的选择基础逻辑，增强小部件在单行和多行选择中的显示效果。

- **修复**
	- 解决了小部件在某些情况下未能正确显示的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->