### PR TITLE
fix: set _currentScope when update tabList in constructor

### DIFF
--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -139,6 +139,7 @@ export class PreferenceSettingsService extends Disposable implements IPreference
     const userBeforeWorkspace = this.preferenceService.get<boolean>('settings.userBeforeWorkspace', false);
     if (userBeforeWorkspace) {
       this.updateTabList(userBeforeWorkspace);
+      this._currentScope = this.tabList[this.tabIndex];
     }
 
     this.addDispose([


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
settings.userBeforeWorkspace 设置为 true 时，此时在 constructor 会更新 tabList，但未更新 currentScope，导致 ui 上 tab 渲染的是 user preference，但实际操作的是 workspace preference
![image](https://github.com/user-attachments/assets/de9ef2af-cfd9-4181-8335-2932e7062a8c)

### Changelog
修复 userBeforeWorkspace setting 配置设置异常的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了用户在工作区设置中的首选项控制，允许动态调整当前选项卡的上下文，提升用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->