### PR TITLE
feat(inline-diff): adjust data calculation for changed lines

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -520,4 +520,8 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
   getZone(): LineRange {
     return this.livePreviewDiffDecorationModel.getZone();
   }
+
+  getTotalCodeInfo() {
+    return this.livePreviewDiffDecorationModel.getTotalCodeInfo();
+  }
 }

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.component.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.component.tsx
@@ -212,6 +212,10 @@ export class AcceptPartialEditWidget extends ReactInlineContentWidget {
     this._group = group;
   }
 
+  get isPending(): boolean {
+    return this.status === 'pending';
+  }
+
   public accept(addedLinesCount: number, deletedLinesCount: number): void {
     this.status = 'accept';
     this.addedLinesCount = addedLinesCount;

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -44,6 +44,15 @@ export interface ILivePreviewDiffDecorationSnapshotData {
   zone: LineRange;
 }
 
+export interface ITotalCodeInfo {
+  totalAddedLinesCount: number;
+  totalDeletedLinesCount: number;
+  totalChangedLinesCount: number;
+  unresolvedAddedLinesCount: number;
+  unresolvedDeletedLinesCount: number;
+  unresolvedChangedLinesCount: number;
+}
+
 @Injectable({ multiple: true })
 export class LivePreviewDiffDecorationModel extends Disposable {
   @Autowired(INJECTOR_TOKEN)
@@ -430,7 +439,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
         deletedLinesCount,
         type,
       },
-      ...this.getTotalCodeCount(),
+      ...this.getTotalCodeInfo(),
     };
 
     this.monacoEditor.focus();
@@ -451,15 +460,43 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     return newElement;
   }
 
-  protected getTotalCodeCount(): {
-    totalAddedLinesCount: number;
-    totalDeletedLinesCount: number;
-  } {
-    const list = this.partialEditWidgetList.filter((w) => w.isAccepted);
+  /**
+   * 获取当前编辑器的代码采纳状态
+   * 1. 已经采纳的代码信息
+   * 2. 还未处理的代码信息
+   */
+  getTotalCodeInfo(): ITotalCodeInfo {
+    const resolvedList = this.partialEditWidgetList.filter((w) => w.isAccepted);
+    const unresolvedList = this.partialEditWidgetList.filter((w) => w.isPending);
+
+    const resolvedStatus = caculate(resolvedList);
+    const unresolvedStatus = caculate(unresolvedList);
+
     return {
-      totalAddedLinesCount: list.reduce((prev, current) => prev + current.addedLinesCount, 0),
-      totalDeletedLinesCount: list.reduce((prev, current) => prev + current.deletedLinesCount, 0),
+      totalAddedLinesCount: resolvedStatus.added,
+      totalDeletedLinesCount: resolvedStatus.deleted,
+      totalChangedLinesCount: resolvedStatus.changed,
+      unresolvedAddedLinesCount: unresolvedStatus.added,
+      unresolvedDeletedLinesCount: unresolvedStatus.deleted,
+      unresolvedChangedLinesCount: unresolvedStatus.changed,
     };
+
+    // 代码除了新增和删除行，还需要统计变更行
+    // 1. 新增 N 行 => N
+    // 2. 删除 N 行 => N
+    // 3. 新增 M 行，删除 N 行 => max(M, N)
+    // 综上所述，变更行数 = sum(list.map(item => max(新增行数, 删除行数)))
+    function caculate(list: AcceptPartialEditWidget[]) {
+      const result = { added: 0, deleted: 0, changed: 0 };
+      list.forEach((widget) => {
+        const addedLinesCount = widget.addedLinesCount;
+        const deletedLinesCount = widget.deletedLinesCount;
+        result.added += addedLinesCount;
+        result.deleted += deletedLinesCount;
+        result.changed += Math.max(addedLinesCount, deletedLinesCount);
+      });
+      return result;
+    }
   }
 
   /**


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

Change the calculation from only considering added lines to using the maximum of added or removed lines.

inline diff 的变更行数口径调整。

针对单个采纳块：
1. 新增 M 行 => M
2. 删除 N 行 => N
3. 新增 M 行，删除 N 行 => max(M, N)

然后所有采纳块的行数相加就是整个文本的变更行数

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `InlineStreamDiffHandler` 类中添加了 `getTotalCodeInfo` 方法，以检索代码的总信息。
	- 在 `AcceptPartialEditWidget` 类中新增 `isPending` 方法，指示小部件的当前状态是否为“待处理”。
	- 引入 `ITotalCodeInfo` 接口，提供有关代码更改的详细统计信息，并在 `LivePreviewDiffDecorationModel` 类中替换了旧的方法。

- **改进**
	- 更新了 `LivePreviewDiffDecorationModel` 类以支持更全面的代码更改概述。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->