### PR TITLE
fix: inline chat controller timing

### DIFF
--- a/packages/ai-native/src/browser/contrib/problem-fix/problem-fix.handler.ts
+++ b/packages/ai-native/src/browser/contrib/problem-fix/problem-fix.handler.ts
@@ -107,11 +107,12 @@ export class ProblemFixHandler extends IAIMonacoContribHandler {
     const model = monacoEditor.getModel();
 
     // 以 marker 的 range 为中心，向上取 2 行，向下取 3 行
+    const endLineNumber = Math.min(part.range.endLineNumber + 3, model!.getLineCount());
     const editRange = new Range(
       Math.max(part.range.startLineNumber - 2, 0),
       1,
-      Math.min(part.range.endLineNumber + 3, model!.getLineCount() ?? 0),
-      model!.getLineMaxColumn(part.range.endLineNumber + 3) ?? 0,
+      endLineNumber,
+      model!.getLineMaxColumn(endLineNumber),
     );
 
     const context = {

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff.handler.ts
@@ -177,7 +177,6 @@ export class InlineDiffHandler extends IAIMonacoContribHandler {
       previewer.onReady(() => {
         if (InlineChatController.is(chatResponse)) {
           const controller = chatResponse as InlineChatController;
-          controller.listen();
 
           disposable.addDispose([
             controller.onData((data) => {
@@ -198,6 +197,8 @@ export class InlineDiffHandler extends IAIMonacoContribHandler {
               onFinish();
             }),
           ]);
+
+          controller.listen();
         } else {
           previewer.setValue((chatResponse as ReplyResponse).message);
           onFinish();

--- a/packages/ai-native/src/browser/widget/inline-input/inline-input.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input.handler.ts
@@ -86,8 +86,6 @@ export class InlineInputHandler extends Disposable {
       if (InlineChatController.is(previewResponse)) {
         const controller = previewResponse as InlineChatController;
 
-        controller.listen();
-
         let latestContent: string | undefined;
         const schedulerEdit: RunOnceScheduler = this.registerDispose(
           new RunOnceScheduler(() => {
@@ -122,6 +120,8 @@ export class InlineInputHandler extends Disposable {
             widget.launchChatStatus(EInlineChatStatus.DONE);
           }),
         ]);
+
+        controller.listen();
       }
     }
   }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

该时序问题会导致当模型回答只有一行时，渲染会为空的情况
![image](https://github.com/user-attachments/assets/5f2b9362-02bc-43a5-acf5-99233840c26d)


### Changelog
修复 inline chat controller 监听的时序问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 改进了问题修复处理程序的编辑范围计算，提高了代码可读性。
  - 优化了事件处理的控制流，确保在数据监听器注册后再开始监听，增强了应用的健壮性。
  - 调整了聊天控制器的监听时机，以改善用户交互响应。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->