### PR TITLE
feat: support multi-line edits rewrite widget

### DIFF
--- a/packages/ai-native/__test__/browser/contrib/intelligent-completions/diff-computer.test.ts
+++ b/packages/ai-native/__test__/browser/contrib/intelligent-completions/diff-computer.test.ts
@@ -1,11 +1,7 @@
 import { multiLineDiffComputer } from '@opensumi/ide-ai-native/lib/browser/contrib/intelligent-completions/diff-computer';
 
 describe('MultiLineDiffComputer', () => {
-  let diffComputer: typeof multiLineDiffComputer;
-
-  beforeEach(() => {
-    diffComputer = multiLineDiffComputer;
-  });
+  const diffComputer = multiLineDiffComputer;
 
   test('equals method should return true for equal strings', () => {
     expect(diffComputer['equals']('a', 'a')).toBe(true);

--- a/packages/ai-native/__test__/browser/contrib/intelligent-completions/diff-computer.test.ts
+++ b/packages/ai-native/__test__/browser/contrib/intelligent-completions/diff-computer.test.ts
@@ -1,10 +1,10 @@
-import { MultiLineDiffComputer } from '@opensumi/ide-ai-native/lib/browser/contrib/intelligent-completions/diff-computer';
+import { multiLineDiffComputer } from '@opensumi/ide-ai-native/lib/browser/contrib/intelligent-completions/diff-computer';
 
 describe('MultiLineDiffComputer', () => {
-  let diffComputer: MultiLineDiffComputer;
+  let diffComputer: typeof multiLineDiffComputer;
 
   beforeEach(() => {
-    diffComputer = new MultiLineDiffComputer();
+    diffComputer = multiLineDiffComputer;
   });
 
   test('equals method should return true for equal strings', () => {

--- a/packages/ai-native/__test__/browser/contrib/intelligent-completions/multi-line.decoration.test.ts
+++ b/packages/ai-native/__test__/browser/contrib/intelligent-completions/multi-line.decoration.test.ts
@@ -6,7 +6,7 @@ import {
 import { ICodeEditor, IPosition } from '@opensumi/ide-monaco';
 import { monacoApi } from '@opensumi/ide-monaco/lib/browser/monaco-api';
 
-import { IDiffChangeResult } from '../../../../lib/browser/contrib/intelligent-completions/diff-computer';
+import { IMultiLineDiffChangeResult } from '../../../../lib/browser/contrib/intelligent-completions/diff-computer';
 import { EnhanceDecorationsCollection } from '../../../../src/browser/model/enhanceDecorationsCollection';
 
 describe('MultiLineDecorationModel', () => {
@@ -43,7 +43,7 @@ greet(person); // Output: "Hello, OpenSumi!"`);
   });
 
   it('should split diff changes correctly', () => {
-    const lines: IDiffChangeResult[] = [
+    const lines: IMultiLineDiffChangeResult[] = [
       { value: 'line1\nline2', added: true, removed: false },
       { value: 'line3', added: false, removed: true },
     ];
@@ -81,7 +81,7 @@ greet(person); // Output: "Hello, OpenSumi!"`);
   });
 
   it('should apply inline decorations correctly', () => {
-    const changes: IDiffChangeResult[] = [
+    const changes: IMultiLineDiffChangeResult[] = [
       { value: 'const person: Person = {\n  name: "' },
       { value: 'Hello ', added: true, removed: undefined },
       { value: 'OpenSumi",\n  age: 18' },

--- a/packages/ai-native/__test__/browser/contrib/intelligent-completions/multi-line.decoration.test.ts
+++ b/packages/ai-native/__test__/browser/contrib/intelligent-completions/multi-line.decoration.test.ts
@@ -6,7 +6,7 @@ import {
 import { ICodeEditor, IPosition } from '@opensumi/ide-monaco';
 import { monacoApi } from '@opensumi/ide-monaco/lib/browser/monaco-api';
 
-import { IMultiLineDiffChangeResult } from '../../../../lib/browser/contrib/intelligent-completions/diff-computer';
+import { IMultiLineDiffChangeResult } from '../../../../src/browser/contrib/intelligent-completions/diff-computer';
 import { EnhanceDecorationsCollection } from '../../../../src/browser/model/enhanceDecorationsCollection';
 
 describe('MultiLineDecorationModel', () => {

--- a/packages/ai-native/__test__/browser/contrib/intelligent-completions/multi-line.decoration.test.ts
+++ b/packages/ai-native/__test__/browser/contrib/intelligent-completions/multi-line.decoration.test.ts
@@ -96,20 +96,13 @@ greet(person); // Output: "Hello, OpenSumi!"`);
       cursorPosition,
     );
 
-    expect(result).toEqual([
-      {
-        lineNumber: 8,
-        column: 10,
-        newValue: '  name: "Hello ',
-        oldValue: '  name: "',
-      },
-      {
-        lineNumber: 9,
-        column: 10,
-        newValue: '  age: 18 + 1',
-        oldValue: '  age: 18',
-      },
-    ]);
+    expect(result).toEqual({
+      fullLineMods: { 10: [], 6: [], 7: [], 8: [], 9: [] },
+      inlineMods: [
+        { column: 10, lineNumber: 8, newValue: '  name: "Hello ', oldValue: '  name: "' },
+        { column: 10, lineNumber: 9, newValue: '  age: 18 + 1', oldValue: '  age: 18' },
+      ],
+    });
   });
 
   it('should update line modification decorations correctly', () => {

--- a/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
+++ b/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
@@ -6,7 +6,7 @@ import {
   InlineDiffPartialEditsIsVisible,
   InlineHintWidgetIsVisible,
   InlineInputWidgetIsVisible,
-  MultiLineCompletionsIsVisible,
+  MultiLineEditsIsVisible,
 } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
 import { ContextKeyService } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/browser/contextKeyService';
 import { IContextKeyServiceTarget } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
@@ -23,7 +23,7 @@ export class AINativeContextKey {
   public readonly inlineHintWidgetIsVisible: IContextKey<boolean>;
   public readonly inlineInputWidgetIsVisible: IContextKey<boolean>;
   public readonly inlineDiffPartialEditsIsVisible: IContextKey<boolean>;
-  public readonly multiLineCompletionsIsVisible: IContextKey<boolean>;
+  public readonly multiLineEditsIsVisible: IContextKey<boolean>;
 
   constructor(@Optional() dom?: HTMLElement | IContextKeyServiceTarget | ContextKeyService) {
     this._contextKeyService = this.globalContextKeyService.createScoped(dom);
@@ -32,6 +32,6 @@ export class AINativeContextKey {
     this.inlineHintWidgetIsVisible = InlineHintWidgetIsVisible.bind(this._contextKeyService);
     this.inlineInputWidgetIsVisible = InlineInputWidgetIsVisible.bind(this._contextKeyService);
     this.inlineDiffPartialEditsIsVisible = InlineDiffPartialEditsIsVisible.bind(this._contextKeyService);
-    this.multiLineCompletionsIsVisible = MultiLineCompletionsIsVisible.bind(this._contextKeyService);
+    this.multiLineEditsIsVisible = MultiLineEditsIsVisible.bind(this._contextKeyService);
   }
 }

--- a/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
+++ b/packages/ai-native/src/browser/contextkey/ai-native.contextkey.service.ts
@@ -24,6 +24,9 @@ export class AINativeContextKey {
   public readonly inlineInputWidgetIsVisible: IContextKey<boolean>;
   public readonly inlineDiffPartialEditsIsVisible: IContextKey<boolean>;
   public readonly multiLineEditsIsVisible: IContextKey<boolean>;
+  public get contextKeyService() {
+    return this._contextKeyService;
+  }
 
   constructor(@Optional() dom?: HTMLElement | IContextKeyServiceTarget | ContextKeyService) {
     this._contextKeyService = this.globalContextKeyService.createScoped(dom);

--- a/packages/ai-native/src/browser/contrib/inline-completions/inline-completions.handler.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/inline-completions.handler.ts
@@ -18,7 +18,6 @@ import { InlineCompletionContextKeys } from '@opensumi/monaco-editor-core/esm/vs
 
 import { IAIMonacoContribHandler } from '../base';
 import { IIntelligentCompletionsResult } from '../intelligent-completions/intelligent-completions';
-import { IntelligentCompletionsHandler } from '../intelligent-completions/intelligent-completions.handler';
 
 import { AIInlineCompletionsProvider } from './completeProvider';
 import { AICompletionsService } from './service/ai-completions.service';
@@ -33,9 +32,6 @@ export class InlineCompletionHandler extends IAIMonacoContribHandler {
 
   @Autowired(AIInlineCompletionsProvider)
   private readonly aiInlineCompletionsProvider: AIInlineCompletionsProvider;
-
-  @Autowired(IntelligentCompletionsHandler)
-  private readonly intelligentCompletionsHandler: IntelligentCompletionsHandler;
 
   @Autowired(AICompletionsService)
   private aiCompletionsService: AICompletionsService;

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
@@ -1,0 +1,44 @@
+import { ICodeEditor, IModelDeltaDecoration, IRange } from '@opensumi/ide-monaco';
+
+import { EnhanceDecorationsCollection } from '../../model/enhanceDecorationsCollection';
+
+import { IMultiLineDiffChangeResult } from './diff-computer';
+
+export class AdditionsDeletionsDecorationModel {
+  private deletionsDecorations: EnhanceDecorationsCollection;
+
+  constructor(private readonly editor: ICodeEditor) {
+    this.deletionsDecorations = new EnhanceDecorationsCollection(this.editor);
+  }
+
+  generateRange(wordChanges: IMultiLineDiffChangeResult[], zoneRange: IRange, eol: string) {
+    const ranges: IRange[] = [];
+
+    let currentLineNumber = 1;
+    let currentColumn = 1;
+    for (const change of wordChanges) {
+      const lines = change.value.split(eol);
+      const len = lines.length;
+
+      const endLineNumber = currentLineNumber + len - 1;
+      const endColumn = len > 1 ? lines[len - 1].length + 1 : currentColumn + change.value.length;
+
+      if (change.added) {
+        ranges.push({
+          startLineNumber: currentLineNumber + zoneRange.startLineNumber - 1,
+          startColumn: currentColumn,
+          endLineNumber: endLineNumber + zoneRange.startLineNumber - 1,
+          endColumn,
+        });
+      }
+
+      currentColumn = endColumn;
+      currentLineNumber = endLineNumber;
+    }
+    return ranges;
+  }
+
+  setDeletionsDecoration(decoration: IModelDeltaDecoration[]) {
+    this.deletionsDecorations.set(decoration);
+  }
+}

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
@@ -44,6 +44,10 @@ export class AdditionsDeletionsDecorationModel {
     return ranges;
   }
 
+  clearDecorations() {
+    this.deletionsDecorations.clear();
+  }
+
   updateDeletionsDecoration(wordChanges: IMultiLineDiffChangeResult[], range: IRange, eol: string) {
     const deletionRanges = this.generateRange(
       wordChanges.map((change) => {

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
@@ -1,15 +1,18 @@
 import { ICodeEditor, IModelDeltaDecoration, IRange, TrackedRangeStickiness } from '@opensumi/ide-monaco';
 
 import { EnhanceDecorationsCollection } from '../../model/enhanceDecorationsCollection';
+import { REWRITE_DECORATION_INLINE_ADD } from '../../widget/rewrite/rewrite-widget';
 
 import { IMultiLineDiffChangeResult } from './diff-computer';
 import styles from './intelligent-completions.module.less';
 
 export class AdditionsDeletionsDecorationModel {
   private deletionsDecorations: EnhanceDecorationsCollection;
+  private additionsDecorations: EnhanceDecorationsCollection;
 
   constructor(private readonly editor: ICodeEditor) {
     this.deletionsDecorations = new EnhanceDecorationsCollection(this.editor);
+    this.additionsDecorations = new EnhanceDecorationsCollection(this.editor);
   }
 
   private generateRange(wordChanges: IMultiLineDiffChangeResult[], zoneRange: IRange, eol: string) {
@@ -44,8 +47,12 @@ export class AdditionsDeletionsDecorationModel {
     return ranges;
   }
 
-  clearDecorations() {
+  clearDeletionsDecorations() {
     this.deletionsDecorations.clear();
+  }
+
+  clearAdditionsDecorations() {
+    this.additionsDecorations.clear();
   }
 
   updateDeletionsDecoration(wordChanges: IMultiLineDiffChangeResult[], range: IRange, eol: string) {
@@ -71,6 +78,19 @@ export class AdditionsDeletionsDecorationModel {
         options: {
           description: 'suggestion_deletions_background',
           className: styles.suggestion_deletions_background,
+          stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+        },
+      })),
+    );
+  }
+
+  updateAdditionsDecoration(additionRanges: IRange[]) {
+    this.additionsDecorations.set(
+      additionRanges.map((range) => ({
+        range,
+        options: {
+          description: REWRITE_DECORATION_INLINE_ADD,
+          className: styles.suggestion_additions_background,
           stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
         },
       })),

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/additions-deletions.decoration.ts
@@ -30,11 +30,16 @@ export class AdditionsDeletionsDecorationModel {
           endLineNumber: endLineNumber + zoneRange.startLineNumber - 1,
           endColumn,
         });
+        currentColumn = endColumn;
+        currentLineNumber = endLineNumber;
       }
 
-      currentColumn = endColumn;
-      currentLineNumber = endLineNumber;
+      if (!change.removed) {
+        currentColumn = endColumn;
+        currentLineNumber = endLineNumber;
+      }
     }
+
     return ranges;
   }
 

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
@@ -353,7 +353,7 @@ export const computeMultiLineDiffChanges = (
 
   const mergeRewriteLine = mergeMultiLineDiffChanges(rewriteDiffResult, eol);
   const isOnlyAddingToEachWord = !mergeRewriteLine.some(
-    (item) => item.added !== true && item.removed === true && item.value !== eol,
+    (item) => item.added !== true && item.removed && item.value !== eol,
   );
 
   const mergeMultiLine = mergeMultiLineDiffChanges(multiLineDiffResult, eol);

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
@@ -188,7 +188,6 @@ export class MultiLineDiffComputer {
   }
 }
 
-const nonWhitespacePattern = /\S/;
 const identifierPattern = /^[a-zA-Z]+$/u;
 const splitPattern = /([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/;
 
@@ -196,7 +195,7 @@ export class RewriteDiffComputer extends MultiLineDiffComputer {
   override equals(a: string, b: string): boolean {
     const lowerA = a.toLowerCase();
     const lowerB = b.toLowerCase();
-    return lowerA === lowerB || (!nonWhitespacePattern.test(lowerA) && !nonWhitespacePattern.test(lowerB));
+    return lowerA === lowerB;
   }
 
   override tokenize(content: string): string[] {

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
@@ -3,13 +3,13 @@ import { empty } from '@opensumi/ide-utils/lib/strings';
 /**
  * @internal
  */
-export interface IDiffChangeResult {
+export interface IMultiLineDiffChangeResult {
   added?: boolean;
   removed?: boolean;
   value: string;
 }
 
-interface IResultWithCount extends IDiffChangeResult {
+interface IResultWithCount extends IMultiLineDiffChangeResult {
   count: number;
 }
 

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/diff-computer.ts
@@ -1,3 +1,4 @@
+import { ICodeEditor, IRange, ITextModel } from '@opensumi/ide-monaco';
 import { empty } from '@opensumi/ide-utils/lib/strings';
 
 /**
@@ -18,7 +19,7 @@ interface IElement {
   changeResult: IResultWithCount[];
 }
 
-export class MultiLineDiffComputer {
+class MultiLineDiffComputer {
   private extractCommon(element: IElement, modified: string[], original: string[], diagonal: number): number {
     const modifiedLength = modified.length;
     const originalLength = original.length;
@@ -191,7 +192,7 @@ export class MultiLineDiffComputer {
 const identifierPattern = /^[a-zA-Z]+$/u;
 const splitPattern = /([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/;
 
-export class RewriteDiffComputer extends MultiLineDiffComputer {
+class RewriteDiffComputer extends MultiLineDiffComputer {
   override equals(a: string, b: string): boolean {
     const lowerA = a.toLowerCase();
     const lowerB = b.toLowerCase();
@@ -219,3 +220,198 @@ export class RewriteDiffComputer extends MultiLineDiffComputer {
     return tokens;
   }
 }
+
+export const multiLineDiffComputer = new MultiLineDiffComputer();
+export const rewriteDiffComputer = new RewriteDiffComputer();
+
+export const mergeMultiLineDiffChanges = (
+  lines: IMultiLineDiffChangeResult[],
+  eol: string,
+): IMultiLineDiffChangeResult[] => {
+  const modifiedLines = lines.flatMap((line) => {
+    const segments = line.value.split(eol);
+    const wrap = (value: string): IMultiLineDiffChangeResult => ({ value, added: line.added, removed: line.removed });
+
+    return segments
+      .flatMap((segment, index) => {
+        if (index < segments.length - 1) {
+          return [wrap(segment), wrap(eol)];
+        }
+
+        return wrap(segment);
+      })
+      .filter((line) => line.value !== empty);
+  });
+
+  // 对处理后的结果进行调整，确保相邻的添加和删除操作合并
+  for (let i = 0; i < modifiedLines.length - 1; i++) {
+    const currentLine = modifiedLines[i];
+    const nextLine = modifiedLines[i + 1];
+    // 如果当前行是删除操作，下一行是添加操作，并且下一行的值以当前行的值开头，则合并这两个操作
+    if (currentLine.removed && nextLine.added && nextLine.value.startsWith(currentLine.value)) {
+      currentLine.added = true;
+      currentLine.removed = true;
+    }
+  }
+
+  return modifiedLines;
+};
+
+/**
+ * 根据原始内容和要修改的内容，返回字符级或单词级的差异
+ */
+export const computeMultiLineDiffChanges = (
+  originalContent: string,
+  modifiedContent: string,
+  monacoEditor: ICodeEditor,
+  lineNumber: number,
+  eol: string,
+) => {
+  let rewriteDiffResult: IMultiLineDiffChangeResult[] =
+    rewriteDiffComputer.diff(originalContent, modifiedContent) || [];
+  let multiLineDiffResult: IMultiLineDiffChangeResult[] =
+    multiLineDiffComputer.diff(originalContent, modifiedContent) || [];
+
+  const originalLines = originalContent.split(eol);
+  const modifiedLines = modifiedContent.split(eol);
+
+  if (
+    originalLines.length === modifiedLines.length &&
+    originalLines.every((value, index) => modifiedLines[index].startsWith(value))
+  ) {
+    multiLineDiffResult = originalLines
+      .map((value, index) => {
+        const modifiedLine = modifiedLines[index];
+        const diffElements: IMultiLineDiffChangeResult[] = [
+          {
+            value,
+          },
+        ];
+
+        if (modifiedLine !== value) {
+          const addedPart = modifiedLine.substring(value.length);
+          diffElements.push(
+            {
+              value: addedPart,
+              added: true,
+            },
+            {
+              value: eol,
+            },
+          );
+        } else {
+          diffElements[0].value = diffElements[0].value + eol;
+        }
+        return diffElements;
+      })
+      .flat();
+  }
+
+  const currentCursorPosition = monacoEditor.getPosition();
+
+  if (currentCursorPosition) {
+    const lineAndColumn = {
+      lineNumber: currentCursorPosition.lineNumber - lineNumber + 1,
+      column: currentCursorPosition.column,
+    };
+
+    const prefix = originalLines.slice(0, lineAndColumn.lineNumber - 1).join(eol);
+    const linePrefix = originalLines[lineAndColumn.lineNumber - 1].slice(0, lineAndColumn.column - 1);
+
+    const prefixMatch = prefix === modifiedLines.slice(0, lineAndColumn.lineNumber - 1).join(eol);
+    const linePrefixMatch =
+      linePrefix === modifiedLines[lineAndColumn.lineNumber - 1].slice(0, lineAndColumn.column - 1);
+
+    if (prefixMatch && linePrefixMatch) {
+      const suffix = (line: string[]) =>
+        line[lineAndColumn.lineNumber - 1].slice(lineAndColumn.column - 1) +
+        eol +
+        line.slice(lineAndColumn.lineNumber).join(eol);
+
+      const modifiedContent = suffix(modifiedLines);
+      const originalContent = suffix(originalLines);
+      const commonPrefix =
+        prefix + (originalLines.slice(0, lineAndColumn.lineNumber - 1).length > 0 ? eol : empty) + linePrefix;
+
+      if (modifiedContent.endsWith(originalContent)) {
+        const modifiedContentPrefix = modifiedContent.slice(0, modifiedContent.length - originalContent.length);
+        multiLineDiffResult = [
+          {
+            value: commonPrefix,
+          },
+          {
+            value: modifiedContentPrefix,
+            added: true,
+          },
+          {
+            value: originalContent,
+          },
+        ];
+      }
+    }
+  }
+
+  const mergeRewriteLine = mergeMultiLineDiffChanges(rewriteDiffResult, eol);
+  const isOnlyAddingToEachWord = !mergeRewriteLine.some(
+    (item) => item.added !== true && item.removed === true && item.value !== eol,
+  );
+
+  const mergeMultiLine = mergeMultiLineDiffChanges(multiLineDiffResult, eol);
+
+  return {
+    singleLineCharChanges: mergeMultiLine,
+    charChanges: multiLineDiffResult,
+    wordChanges: rewriteDiffResult,
+    isOnlyAddingToEachWord,
+  };
+};
+
+/**
+ * 将单词级别的 change 转换为行级别的 change 映射
+ */
+export const wordChangesToLineChangesMap = (
+  wordChanges: IMultiLineDiffChangeResult[],
+  range: IRange,
+  model: ITextModel | null,
+) => {
+  const lineChangesMap: { [lineNumber: number]: IMultiLineDiffChangeResult[][] } = {};
+  const eol = model?.getEOL()!;
+
+  let currentLineNumber = range.startLineNumber;
+
+  const addChange = (change: IMultiLineDiffChangeResult) => {
+    if (!lineChangesMap[currentLineNumber]) {
+      lineChangesMap[currentLineNumber] = [];
+    }
+    lineChangesMap[currentLineNumber].push([change]);
+  };
+
+  const pushToLastChange = (change: IMultiLineDiffChangeResult) => {
+    const lastChanges = lineChangesMap[currentLineNumber]?.[lineChangesMap[currentLineNumber].length - 1];
+    if (lastChanges) {
+      lastChanges.push(change);
+    } else {
+      addChange(change);
+    }
+  };
+
+  const moveToNextLine = () => {
+    currentLineNumber++;
+  };
+
+  wordChanges.forEach((change) => {
+    const { value, added, removed } = change;
+    const segments = value.split(eol);
+
+    segments.forEach((segment, index) => {
+      if (index === 0) {
+        pushToLastChange({ value: segment, added, removed });
+      } else {
+        moveToNextLine();
+        addChange({ value: segment, added, removed });
+      }
+    });
+  });
+
+  return lineChangesMap;
+};

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.contribution.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.contribution.ts
@@ -10,7 +10,7 @@ import {
   AI_MULTI_LINE_COMPLETION_ACCEPT,
   AI_MULTI_LINE_COMPLETION_HIDE,
 } from '@opensumi/ide-core-browser/lib/ai-native/command';
-import { MultiLineCompletionsIsVisible } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
+import { MultiLineEditsIsVisible } from '@opensumi/ide-core-browser/lib/contextkey/ai-native';
 import { CommandContribution, CommandRegistry, Domain } from '@opensumi/ide-core-common';
 
 import { IntelligentCompletionsHandler } from './intelligent-completions.handler';
@@ -38,7 +38,7 @@ export class IntelligentCompletionsContribution implements KeybindingContributio
     keybindings.registerKeybinding({
       command: AI_MULTI_LINE_COMPLETION_HIDE.id,
       keybinding: Key.ESCAPE.code,
-      when: MultiLineCompletionsIsVisible.raw,
+      when: MultiLineEditsIsVisible.raw,
       priority: 100,
     });
 
@@ -46,7 +46,7 @@ export class IntelligentCompletionsContribution implements KeybindingContributio
       {
         command: AI_MULTI_LINE_COMPLETION_ACCEPT.id,
         keybinding: Key.TAB.code,
-        when: MultiLineCompletionsIsVisible.raw,
+        when: MultiLineEditsIsVisible.raw,
       },
       KeybindingScope.USER,
     );

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
@@ -376,7 +376,6 @@ export class IntelligentCompletionsHandler extends Disposable {
       currentLineNumber >= totalLines || (currentLineNumber++, (lineChangesMap[currentLineNumber] = []));
     };
 
-    // console.log("🚀 ~ IntelligentCompletionsHandler ~ wordChanges:", wordChanges)
     for (let changeIndex = 0; changeIndex < wordChanges.length; changeIndex++) {
       const currentChange = wordChanges[changeIndex];
       const { value: currentValue, added: isAdded, removed: isRemoved } = currentChange;
@@ -482,8 +481,6 @@ export class IntelligentCompletionsHandler extends Disposable {
       }
     }
 
-    // console.log("🚀 ~ IntelligentCompletionsHandler ~ lineChangesMap ~ lineChangesMap:", lineChangesMap)
-
     const allLineChanges = Object.values(lineChangesMap).map((lineChanges) => ({
       changes: lineChanges
         .map((change) => change.filter((item) => item.value.trim() !== empty))
@@ -495,13 +492,9 @@ export class IntelligentCompletionsHandler extends Disposable {
     if (allLineChanges.every(({ changes }) => changes.every((change) => change.every(({ removed }) => removed)))) {
       // 处理全是删除的情况
       this.rewriteWidget.renderTextLineThrough(range, allLineChanges);
-      // console.log("🚀 ~ IntelligentCompletionsHandler ~ allLineChanges:", allLineChanges)
     } else {
       this.rewriteWidget.renderVirtualEditor(newValue, range, wordChanges);
     }
-
-    // console.log("🚀 ~ IntelligentCompletionsHandler ~ showChangesOnTheRight ~ wordChanges:", wordChanges)
-    // console.log("🚀 ~ IntelligentCompletionsHandler ~ showChangesOnTheRight ~ lineChanges:", lineChanges)
   }
 
   public hide() {

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
@@ -57,7 +57,7 @@ export class IntelligentCompletionsHandler extends Disposable {
   }
 
   private rewriteWidget: RewriteWidget | null;
-  private whenMultiLineEditsVisibleDispose: Disposable = new Disposable();
+  private whenMultiLineEditsVisibleDisposable: Disposable = new Disposable();
 
   private disposeRewriteWidget() {
     if (this.rewriteWidget) {
@@ -147,12 +147,12 @@ export class IntelligentCompletionsHandler extends Disposable {
       this.renderRewriteWidget(wordChanges, model, range, insertTextString);
     }
 
-    if (this.whenMultiLineEditsVisibleDispose.disposed) {
-      this.whenMultiLineEditsVisibleDispose = new Disposable();
+    if (this.whenMultiLineEditsVisibleDisposable.disposed) {
+      this.whenMultiLineEditsVisibleDisposable = new Disposable();
     }
     if (this.aiNativeContextKey.multiLineEditsIsVisible.get()) {
       // 监听当前光标位置的变化，如果超出 range 区域则取消 multiLine edits
-      this.whenMultiLineEditsVisibleDispose.addDispose(
+      this.whenMultiLineEditsVisibleDisposable.addDispose(
         this.monacoEditor.onDidChangeCursorPosition((event: ICursorPositionChangedEvent) => {
           const position = event.position;
           if (position.lineNumber < range.startLineNumber || position.lineNumber > range.endLineNumber) {
@@ -262,13 +262,13 @@ export class IntelligentCompletionsHandler extends Disposable {
     );
 
     const multiLineEditsIsVisibleKey = new Set([MultiLineEditsIsVisible.raw]);
-    this.addDispose(this.whenMultiLineEditsVisibleDispose);
+    this.addDispose(this.whenMultiLineEditsVisibleDisposable);
     this.addDispose(
       this.aiNativeContextKey.contextKeyService!.onDidChangeContext((e) => {
         if (e.payload.affectsSome(multiLineEditsIsVisibleKey)) {
           const isVisible = this.aiNativeContextKey.multiLineEditsIsVisible.get();
           if (!isVisible) {
-            this.whenMultiLineEditsVisibleDispose.dispose();
+            this.whenMultiLineEditsVisibleDisposable.dispose();
           }
         }
       }),

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
@@ -150,19 +150,22 @@ export class IntelligentCompletionsHandler extends Disposable {
     if (this.whenMultiLineEditsVisibleDisposable.disposed) {
       this.whenMultiLineEditsVisibleDisposable = new Disposable();
     }
-    if (this.aiNativeContextKey.multiLineEditsIsVisible.get()) {
-      // 监听当前光标位置的变化，如果超出 range 区域则取消 multiLine edits
-      this.whenMultiLineEditsVisibleDisposable.addDispose(
-        this.monacoEditor.onDidChangeCursorPosition((event: ICursorPositionChangedEvent) => {
+    // 监听当前光标位置的变化，如果超出 range 区域则取消 multiLine edits
+    this.whenMultiLineEditsVisibleDisposable.addDispose(
+      this.monacoEditor.onDidChangeCursorPosition((event: ICursorPositionChangedEvent) => {
+        const isVisible = this.aiNativeContextKey.multiLineEditsIsVisible.get();
+        if (isVisible) {
           const position = event.position;
           if (position.lineNumber < range.startLineNumber || position.lineNumber > range.endLineNumber) {
             runWhenIdle(() => {
               this.hide();
             });
           }
-        }),
-      );
-    }
+        } else {
+          this.whenMultiLineEditsVisibleDisposable.dispose();
+        }
+      }),
+    );
   }
 
   private async renderRewriteWidget(

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.handler.ts
@@ -5,10 +5,9 @@ import {
   IAICompletionOption,
   IDisposable,
   IntelligentCompletionsRegistryToken,
-  isUndefined,
 } from '@opensumi/ide-core-common';
 import { IEditor } from '@opensumi/ide-editor';
-import { ICodeEditor, IRange, ITextModel, Position, Range, TrackedRangeStickiness } from '@opensumi/ide-monaco';
+import { ICodeEditor, IRange, ITextModel, Position } from '@opensumi/ide-monaco';
 import { empty } from '@opensumi/ide-utils/lib/strings';
 import { EditOperation } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/editOperation';
 
@@ -16,10 +15,14 @@ import { AINativeContextKey } from '../../contextkey/ai-native.contextkey.servic
 import { RewriteWidget } from '../../widget/rewrite/rewrite-widget';
 
 import { AdditionsDeletionsDecorationModel } from './additions-deletions.decoration';
-import { IMultiLineDiffChangeResult, MultiLineDiffComputer, RewriteDiffComputer } from './diff-computer';
+import {
+  IMultiLineDiffChangeResult,
+  computeMultiLineDiffChanges,
+  mergeMultiLineDiffChanges,
+  wordChangesToLineChangesMap,
+} from './diff-computer';
 import { IIntelligentCompletionsResult } from './intelligent-completions';
 import { IntelligentCompletionsRegistry } from './intelligent-completions.feature.registry';
-import styles from './intelligent-completions.module.less';
 import { MultiLineDecorationModel } from './multi-line.decoration';
 
 @Injectable()
@@ -37,9 +40,6 @@ export class IntelligentCompletionsHandler extends Disposable {
     this.cancelIndicator = new CancellationTokenSource();
   }
 
-  private multiLineDiffComputer: MultiLineDiffComputer = new MultiLineDiffComputer();
-  private rewriteDiffComputer: RewriteDiffComputer = new RewriteDiffComputer();
-
   private multiLineDecorationModel: MultiLineDecorationModel;
   private additionsDeletionsDecorationModel: AdditionsDeletionsDecorationModel;
 
@@ -55,151 +55,6 @@ export class IntelligentCompletionsHandler extends Disposable {
   }
 
   private rewriteWidget: RewriteWidget;
-
-  private mergeDiffChanges(lines: IMultiLineDiffChangeResult[], eol: string): IMultiLineDiffChangeResult[] {
-    const modifiedLines = lines.flatMap((line) => {
-      const segments = line.value.split(eol);
-      const wrap = (value: string): IMultiLineDiffChangeResult => ({ value, added: line.added, removed: line.removed });
-
-      return segments
-        .flatMap((segment, index) => {
-          if (index < segments.length - 1) {
-            return [wrap(segment), wrap(eol)];
-          }
-
-          return wrap(segment);
-        })
-        .filter((line) => line.value !== empty);
-    });
-
-    // 对处理后的结果进行调整，确保相邻的添加和删除操作合并
-    for (let i = 0; i < modifiedLines.length - 1; i++) {
-      const currentLine = modifiedLines[i];
-      const nextLine = modifiedLines[i + 1];
-      // 如果当前行是删除操作，下一行是添加操作，并且下一行的值以当前行的值开头，则合并这两个操作
-      if (currentLine.removed && nextLine.added && nextLine.value.startsWith(currentLine.value)) {
-        currentLine.added = true;
-        currentLine.removed = true;
-      }
-    }
-
-    return modifiedLines;
-  }
-
-  /**
-   * 根据原始内容和要修改的内容，返回字符级或单词级的差异
-   * @param originalContent 原始内容
-   * @param modifiedContent 修改后的内容
-   * @param lineNumber 行号
-   * @param eol 行结束符
-   * @returns
-   */
-  private getChanges(originalContent: string, modifiedContent: string, lineNumber: number, eol: string) {
-    let rewriteDiffResult: IMultiLineDiffChangeResult[] =
-      this.rewriteDiffComputer.diff(originalContent, modifiedContent) || [];
-    let multiLineDiffResult: IMultiLineDiffChangeResult[] =
-      this.multiLineDiffComputer.diff(originalContent, modifiedContent) || [];
-
-    let isModified = false;
-
-    const originalLines = originalContent.split(eol);
-    const modifiedLines = modifiedContent.split(eol);
-
-    try {
-      if (
-        !isModified &&
-        originalLines.length === modifiedLines.length &&
-        originalLines.every((value, index) => modifiedLines[index].startsWith(value))
-      ) {
-        isModified = true;
-        multiLineDiffResult = originalLines
-          .map((value, index) => {
-            const modifiedLine = modifiedLines[index];
-            const diffElements: IMultiLineDiffChangeResult[] = [
-              {
-                value,
-              },
-            ];
-
-            if (modifiedLine !== value) {
-              const addedPart = modifiedLine.substring(value.length);
-              diffElements.push({
-                value: addedPart,
-                added: true,
-              });
-              diffElements.push({
-                value: eol,
-              });
-            } else {
-              diffElements[0].value = diffElements[0].value + eol;
-            }
-            return diffElements;
-          })
-          .flat();
-      }
-
-      const currentCursorPosition = this.monacoEditor.getPosition();
-      const lineAndColumn = {
-        lineNumber: (currentCursorPosition?.lineNumber ?? 1) - lineNumber + 1,
-        column: currentCursorPosition?.column ?? 1,
-      };
-
-      if (!isModified && !isUndefined(currentCursorPosition) && lineAndColumn) {
-        const prefix = originalLines.slice(0, lineAndColumn.lineNumber - 1).join(eol);
-        const linePrefix = originalLines[lineAndColumn.lineNumber - 1].slice(0, lineAndColumn.column - 1);
-
-        const prefixMatch = prefix === modifiedLines.slice(0, lineAndColumn.lineNumber - 1).join(eol);
-        const linePrefixMatch =
-          linePrefix === modifiedLines[lineAndColumn.lineNumber - 1].slice(0, lineAndColumn.column - 1);
-
-        if (prefixMatch && linePrefixMatch) {
-          const modifiedContent =
-            modifiedLines[lineAndColumn.lineNumber - 1].slice(lineAndColumn.column - 1) +
-            eol +
-            modifiedLines.slice(lineAndColumn.lineNumber).join(eol);
-          const originalContent =
-            originalLines[lineAndColumn.lineNumber - 1].slice(lineAndColumn.column - 1) +
-            eol +
-            originalLines.slice(lineAndColumn.lineNumber).join(eol);
-          const commonPrefix =
-            prefix + (originalLines.slice(0, lineAndColumn.lineNumber - 1).length > 0 ? eol : empty) + linePrefix;
-
-          if (modifiedContent.endsWith(originalContent)) {
-            isModified = true;
-            const modifiedContentPrefix = modifiedContent.slice(0, modifiedContent.length - originalContent.length);
-            multiLineDiffResult = [
-              {
-                value: commonPrefix,
-              },
-              {
-                value: modifiedContentPrefix,
-                added: true,
-              },
-              {
-                value: originalContent,
-              },
-            ];
-          }
-        }
-      }
-    } catch (error) {
-      // error
-    }
-
-    const mergeRewriteLine = this.mergeDiffChanges(rewriteDiffResult, eol);
-    const isOnlyAddingToEachWord = !mergeRewriteLine.some(
-      (item) => item.added !== true && item.removed === true && item.value !== eol,
-    );
-
-    const mergeMultiLine = this.mergeDiffChanges(multiLineDiffResult, eol);
-
-    return {
-      singleLineCharChanges: mergeMultiLine,
-      charChanges: multiLineDiffResult,
-      wordChanges: rewriteDiffResult,
-      isOnlyAddingToEachWord,
-    };
-  }
 
   public async fetchProvider(bean: IAICompletionOption): Promise<IIntelligentCompletionsResult | undefined> {
     const provider = this.intelligentCompletionsRegistry.getProvider();
@@ -237,7 +92,13 @@ export class IntelligentCompletionsHandler extends Disposable {
     const originalContent = model?.getValueInRange(range);
     const eol = this.model.getEOL();
 
-    const changes = this.getChanges(originalContent!, insertTextString, range.startLineNumber, eol);
+    const changes = computeMultiLineDiffChanges(
+      originalContent!,
+      insertTextString,
+      this.monacoEditor,
+      range.startLineNumber,
+      eol,
+    );
 
     if (!changes) {
       return;
@@ -245,240 +106,56 @@ export class IntelligentCompletionsHandler extends Disposable {
 
     const { singleLineCharChanges, charChanges, wordChanges, isOnlyAddingToEachWord } = changes;
 
-    let isEOLAdded = false;
-    let isMiddle = false;
-    let isEnd = false;
-
-    for (const change of singleLineCharChanges) {
-      if (change.added && change.value === eol) {
-        isEnd = true;
-        if (!change.added && !change.removed) {
-          if (change.value === eol) {
-            isMiddle = false;
-            isEnd = false;
-          } else {
-            if (isMiddle && isEnd) {
-              isEOLAdded = true;
-              break;
-            }
-            isMiddle = true;
-          }
-        }
-      }
-    }
-
-    const startOffset = this.model.getOffsetAt(
-      Position.lift({ lineNumber: range.startLineNumber, column: range.startColumn }),
-    );
-    const endOffset = this.model.getOffsetAt(
-      Position.lift({ lineNumber: range.endLineNumber, column: range.endColumn }),
-    );
+    const startOffset = this.model.getOffsetAt({ lineNumber: range.startLineNumber, column: range.startColumn });
+    const endOffset = this.model.getOffsetAt({ lineNumber: range.endLineNumber, column: range.endColumn });
     const allText = this.model.getValue();
     // 这里是为了能在 rewrite widget 的 editor 当中完整的复用代码高亮与语法检测的能力
     const newValue = allText.substring(0, startOffset) + insertText + allText.substring(endOffset);
 
-    if (position && isOnlyAddingToEachWord && !isEOLAdded && charChanges.length <= 20 && wordChanges.length <= 20) {
+    // 限制 change 数量，超过这个数量直接显示智能重写
+    const maxCharChanges = 20;
+    const maxWordChanges = 20;
+
+    if (
+      position &&
+      isOnlyAddingToEachWord &&
+      charChanges.length <= maxCharChanges &&
+      wordChanges.length <= maxWordChanges
+    ) {
       const modificationsResult = this.multiLineDecorationModel.applyInlineDecorations(
         this.monacoEditor,
-        this.mergeDiffChanges(singleLineCharChanges, eol),
+        mergeMultiLineDiffChanges(singleLineCharChanges, eol),
         position.lineNumber,
         position,
       );
+
       if (!modificationsResult) {
         this.aiNativeContextKey.multiLineCompletionsIsVisible.reset();
         this.multiLineDecorationModel.clearDecorations();
-        this.showChangesOnTheRight(wordChanges, model, eol, range, newValue);
+        this.showChangesOnTheRight(wordChanges, model, range, newValue);
       } else if (modificationsResult && modificationsResult.inlineMods) {
         this.aiNativeContextKey.multiLineCompletionsIsVisible.set(true);
         this.multiLineDecorationModel.updateLineModificationDecorations(modificationsResult.inlineMods);
       }
     } else {
-      const deletionRanges = this.additionsDeletionsDecorationModel.generateRange(
-        wordChanges.map((change) => {
-          const value = change.value;
-
-          if (change.removed) {
-            return { value, added: true };
-          } else if (change.added) {
-            return { value, removed: true };
-          }
-
-          return change;
-        }),
-        range,
-        eol,
-      );
-
-      this.additionsDeletionsDecorationModel.setDeletionsDecoration(
-        deletionRanges.map((range) => ({
-          range,
-          options: {
-            description: 'suggestion_deletions_background',
-            className: styles.suggestion_deletions_background,
-            stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-          },
-        })),
-      );
-
-      this.showChangesOnTheRight(wordChanges, model, eol, range, newValue);
+      this.additionsDeletionsDecorationModel.updateDeletionsDecoration(wordChanges, range, eol);
+      this.showChangesOnTheRight(wordChanges, model, range, newValue);
     }
   }
 
   private showChangesOnTheRight(
     wordChanges: IMultiLineDiffChangeResult[],
     model: ITextModel | null,
-    eol: string,
     range: IRange,
     newValue: string,
   ) {
-    const lineChangesMap: { [lineNumber in number]: IMultiLineDiffChangeResult[][] } = {};
-    let currentLineNumber = range.startLineNumber;
+    const lineChangesMap = wordChangesToLineChangesMap(wordChanges, range, model);
 
     this.rewriteWidget.hide();
 
     const cursorPosition = this.monacoEditor.getPosition();
     if (!cursorPosition) {
       return;
-    }
-
-    const getLastLineChanges = () => {
-      if (!lineChangesMap[currentLineNumber]) {
-        lineChangesMap[currentLineNumber] = [];
-      }
-      const lastLineIndex = lineChangesMap[currentLineNumber].length - 1;
-      if (lastLineIndex < 0) {
-        lineChangesMap[currentLineNumber][0] = [];
-        return lineChangesMap[currentLineNumber][0];
-      }
-      let lastLineChanges = lineChangesMap[currentLineNumber][lastLineIndex];
-      if (!lastLineChanges) {
-        lineChangesMap[currentLineNumber][lastLineIndex] = [];
-        lastLineChanges = lineChangesMap[currentLineNumber][lastLineIndex];
-      }
-      return lastLineChanges;
-    };
-
-    const addNewLineChanges = (change: IMultiLineDiffChangeResult) => {
-      const currentLineChanges = lineChangesMap[currentLineNumber];
-      if (!currentLineChanges) {
-        lineChangesMap[currentLineNumber] = [[change]];
-        return;
-      }
-      currentLineChanges.push([change]);
-    };
-
-    const pushToLastLineChanges = (change: IMultiLineDiffChangeResult) => {
-      getLastLineChanges().push(change);
-    };
-
-    const moveNextLine = () => {
-      const totalLines = model?.getLineCount() ?? 1;
-      currentLineNumber >= totalLines || (currentLineNumber++, (lineChangesMap[currentLineNumber] = []));
-    };
-
-    for (let changeIndex = 0; changeIndex < wordChanges.length; changeIndex++) {
-      const currentChange = wordChanges[changeIndex];
-      const { value: currentValue, added: isAdded, removed: isRemoved } = currentChange;
-      const splitValue = currentValue.split(eol);
-      if (isAdded) {
-        if (changeIndex === 0) {
-          const previousLine = range.startLineNumber - 1;
-          const previousLineContent = model!.getLineContent(previousLine);
-          lineChangesMap[previousLine] = [
-            [
-              {
-                value: previousLineContent,
-              },
-            ],
-            ...currentChange.value.split(eol).map((segment) => [
-              {
-                value: segment,
-                added: true,
-              },
-            ]),
-          ];
-          continue;
-        }
-        for (let segmentIndex = 0; segmentIndex < splitValue.length; segmentIndex++) {
-          const currentSegment = splitValue[segmentIndex];
-          if (segmentIndex === 0) {
-            pushToLastLineChanges({
-              value: currentSegment,
-              added: isAdded,
-              removed: isRemoved,
-            });
-            continue;
-          }
-          segmentIndex === splitValue.length - 1 && changeIndex !== wordChanges.length - 1 && moveNextLine(),
-            addNewLineChanges({
-              value: currentSegment,
-              added: isAdded,
-              removed: isRemoved,
-            });
-        }
-        continue;
-      }
-      if (isRemoved) {
-        if (currentValue.replace(/\r?\n/g, empty) === empty) {
-          continue;
-        }
-        for (let segmentIndex = 0; segmentIndex < splitValue.length; segmentIndex++) {
-          const currentSegment = splitValue[segmentIndex];
-          if (segmentIndex === 0) {
-            pushToLastLineChanges({
-              value: currentSegment,
-              added: isAdded,
-              removed: isRemoved,
-            });
-            continue;
-          }
-          currentSegment !== empty &&
-            (moveNextLine(),
-            addNewLineChanges({
-              value: currentSegment,
-              added: isAdded,
-              removed: isRemoved,
-            }));
-        }
-        continue;
-      }
-      if (currentValue === eol) {
-        const previousChange = wordChanges[changeIndex - 1];
-        if (previousChange && previousChange.added && previousChange.value.includes(eol)) {
-          const lastLineChanges = getLastLineChanges();
-          const lastChange = lastLineChanges.pop();
-          lastLineChanges.length === 0 && currentLineNumber > 0 && lineChangesMap[currentLineNumber--].pop(),
-            addNewLineChanges({
-              value: lastChange?.value ?? empty,
-              added: true,
-            });
-          continue;
-        }
-      }
-      for (let segmentIndex = 0; segmentIndex < splitValue.length; segmentIndex++) {
-        const currentSegment = splitValue[segmentIndex];
-        if (segmentIndex === 0) {
-          pushToLastLineChanges({
-            value: currentSegment,
-            added: isAdded,
-            removed: isRemoved,
-          });
-          continue;
-        }
-        if (segmentIndex !== splitValue.length - 1) {
-          moveNextLine();
-        } else {
-          const nextChange = wordChanges[changeIndex + 1];
-          nextChange &&
-            (nextChange.removed || (nextChange.added && currentSegment !== empty && !nextChange.value.includes(eol))) &&
-            moveNextLine();
-        }
-        addNewLineChanges({
-          value: currentSegment,
-          added: isAdded,
-          removed: isRemoved,
-        });
-      }
     }
 
     const allLineChanges = Object.values(lineChangesMap).map((lineChanges) => ({

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.module.less
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.module.less
@@ -1,0 +1,4 @@
+.suggestion_deletions_background {
+  background-color: var(--editorError-foreground) !important;
+  opacity: 0.17;
+}

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.module.less
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.module.less
@@ -1,4 +1,7 @@
 .suggestion_deletions_background {
-  background-color: var(--editorError-foreground) !important;
-  opacity: 0.17;
+  background-color: var(--aiNative-multiLineEditsDeletionsBackground) !important;
+}
+
+.suggestion_additions_background {
+  background-color: var(--aiNative-multiLineEditsAdditionsBackground) !important;
 }

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/multi-line.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/multi-line.decoration.ts
@@ -5,7 +5,7 @@ import { LineDecoration } from '@opensumi/monaco-editor-core/esm/vs/editor/commo
 
 import { EnhanceDecorationsCollection } from '../../model/enhanceDecorationsCollection';
 
-import { IDiffChangeResult } from './diff-computer';
+import { IMultiLineDiffChangeResult } from './diff-computer';
 
 export interface IModificationsInline {
   newValue: string;
@@ -49,10 +49,10 @@ export class MultiLineDecorationModel {
   /**
    * 切割 diff 计算结果的换行符
    */
-  private splitDiffChanges(lines: IDiffChangeResult[], eol: string): IDiffChangeResult[] {
+  private splitDiffChanges(lines: IMultiLineDiffChangeResult[], eol: string): IMultiLineDiffChangeResult[] {
     const modifiedLines = lines.flatMap((line) => {
       const segments = line.value.split(eol);
-      const wrap = (value: string): IDiffChangeResult => ({ value, added: line.added, removed: line.removed });
+      const wrap = (value: string): IMultiLineDiffChangeResult => ({ value, added: line.added, removed: line.removed });
 
       return segments
         .flatMap((segment, index) => {
@@ -102,8 +102,8 @@ export class MultiLineDecorationModel {
   private processLineModifications(
     waitAddModificationsLines: IModificationsInline[],
     eol: string,
-    previous: IDiffChangeResult,
-    next?: IDiffChangeResult,
+    previous: IMultiLineDiffChangeResult,
+    next?: IMultiLineDiffChangeResult,
     includeInline = true,
   ) {
     const lines = this.combineContinuousMods(waitAddModificationsLines);
@@ -232,7 +232,7 @@ export class MultiLineDecorationModel {
 
   public applyInlineDecorations(
     editor: ICodeEditor,
-    changes: IDiffChangeResult[],
+    changes: IMultiLineDiffChangeResult[],
     startLine: number,
     cursorPosition: IPosition,
   ): IModificationsInlineAndMap | undefined {
@@ -259,12 +259,12 @@ export class MultiLineDecorationModel {
 
     let previousValue = empty;
     let isEmptyLine = currentLineText.trim() === empty;
-    let lastChange: IDiffChangeResult;
+    let lastChange: IMultiLineDiffChangeResult;
     let waitAddModificationsLines: IModificationsInline[] = [];
     let currentLineIndex = currentLine;
     let columnNumber = 1;
 
-    const processChange = (change: IDiffChangeResult | undefined) => {
+    const processChange = (change: IMultiLineDiffChangeResult | undefined) => {
       const isUniqueLine = !resultModifications.some(
         (modification) => modification.lineNumber === currentLine && modification.lockLineGhostText,
       );

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
@@ -1,0 +1,16 @@
+.rewrite_widget_container {
+  border: 1px solid var(--panel-border);
+  overflow: hidden;
+  user-select: none;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+
+  .virtual_editor_container {
+    height: inherit;
+  }
+}
+
+.ghost_text_decoration_inline_add {
+  background-color: var(--vscode-diffEditor-insertedTextBackground) !important;
+}

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
@@ -11,6 +11,39 @@
   }
 }
 
+.deletions_code_line {
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+
+  .space_span {
+    display: inline-block;
+  }
+
+  .text_span {
+    white-space: nowrap;
+  }
+}
+
 .ghost_text_decoration_inline_add {
-  background-color: var(--vscode-diffEditor-insertedTextBackground) !important;
+  background-color: var(--diffEditor-insertedTextBackground) !important;
+}
+
+.ghost_text_decoration_remove {
+  opacity: 0.2;
+}
+
+.ghost_text_decoration_inline_remove {
+  opacity: 0.2;
+  text-decoration: line-through;
+}
+
+.ghost_text_decoration_inline_add {
+  background-color: var(--diffEditor-insertedTextBackground) !important;
+}
+
+.ghost_text_decoration {
+  background-color: var(--editorGhostText-background);
+  border: 1px solid var(--editorGhostText-border);
+  color: var(--editorGhostText-foreground) !important;
 }

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
@@ -26,7 +26,7 @@
 }
 
 .ghost_text_decoration_inline_add {
-  background-color: var(--diffEditor-insertedTextBackground) !important;
+  background-color: var(--aiNative-multiLineEditsAdditionsBackground) !important;
 }
 
 .ghost_text_decoration_remove {
@@ -36,10 +36,6 @@
 .ghost_text_decoration_inline_remove {
   opacity: 0.2;
   text-decoration: line-through;
-}
-
-.ghost_text_decoration_inline_add {
-  background-color: var(--diffEditor-insertedTextBackground) !important;
 }
 
 .ghost_text_decoration {

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.module.less
@@ -26,7 +26,7 @@
 }
 
 .ghost_text_decoration_inline_add {
-  background-color: var(--aiNative-multiLineEditsAdditionsBackground) !important;
+  background-color: var(--aiNative-multiLineEditsAdditionsBackground);
 }
 
 .ghost_text_decoration_remove {
@@ -41,5 +41,5 @@
 .ghost_text_decoration {
   background-color: var(--editorGhostText-background);
   border: 1px solid var(--editorGhostText-border);
-  color: var(--editorGhostText-foreground) !important;
+  color: var(--editorGhostText-foreground);
 }

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -141,7 +141,7 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
         }
       });
 
-      setEditorSize({ width: maxColumnWidth * spaceWidth, height: lineHeight * lineCount });
+      setEditorSize({ width: maxColumnWidth * spaceWidth, height: lineHeight * (lineCount + 1) });
     },
     [editorSize, editor],
   );
@@ -190,11 +190,13 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
         const modelService = StandaloneServices.get(IModelService);
         const languageSelection: ILanguageSelection = { languageId: model.getLanguageId(), onDidChange: Event.None };
 
-        const virtualModel = modelService.createModel(newValue, languageSelection);
+        const virtualModel = modelService.createModel('', languageSelection);
         _virtualEditor.setModel(virtualModel);
 
         setVirtualEditor(_virtualEditor);
       }
+
+      _virtualEditor.setValue(newValue);
 
       changeDecorations(_virtualEditor, range, wordChanges);
     },

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -244,7 +244,7 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
           let isOnlySpaces = true;
           let removedText = '';
           let textLength = 0;
-          const lineElements: React.ReactElement[] = [];
+          const lineElements: React.JSX.Element[] = [];
 
           for (const item of change) {
             const { value, added, removed } = item;

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef } from 'react';
+
+import { Injectable } from '@opensumi/di';
+import { Event, MonacoService, useInjectable } from '@opensumi/ide-core-browser';
+import * as monaco from '@opensumi/ide-monaco';
+import { ICodeEditor } from '@opensumi/ide-monaco';
+import { ReactInlineContentWidget } from '@opensumi/ide-monaco/lib/browser/ai-native/BaseInlineContentWidget';
+import { IEditorOptions } from '@opensumi/ide-monaco/lib/browser/monaco-api/editor';
+import { ILanguageSelection } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
+import { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
+import { IModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/services/model';
+import { StandaloneServices } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
+
+const editorOptions: IEditorOptions = {
+  fixedOverflowWidgets: true,
+  readOnly: false,
+  lineNumbers: 'on',
+  glyphMargin: true,
+
+  scrollBeyondLastLine: false,
+  rulers: undefined,
+  overviewRulerBorder: undefined,
+  overviewRulerLanes: 0,
+  padding: { top: 0, bottom: 0 },
+  folding: false,
+  stickyScroll: { enabled: false },
+  minimap: { enabled: false },
+  automaticLayout: true,
+
+  scrollbar: {
+    horizontal: void 0,
+    vertical: void 0,
+    horizontalScrollbarSize: 0,
+    verticalScrollbarSize: 0,
+    arrowSize: 0,
+    verticalSliderSize: 0,
+    horizontalSliderSize: 0,
+    ignoreHorizontalScrollbarInContentHeight: true,
+  },
+  hover: {
+    enabled: false,
+  },
+};
+
+interface IVirtualEditorHandler {
+  getVirtualModel: () => monaco.editor.ITextModel;
+}
+
+interface IVirtualEditorProviderProps {
+  editor: ICodeEditor;
+  onReady?: (handler: IVirtualEditorHandler) => void;
+}
+
+const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) => {
+  const { editor, onReady } = props;
+  const monacoService: MonacoService = useInjectable(MonacoService);
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const model: ITextModel | null = editor.getModel();
+
+    if (!model) {
+      return;
+    }
+
+    const virtualEditor = monacoService.createCodeEditor(editorRef.current!, {
+      ...editorOptions,
+      lineDecorationsWidth: editor.getLayoutInfo().decorationsWidth,
+      lineNumbersMinChars: editor.getOption(monaco.editor.EditorOption.lineNumbersMinChars),
+    });
+
+    const modelService = StandaloneServices.get(IModelService);
+    const languageSelection: ILanguageSelection = { languageId: model.getLanguageId(), onDidChange: Event.None };
+
+    const virtualModel = modelService.createModel('', languageSelection);
+
+    virtualEditor.setModel(virtualModel);
+
+    if (onReady) {
+      onReady({
+        getVirtualModel: () => virtualModel,
+      });
+    }
+
+    return () => {
+      if (virtualEditor) {
+        virtualEditor.dispose();
+      }
+    };
+  }, [editor]);
+
+  return <div ref={editorRef}></div>;
+});
+
+@Injectable({ multiple: true })
+export class RewriteWidget extends ReactInlineContentWidget {
+  private virtualModel: monaco.editor.ITextModel | null = null;
+
+  public renderView(): React.ReactNode {
+    return (
+      <VirtualEditorProvider
+        editor={this.editor}
+        onReady={(handler) => {
+          this.virtualModel = handler.getVirtualModel();
+        }}
+      />
+    );
+  }
+  public id(): string {
+    return 'RewriteWidget';
+  }
+
+  public getModel(): ITextModel {
+    return this.virtualModel!;
+  }
+}

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -1,21 +1,30 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Injectable } from '@opensumi/di';
 import { Event, MonacoService, useInjectable } from '@opensumi/ide-core-browser';
 import * as monaco from '@opensumi/ide-monaco';
 import { ICodeEditor } from '@opensumi/ide-monaco';
-import { ReactInlineContentWidget } from '@opensumi/ide-monaco/lib/browser/ai-native/BaseInlineContentWidget';
+import {
+  ReactInlineContentWidget,
+  ShowAIContentOptions,
+} from '@opensumi/ide-monaco/lib/browser/ai-native/BaseInlineContentWidget';
 import { IEditorOptions } from '@opensumi/ide-monaco/lib/browser/monaco-api/editor';
+import { space } from '@opensumi/ide-utils/lib/strings';
 import { ILanguageSelection } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
 import { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
 import { IModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/services/model';
 import { StandaloneServices } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 
+import { IMultiLineDiffChangeResult } from '../../contrib/intelligent-completions/diff-computer';
+
+import styles from './rewrite-widget.module.less';
+
 const editorOptions: IEditorOptions = {
   fixedOverflowWidgets: true,
-  readOnly: false,
-  lineNumbers: 'on',
-  glyphMargin: true,
+  readOnly: true,
+  domReadOnly: true,
+  lineNumbers: 'off',
+  glyphMargin: false,
 
   scrollBeyondLastLine: false,
   rulers: undefined,
@@ -28,8 +37,8 @@ const editorOptions: IEditorOptions = {
   automaticLayout: true,
 
   scrollbar: {
-    horizontal: void 0,
-    vertical: void 0,
+    horizontal: 'hidden',
+    vertical: 'hidden',
     horizontalScrollbarSize: 0,
     verticalScrollbarSize: 0,
     arrowSize: 0,
@@ -40,10 +49,14 @@ const editorOptions: IEditorOptions = {
   hover: {
     enabled: false,
   },
+  guides: {
+    indentation: false,
+  },
 };
 
 interface IVirtualEditorHandler {
-  getVirtualModel: () => monaco.editor.ITextModel;
+  getVirtualEditor: () => ICodeEditor;
+  changeDecorations: (range: monaco.IRange, wordChanges: IMultiLineDiffChangeResult[]) => void;
 }
 
 interface IVirtualEditorProviderProps {
@@ -55,6 +68,84 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
   const { editor, onReady } = props;
   const monacoService: MonacoService = useInjectable(MonacoService);
   const editorRef = useRef<HTMLDivElement>(null);
+  const [editorSize, setEditorSize] = useState({ width: 300, height: 60 });
+  const [marginLeft, setMarginLeft] = useState(0);
+
+  const changeDecorations = useCallback(
+    (virtualEditor: ICodeEditor, range: monaco.IRange, wordChanges: IMultiLineDiffChangeResult[]): void => {
+      const eol = editor.getModel()!.getEOL();
+
+      let currentLineNumber = range.startLineNumber;
+      let currentColumn = range.startColumn;
+
+      const virtualModel = virtualEditor.getModel()!;
+
+      virtualEditor.changeDecorations((decorations) => {
+        if (virtualEditor) {
+          virtualModel
+            .getAllDecorations()
+            .map((decoration) => decoration.id)
+            .forEach((decorationId) => decorations.removeDecoration(decorationId));
+
+          for (const change of wordChanges) {
+            if (change.removed) {
+              continue;
+            }
+            const lines = change.value.split(eol);
+            for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+              const line = lines[lineIndex];
+              if (lineIndex !== 0) {
+                currentLineNumber++;
+                currentColumn = 1;
+              }
+              if (change.added) {
+                decorations.addDecoration(
+                  new monaco.Range(currentLineNumber, currentColumn, currentLineNumber, currentColumn + line.length),
+                  {
+                    description: 'ghost-text-decoration',
+                    className: styles.ghost_text_decoration_inline_add,
+                  },
+                );
+              }
+              currentColumn += line.length;
+            }
+          }
+        }
+      });
+
+      const lineHeight = virtualEditor!.getOption(monaco.editor.EditorOption.lineHeight);
+      virtualEditor?.setScrollTop(Math.max(range.startLineNumber - 1, 0) * lineHeight);
+
+      const lineCount = currentLineNumber - range.startLineNumber;
+      const spaceWidth = virtualEditor!.getOption(monaco.editor.EditorOption.fontInfo).spaceWidth;
+      let maxColumnWidth = 0;
+      const tabSize = virtualModel.getOptions().tabSize;
+      Array.from(
+        {
+          length: lineCount + 1,
+        },
+        (_, index) => range.startLineNumber + index,
+      ).forEach((lineNumber) => {
+        const lineContent = virtualModel.getLineContent(lineNumber);
+        let columnWidth = 0;
+        for (const char of lineContent) {
+          char === space ? (columnWidth += tabSize) : (columnWidth += 1);
+          maxColumnWidth = Math.max(maxColumnWidth, columnWidth);
+        }
+      });
+      setEditorSize({ width: maxColumnWidth * spaceWidth, height: lineHeight * lineCount });
+
+      let maxLineColumn = 0;
+      for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
+        const lineMaxColumn = virtualModel.getLineMaxColumn(lineNumber);
+        maxLineColumn = Math.max(maxLineColumn, lineMaxColumn);
+      }
+      setMarginLeft(maxLineColumn * spaceWidth + 10);
+
+      // console.log("🚀 ~ RewriteWidget ~ changeDecorations ~ this.editorSize:", Ke * Se, Ee * Ve)
+    },
+    [editorSize, editor],
+  );
 
   useEffect(() => {
     const model: ITextModel | null = editor.getModel();
@@ -63,11 +154,7 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
       return;
     }
 
-    const virtualEditor = monacoService.createCodeEditor(editorRef.current!, {
-      ...editorOptions,
-      lineDecorationsWidth: editor.getLayoutInfo().decorationsWidth,
-      lineNumbersMinChars: editor.getOption(monaco.editor.EditorOption.lineNumbersMinChars),
-    });
+    const virtualEditor = monacoService.createCodeEditor(editorRef.current!, editorOptions);
 
     const modelService = StandaloneServices.get(IModelService);
     const languageSelection: ILanguageSelection = { languageId: model.getLanguageId(), onDidChange: Event.None };
@@ -78,7 +165,8 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
 
     if (onReady) {
       onReady({
-        getVirtualModel: () => virtualModel,
+        getVirtualEditor: () => virtualEditor,
+        changeDecorations: (range, wordChanges) => changeDecorations(virtualEditor, range, wordChanges),
       });
     }
 
@@ -87,21 +175,28 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
         virtualEditor.dispose();
       }
     };
-  }, [editor]);
+  }, [editor, onReady]);
 
-  return <div ref={editorRef}></div>;
+  return (
+    <div
+      className={styles.rewrite_widget_container}
+      style={{ width: editorSize.width, height: editorSize.height, marginLeft }}
+    >
+      <div className={styles.virtual_editor_container} ref={editorRef}></div>;
+    </div>
+  );
 });
 
 @Injectable({ multiple: true })
 export class RewriteWidget extends ReactInlineContentWidget {
-  private virtualModel: monaco.editor.ITextModel | null = null;
+  private virtualEditorHandler: IVirtualEditorHandler | null = null;
 
   public renderView(): React.ReactNode {
     return (
       <VirtualEditorProvider
         editor={this.editor}
         onReady={(handler) => {
-          this.virtualModel = handler.getVirtualModel();
+          this.virtualEditorHandler = handler;
         }}
       />
     );
@@ -110,7 +205,26 @@ export class RewriteWidget extends ReactInlineContentWidget {
     return 'RewriteWidget';
   }
 
-  public getModel(): ITextModel {
-    return this.virtualModel!;
+  public getVirtualEditor(): ICodeEditor {
+    return this.virtualEditorHandler!.getVirtualEditor();
+  }
+
+  override show(options: ShowAIContentOptions): void {
+    const { position } = options;
+
+    if (!position) {
+      return;
+    }
+
+    const { lineNumber } = position;
+
+    // const model = this.editor.getModel();
+    // const maxLine = model?.getLineMaxColumn(lineNumber) || Number.MAX_SAFE_INTEGER;
+
+    super.show({ position: monaco.Position.lift({ lineNumber, column: 1 }) });
+  }
+
+  public changeDecorations(range: monaco.IRange, wordChanges: IMultiLineDiffChangeResult[]): void {
+    this.virtualEditorHandler!.changeDecorations(range, wordChanges);
   }
 }

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -240,53 +240,57 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
           <span className={cls(styles.text_span, className)}>{textContent}</span>
         );
 
-        return changes.map((change, index) => {
-          let isOnlySpaces = true;
-          let removedText = '';
-          let textLength = 0;
-          const lineElements: React.JSX.Element[] = [];
+        return (
+          <React.Fragment>
+            {changes.map((change, index) => {
+              let isOnlySpaces = true;
+              let removedText = '';
+              let textLength = 0;
+              const lineElements: React.JSX.Element[] = [];
 
-          for (const item of change) {
-            const { value, added, removed } = item;
-            if (removed) {
-              removedText += value;
-            } else {
-              isOnlySpaces = false;
-              textLength += value.length;
-              const leadingSpaces = value.length - value.trimStart().length;
-              const trailingSpaces = value.length - value.trimEnd().length;
-              const trimmedValue = value.trim();
+              for (const item of change) {
+                const { value, added, removed } = item;
+                if (removed) {
+                  removedText += value;
+                } else {
+                  isOnlySpaces = false;
+                  textLength += value.length;
+                  const leadingSpaces = value.length - value.trimStart().length;
+                  const trailingSpaces = value.length - value.trimEnd().length;
+                  const trimmedValue = value.trim();
 
-              lineElements.push(createSpaceSpan(leadingSpaces));
-              if (trimmedValue) {
-                lineElements.push(
-                  createTextSpan(
-                    trimmedValue,
-                    added ? styles.ghost_text_decoration_inline_add : styles.ghost_text_decoration,
-                  ),
-                );
-                lineElements.push(createSpaceSpan(trailingSpaces));
+                  lineElements.push(createSpaceSpan(leadingSpaces));
+                  if (trimmedValue) {
+                    lineElements.push(
+                      createTextSpan(
+                        trimmedValue,
+                        added ? styles.ghost_text_decoration_inline_add : styles.ghost_text_decoration,
+                      ),
+                    );
+                    lineElements.push(createSpaceSpan(trailingSpaces));
+                  }
+                }
               }
-            }
-          }
 
-          if (isOnlySpaces) {
-            const leadingSpaces = removedText.length - removedText.trimStart().length;
-            const trailingSpaces = removedText.length - removedText.trimEnd().length;
-            const trimmedRemovedText = removedText.trim();
-            lineElements.push(createSpaceSpan(leadingSpaces, styles.ghost_text_decoration_remove));
-            if (trimmedRemovedText) {
-              lineElements.push(createTextSpan(trimmedRemovedText, styles.ghost_text_decoration_inline_remove));
-              lineElements.push(createSpaceSpan(trailingSpaces, styles.ghost_text_decoration_inline_remove));
-            }
-          }
+              if (isOnlySpaces) {
+                const leadingSpaces = removedText.length - removedText.trimStart().length;
+                const trailingSpaces = removedText.length - removedText.trimEnd().length;
+                const trimmedRemovedText = removedText.trim();
+                lineElements.push(createSpaceSpan(leadingSpaces, styles.ghost_text_decoration_remove));
+                if (trimmedRemovedText) {
+                  lineElements.push(createTextSpan(trimmedRemovedText, styles.ghost_text_decoration_inline_remove));
+                  lineElements.push(createSpaceSpan(trailingSpaces, styles.ghost_text_decoration_inline_remove));
+                }
+              }
 
-          return (
-            <div key={index} className={styles.deletions_code_line} style={{ height: `${lineHeight}px` }}>
-              {lineElements}
-            </div>
-          );
-        });
+              return (
+                <div key={index} className={styles.deletions_code_line} style={{ height: `${lineHeight}px` }}>
+                  {lineElements}
+                </div>
+              );
+            })}
+          </React.Fragment>
+        );
       };
 
       if (refRoot.current) {
@@ -296,11 +300,11 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
 
       refRoot.current = ReactDOMClient.createRoot(ref.current);
       refRoot.current.render(
-        <>
+        <React.Fragment>
           {lineChanges.map((lineChange, index) => (
             <LineElement key={index} changes={lineChange.changes} />
           ))}
-        </>,
+        </React.Fragment>,
       );
     },
     [editor, ref, virtualEditor, refRoot],

--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -9,6 +9,7 @@ import {
   ShowAIContentOptions,
 } from '@opensumi/ide-monaco/lib/browser/ai-native/BaseInlineContentWidget';
 import { IEditorOptions } from '@opensumi/ide-monaco/lib/browser/monaco-api/editor';
+import { ContentWidgetPositionPreference } from '@opensumi/ide-monaco/lib/browser/monaco-exports/editor';
 import { space } from '@opensumi/ide-utils/lib/strings';
 import { ILanguageSelection } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
 import { ITextModel } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
@@ -133,6 +134,7 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
           maxColumnWidth = Math.max(maxColumnWidth, columnWidth);
         }
       });
+
       setEditorSize({ width: maxColumnWidth * spaceWidth, height: lineHeight * lineCount });
 
       let maxLineColumn = 0;
@@ -141,8 +143,6 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
         maxLineColumn = Math.max(maxLineColumn, lineMaxColumn);
       }
       setMarginLeft(maxLineColumn * spaceWidth + 10);
-
-      // console.log("🚀 ~ RewriteWidget ~ changeDecorations ~ this.editorSize:", Ke * Se, Ee * Ve)
     },
     [editorSize, editor],
   );
@@ -191,6 +191,8 @@ const VirtualEditorProvider = React.memo((props: IVirtualEditorProviderProps) =>
 export class RewriteWidget extends ReactInlineContentWidget {
   private virtualEditorHandler: IVirtualEditorHandler | null = null;
 
+  positionPreference: ContentWidgetPositionPreference[] = [ContentWidgetPositionPreference.EXACT];
+
   public renderView(): React.ReactNode {
     return (
       <VirtualEditorProvider
@@ -217,9 +219,6 @@ export class RewriteWidget extends ReactInlineContentWidget {
     }
 
     const { lineNumber } = position;
-
-    // const model = this.editor.getModel();
-    // const maxLine = model?.getLineMaxColumn(lineNumber) || Number.MAX_SAFE_INTEGER;
 
     super.show({ position: monaco.Position.lift({ lineNumber, column: 1 }) });
   }

--- a/packages/core-browser/src/contextkey/ai-native.ts
+++ b/packages/core-browser/src/contextkey/ai-native.ts
@@ -5,4 +5,4 @@ export const InlineCompletionIsTrigger = new RawContextKey('ai.native.inlineComp
 export const InlineHintWidgetIsVisible = new RawContextKey('ai.native.inlineHintWidgetIsVisible', false);
 export const InlineInputWidgetIsVisible = new RawContextKey('ai.native.inlineInputWidgetIsVisible', false);
 export const InlineDiffPartialEditsIsVisible = new RawContextKey('ai.native.inlineDiffPartialEditsIsVisible', false);
-export const MultiLineCompletionsIsVisible = new RawContextKey('ai.native.multiLineCompletionsIsVisible', false);
+export const MultiLineEditsIsVisible = new RawContextKey('ai.native.multiLineEditsIsVisible', false);

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -432,12 +432,19 @@ export class AINativeContribution implements AINativeCoreContribution {
       };
 
       const insertRandomStrings = (originalString) => {
-        const numberOfInserts = Math.floor(Math.random() * 3) + 1;
+        const minChanges = 2;
+        const maxChanges = 5;
+        const changesCount = Math.floor(Math.random() * (maxChanges - minChanges + 1)) + minChanges;
         let modifiedString = originalString;
-        for (let i = 0; i < numberOfInserts; i++) {
-          const randomString = getRandomString(Math.floor(Math.random() * 2) + 1);
-          const position = Math.floor(Math.random() * (modifiedString.length + 1));
-          modifiedString = modifiedString.slice(0, position) + randomString + modifiedString.slice(position);
+        for (let i = 0; i < changesCount; i++) {
+          const randomIndex = Math.floor(Math.random() * originalString.length);
+          const operation = Math.random() < 0.5 ? 'delete' : 'insert';
+          if (operation === 'delete') {
+            modifiedString = modifiedString.slice(0, randomIndex) + modifiedString.slice(randomIndex + 1);
+          } else {
+            const randomChar = getRandomString(1);
+            modifiedString = modifiedString.slice(0, randomIndex) + randomChar + modifiedString.slice(randomIndex);
+          }
         }
         return modifiedString;
       };

--- a/packages/theme/src/common/color-tokens/ai-native.ts
+++ b/packages/theme/src/common/color-tokens/ai-native.ts
@@ -36,3 +36,20 @@ export const designInlineDiffDiscardPartialEdit = registerColor(
   '',
   true,
 );
+
+/**
+ * multi-line edits colors
+ */
+export const designMultiLineEditsDeletionsBackground = registerColor(
+  'aiNative.multiLineEditsDeletionsBackground',
+  { dark: defaultRemoveColor, light: defaultRemoveColor, hcDark: null, hcLight: null },
+  '',
+  true,
+);
+
+export const designMultiLineEditsAdditionsBackground = registerColor(
+  'aiNative.multiLineEditsAdditionsBackground',
+  { dark: defaultInsertColor, light: defaultInsertColor, hcDark: null, hcLight: null },
+  '',
+  true,
+);


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

- [x] 新增 rewrite widget 部件，根据返回的补全内容和光标位置决定是否显示
- [x] 支持采纳/弃用，并新增相应的 decoration 显示

有三种情况可以隐藏该 widget
1. 按 esc 主动隐藏
2. 编辑代码时自动隐藏
3. 当光标位置超出补全的 range 时自动隐藏
  
示例

https://github.com/user-attachments/assets/6fcfd39d-c3d7-4d44-809a-1396097e883c


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 引入了 `AdditionsDeletionsDecorationModel` 类，增强代码编辑器中的修改视觉效果。
	- 添加了一个新的虚拟代码编辑器组件，提升编辑器功能。
	- 新增颜色标记以区分多行编辑的添加和删除。

- **增强功能**
	- 改进了文本差异处理逻辑，提供更精确的文本比较和可视化效果。
	- 增强了对行内和全行修改的管理能力。
	- 改进了文本装饰的应用，提供更好的用户体验。

- **修复**
	- 解决了重复条目的问题，确保修改结果的唯一性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->