### PR TITLE
feat: send data by chunk in websocket

### DIFF
--- a/packages/connection/__test__/browser/index.test.ts
+++ b/packages/connection/__test__/browser/index.test.ts
@@ -1,4 +1,4 @@
-import { furySerializer } from '@opensumi/ide-connection';
+import { WSWebSocketConnection, furySerializer } from '@opensumi/ide-connection';
 import { ReconnectingWebSocketConnection } from '@opensumi/ide-connection/lib/common/connection/drivers/reconnecting-websocket';
 import { sleep } from '@opensumi/ide-core-common';
 import { Server, WebSocket } from '@opensumi/mock-socket';
@@ -21,10 +21,11 @@ describe('connection browser', () => {
       let data2Received = false;
 
       mockServer.on('connection', (socket) => {
-        socket.on('message', (msg) => {
+        const connection = new WSWebSocketConnection(socket as any);
+        connection.onMessage((msg) => {
           const msgObj = furySerializer.deserialize(msg as Uint8Array);
           if (msgObj.kind === 'open') {
-            socket.send(
+            connection.send(
               furySerializer.serialize({
                 id: msgObj.id,
                 kind: 'server-ready',
@@ -75,6 +76,6 @@ describe('connection browser', () => {
       mockServer.close();
       wsChannelHandler.dispose();
     },
-    20 * 1000,
+    20 * 10000000,
   );
 });

--- a/packages/connection/__test__/browser/index.test.ts
+++ b/packages/connection/__test__/browser/index.test.ts
@@ -76,6 +76,6 @@ describe('connection browser', () => {
       mockServer.close();
       wsChannelHandler.dispose();
     },
-    20 * 10000000,
+    20 * 1000,
   );
 });

--- a/packages/connection/__test__/common/buffers.test.ts
+++ b/packages/connection/__test__/common/buffers.test.ts
@@ -278,7 +278,11 @@ describe('Buffers', () => {
       expect(buffer.slice(2, 3)).toEqual(new Uint8Array([2]));
     });
   });
-
+  it('should handle splice at exact chunk boundary', () => {
+    const buffer = createEnhanced([0, 1, 2, 3, 4, 5], [3, 3]);
+    buffer.splice(3, 2, new Uint8Array([99]));
+    expect(buffer.slice()).toEqual(new Uint8Array([0, 1, 2, 99, 5]));
+  });
   // 测试非法索引访问
   describe('Invalid Access Handling', () => {
     const buffer = create([1, 2, 3], [3]);
@@ -384,6 +388,21 @@ describe('Buffers', () => {
 
       expect(duration).toBeLessThan(50);
       expect(slice.byteLength).toBe(1024 * 1024);
+    });
+
+    it('should handle 1000 splices under 1s', () => {
+      const buf = createEnhanced(
+        new Array(10000).fill(0).map((_, i) => i),
+        [100, 900, 9000],
+      );
+
+      const start = performance.now();
+      for (let i = 0; i < 1000; i++) {
+        buf.splice(i % 100, 5, new Uint8Array([i]));
+      }
+      const duration = performance.now() - start;
+
+      expect(duration).toBeLessThan(1000);
     });
   });
 });

--- a/packages/connection/__test__/common/frame-decoder.test.ts
+++ b/packages/connection/__test__/common/frame-decoder.test.ts
@@ -35,7 +35,9 @@ console.timeEnd('createPayload');
 // 1m
 const pressure = 1024 * 1024;
 
-const purePackets = [p1k, p64k, p128k, p5m, p10m].map((v) => [LengthFieldBasedFrameDecoder.construct(v), v] as const);
+const purePackets = [p1k, p64k, p128k, p5m, p10m].map(
+  (v) => [LengthFieldBasedFrameDecoder.construct(v).dump(), v] as const,
+);
 
 const size = purePackets.reduce((acc, v) => acc + v[0].byteLength, 0);
 
@@ -48,7 +50,7 @@ purePackets.forEach((v) => {
 });
 
 const mixedPackets = [p1m, p5m].map((v) => {
-  const sumiPacket = LengthFieldBasedFrameDecoder.construct(v);
+  const sumiPacket = LengthFieldBasedFrameDecoder.construct(v).dump();
   const newPacket = createPayload(1024 + sumiPacket.byteLength);
   newPacket.set(sumiPacket, 1024);
   return [newPacket, v] as const;
@@ -59,7 +61,7 @@ const packets = [...purePackets, ...mixedPackets];
 describe('frame decoder', () => {
   it('can create frame', () => {
     const content = new Uint8Array([1, 2, 3]);
-    const packet = LengthFieldBasedFrameDecoder.construct(content);
+    const packet = LengthFieldBasedFrameDecoder.construct(content).dump();
     const reader = BinaryReader({});
 
     reader.reset(packet);
@@ -116,7 +118,7 @@ describe('frame decoder', () => {
 
   it('can decode a stream it has no valid length info', (done) => {
     const v = createPayload(1024);
-    const sumiPacket = LengthFieldBasedFrameDecoder.construct(v);
+    const sumiPacket = LengthFieldBasedFrameDecoder.construct(v).dump();
 
     const decoder = new LengthFieldBasedFrameDecoder();
     decoder.onData((data) => {

--- a/packages/connection/__test__/common/frame-decoder.test.ts
+++ b/packages/connection/__test__/common/frame-decoder.test.ts
@@ -168,7 +168,7 @@ describe('frame decoder', () => {
     }
 
     // 等待处理完成
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     expect(received.length).toBe(1000);
     received.forEach((data, i) => {

--- a/packages/connection/__test__/node/index.test.ts
+++ b/packages/connection/__test__/node/index.test.ts
@@ -8,7 +8,7 @@ import { SumiConnection } from '@opensumi/ide-connection/src/common/rpc/connecti
 import { Deferred } from '@opensumi/ide-core-common';
 
 import { RPCService } from '../../src';
-import { RPCServiceCenter, initRPCService } from '../../src/common';
+import { ChannelMessage, RPCServiceCenter, initRPCService } from '../../src/common';
 import { CommonChannelPathHandler } from '../../src/common/server-handler';
 import { WSChannel } from '../../src/common/ws-channel';
 import { CommonChannelHandler, WebSocketServerRoute } from '../../src/node';
@@ -62,14 +62,16 @@ describe('connection', () => {
     });
     const clientId = 'TEST_CLIENT';
     const wsConnection = new WSWebSocketConnection(connection);
+    const wrappedConnection = wrapSerializer(wsConnection, furySerializer);
+
     const channel = new WSChannel(wrapSerializer(wsConnection, furySerializer), {
       id: 'TEST_CHANNEL_ID',
     });
-    connection.on('message', (msg: Uint8Array) => {
-      const msgObj = furySerializer.deserialize(msg);
-      if (msgObj.kind === 'server-ready') {
-        if (msgObj.id === 'TEST_CHANNEL_ID') {
-          channel.dispatch(msgObj);
+
+    wrappedConnection.onMessage((msg: ChannelMessage) => {
+      if (msg.kind === 'server-ready') {
+        if (msg.id === 'TEST_CHANNEL_ID') {
+          channel.dispatch(msg);
         }
       }
     });

--- a/packages/connection/__test__/node/ws-channel.test.ts
+++ b/packages/connection/__test__/node/ws-channel.test.ts
@@ -85,7 +85,7 @@ describe('ws channel node', () => {
         }),
         new Promise<void>((resolve) => {
           for (let i = 0; i < total; i++) {
-            channel2.send('hello');
+            channel2.send('hello' + i);
           }
           resolve();
         }),
@@ -95,7 +95,7 @@ describe('ws channel node', () => {
       socket2.destroy();
       socket2.end();
     },
-    20 * 1000,
+    30 * 1000,
   );
 
   it(
@@ -149,6 +149,6 @@ describe('ws channel node', () => {
       socket2.destroy();
       socket2.end();
     },
-    20 * 1000,
+    30 * 1000,
   );
 });

--- a/packages/connection/src/common/buffers/buffers.ts
+++ b/packages/connection/src/common/buffers/buffers.ts
@@ -5,6 +5,7 @@
  */
 
 export const emptyBuffer = new Uint8Array(0);
+export const buffer4Capacity = new Uint8Array(4);
 
 export function copy(
   source: Uint8Array,
@@ -58,6 +59,39 @@ export class Buffers {
     }
 
     const target = new Uint8Array(end - start);
+
+    let ti = 0;
+    for (let ii = si; ti < end - start && ii < buffers.length; ii++) {
+      const len = buffers[ii].length;
+
+      const _start = ti === 0 ? start - startBytes : 0;
+      const _end = ti + len >= end - start ? Math.min(_start + (end - start) - ti, len) : len;
+      copy(buffers[ii], target, ti, _start, _end);
+      ti += _end - _start;
+    }
+
+    return target;
+  }
+
+  slice4(start: number) {
+    let end = start + 4;
+    const buffers = this.buffers;
+
+    if (end > this.size) {
+      end = this.size;
+    }
+
+    if (start >= end) {
+      return emptyBuffer;
+    }
+
+    let startBytes = 0;
+    let si = 0;
+    for (; si < buffers.length && startBytes + buffers[si].length <= start; si++) {
+      startBytes += buffers[si].length;
+    }
+
+    const target = buffer4Capacity;
 
     let ti = 0;
     for (let ii = si; ti < end - start && ii < buffers.length; ii++) {
@@ -265,6 +299,12 @@ export class Cursor {
     const end = this.offset + n;
     const buffers = this.buffers.slice(this.offset, end);
     this.skip(n);
+    return buffers;
+  }
+
+  read4() {
+    const buffers = this.buffers.slice4(this.offset);
+    this.skip(4);
     return buffers;
   }
 

--- a/packages/connection/src/common/connection/drivers/frame-decoder.ts
+++ b/packages/connection/src/common/connection/drivers/frame-decoder.ts
@@ -24,7 +24,6 @@ const lengthFieldLength = 4;
  * we use a length field to represent the length of the data, and then read the data according to the length
  */
 export class LengthFieldBasedFrameDecoder {
-  private static readonly MAX_FRAME_SIZE = 1 * 1024 * 1024; // 1MB
   private static readonly MAX_ITERATIONS = 50;
 
   private _onDataListener: MaybeNull<(data: Uint8Array) => void>;
@@ -52,12 +51,6 @@ export class LengthFieldBasedFrameDecoder {
   }
 
   push(chunk: Uint8Array): void {
-    // 如果新数据太大，只接收部分
-    if (chunk.byteLength > LengthFieldBasedFrameDecoder.MAX_FRAME_SIZE) {
-      console.warn('[Frame Decoder] Chunk too large, truncating');
-      chunk = chunk.slice(0, LengthFieldBasedFrameDecoder.MAX_FRAME_SIZE);
-    }
-
     this.buffers.push(chunk);
 
     // 确保同一时间只有一个处理过程

--- a/packages/connection/src/common/connection/drivers/frame-decoder.ts
+++ b/packages/connection/src/common/connection/drivers/frame-decoder.ts
@@ -24,7 +24,7 @@ const lengthFieldLength = 4;
  * we use a length field to represent the length of the data, and then read the data according to the length
  */
 export class LengthFieldBasedFrameDecoder {
-  private static readonly MAX_FRAME_SIZE = 1 * 1024 * 1024;  // 1MB
+  private static readonly MAX_FRAME_SIZE = 1 * 1024 * 1024; // 1MB
   private static readonly MAX_ITERATIONS = 50;
 
   private _onDataListener: MaybeNull<(data: Uint8Array) => void>;
@@ -84,7 +84,7 @@ export class LengthFieldBasedFrameDecoder {
       iterations++;
       // 每处理几个包就让出执行权
       if (iterations % 10 === 0) {
-        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 0));
       }
     }
   }
@@ -168,12 +168,12 @@ export class LengthFieldBasedFrameDecoder {
     let result = iter.next();
     while (!result.done) {
       switch (result.value) {
-        case 0x0d:  // \r
+        case 0x0d: // \r
           switch (this.state) {
             case 0:
               this.state = 1;
               break;
-            case 2:  // 第二个 \r
+            case 2: // 第二个 \r
               this.state = 3;
               break;
             default:
@@ -181,12 +181,12 @@ export class LengthFieldBasedFrameDecoder {
               break;
           }
           break;
-        case 0x0a:  // \n
+        case 0x0a: // \n
           switch (this.state) {
             case 1:
               this.state = 2;
               break;
-            case 3:  // 第二个 \n
+            case 3: // 第二个 \n
               this.state = 4;
               iter.return();
               break;

--- a/packages/connection/src/common/connection/drivers/frame-decoder.ts
+++ b/packages/connection/src/common/connection/drivers/frame-decoder.ts
@@ -209,21 +209,18 @@ export class LengthFieldBasedFrameDecoder {
     this.reset();
   }
 
-  static writer = BinaryWriter({});
-
   static construct(content: Uint8Array) {
+    // 每次都创建新的 writer，避免所有权问题
+    const writer = BinaryWriter({});
 
-    // 确保 writer 没有被持有
     try {
-      LengthFieldBasedFrameDecoder.writer.reset();
+      writer.buffer(indicator);
+      writer.uint32(content.byteLength);
+      writer.buffer(content);
+      return writer;
     } catch (error) {
-      console.warn('[Frame Decoder] Writer reset failed, creating new writer');
-      LengthFieldBasedFrameDecoder.writer = BinaryWriter({});
+      console.warn('[Frame Decoder] Error constructing frame:', error);
+      throw error;
     }
-
-    LengthFieldBasedFrameDecoder.writer.buffer(indicator);
-    LengthFieldBasedFrameDecoder.writer.uint32(content.byteLength);
-    LengthFieldBasedFrameDecoder.writer.buffer(content);
-    return LengthFieldBasedFrameDecoder.writer;
   }
 }

--- a/packages/connection/src/common/connection/drivers/reconnecting-websocket.ts
+++ b/packages/connection/src/common/connection/drivers/reconnecting-websocket.ts
@@ -21,10 +21,13 @@ export class ReconnectingWebSocketConnection extends BaseConnection<Uint8Array> 
   }
 
   send(data: Uint8Array): void {
-    const packet = LengthFieldBasedFrameDecoder.construct(data);
+    const handle = LengthFieldBasedFrameDecoder.construct(data).dumpAndOwn();
+    const packet = handle.get();
     for (let i = 0; i < packet.byteLength; i += chunkSize) {
       this.socket.send(packet.subarray(i, i + chunkSize));
     }
+
+    handle.dispose();
   }
 
   isOpen(): boolean {

--- a/packages/connection/src/common/connection/drivers/stream.ts
+++ b/packages/connection/src/common/connection/drivers/stream.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { IDisposable } from '@opensumi/ide-core-common';
 
 import { BaseConnection } from './base';
@@ -22,10 +23,15 @@ export class StreamConnection extends BaseConnection<Uint8Array> {
 
   send(data: Uint8Array): void {
     const handle = LengthFieldBasedFrameDecoder.construct(data).dumpAndOwn();
-    this.writable.write(handle.get(), () => {
-      // TODO: logger error
-    });
-    handle.dispose();
+    try {
+      this.writable.write(handle.get(), (error) => {
+        if (error) {
+          console.error('Failed to write data:', error);
+        }
+      });
+    } finally {
+      handle.dispose();
+    }
   }
 
   onMessage(cb: (data: Uint8Array) => void): IDisposable {

--- a/packages/connection/src/common/connection/drivers/stream.ts
+++ b/packages/connection/src/common/connection/drivers/stream.ts
@@ -21,10 +21,11 @@ export class StreamConnection extends BaseConnection<Uint8Array> {
   }
 
   send(data: Uint8Array): void {
-    const result = LengthFieldBasedFrameDecoder.construct(data);
-    this.writable.write(result, () => {
+    const handle = LengthFieldBasedFrameDecoder.construct(data).dumpAndOwn();
+    this.writable.write(handle.get(), () => {
       // TODO: logger error
     });
+    handle.dispose();
   }
 
   onMessage(cb: (data: Uint8Array) => void): IDisposable {

--- a/packages/connection/src/common/connection/drivers/ws-websocket.ts
+++ b/packages/connection/src/common/connection/drivers/ws-websocket.ts
@@ -16,7 +16,7 @@ interface SendQueueItem {
 
 export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
   protected decoder = new LengthFieldBasedFrameDecoder();
-  private static readonly MAX_QUEUE_SIZE = 100; // 限制队列长度
+  private static readonly MAX_QUEUE_SIZE = 1000; // 限制队列长度
 
   private sendQueue: SendQueueItem[] = [];
   private pendingSize = 0;
@@ -30,7 +30,9 @@ export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
   }
 
   private async processSendQueue() {
-    if (this.sending) { return; }
+    if (this.sending) {
+      return;
+    }
     this.sending = true;
 
     while (this.sendQueue.length > 0) {

--- a/packages/connection/src/common/connection/drivers/ws-websocket.ts
+++ b/packages/connection/src/common/connection/drivers/ws-websocket.ts
@@ -7,8 +7,20 @@ import { LengthFieldBasedFrameDecoder } from './frame-decoder';
 
 import type WebSocket from 'ws';
 
+interface SendQueueItem {
+  data: Uint8Array;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
 export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
   protected decoder = new LengthFieldBasedFrameDecoder();
+  private static readonly MAX_QUEUE_SIZE = 100; // 限制队列长度
+  private static readonly MAX_PENDING_SIZE = 50 * 1024 * 1024; // 50MB 总待发送数据限制
+
+  private sendQueue: SendQueueItem[] = [];
+  private pendingSize = 0;
+  private sending = false;
 
   constructor(public socket: WebSocket) {
     super();
@@ -17,14 +29,68 @@ export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
     });
   }
 
-  send(data: Uint8Array): void {
-    const handle = LengthFieldBasedFrameDecoder.construct(data).dumpAndOwn();
-    const packet = handle.get();
-    for (let i = 0; i < packet.byteLength; i += chunkSize) {
-      this.socket.send(packet.subarray(i, i + chunkSize));
+  private async processSendQueue() {
+    if (this.sending) { return; }
+    this.sending = true;
+
+    while (this.sendQueue.length > 0) {
+      const { data, resolve, reject } = this.sendQueue[0];
+      let handle: { get: () => Uint8Array; dispose: () => void } | null = null;
+
+      try {
+        handle = LengthFieldBasedFrameDecoder.construct(data).dumpAndOwn();
+        const packet = handle.get();
+
+        for (let i = 0; i < packet.byteLength; i += chunkSize) {
+          if (!this.isOpen()) {
+            throw new Error('Connection closed while sending');
+          }
+
+          await new Promise<void>((resolve, reject) => {
+            const chunk = packet.subarray(i, Math.min(i + chunkSize, packet.byteLength));
+            this.socket.send(chunk, { binary: true }, (error?: Error) => {
+              if (error) {
+                reject(error);
+              } else {
+                resolve();
+              }
+            });
+          });
+        }
+
+        resolve();
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      } finally {
+        if (handle) {
+          try {
+            handle.dispose();
+          } catch (error) {
+            console.warn('[WSWebSocket] Error disposing handle:', error);
+          }
+        }
+        this.pendingSize -= this.sendQueue[0].data.byteLength;
+        this.sendQueue.shift();
+      }
     }
 
-    handle.dispose();
+    this.sending = false;
+  }
+
+  send(data: Uint8Array): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      // 检查队列大小限制
+      if (this.sendQueue.length >= WSWebSocketConnection.MAX_QUEUE_SIZE) {
+        reject(new Error('Send queue full'));
+        return;
+      }
+
+      this.pendingSize += data.byteLength;
+      this.sendQueue.push({ data, resolve, reject });
+      this.processSendQueue().catch((error) => {
+        console.error('[WSWebSocket] Error processing queue:', error);
+      });
+    });
   }
 
   onMessage(cb: (data: Uint8Array) => void): IDisposable {
@@ -45,5 +111,12 @@ export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
 
   dispose(): void {
     this.socket.removeAllListeners();
+    // 拒绝所有待发送的消息
+    while (this.sendQueue.length > 0) {
+      const { reject } = this.sendQueue.shift()!;
+      reject(new Error('Connection disposed'));
+    }
+    this.pendingSize = 0;
+    this.sending = false;
   }
 }

--- a/packages/connection/src/common/connection/drivers/ws-websocket.ts
+++ b/packages/connection/src/common/connection/drivers/ws-websocket.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { IDisposable } from '@opensumi/ide-core-common';
 
 import { chunkSize } from '../../constants';
@@ -16,7 +17,6 @@ interface SendQueueItem {
 export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
   protected decoder = new LengthFieldBasedFrameDecoder();
   private static readonly MAX_QUEUE_SIZE = 100; // 限制队列长度
-  private static readonly MAX_PENDING_SIZE = 50 * 1024 * 1024; // 50MB 总待发送数据限制
 
   private sendQueue: SendQueueItem[] = [];
   private pendingSize = 0;

--- a/packages/connection/src/common/connection/drivers/ws-websocket.ts
+++ b/packages/connection/src/common/connection/drivers/ws-websocket.ts
@@ -1,24 +1,31 @@
 import { IDisposable } from '@opensumi/ide-core-common';
 
+import { chunkSize } from '../../constants';
+
 import { BaseConnection } from './base';
+import { LengthFieldBasedFrameDecoder } from './frame-decoder';
 
 import type WebSocket from 'ws';
 
 export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
+  protected decoder = new LengthFieldBasedFrameDecoder();
+
   constructor(public socket: WebSocket) {
     super();
+    this.socket.on('message', (data: Buffer) => {
+      this.decoder.push(data);
+    });
   }
+
   send(data: Uint8Array): void {
-    this.socket.send(data);
+    const packet = LengthFieldBasedFrameDecoder.construct(data);
+    for (let i = 0; i < packet.byteLength; i += chunkSize) {
+      this.socket.send(packet.subarray(i, i + chunkSize));
+    }
   }
 
   onMessage(cb: (data: Uint8Array) => void): IDisposable {
-    this.socket.on('message', cb);
-    return {
-      dispose: () => {
-        this.socket.off('message', cb);
-      },
-    };
+    return this.decoder.onData(cb);
   }
   onceClose(cb: () => void): IDisposable {
     this.socket.once('close', cb);

--- a/packages/connection/src/common/connection/drivers/ws-websocket.ts
+++ b/packages/connection/src/common/connection/drivers/ws-websocket.ts
@@ -18,10 +18,13 @@ export class WSWebSocketConnection extends BaseConnection<Uint8Array> {
   }
 
   send(data: Uint8Array): void {
-    const packet = LengthFieldBasedFrameDecoder.construct(data);
+    const handle = LengthFieldBasedFrameDecoder.construct(data).dumpAndOwn();
+    const packet = handle.get();
     for (let i = 0; i < packet.byteLength; i += chunkSize) {
       this.socket.send(packet.subarray(i, i + chunkSize));
     }
+
+    handle.dispose();
   }
 
   onMessage(cb: (data: Uint8Array) => void): IDisposable {

--- a/packages/connection/src/common/constants.ts
+++ b/packages/connection/src/common/constants.ts
@@ -1,3 +1,6 @@
 export const METHOD_NOT_REGISTERED = '$$METHOD_NOT_REGISTERED';
 
+/**
+ * 分片大小, 8MB
+ */
 export const chunkSize = 8 * 1024 * 1024;

--- a/packages/connection/src/common/constants.ts
+++ b/packages/connection/src/common/constants.ts
@@ -1,1 +1,3 @@
 export const METHOD_NOT_REGISTERED = '$$METHOD_NOT_REGISTERED';
+
+export const chunkSize = 8 * 1024 * 1024;

--- a/packages/connection/src/common/constants.ts
+++ b/packages/connection/src/common/constants.ts
@@ -1,6 +1,6 @@
 export const METHOD_NOT_REGISTERED = '$$METHOD_NOT_REGISTERED';
 
 /**
- * 分片大小, 8MB
+ * 分片大小, 1MB
  */
-export const chunkSize = 8 * 1024 * 1024;
+export const chunkSize = 1 * 1024 * 1024;

--- a/packages/connection/src/common/fury-extends/one-of.ts
+++ b/packages/connection/src/common/fury-extends/one-of.ts
@@ -68,6 +68,9 @@ export const oneOf = (
       case 7:
         v = serializers[7].read();
         break;
+      default: {
+        throw new Error('unknown index: ' + idx);
+      }
     }
 
     v.kind = kinds[idx];

--- a/packages/connection/src/node/common-channel-handler.ts
+++ b/packages/connection/src/node/common-channel-handler.ts
@@ -42,8 +42,7 @@ export class CommonChannelHandler extends BaseCommonChannelHandler implements We
       ...this.options.wsServerOptions,
     });
     this.wsServer.on('connection', (connection: WebSocket) => {
-      const wsConnection = new WSWebSocketConnection(connection);
-      this.receiveConnection(wsConnection);
+      this.receiveConnection(new WSWebSocketConnection(connection));
     });
   }
 

--- a/packages/core-browser/__tests__/bootstrap/connection.test.ts
+++ b/packages/core-browser/__tests__/bootstrap/connection.test.ts
@@ -1,6 +1,6 @@
 import { WSChannelHandler } from '@opensumi/ide-connection/lib/browser';
 import { ReconnectingWebSocketConnection } from '@opensumi/ide-connection/lib/common/connection/drivers/reconnecting-websocket';
-import { BrowserConnectionErrorEvent, IEventBus } from '@opensumi/ide-core-common';
+import { BrowserConnectionErrorEvent, IEventBus, sleep } from '@opensumi/ide-core-common';
 import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { Server, WebSocket } from '@opensumi/mock-socket';
@@ -34,11 +34,8 @@ describe('packages/core-browser/src/bootstrap/connection.test.ts', () => {
     const channelHandler = new WSChannelHandler(ReconnectingWebSocketConnection.forURL(fakeWSURL), 'test-client-id');
     createConnectionService(injector, [], channelHandler);
     stateService.state = 'core_module_initialized';
-    new Promise<void>((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 4000);
-    }).then(() => {
+
+    sleep(4000).then(() => {
       mockServer.simulate('error');
     });
   });


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

一次性发送几十M的文件会导致线程卡顿，大文件分 chunk 发送

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 优化了组件树刷新和数组处理机制，提高加载及响应速度。
	- 改进了 WebSocket 连接的数据处理与消息传输逻辑，增强了异常处理和系统稳定性。
	- 优化了数据解码、缓冲区管理及切片方法，提升了大批量数据处理效率。

- **New Features**
	- 引入了异步消息发送机制和队列管理，确保数据传输更顺畅。
	- 新增了缓冲区切片和读取方法，提高小数据块处理能力。
	- 增强了测试覆盖，确保缓冲区和游标的边界情况得到验证。
	- 新增了对 WebSocket 消息处理的类型安全支持。
	- 增加了对空缓冲区和边界情况的处理测试，确保方法的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->