### PR TITLE
fix: inline input allow editor overflow

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-input/inline-input-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input-widget.tsx
@@ -88,6 +88,7 @@ export class InlineInputChatWidget extends AIInlineContentWidget {
   @Autowired(InlineInputChatService)
   private inlineInputChatService: InlineInputChatService;
 
+  allowEditorOverflow = true;
   positionPreference = [ContentWidgetPositionPreference.ABOVE];
 
   override dispose(): void {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复 inline input 对话框在第一行时被遮挡的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在`InlineInputChatWidget`中新增了`allowEditorOverflow`属性，允许编辑器超出其指定区域，从而提供更灵活的用户界面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->