### PR TITLE
fix: right panel has two resize handle

### DIFF
--- a/packages/ai-native/src/browser/chat/chat.module.less
+++ b/packages/ai-native/src/browser/chat/chat.module.less
@@ -81,6 +81,7 @@
     padding: 12px 0 12px 16px;
     box-sizing: border-box;
     background-color: var(--editorGroupHeader-tabsBackground);
+    user-select: none;
 
     .left {
       display: flex;

--- a/packages/ai-native/src/browser/layout/layout.module.less
+++ b/packages/ai-native/src/browser/layout/layout.module.less
@@ -1,14 +1,5 @@
-/**
-* -------------------------------------------- 右侧 chat 面板样式 --------------------------------------------
-*/
 #ai_chat_panel {
   height: 100%;
-
-  div[class*='tab_panel'] {
-    &::before {
-      content: none;
-    }
-  }
 
   :global {
     .rce-mbox-left-notch,

--- a/packages/core-browser/src/components/layout/split-panel.tsx
+++ b/packages/core-browser/src/components/layout/split-panel.tsx
@@ -247,7 +247,10 @@ export const SplitPanel: React.FC<SplitPanelProps> = (props) => {
             } else if (getProp(childList[index - 1], 'flexGrow')) {
               flexMode = ResizeFlexMode.Next;
             }
-            const noResize = getProp(targetElement, 'noResize') || locks[index - 1];
+            const noResize =
+              splitPanelService.checkChildNoResize(targetElement) ||
+              getProp(targetElement, 'noResize') ||
+              locks[index - 1];
             if (!noResize) {
               result.push(
                 <ResizeHandle

--- a/packages/design/src/browser/style/design.module.less
+++ b/packages/design/src/browser/style/design.module.less
@@ -706,12 +706,6 @@
     }
   }
 
-  .design-tab_panel {
-    &::before {
-      content: none;
-    }
-  }
-
   .design-tab_panel_hidden {
     display: none;
   }
@@ -722,6 +716,12 @@
 
   .design-extension_item {
     border-radius: 8px;
+  }
+}
+
+.design-tab_panel {
+  &::before {
+    content: none !important;
   }
 }
 

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -5,6 +5,7 @@ import {
   CommandContribution,
   CommandRegistry,
   CommandService,
+  DisposableStore,
   FILE_COMMANDS,
   IApplicationService,
   IClipboardService,
@@ -76,6 +77,8 @@ export class FileTreeContribution
     ClientAppContribution,
     MainLayoutContribution
 {
+  private _disposables = new DisposableStore();
+
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
@@ -156,12 +159,14 @@ export class FileTreeContribution
       EXPLORER_CONTAINER_ID,
     );
     // 监听工作区变化更新标题
-    this.workspaceService.onWorkspaceLocationChanged(() => {
-      const handler = this.mainLayoutService.getTabbarHandler(EXPLORER_CONTAINER_ID);
-      if (handler) {
-        handler.updateViewTitle(RESOURCE_VIEW_ID, this.getWorkspaceTitle());
-      }
-    });
+    this._disposables.add(
+      this.workspaceService.onWorkspaceLocationChanged(() => {
+        const handler = this.mainLayoutService.getTabbarHandler(EXPLORER_CONTAINER_ID);
+        if (handler) {
+          handler.updateViewTitle(RESOURCE_VIEW_ID, this.getWorkspaceTitle());
+        }
+      }),
+    );
   }
 
   onDidStart() {
@@ -1254,5 +1259,9 @@ export class FileTreeContribution
     const uris = this.willDeleteUris.slice();
     this.willDeleteUris = [];
     return this.fileTreeModelService.deleteFileByUris(uris);
+  }
+
+  dispose() {
+    this._disposables.dispose();
   }
 }

--- a/packages/main-layout/src/browser/tabbar/panel.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/panel.view.tsx
@@ -61,7 +61,7 @@ export const BaseTabPanelView: React.FC<IBaseTabPanelView> = observer((props) =>
   return (
     <div
       id={id}
-      className={cls(styles_tab_panel, {
+      className={cls('kt-tab-panel', styles_tab_panel, {
         [styles_tab_panel_hidden]: !tabbarService.currentContainerId,
       })}
     >


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes

### Background or solution

修复右侧面板会有两个 resize handle 导致间距较大

![CleanShot 2024-08-21 at 21 15 24@2x](https://github.com/user-attachments/assets/f02cf005-be6e-4ec7-a2b9-b2db162a4773)


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 改进了聊天模块的用户界面，新增了防止文本选择的样式，提升用户体验。
	- 引入了用于检查子组件是否可调整大小的新功能，增强布局的灵活性。
	- 对文件树管理进行了优化，确保资源的有效管理，提升应用性能与稳定性。
	- 修改了标签面板的样式，增强组件的样式一致性。

- **样式**
	- 精简了聊天面板的样式，可能导致更清晰但较少细节的界面。
	- 修改了设计标签面板的样式，提升样式优先级控制。

- **修复**
	- 通过引入资源管理机制，解决了潜在的内存泄漏问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->