### PR TITLE
fix: add keyboard focus and accessibility support for editor tabs and close buttons

### DIFF
--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -39,6 +39,7 @@ import { LayoutViewSizeConfig } from '@opensumi/ide-core-browser/lib/layout/cons
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
 import { IMenuRegistry, MenuId } from '@opensumi/ide-core-browser/lib/menu/next';
 import { useInjectable, useUpdateOnEventBusEvent } from '@opensumi/ide-core-browser/lib/react-hooks';
+import { formatLocalize } from '@opensumi/ide-core-common';
 
 import {
   IEditorGroup,
@@ -378,7 +379,9 @@ export const Tabs = ({ group }: ITabsProps) => {
       return editorTabService.renderEditorTab(
         <>
           <div className={tabsLoadingMap[resource.uri.toString()] ? 'loading_indicator' : cls(resource.icon)}> </div>
-          <div>{resource.name}</div>
+          <div tabIndex={0} role='tab' aria-selected={isCurrent ? 'true' : 'false'}>
+            {resource.name}
+          </div>
           {subname ? <div className={styles.subname}>{subname}</div> : null}
           {decoration.readOnly ? (
             <span className={cls(getExternalIcon('lock'), styles.editor_readonly_icon)}></span>
@@ -398,7 +401,12 @@ export const Tabs = ({ group }: ITabsProps) => {
               }}
             >
               {editorTabService.renderTabCloseComponent(
-                <div className={cls(getIcon('close'), styles_kt_editor_close_icon)} />,
+                <div
+                  className={cls(getIcon('close'), styles_kt_editor_close_icon)}
+                  tabIndex={0}
+                  role='button'
+                  aria-label={formatLocalize('editor.closeTab.title', resource.name)}
+                />,
               )}
             </div>
           </div>
@@ -419,6 +427,7 @@ export const Tabs = ({ group }: ITabsProps) => {
           [styles_kt_editor_tabs_current_last]: curTabIndex === group.resources.length - 1,
         })}
         ref={contentRef as any}
+        role='tablist'
       >
         {group.resources.map((resource, i) => {
           let ref: HTMLDivElement | null;


### PR DESCRIPTION
### Types

- [ ] 🐛 Bug Fixes

### Background or solution
为编辑器的tab和关闭按钮添加键盘焦点和无障碍属性支持，tab和关闭按钮支持键盘聚焦，屏幕阅读器朗读，选中的tab有选中提示。
![编辑器代码解释](https://github.com/user-attachments/assets/908cae21-b6c6-49e0-b5be-ea49d6d8fc1c)

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增强了标签组件的可访问性，支持屏幕阅读器。
	- 添加了ARIA角色和属性，改善用户体验。
	- 更新了关闭按钮的可访问性，提供本地化描述。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->