### PR TITLE
fix: textmate service is not compatible with monaco 0.47

### DIFF
--- a/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
+++ b/packages/editor/src/browser/monaco-contrib/tokenizer/textmate.service.ts
@@ -921,6 +921,16 @@ export class TextmateService extends WithEventBus implements ITextmateTokenizerS
 
   dispose() {
     super.dispose();
-    this.monacoLanguageService['_encounteredLanguages'].clear();
+    if (this.monacoLanguageService['_requestedRichLanguages']) {
+      this.monacoLanguageService['_requestedRichLanguages'].clear();
+    } else {
+      this.logger.warn('monaco language service not found _requestedRichLanguages');
+    }
+
+    if (this.monacoLanguageService['_requestedBasicLanguages']) {
+      this.monacoLanguageService['_requestedBasicLanguages'].clear();
+    } else {
+      this.logger.warn('monaco language service not found _requestedBasicLanguages');
+    }
   }
 }


### PR DESCRIPTION
### Types
- [X] 🐛 Bug Fixes

### Background or solution
![image](https://github.com/user-attachments/assets/ad482239-d7b7-4729-861a-e75a344057f1)

### Changelog
fix textmate service is not compatible with monaco 0.47

