### PR TITLE
fix: event driven state

### DIFF
--- a/packages/core-browser/src/react-hooks/injectable-hooks.tsx
+++ b/packages/core-browser/src/react-hooks/injectable-hooks.tsx
@@ -49,11 +49,11 @@ export function useEventDrivenState<T, Events extends EventEmitter<any>, Event e
   const [state, setState] = useState(memorizeFactory(emitter));
 
   useEffect(() => {
-    // 绑定事件前先取下值，避免期间事件已 emit
-    setState(() => memorizeFactory(emitter));
     const listener = (...args: any[]) => {
       setState(() => memorizeFactory(emitter));
     };
+    // 绑定事件前先取下值，避免期间事件已 emit
+    listener();
     emitter.on(eventName, listener);
     return () => emitter.off(eventName, listener);
   }, [emitter]);

--- a/packages/core-browser/src/react-hooks/injectable-hooks.tsx
+++ b/packages/core-browser/src/react-hooks/injectable-hooks.tsx
@@ -52,7 +52,7 @@ export function useEventDrivenState<T, Events extends EventEmitter<any>, Event e
     // 绑定事件前先取下值，避免期间事件已 emit
     setState(() => memorizeFactory(emitter));
     const listener = (...args: any[]) => {
-      setState(memorizeFactory(emitter));
+      setState(() => memorizeFactory(emitter));
     };
     emitter.on(eventName, listener);
     return () => emitter.off(eventName, listener);

--- a/packages/core-browser/src/react-hooks/memorize-fn.ts
+++ b/packages/core-browser/src/react-hooks/memorize-fn.ts
@@ -1,0 +1,7 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+export function useMemorizeFn<T extends (...args: any[]) => any>(fn: T) {
+  const fnRef = useRef<T>(fn);
+  fnRef.current = useMemo(() => fn, [fn]);
+  return useCallback((...args: any) => fnRef.current(...args), []) as T;
+}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution
useEffect 一般在渲染后 120 ms 内触发，此时绑定事件，可能 factory 内关联的 state 已经被其它 service 更新，导致无法获取到在这期间内被更新的值，因此在 on 前需取下值
### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了 `useMemorizeFn` 自定义 React 钩子，优化组件中的函数引用，减少不必要的重新创建。
	- 改进了 `useEventDrivenState` 钩子的功能，通过记忆化工厂函数来提升状态管理的性能和响应速度。

- **文档**
	- 更新了导出或公共实体的声明，以反映新功能的引入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->