### PR TITLE
style: fix editor tab style

### DIFF
--- a/packages/editor/src/browser/editor-scrollbar/index.module.less
+++ b/packages/editor/src/browser/editor-scrollbar/index.module.less
@@ -82,7 +82,7 @@
     top: 0px;
     opacity: 0;
   }
-  // rgba(106, 115, 125, 0.2) 0 6px 6px -6px inset
+
   .scrollbar-decoration-vertical-l {
     left: 0px;
     border-left: 1px solid var(--kt-panelTab-border);

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -179,7 +179,7 @@
   }
   .kt_editor_tabs_content {
     overflow-y: hidden;
-    display: inline-flex;
+    display: flex;
     position: relative;
     height: 100%;
     &.kt_on_drag_over {
@@ -192,8 +192,6 @@
       display: flex;
       position: relative;
       align-items: center;
-      flex-shrink: 1;
-      flex-grow: 1;
       padding: 0 12px;
       border-right: 1px solid var(--tab-border);
       height: 100%;
@@ -204,7 +202,6 @@
       color: var(--tab-inactiveForeground);
       background: var(--tab-inactiveBackground);
       border-top: 1px solid transparent;
-      box-sizing: border-box;
       z-index: 1;
       word-break: keep-all;
       white-space: nowrap;

--- a/packages/editor/src/browser/editor.module.less
+++ b/packages/editor/src/browser/editor.module.less
@@ -48,6 +48,7 @@
     position: absolute;
     width: 100%;
     height: 100%;
+    pointer-events: none;
   }
   .kt_editor_tabs {
     display: flex;
@@ -130,12 +131,6 @@
     &.kt_on_drag_over {
       background-color: var(--editorGroup-dropBackground);
     }
-  }
-
-  .kt_editor_tabs_scroll_wrapper {
-    flex-grow: 1;
-    width: 100%;
-    position: relative;
   }
 
   .kt_editor_tabs_scroll {
@@ -348,7 +343,7 @@
   }
 
   .editorGroupHeader {
-    z-index: var(--stacking-level-background, 0);
+    z-index: var(--stacking-level-workbench, 1);
     position: relative;
   }
 

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -567,6 +567,11 @@ export const EditorActions = forwardRef<HTMLDivElement, IEditorActionsProps>(
     const [hasFocus, setHasFocus] = useState<boolean>(editorService.currentEditorGroup === group);
     const [args, setArgs] = useState<[URI, IEditorGroup, MaybeNull<URI>] | undefined>(acquireArgs());
 
+    /**
+     * 集成场景下可以不展示任何菜单，可以用以下代码取消菜单注册
+     * registry.unregisterMenuId(MenuId.EditorTitle);
+     * registry.unregisterMenuId(MenuId.EditorTitleRun);
+     */
     const noActions = menu.getMergedMenuNodes().length === 0;
 
     useEffect(() => {

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -109,7 +109,6 @@ export const getDefaultClientAppOpts = ({
       'general.productIconTheme': 'opensumi-icons',
       'application.confirmExit': 'never',
       'editor.quickSuggestionsDelay': 100,
-      'editor.showActionWhenGroupEmpty': true,
     },
     defaultPanels: {
       bottom: '@opensumi/ide-terminal-next',

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -109,6 +109,7 @@ export const getDefaultClientAppOpts = ({
       'general.productIconTheme': 'opensumi-icons',
       'application.confirmExit': 'never',
       'editor.quickSuggestionsDelay': 100,
+      'editor.showActionWhenGroupEmpty': true,
     },
     defaultPanels: {
       bottom: '@opensumi/ide-terminal-next',


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
- [x] 💄 Style Changes

### Background or solution

当没有 tab 的时候 editor tabbar 会出现一个滚动条，并且 action 不能点击。

有滚动条是因为 inline-flex：
1. [Why scrollHeight is bigger than offsetHeight, when used inline-block and DOCTYPE html?](https://stackoverflow.com/questions/32518273/why-scrollheight-is-bigger-than-offsetheight-when-used-inline-block-and-doctype)
2. [What is the difference between offsetHeight and scrollHeight of an element in DOM?](https://stackoverflow.com/questions/19719797/what-is-the-difference-between-offsetheight-and-scrollheight-of-an-element-in-do)

action 不能点击是因为 zindex 问题

![CleanShot 2024-08-26 at 20 15 41@2x](https://github.com/user-attachments/assets/f074e26a-f9fa-4f15-8854-487439a596de)


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在编辑器设置中新增选项，允许在编辑器组为空时显示操作，提高用户体验。
- **样式**
	- 修改编辑器组件的样式，优化布局和交互模型，增强可用性和性能。
	- 移除无效的样式注释，简化滚动条装饰样式。
- **文档**
	- 在 `EditorActions` 组件中添加注释，指导开发者如何在集成场景中注销菜单项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->