### PR TITLE
fix: inline chat first line overflow visible

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.handler.ts
@@ -560,7 +560,7 @@ export class InlineChatHandler extends Disposable {
           if (crossSelection.endLineNumber === model!.getLineCount()) {
             // 如果用户是选中了最后一行，直接显示在最后一行
             const lineHeight = monacoEditor.getOption(monacoApi.editor.EditorOption.lineHeight);
-            this.aiInlineContentWidget.offsetTop(lineHeight * count + 12);
+            this.aiInlineContentWidget.setOffsetTop(lineHeight * count + 12);
           }
         });
       }),

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
@@ -157,15 +157,13 @@ const AIInlineChatController = (props: IAIInlineChatControllerProps) => {
     );
   }, [operationList, moreOperation, customOperationRender, onResultClick, status, interactiveInputVisible]);
 
-  return (
-    <div className={styles.inline_chat_controller_box} style={isDone ? { transform: 'translateY(-15px)' } : {}}>
-      {renderContent()}
-    </div>
-  );
+  return <div className={styles.inline_chat_controller_box}>{renderContent()}</div>;
 };
 
 @Injectable({ multiple: true })
 export class AIInlineContentWidget extends ReactInlineContentWidget {
+  allowEditorOverflow = true;
+
   @Autowired(INJECTOR_TOKEN)
   private readonly injector: Injector;
 
@@ -173,8 +171,6 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
   private readonly inlineChatFeatureRegistry: InlineChatFeatureRegistry;
 
   private readonly aiNativeContextKey: AINativeContextKey;
-
-  private originTop = 0;
 
   private readonly _onActionClickEmitter = new Emitter<{ actionId: string; source: string }>();
   public readonly onActionClick = this._onActionClickEmitter.event;
@@ -279,13 +275,8 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
     this.options = options;
   }
 
-  public offsetTop(top: number): void {
-    if (this.originTop === 0) {
-      const top = this.domNode.style.top;
-      this.originTop = top ? parseInt(top, 10) : 0;
-    }
-
-    this.domNode.style.top = `${this.originTop + top}px`;
+  public setOffsetTop(top: number): void {
+    this.domNode.style.transform = `translateY(${top}px)`;
   }
 
   id(): string {

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -61,7 +61,6 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
 
   public previewerOptions: IDiffPreviewerOptions;
 
-  private livePreviewDiffDecorationModel: LivePreviewDiffDecorationModel;
   private originalModel: ITextModel;
   private virtualModel: ITextModel;
 
@@ -69,6 +68,8 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
   private rawOriginalTextLines: string[];
   private rawOriginalTextLinesTokens: LineTokens[] = [];
   private undoRedoGroup: UndoRedoGroup;
+
+  public livePreviewDiffDecorationModel: LivePreviewDiffDecorationModel;
 
   constructor(private readonly monacoEditor: ICodeEditor) {
     super();

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -159,6 +159,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     this.updateZone(zone);
   }
 
+  getRemovedWidgets(): RemovedZoneWidget[] {
+    return this.removedZoneWidgets;
+  }
+
   restoreSnapshot(snapshot: ILivePreviewDiffDecorationSnapshotData): void {
     const {
       addedDecList,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before
![image](https://github.com/user-attachments/assets/16d4f154-057c-4de1-a3e8-bc4414ae630b)


after
![image](https://github.com/user-attachments/assets/5099bf58-bbef-495c-81dc-db49b5ba5b56)


### Changelog
允许 inline chat 的操作项在首行溢出展示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了内联聊天控件的位置设置方法，提升了控件的性能和灵活性。
	- 新增属性`allowEditorOverflow`，优化内容溢出管理。
	- 新增方法`getRemovedWidgets`，增强了对已移除小部件的管理能力。
  
- **bug修复**
	- 调整了内联内容小部件的位置逻辑，确保其与删除行正确对齐，改善用户体验。

- **文档**
	- 修改了多个类的公共成员访问权限，以提高可访问性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->