### PR TITLE
fix: document status may out of sync

### DIFF
--- a/packages/addons/__tests__/browser/file-search.contribution.test.ts
+++ b/packages/addons/__tests__/browser/file-search.contribution.test.ts
@@ -244,6 +244,9 @@ describe('file-search-quickopen', () => {
         },
         dispose: jest.fn(),
       }),
+      getModelDescription: () => ({
+        languageId: 'javascript',
+      }),
     });
     fileSearchQuickOpenHandler = injector.get(FileSearchQuickCommandHandler);
   });

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -231,6 +231,7 @@ export class DebugBreakpointsService extends WithEventBus {
         }
         const getContent = model.getLineContent(line);
         node.fireDescriptionChange(getContent.trim());
+        monacoModel.dispose();
       }
     }
   }

--- a/packages/editor/__tests__/browser/editor.feature.test.ts
+++ b/packages/editor/__tests__/browser/editor.feature.test.ts
@@ -102,6 +102,9 @@ describe('editor status bar item test', () => {
       },
       dispose: jest.fn(),
     }),
+    getModelDescription: () => ({
+      languageId: 'javascript',
+    }),
   });
 
   it('formatter select test', async () => {

--- a/packages/editor/src/browser/doc-model/editor-document-model-service.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model-service.ts
@@ -237,8 +237,7 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
     }
 
     const instance = ref.instance;
-    ref.dispose();
-    return {
+    const resullt = {
       alwaysDirty: instance.alwaysDirty,
       closeAutoSave: instance.closeAutoSave,
       disposeEvenDirty: instance.disposeEvenDirty,
@@ -251,6 +250,8 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
       id: instance.id,
       savable: instance.savable,
     };
+    ref.dispose();
+    return resullt;
   }
 
   getAllModels(): IEditorDocumentModel[] {

--- a/packages/editor/src/browser/doc-model/editor-document-model-service.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model-service.ts
@@ -23,7 +23,7 @@ import { IHashCalculateService } from '@opensumi/ide-core-common/lib/hash-calcul
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { EOL } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
-import { IEditorDocumentModel } from '../../common/editor';
+import { IEditorDocumentDescription, IEditorDocumentModel } from '../../common/editor';
 
 import { EditorDocumentModel } from './editor-document-model';
 import {
@@ -228,6 +228,29 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
 
   getModelReference(uri: URI, reason?: string | undefined): IRef<IEditorDocumentModel> | null {
     return this._modelReferenceManager.getReferenceIfHasInstance(uri.toString(), reason);
+  }
+
+  getModelDescription(uri: URI, reason?: string): IEditorDocumentDescription | null {
+    const ref = this.getModelReference(uri, reason);
+    if (!ref) {
+      return null;
+    }
+
+    const instance = ref.instance;
+    ref.dispose();
+    return {
+      alwaysDirty: instance.alwaysDirty,
+      closeAutoSave: instance.closeAutoSave,
+      disposeEvenDirty: instance.disposeEvenDirty,
+      eol: instance.eol,
+      encoding: instance.encoding,
+      dirty: instance.dirty,
+      languageId: instance.languageId,
+      readonly: instance.readonly,
+      uri: instance.uri,
+      id: instance.id,
+      savable: instance.savable,
+    };
   }
 
   getAllModels(): IEditorDocumentModel[] {

--- a/packages/editor/src/browser/doc-model/saveParticipants.ts
+++ b/packages/editor/src/browser/doc-model/saveParticipants.ts
@@ -283,6 +283,7 @@ export class TrimFinalNewLinesParticipant extends WithEventBus {
 
       const model = modelRef.instance.getMonacoModel();
       this.doTrimFinalNewLines(model, e.payload.reason !== SaveReason.Manual);
+      modelRef.dispose();
     }
   }
 

--- a/packages/editor/src/browser/doc-model/types.ts
+++ b/packages/editor/src/browser/doc-model/types.ts
@@ -12,7 +12,7 @@ import * as monaco from '@opensumi/ide-monaco';
 import { EOL, EndOfLineSequence } from '@opensumi/ide-monaco/lib/browser/monaco-api/types';
 
 import { IEditorDocumentModelContentChange, SaveReason } from '../../common';
-import { IEditorDocumentModel, IEditorDocumentModelRef } from '../../common/editor';
+import { IEditorDocumentDescription, IEditorDocumentModel, IEditorDocumentModelRef } from '../../common/editor';
 
 export interface IDocModelUpdateOptions extends monaco.editor.ITextModelUpdateOptions {
   detectIndentation?: boolean;
@@ -130,6 +130,7 @@ export interface IEditorDocumentModelService {
    * 当文档从来没有被打开过时，返回null
    */
   getModelReference(uri: URI, reason?: string): IEditorDocumentModelRef | null;
+  getModelDescription(uri: URI, reason?: string): IEditorDocumentDescription | null;
 
   /**
    * 获得全部model

--- a/packages/editor/src/browser/doc-model/types.ts
+++ b/packages/editor/src/browser/doc-model/types.ts
@@ -193,6 +193,7 @@ export interface IEditorDocumentModelOptionChangedEventPayload {
   encoding?: string;
   languageId?: string;
   eol?: EOL;
+  dirty?: boolean;
 }
 
 export class EditorDocumentModelCreationEvent extends BasicEvent<IEditorDocumentModelCreationEventPayload> {}

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -808,16 +808,12 @@ export class EditorContribution
           return;
         }
 
-        const ref = this.editorDocumentModelService.getModelReference(uri);
+        const ref = this.editorDocumentModelService.getModelDescription(uri);
         if (!ref) {
           return;
         }
 
-        const encoding = ref.instance.encoding;
-
-        ref.dispose();
-
-        return encoding;
+        return ref.encoding;
       },
     });
 
@@ -841,8 +837,8 @@ export class EditorContribution
 
         const provider = await this.contentRegistry.getProvider(uri);
         const guessedEncoding = await provider?.guessEncoding?.(uri);
-        const ref = this.editorDocumentModelService.getModelReference(uri);
-        const currentEncoding = documentModel?.encoding ?? ref?.instance.encoding;
+        const ref = this.editorDocumentModelService.getModelDescription(uri);
+        const currentEncoding = documentModel?.encoding ?? ref?.encoding;
 
         let matchIndex: number | undefined;
         const encodingItems: QuickPickItem<string>[] = Object.keys(SUPPORTED_ENCODINGS)

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -808,7 +808,16 @@ export class EditorContribution
           return;
         }
 
-        return this.editorDocumentModelService.getModelReference(uri)?.instance.encoding;
+        const ref = this.editorDocumentModelService.getModelReference(uri);
+        if (!ref) {
+          return;
+        }
+
+        const encoding = ref.instance.encoding;
+
+        ref.dispose();
+
+        return encoding;
       },
     });
 

--- a/packages/editor/src/browser/format/formatter-selector.ts
+++ b/packages/editor/src/browser/format/formatter-selector.ts
@@ -47,12 +47,11 @@ export class FormattingSelector implements IFormattingSelector {
     mode: FormattingMode,
     _kind: FormattingKind,
   ): Promise<T | undefined> {
-    const docRef = this.modelService.getModelReference(URI.from(document.uri.toJSON()));
+    const docRef = this.modelService.getModelDescription(URI.from(document.uri.toJSON()));
     if (!docRef) {
       return;
     }
-    const languageId = docRef.instance.languageId;
-    docRef.dispose();
+    const languageId = docRef.languageId;
     const preferred = this.getPreferedFormatter(languageId);
 
     const elements: { [key: string]: T } = {};
@@ -120,12 +119,11 @@ export class FormattingSelector implements IFormattingSelector {
     formatters: T[],
     document: ITextModel,
   ): Promise<T | undefined> {
-    const docRef = this.modelService.getModelReference(URI.from(document.uri.toJSON()));
+    const docRef = this.modelService.getModelDescription(URI.from(document.uri.toJSON()));
     if (!docRef) {
       return;
     }
-    const languageId = docRef.instance.languageId;
-    docRef.dispose();
+    const languageId = docRef.languageId;
 
     const elements: { [key: string]: T } = {};
     formatters.forEach((provider: T) => {

--- a/packages/editor/src/browser/format/formatter-selector.ts
+++ b/packages/editor/src/browser/format/formatter-selector.ts
@@ -47,11 +47,11 @@ export class FormattingSelector implements IFormattingSelector {
     mode: FormattingMode,
     _kind: FormattingKind,
   ): Promise<T | undefined> {
-    const docRef = this.modelService.getModelDescription(URI.from(document.uri.toJSON()));
-    if (!docRef) {
+    const docDesc = this.modelService.getModelDescription(URI.from(document.uri.toJSON()));
+    if (!docDesc) {
       return;
     }
-    const languageId = docRef.languageId;
+    const languageId = docDesc.languageId;
     const preferred = this.getPreferedFormatter(languageId);
 
     const elements: { [key: string]: T } = {};
@@ -119,11 +119,11 @@ export class FormattingSelector implements IFormattingSelector {
     formatters: T[],
     document: ITextModel,
   ): Promise<T | undefined> {
-    const docRef = this.modelService.getModelDescription(URI.from(document.uri.toJSON()));
-    if (!docRef) {
+    const docDesc = this.modelService.getModelDescription(URI.from(document.uri.toJSON()));
+    if (!docDesc) {
       return;
     }
-    const languageId = docRef.languageId;
+    const languageId = docDesc.languageId;
 
     const elements: { [key: string]: T } = {};
     formatters.forEach((provider: T) => {

--- a/packages/editor/src/browser/fs-resource/fs-resource.ts
+++ b/packages/editor/src/browser/fs-resource/fs-resource.ts
@@ -181,12 +181,10 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
     this.cachedFileStat.delete(resource.uri.toString());
   }
   async shouldCloseResourceWithoutConfirm(resource: IResource) {
-    const documentModelRef = this.documentModelService.getModelReference(resource.uri, 'close-resource-check');
-    if (documentModelRef && documentModelRef.instance.dirty) {
-      documentModelRef.dispose();
+    const documentModelRef = this.documentModelService.getModelDescription(resource.uri, 'close-resource-check');
+    if (documentModelRef && documentModelRef.dirty) {
       return true;
     }
-    documentModelRef?.dispose();
     return false;
   }
   async close(resource: IResource, saveAction?: AskSaveResult) {
@@ -225,15 +223,10 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
         }
       }
     }
-    const documentModelRef = this.documentModelService.getModelReference(resource.uri, 'close-resource-check');
-    if (!documentModelRef || !documentModelRef.instance.dirty) {
-      if (documentModelRef) {
-        documentModelRef.dispose();
-      }
+    const documentModelRef = this.documentModelService.getModelDescription(resource.uri, 'close-resource-check');
+    if (!documentModelRef || !documentModelRef.dirty) {
       return true;
     }
-
-    documentModelRef?.dispose();
 
     // 询问用户是否保存
     const buttons = {

--- a/packages/editor/src/browser/fs-resource/fs-resource.ts
+++ b/packages/editor/src/browser/fs-resource/fs-resource.ts
@@ -206,6 +206,7 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
       documentModelRef.dispose();
       return false;
     } else {
+      documentModelRef.dispose();
       return true;
     }
   }

--- a/packages/editor/src/browser/fs-resource/fs-resource.ts
+++ b/packages/editor/src/browser/fs-resource/fs-resource.ts
@@ -183,8 +183,10 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
   async shouldCloseResourceWithoutConfirm(resource: IResource) {
     const documentModelRef = this.documentModelService.getModelReference(resource.uri, 'close-resource-check');
     if (documentModelRef && documentModelRef.instance.dirty) {
+      documentModelRef.dispose();
       return true;
     }
+    documentModelRef?.dispose();
     return false;
   }
   async close(resource: IResource, saveAction?: AskSaveResult) {
@@ -229,6 +231,8 @@ export class FileSystemResourceProvider extends WithEventBus implements IResourc
       }
       return true;
     }
+
+    documentModelRef?.dispose();
 
     // 询问用户是否保存
     const buttons = {

--- a/packages/editor/src/browser/hooks/useEditor.ts
+++ b/packages/editor/src/browser/hooks/useEditor.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { URI, useInjectable } from '@opensumi/ide-core-browser';
+import { DisposableStore, URI, useInjectable } from '@opensumi/ide-core-browser';
 
 import { IEditorDocumentModelService } from '../doc-model/types';
 import { IEditorDocumentModelRef } from '../types';
@@ -10,23 +10,28 @@ export function useEditorDocumentModelRef(uri: URI) {
   const [ref, setRef] = useState<IEditorDocumentModelRef | null>(null);
 
   useEffect(() => {
+    const toDispose = new DisposableStore();
     const run = () => {
       const ref = documentService.getModelReference(uri);
       if (ref) {
         setRef(ref);
+        toDispose.add({
+          dispose() {
+            ref.dispose();
+          },
+        });
       }
     };
 
-    const toDispose = documentService.onDocumentModelCreated(uri.toString(), () => {
-      run();
-    });
+    toDispose.add(
+      documentService.onDocumentModelCreated(uri.toString(), () => {
+        run();
+      }),
+    );
 
     run();
     return () => {
       toDispose.dispose();
-      if (ref) {
-        ref.dispose();
-      }
     };
   }, [uri]);
 

--- a/packages/editor/src/browser/hooks/useEditor.ts
+++ b/packages/editor/src/browser/hooks/useEditor.ts
@@ -3,23 +3,19 @@ import { useEffect, useState } from 'react';
 import { DisposableStore, URI, useInjectable } from '@opensumi/ide-core-browser';
 
 import { IEditorDocumentModelService } from '../doc-model/types';
-import { IEditorDocumentModelRef } from '../types';
+import { IEditorDocumentModel } from '../types';
 
-export function useEditorDocumentModelRef(uri: URI) {
+export function useEditorDocumentModel(uri: URI) {
   const documentService: IEditorDocumentModelService = useInjectable(IEditorDocumentModelService);
-  const [ref, setRef] = useState<IEditorDocumentModelRef | null>(null);
+  const [instance, setInstance] = useState<IEditorDocumentModel | null>(null);
 
   useEffect(() => {
     const toDispose = new DisposableStore();
     const run = () => {
       const ref = documentService.getModelReference(uri);
       if (ref) {
-        setRef(ref);
-        toDispose.add({
-          dispose() {
-            ref.dispose();
-          },
-        });
+        setInstance(ref.instance);
+        ref.dispose();
       }
     };
 
@@ -35,5 +31,5 @@ export function useEditorDocumentModelRef(uri: URI) {
     };
   }, [uri]);
 
-  return ref;
+  return instance;
 }

--- a/packages/editor/src/browser/merge-conflict/merge-conflict.model.ts
+++ b/packages/editor/src/browser/merge-conflict/merge-conflict.model.ts
@@ -4,12 +4,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { formatLocalize, useInjectable } from '@opensumi/ide-core-browser';
 import { DisposableStore, URI } from '@opensumi/ide-utils';
 
-import { useEditorDocumentModelRef } from '../hooks/useEditor';
+import { useEditorDocumentModel } from '../hooks/useEditor';
 
 import { MergeConflictService } from './merge-conflict.service';
 
 export function useMergeConflictModel(uri: URI) {
-  const editorModel = useEditorDocumentModelRef(uri);
+  const editorModel = useEditorDocumentModel(uri);
 
   /**
    * 如果是原来就有冲突的文件，当冲突没了之后，仍然显示冲突
@@ -28,9 +28,8 @@ export function useMergeConflictModel(uri: URI) {
     const disposables = new DisposableStore();
 
     if (editorModel) {
-      const { instance } = editorModel;
       const run = () => {
-        const n = mergeConflictService.scanDocument(instance.getMonacoModel());
+        const n = mergeConflictService.scanDocument(editorModel.getMonacoModel());
         setConflictsCount(n);
         if (n > 0) {
           setIsInitialVisiable(true);
@@ -40,7 +39,7 @@ export function useMergeConflictModel(uri: URI) {
       const debounceRun = debounce(run, 150);
 
       disposables.add(
-        instance.getMonacoModel().onDidChangeContent(() => {
+        editorModel.getMonacoModel().onDidChangeContent(() => {
           debounceRun();
         }),
       );

--- a/packages/editor/src/browser/monaco-contrib/callHierarchy/callHierarchy.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/callHierarchy/callHierarchy.service.ts
@@ -112,8 +112,10 @@ export class CallHierarchyService implements ICallHierarchyService {
   }
 
   async prepareCallHierarchyProvider(resource: Uri, position: Position) {
-    let textModel = this.modelService.getModelReference(URI.parse(resource.toString()))?.instance.getMonacoModel();
-    let textModelReference: IDisposable | undefined;
+    let textModelReference = this.modelService.getModelReference(URI.parse(resource.toString()));
+    let textModel: ITextModel | undefined = textModelReference?.instance.getMonacoModel();
+    textModelReference?.dispose();
+
     if (!textModel) {
       const result = await this.modelService.createModelReference(URI.parse(resource.toString()));
       textModel = result.instance.getMonacoModel();

--- a/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/typeHierarchy/typeHierarchy.service.ts
@@ -104,8 +104,11 @@ export class TypeHierarchyService implements ITypeHierarchyService {
   }
 
   async prepareTypeHierarchyProvider(resource: Uri, position: Position) {
-    let textModel = this.modelService.getModelReference(URI.parse(resource.toString()))?.instance.getMonacoModel();
-    let textModelReference: IDisposable | undefined;
+    let textModelReference = this.modelService.getModelReference(URI.parse(resource.toString()));
+
+    let textModel: ITextModel | undefined = textModelReference?.instance.getMonacoModel();
+    textModelReference?.dispose();
+
     if (!textModel) {
       const result = await this.modelService.createModelReference(URI.parse(resource.toString()));
       textModel = result.instance.getMonacoModel();

--- a/packages/editor/src/browser/untitled-resource.ts
+++ b/packages/editor/src/browser/untitled-resource.ts
@@ -173,8 +173,10 @@ export class UntitledSchemeResourceProvider extends WithEventBus implements IRes
   async shouldCloseResourceWithoutConfirm(resource: IResource) {
     const documentModelRef = this.documentModelService.getModelReference(resource.uri, 'close-resource-check');
     if (documentModelRef && documentModelRef.instance.dirty) {
+      documentModelRef.dispose();
       return true;
     }
+    documentModelRef?.dispose();
     return false;
   }
 
@@ -195,6 +197,7 @@ export class UntitledSchemeResourceProvider extends WithEventBus implements IRes
       documentModelRef.dispose();
       return false;
     } else {
+      documentModelRef.dispose();
       return true;
     }
   }

--- a/packages/editor/src/browser/untitled-resource.ts
+++ b/packages/editor/src/browser/untitled-resource.ts
@@ -171,12 +171,10 @@ export class UntitledSchemeResourceProvider extends WithEventBus implements IRes
   }
 
   async shouldCloseResourceWithoutConfirm(resource: IResource) {
-    const documentModelRef = this.documentModelService.getModelReference(resource.uri, 'close-resource-check');
-    if (documentModelRef && documentModelRef.instance.dirty) {
-      documentModelRef.dispose();
+    const documentModelRef = this.documentModelService.getModelDescription(resource.uri, 'close-resource-check');
+    if (documentModelRef && documentModelRef.dirty) {
       return true;
     }
-    documentModelRef?.dispose();
     return false;
   }
 
@@ -203,11 +201,8 @@ export class UntitledSchemeResourceProvider extends WithEventBus implements IRes
   }
 
   async shouldCloseResource(resource: IResource) {
-    const documentModelRef = this.documentModelService.getModelReference(resource.uri, 'close-resource-check');
-    if (!documentModelRef || !documentModelRef.instance.dirty) {
-      if (documentModelRef) {
-        documentModelRef.dispose();
-      }
+    const documentModelRef = this.documentModelService.getModelDescription(resource.uri, 'close-resource-check');
+    if (!documentModelRef || !documentModelRef.dirty) {
       return true;
     }
     // 询问用户是否保存

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -436,10 +436,9 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
     // contextKeys
     const getLanguageFromModel = (uri: URI) => {
       let result: string | null = null;
-      const modelRef = this.documentModelManager.getModelReference(uri, 'resourceContextKey');
+      const modelRef = this.documentModelManager.getModelDescription(uri, 'resourceContextKey');
       if (modelRef) {
-        result = modelRef.instance.languageId;
-        modelRef.dispose();
+        result = modelRef.languageId;
       }
       return result;
     };
@@ -890,12 +889,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
     if (!this._resourceContext) {
       const getLanguageFromModel = (uri: URI) => {
         let result: string | null = null;
-        const modelRef = this.documentModelManager.getModelReference(uri, 'resourceContextKey');
+        const modelRef = this.documentModelManager.getModelDescription(uri, 'resourceContextKey');
         if (modelRef) {
-          if (modelRef) {
-            result = modelRef.instance.languageId;
-          }
-          modelRef.dispose();
+          result = modelRef.languageId;
         }
         return result;
       };
@@ -2337,11 +2333,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
 
   hasDirty(): boolean {
     for (const r of this.resources) {
-      const docRef = this.documentModelManager.getModelReference(r.uri);
+      const docRef = this.documentModelManager.getModelDescription(r.uri);
       if (docRef) {
-        const isDirty = docRef.instance.dirty;
-        docRef.dispose();
-        if (isDirty) {
+        if (docRef.dirty) {
           return true;
         }
       }
@@ -2355,15 +2349,13 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
   calcDirtyCount(countedUris: Set<string> = new Set<string>()): number {
     let count = 0;
     for (const r of this.resources) {
-      const docRef = this.documentModelManager.getModelReference(r.uri, 'calc-dirty-count');
+      const docRef = this.documentModelManager.getModelDescription(r.uri, 'calc-dirty-count');
       if (countedUris.has(r.uri.toString())) {
         continue;
       }
       countedUris.add(r.uri.toString());
       if (docRef) {
-        const isDirty = docRef.instance.dirty;
-        docRef.dispose();
-        if (isDirty) {
+        if (docRef.dirty) {
           count += 1;
         }
       }

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -44,6 +44,7 @@ import {
   debounce,
   formatLocalize,
   getDebugLogger,
+  isDefined,
   isUndefinedOrNull,
   localize,
   makeRandomHexString,
@@ -714,12 +715,10 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
   /**
    * 当前打开的所有resource
    */
-  // @observable.shallow
   resources: IResource[] = [];
 
   resourceStatus: Map<IResource, Promise<void>> = new Map();
 
-  // @observable.ref
   _currentResource: IResource | null;
 
   _currentOpenType: IEditorOpenType | null;
@@ -1410,6 +1409,9 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
           }
           if (options && options.label) {
             resource.name = options.label;
+          }
+          if (options && isDefined(options.supportsRevive)) {
+            resource.supportsRevive = options.supportsRevive;
           }
           let replaceResource: IResource | null = null;
           if (options && options.index !== undefined && options.index < this.resources.length) {

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -2302,9 +2302,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
     // 否则使用 document 进行保存 (如果有)
     const docRef = this.documentModelManager.getModelReference(resource.uri);
     if (docRef) {
-      if (docRef.instance.dirty) {
-        await docRef.instance.save(undefined, reason);
-      }
+      await docRef.instance.save(undefined, reason);
       docRef.dispose();
     }
   }

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -636,6 +636,8 @@ export interface IResourceOpenOptions {
    * 当关闭时指定 force 参数，用来跳过 shouldClose 等逻辑
    */
   forceClose?: boolean;
+
+  supportsRevive?: boolean;
 }
 
 export interface IResourceOpenResult {

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -29,10 +29,66 @@ import type { ITextModel, ITextModelUpdateOptions } from '@opensumi/monaco-edito
 
 export { ShowLightbulbIconMode } from '@opensumi/ide-monaco';
 
+export interface IEditorDocumentDescription {
+  /**
+   * 文档URI
+   */
+  readonly uri: URI;
+
+  /**
+   * A unique identifier associated with this model.
+   */
+  readonly id: string;
+
+  /**
+   * 编码
+   */
+  readonly encoding: string;
+
+  /**
+   * 行末结束
+   */
+  readonly eol: EOL;
+
+  /**
+   * 语言Id
+   */
+  readonly languageId: string;
+
+  /**
+   * 是否被修改过
+   */
+  readonly dirty: boolean;
+
+  /**
+   * 能否修改
+   */
+  readonly readonly: boolean;
+
+  /**
+   * 能否保存
+   */
+  readonly savable: boolean;
+
+  /**
+   * 是否永远都显示 dirty
+   */
+  readonly alwaysDirty: boolean;
+
+  /**
+   * 即便是 dirty 也要被 dispose
+   */
+  readonly disposeEvenDirty: boolean;
+
+  /**
+   * 是否关闭自动保存功能
+   */
+  readonly closeAutoSave: boolean;
+}
+
 /**
  * editorDocumentModel is a wrapped concept for monaco's textModel
  */
-
 export interface IEditorDocumentModel extends IDisposable {
   /**
    * 文档URI

--- a/packages/extension/src/browser/vscode/api/main.thread.doc.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.doc.ts
@@ -184,6 +184,7 @@ export class MainThreadExtensionDocumentData extends WithEventBus implements IMa
       encoding: e.payload.encoding,
       uri: e.payload.uri.toString(),
       languageId: e.payload.languageId,
+      dirty: e.payload.dirty,
     });
   }
 

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -25,7 +25,7 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
   editorService: WorkbenchEditorService;
 
   @Autowired(FileSearchServicePath)
-  private readonly fileSearchService;
+  private readonly fileSearchService: IFileSearchService;
 
   @Autowired(IExtensionStorageService)
   extensionStorageService: IExtensionStorageService;

--- a/packages/extension/src/common/vscode/doc.ts
+++ b/packages/extension/src/common/vscode/doc.ts
@@ -70,6 +70,7 @@ export interface IExtensionDocumentModelOptionsChangedEvent {
   uri: string;
   encoding?: string;
   languageId?: string;
+  dirty?: boolean;
 }
 
 export interface IExtensionDocumentModelOpenedEvent {

--- a/packages/extension/src/hosted/api/vscode/doc/doc-manager.host.ts
+++ b/packages/extension/src/hosted/api/vscode/doc/doc-manager.host.ts
@@ -180,7 +180,7 @@ export class ExtensionDocumentDataManagerImpl implements ExtensionDocumentDataMa
     const document = this._documents.get(e.uri);
     if (document) {
       // 和 vscode 表现保持一致，接收到 languages 变更时，发送一个 close 和一个 open 事件
-      if (isDefined(e.languageId)) {
+      if (isDefined(e.languageId) && e.languageId !== document._getLanguageId()) {
         document._acceptLanguageId(e.languageId);
         this._onDidCloseTextDocument.fire(document.document);
         this._onDidOpenTextDocument.fire(document.document);

--- a/packages/extension/src/hosted/api/vscode/doc/doc-manager.host.ts
+++ b/packages/extension/src/hosted/api/vscode/doc/doc-manager.host.ts
@@ -5,6 +5,7 @@ import {
   Emitter,
   IDisposable,
   URI,
+  isDefined,
   isUTF8,
   normalizeFileUrl,
 } from '@opensumi/ide-core-common';
@@ -178,11 +179,14 @@ export class ExtensionDocumentDataManagerImpl implements ExtensionDocumentDataMa
   $fireModelOptionsChangedEvent(e: IExtensionDocumentModelOptionsChangedEvent) {
     const document = this._documents.get(e.uri);
     if (document) {
-      // 和vscode中相同，接收到languages变更时，发送一个close和一个open事件
-      if (e.languageId) {
+      // 和 vscode 表现保持一致，接收到 languages 变更时，发送一个 close 和一个 open 事件
+      if (isDefined(e.languageId)) {
         document._acceptLanguageId(e.languageId);
         this._onDidCloseTextDocument.fire(document.document);
         this._onDidOpenTextDocument.fire(document.document);
+      }
+      if (isDefined(e.dirty)) {
+        document._acceptIsDirty(e.dirty);
       }
     }
   }
@@ -214,7 +218,7 @@ export class ExtensionDocumentDataManagerImpl implements ExtensionDocumentDataMa
       document: document.document,
       contentChanges: changes.map((change) => ({
         ...change,
-        range: toRange(change.range) as any,
+        range: toRange(change.range),
       })),
       reason,
     });

--- a/packages/extension/src/hosted/api/vscode/doc/ext-data.host.ts
+++ b/packages/extension/src/hosted/api/vscode/doc/ext-data.host.ts
@@ -135,6 +135,10 @@ export class ExtHostDocumentData extends MirrorTextModel {
     this._languageId = newLanguageId;
   }
 
+  _getLanguageId(): string {
+    return this._languageId;
+  }
+
   _acceptIsDirty(isDirty: boolean): void {
     this._isDirty = isDirty;
   }

--- a/packages/file-scheme/__tests__/browser/resource.test.ts
+++ b/packages/file-scheme/__tests__/browser/resource.test.ts
@@ -78,6 +78,9 @@ describe('file scheme tests', () => {
     },
     dispose: () => null,
   }));
+  injector.mock(IEditorDocumentModelService, 'getModelDescription', () => ({
+    dirty: true,
+  }));
 
   injector.addProviders({
     token: FileSchemeDocNodeServicePath,

--- a/packages/search/src/browser/replace.ts
+++ b/packages/search/src/browser/replace.ts
@@ -78,11 +78,7 @@ export async function replace(
 ) {
   const autoSavedDocs = results
     .map((result) => documentModelManager.getModelReference(new URI(result.fileUri)))
-    .filter((doc) => {
-      const result = doc?.instance && !doc.instance.dirty;
-      doc?.dispose();
-      return result;
-    });
+    .filter((doc) => doc?.instance && !doc.instance.dirty);
 
   const edits: Array<IResourceFileEdit | IResourceTextEdit> = [];
   for (const result of results) {
@@ -117,7 +113,10 @@ export async function replace(
     edits,
   });
 
-  autoSavedDocs.forEach((doc) => {
-    doc!.instance.save();
-  });
+  await Promise.all(
+    autoSavedDocs.map(async (doc) => {
+      await doc?.instance.save();
+      doc?.dispose();
+    }),
+  );
 }

--- a/packages/search/src/browser/replace.ts
+++ b/packages/search/src/browser/replace.ts
@@ -78,7 +78,11 @@ export async function replace(
 ) {
   const autoSavedDocs = results
     .map((result) => documentModelManager.getModelReference(new URI(result.fileUri)))
-    .filter((doc) => doc?.instance && !doc.instance.dirty);
+    .filter((doc) => {
+      const result = doc?.instance && !doc.instance.dirty;
+      doc?.dispose();
+      return result;
+    });
 
   const edits: Array<IResourceFileEdit | IResourceTextEdit> = [];
   for (const result of results) {

--- a/packages/search/src/browser/search.service.ts
+++ b/packages/search/src/browser/search.service.ts
@@ -405,11 +405,11 @@ export class ContentSearchClientService extends Disposable implements IContentSe
 
       const uriString = event.uri.toString();
 
-      const docModel = this.documentModelManager.getModelReference(event.uri);
-      if (!docModel) {
+      const docModelRef = this.documentModelManager.getModelReference(event.uri);
+      if (!docModelRef) {
         return;
       }
-      const resultData = this.searchFromDocModel(searchOptions, docModel.instance, this.searchValue, rootDirs);
+      const resultData = this.searchFromDocModel(searchOptions, docModelRef.instance, this.searchValue, rootDirs);
 
       const oldResults = this.searchResults.get(uriString);
 
@@ -435,7 +435,7 @@ export class ContentSearchClientService extends Disposable implements IContentSe
       }
 
       this.onDidChangeEmitter.fire();
-      docModel.dispose();
+      docModelRef.dispose();
     });
   }
 

--- a/packages/search/src/browser/tree/search-tree.service.ts
+++ b/packages/search/src/browser/tree/search-tree.service.ts
@@ -141,6 +141,13 @@ export class ReplaceDocumentModelContentProvider implements IEditorDocumentModel
 
   async updateContent(uri: URI): Promise<any> {
     const sourceFileUri = uri.withScheme(JSON.parse(uri.query).scheme).withoutQuery().withoutFragment();
+
+    let searchResults = this.searchBrowserService.searchResults.get(sourceFileUri.toString());
+
+    if (!searchResults) {
+      return '';
+    }
+
     const sourceDocModelRef =
       this.documentModelManager.getModelReference(sourceFileUri) ||
       (await this.documentModelManager.createModelReference(sourceFileUri));
@@ -151,12 +158,6 @@ export class ReplaceDocumentModelContentProvider implements IEditorDocumentModel
     const replaceViewDocModel = replaceViewDocModelRef.instance;
 
     replaceViewDocModel.updateContent(value);
-
-    let searchResults = this.searchBrowserService.searchResults.get(sourceFileUri.toString());
-
-    if (!searchResults) {
-      return '';
-    }
 
     searchResults = searchResults.map((result) =>
       Object.assign({}, result, {
@@ -174,6 +175,9 @@ export class ReplaceDocumentModelContentProvider implements IEditorDocumentModel
     );
 
     this.contentMap.set(uri.toString(), replaceViewDocModel.getText());
+
+    replaceViewDocModelRef.dispose();
+    sourceDocModelRef.dispose();
   }
 
   onDidChangeContent = this.onDidChangeContentEvent.event;

--- a/packages/search/src/browser/tree/tree-model.service.ts
+++ b/packages/search/src/browser/tree/tree-model.service.ts
@@ -268,6 +268,7 @@ export class SearchModelService extends Disposable {
           }),
           {
             preview,
+            supportsRevive: false,
           },
         );
         if (openResourceResult) {

--- a/packages/workspace-edit/src/browser/refactor-preview.tsx
+++ b/packages/workspace-edit/src/browser/refactor-preview.tsx
@@ -91,7 +91,7 @@ const TextEditNode = observer<ITextEditNodeProps>(({ data: item }) => {
 
     const textModel = model.instance.getMonacoModel();
     const { leftPad, base, rightPad } = splitLeftAndRightPadInTextModel(item.textEdit.range, textModel);
-
+    model.dispose();
     return (
       <div className={styles.refactor_preview_node_wrapper}>
         {leftPad}

--- a/packages/workspace-edit/src/browser/refactor-preview.tsx
+++ b/packages/workspace-edit/src/browser/refactor-preview.tsx
@@ -84,14 +84,14 @@ const TextEditNode = observer<ITextEditNodeProps>(({ data: item }) => {
   const refactorPreviewService = useInjectable<IRefactorPreviewService>(IRefactorPreviewService);
 
   const renderTextEditDiff = () => {
-    const model = modelService.getModelReference(URI.from(item.resource));
-    if (!model) {
+    const modelRef = modelService.getModelReference(URI.from(item.resource));
+    if (!modelRef) {
       return <div className={styles.refactor_preview_node_wrapper}>{item.textEdit.text}</div>;
     }
 
-    const textModel = model.instance.getMonacoModel();
+    const textModel = modelRef.instance.getMonacoModel();
     const { leftPad, base, rightPad } = splitLeftAndRightPadInTextModel(item.textEdit.range, textModel);
-    model.dispose();
+    modelRef.dispose();
     return (
       <div className={styles.refactor_preview_node_wrapper}>
         {leftPad}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

插件层状态不同步，做一下各种时机的同步


主要是做了两件事情：
1. 防止 model ref 被不小心持有，导致磁盘中的文件更新反应不到 browser 层
2. 非 dirty 的文件在被保存时会往 ext 层同步 dirty 状态

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了新的可选属性 `dirty`，用于表示文档是否存在未保存的更改，增强了文档状态管理。
	- 增加了异步方法 `syncDocumentModelToExtThread`，改进文档模型与外部线程的同步。
- **改进**
	- 修改了文档保存逻辑，确保在文档存在时无条件调用保存方法，提高了操作的一致性。
	- 精化了文档状态更新的事件处理逻辑，增强了事件触发的鲁棒性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->