### PR TITLE
fix: getFileType is not work after Node.js 20

### DIFF
--- a/packages/utils/src/encoding.ts
+++ b/packages/utils/src/encoding.ts
@@ -17,7 +17,7 @@ export const UTF16be_BOM = [0xfe, 0xff];
 export const UTF16le_BOM = [0xff, 0xfe];
 export const UTF8_BOM = [0xef, 0xbb, 0xbf];
 
-const ZERO_BYTE_DETECTION_BUFFER_MAX_LEN = 512; // number of bytes to look at to decide about a file being binary or not
+export const ZERO_BYTE_DETECTION_BUFFER_MAX_LEN = 512; // number of bytes to look at to decide about a file being binary or not
 const AUTO_ENCODING_GUESS_MAX_BYTES = 512 * 128; // set an upper limit for the number of bytes we pass on to jschardet
 
 export function isUTF8(encoding: string | null) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution
detectEncodingFromBuffer 使用的是 readStream，这个在经过 fileType 时已经 pipeline，在 node>=20 时无任何事件触发，导致打开大文件时完全卡住，优化了 stream 的写法

### Changelog
