### PR TITLE
fix: electron reload not work

### DIFF
--- a/packages/core-electron-main/src/bootstrap/window.ts
+++ b/packages/core-electron-main/src/bootstrap/window.ts
@@ -202,8 +202,8 @@ export class CodeWindow extends Disposable implements ICodeWindow {
   }
 
   async startNode() {
-    await this.clear();
     this._nodeReady = new Deferred();
+    await this.clear();
     this.node = new KTNodeProcess(
       this.appConfig.nodeEntry,
       this.appConfig.extensionEntry,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution
electron window reload 时，会先设置 isReloading 为 true，然后 web 上触发相关事件后，调用 main 的 closeWindow，这时候如果 isReloading 为 true，则调用 startNode 创建新的 node 进程，startNode 会先 clear 旧的进程，并声称新的 rpcListenPath，在 windows 上由于 kill 进程比较慢，这时候如果 window 已经开始渲染，preload 时从 window-rpc-listen-path 拿到 rpcListenPath，这时候由于 _nodeReady 为旧的，则获取的是上一个 rpcListenPath，导致与 node 连上不上，从而 web 无法正常渲染

### Changelog
先 reset _nodeReady，避免拿到因为旧的 _nodeReady 拿到错误的 rpcListenPath


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 调整了 `startNode` 方法中的操作顺序，优化了节点准备的时机，提升了应用的稳定性和响应速度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->