### PR TITLE
fix: store diff editor state while docs not destory

### DIFF
--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -9,6 +9,7 @@ import {
   Emitter as EventEmitter,
   ILineChange,
   ISelection,
+  LRUCache,
   OnEvent,
   URI,
   WithEventBus,
@@ -604,6 +605,8 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
 
   public onRefOpen = this._onRefOpen.event;
 
+  private diffEditorModelCache = new LRUCache<string, monaco.editor.IDiffEditorViewModel>(100);
+
   protected saveCurrentState() {
     if (this.currentUri) {
       const state = this.monacoDiffEditor.saveViewState();
@@ -635,6 +638,11 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     );
   }
 
+  disposeModel(originalUri: string, modifiedUri: string) {
+    const key = `${originalUri}-${modifiedUri}`;
+    this.diffEditorModelCache.delete(key);
+  }
+
   async compare(
     originalDocModelRef: IEditorDocumentModelRef,
     modifiedDocModelRef: IEditorDocumentModelRef,
@@ -649,7 +657,13 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     }
     const original = this.originalDocModel.getMonacoModel();
     const modified = this.modifiedDocModel.getMonacoModel();
-    const model = this.monacoDiffEditor.createViewModel({ original, modified });
+    const key = `${original.uri.toString()}-${modified.uri.toString()}`;
+    let model = this.diffEditorModelCache.get(key);
+    if (!model || (model as any)._store.isDisposed) {
+      model = this.monacoDiffEditor.createViewModel({ original, modified });
+      this.diffEditorModelCache.set(key, model);
+    }
+
     this.monacoDiffEditor.setModel(model);
 
     if (rawUri) {
@@ -658,6 +672,7 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
       this.currentUri = URI.from({
         scheme: DIFF_SCHEME,
         query: URI.stringifyQuery({
+          name,
           original: this.originalDocModel!.uri.toString(),
           modified: this.modifiedDocModel!.uri.toString(),
         }),
@@ -682,6 +697,8 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
           currentEditor.revealRangeInCenter(range);
         });
       });
+    } else {
+      this.restoreState();
     }
     this._onRefOpen.fire(originalDocModelRef);
     this._onRefOpen.fire(modifiedDocModelRef);
@@ -709,6 +726,7 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
   }
 
   private async updateOptionsOnModelChange() {
+    this.diffEditorModelCache.clear();
     await this.doUpdateDiffOptions();
   }
 

--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -659,7 +659,7 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     const modified = this.modifiedDocModel.getMonacoModel();
     const key = `${original.uri.toString()}-${modified.uri.toString()}`;
     let model = this.diffEditorModelCache.get(key);
-    if (!model || (model as any)._store.isDisposed) {
+    if (!model) {
       model = this.monacoDiffEditor.createViewModel({ original, modified });
       this.diffEditorModelCache.set(key, model);
     }
@@ -726,7 +726,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
   }
 
   private async updateOptionsOnModelChange() {
-    this.diffEditorModelCache.clear();
     await this.doUpdateDiffOptions();
   }
 

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1568,6 +1568,7 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       const query = uri.getParsedQuery();
       this.doDisposeDocRef(new URI(query.original));
       this.doDisposeDocRef(new URI(query.modified));
+      this.diffEditor.disposeModel(query.original, query.modified);
     } else if (uri.scheme === 'mergeEditor') {
       this.mergeEditor && this.mergeEditor.dispose();
     } else {

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -317,6 +317,8 @@ export interface IDiffEditor extends IDisposable {
   getLineChanges(): ILineChange[] | null;
 
   onRefOpen: Event<IEditorDocumentModelRef>;
+
+  disposeModel(originalUri: string, modifiedUri: string): void;
 }
 
 @Injectable()


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fix #3792.

当 Document 销毁时，正常清理 Model 缓存，保证 Diff 文件存在时切换情况下的状态保留逻辑。

### Changelog

修复 Diff Editor 状态恢复逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 引入了一个缓存机制，以优化差异编辑器的性能，避免重复创建模型。
	- 增加了`disposeModel`方法，用于在不再需要时清理缓存的模型。

- **改进**
	- 加强了文档清理过程，确保差异编辑器在文档引用被处理时正确释放模型，防止内存泄漏。
	- 更新了选项变更时的处理逻辑，确保及时反映最新的差异选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->