### PR TITLE
fix: remove global from browser

### DIFF
--- a/packages/addons/src/browser/chrome-devtools.contribution.ts
+++ b/packages/addons/src/browser/chrome-devtools.contribution.ts
@@ -25,7 +25,7 @@ export class ChromeDevtoolsContribution extends Disposable implements ClientAppC
       }
     } else if (command === DevtoolsLantencyCommand.Stop) {
       if (this.interval) {
-        global.clearInterval(this.interval);
+        clearInterval(this.interval);
         this.interval = undefined;
       }
     }
@@ -41,7 +41,7 @@ export class ChromeDevtoolsContribution extends Disposable implements ClientAppC
         Disposable.create(() => {
           window.removeEventListener(EDevtoolsEvent.Latency, this.lantencyHandler);
           if (this.interval) {
-            global.clearInterval(this.interval);
+            clearInterval(this.interval);
             this.interval = undefined;
           }
         }),
@@ -57,7 +57,7 @@ export class ChromeDevtoolsContribution extends Disposable implements ClientAppC
   }
 
   private startRTTInterval() {
-    this.interval = global.setInterval(async () => {
+    this.interval = setInterval(async () => {
       const start = Date.now();
       await this.rttService.measure();
       const rtt = Date.now() - start;

--- a/packages/addons/src/browser/connection-rtt-contribution.ts
+++ b/packages/addons/src/browser/connection-rtt-contribution.ts
@@ -49,7 +49,7 @@ export class ConnectionRTTContribution implements CommandContribution {
         if (!this.interval) {
           return;
         }
-        global.clearInterval(this.interval);
+        clearInterval(this.interval);
         if (this.statusBar) {
           this.statusBar.dispose();
           this.statusBar = undefined;
@@ -59,7 +59,7 @@ export class ConnectionRTTContribution implements CommandContribution {
   }
 
   private startRTTInterval() {
-    this.interval = global.setInterval(async () => {
+    this.interval = setInterval(async () => {
       const start = Date.now();
       await this.rttService.measure();
       const rtt = Date.now() - start;

--- a/packages/connection/src/browser/ws-channel-handler.ts
+++ b/packages/connection/src/browser/ws-channel-handler.ts
@@ -64,7 +64,7 @@ export class WSChannelHandler {
     if (this.heartbeatMessageTimer) {
       clearTimeout(this.heartbeatMessageTimer);
     }
-    this.heartbeatMessageTimer = global.setTimeout(() => {
+    this.heartbeatMessageTimer = setTimeout(() => {
       this.channelMap.forEach((channel) => {
         channel.ping();
       });

--- a/packages/connection/src/common/server-handler.ts
+++ b/packages/connection/src/common/server-handler.ts
@@ -133,7 +133,7 @@ export abstract class BaseCommonChannelHandler {
       clearTimeout(this.heartbeatTimer);
     }
 
-    this.heartbeatTimer = global.setTimeout(() => {
+    this.heartbeatTimer = setTimeout(() => {
       this.doHeartbeat(connection);
       this.heartbeat(connection);
     }, 5000);

--- a/packages/core-browser/src/preferences/early-preferences.ts
+++ b/packages/core-browser/src/preferences/early-preferences.ts
@@ -97,7 +97,7 @@ export function registerLocalStorageProvider(key: string, workspaceFolder?: stri
         return;
       }
 
-      if (global.localStorage) {
+      if (typeof localStorage !== 'undefined') {
         if (value !== undefined) {
           localStorage.setItem(createLocalStorageKey(scope), value);
         } else {
@@ -106,7 +106,7 @@ export function registerLocalStorageProvider(key: string, workspaceFolder?: stri
       }
     },
     get: (scope) => {
-      if (global.localStorage) {
+      if (typeof localStorage !== 'undefined') {
         return localStorage.getItem(createLocalStorageKey(scope)) || undefined;
       }
     },

--- a/packages/core-browser/src/progress/progress-indicator.ts
+++ b/packages/core-browser/src/progress/progress-indicator.ts
@@ -55,7 +55,7 @@ export class ProgressIndicator implements IProgressIndicator {
   private showOnceScheduler(delay?: number) {
     if (typeof delay === 'number') {
       clearTimeout(this.scheduled);
-      this.scheduled = global.setTimeout(this.on, delay);
+      this.scheduled = setTimeout(this.on, delay);
     } else {
       this.on();
     }
@@ -68,14 +68,14 @@ export class ProgressIndicator implements IProgressIndicator {
       // 进度100%随后隐藏
       this.progressModel.worked = this.progressModel.total;
       if (delayed) {
-        global.setTimeout(this.off, 800);
+        setTimeout(this.off, 800);
       } else {
         this.off();
       }
     } else {
       // 通过css淡出隐藏
       if (delayed) {
-        global.setTimeout(this.off, 800);
+        setTimeout(this.off, 800);
       } else {
         this.off();
       }

--- a/packages/core-common/src/node/port.ts
+++ b/packages/core-common/src/node/port.ts
@@ -95,9 +95,7 @@ export function findFreePortFaster(startPort: number, giveUpAfter: number, timeo
     }
   }
   return new Promise<number>((resolve) => {
-    // 使用 global.setTimeout 消除歧义，减少测试问题
-    // ref: https://github.com/Microsoft/TypeScript/issues/30128#issuecomment-467968688
-    timeoutHandle = global.setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       doResolve(0, resolve);
     }, timeout);
 

--- a/packages/extension/src/hosted/api/vscode/ext.host.output.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.output.ts
@@ -89,7 +89,7 @@ export class OutputChannelImpl implements types.OutputChannel {
     }
 
     if (!this.batchedTimer) {
-      this.batchedTimer = global.setTimeout(() => this.flushOutputString(), OUTPUT_BATCH_DURATION_MS);
+      this.batchedTimer = setTimeout(() => this.flushOutputString(), OUTPUT_BATCH_DURATION_MS);
     }
   }
 
@@ -107,7 +107,7 @@ export class OutputChannelImpl implements types.OutputChannel {
     this.proxy.$append(this.name, this.batchedOutputLine);
     this.batchedOutputLine = '';
     if (this.batchedTimer) {
-      global.clearTimeout(this.batchedTimer);
+      clearTimeout(this.batchedTimer);
       this.batchedTimer = null;
     }
   }

--- a/packages/extension/src/hosted/api/vscode/ext.host.statusbar.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.statusbar.ts
@@ -29,7 +29,7 @@ export class ExtHostStatusBar implements IExtHostStatusBar {
     let handle: NodeJS.Timeout | undefined;
 
     if (typeof arg === 'number') {
-      handle = global.setTimeout(() => this.proxy.$dispose(), arg);
+      handle = setTimeout(() => this.proxy.$dispose(), arg);
     } else if (typeof arg !== 'undefined') {
       arg.then(
         () => this.proxy.$dispose(),
@@ -206,7 +206,7 @@ export class StatusBarItemImpl implements vscode.StatusBarItem {
       clearTimeout(this._timeoutHandle);
     }
     // Defer the update so that multiple changes to setters don't cause a redraw each
-    this._timeoutHandle = global.setTimeout(() => {
+    this._timeoutHandle = setTimeout(() => {
       this._timeoutHandle = undefined;
       const commandId = typeof this.command === 'string' ? this.command : this.command?.command;
       const commandArgs = typeof this.command === 'string' ? undefined : this.command?.arguments;

--- a/packages/extension/src/hosted/ext.host.proxy-base.ts
+++ b/packages/extension/src/hosted/ext.host.proxy-base.ts
@@ -153,8 +153,8 @@ export class ExtHostProxy extends Disposable implements IExtHostProxy {
   }
 
   private reconnectOnEvent = () => {
-    global.clearTimeout(this.reconnectingTimer);
-    this.reconnectingTimer = global.setTimeout(() => {
+    clearTimeout(this.reconnectingTimer);
+    this.reconnectingTimer = setTimeout(() => {
       this.logger.warn(this.LOG_TAG, 'reconnecting ext host server');
       this.createSocket();
     }, this.options.retryTime!);
@@ -163,7 +163,7 @@ export class ExtHostProxy extends Disposable implements IExtHostProxy {
   private connectOnEvent = () => {
     this.logger.info(this.LOG_TAG, 'connect success');
     // this.previouslyConnected = true;
-    global.clearTimeout(this.reconnectingTimer);
+    clearTimeout(this.reconnectingTimer);
     this.setRPCMethods();
     this.connectedEmitter.fire();
   };

--- a/packages/extension/src/node/extension.service.ts
+++ b/packages/extension/src/node/extension.service.ts
@@ -548,7 +548,7 @@ export class ExtensionNodeServiceImpl implements IExtensionNodeService {
         /**
          * in web, if current connection is closed, kill the ext process after a threshold
          */
-        const timer = global.setTimeout(() => {
+        const timer = setTimeout(() => {
           this.logger.log(`Dispose client by connectionClientId ${connectionClientId}`);
           this.disposeClientExtProcess(connectionClientId);
         }, this.appConfig.processCloseExitThreshold ?? ExtensionNodeServiceImpl.ProcessCloseExitThreshold);

--- a/packages/main-layout/__tests__/browser/layout.service.test.tsx
+++ b/packages/main-layout/__tests__/browser/layout.service.test.tsx
@@ -49,7 +49,7 @@ describe('main layout test', () => {
     let timeCount = 0;
     window.requestAnimationFrame = (cb) => {
       const cancelToken = 111;
-      const timeoutId = global.setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         timeCount += 30;
         cb(timeCount);
         timeoutIds.delete(timeoutId);

--- a/packages/terminal-next/src/node/pty.manager.remote.ts
+++ b/packages/terminal-next/src/node/pty.manager.remote.ts
@@ -97,7 +97,7 @@ export class PtyServiceManagerRemote extends PtyServiceManager {
       if (reconnectTimer) {
         return;
       }
-      reconnectTimer = global.setTimeout(() => {
+      reconnectTimer = setTimeout(() => {
         this.logger.log('PtyServiceManagerRemote reconnect');
         socket.destroy();
         this.initRemoteConnectionMode(opts);
@@ -111,7 +111,7 @@ export class PtyServiceManagerRemote extends PtyServiceManager {
         socket.setTimeout(0);
       }
       if (reconnectTimer) {
-        global.clearTimeout(reconnectTimer);
+        clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
       this.disposer.addDispose(this.initRPCService(socket));

--- a/packages/terminal-next/src/node/terminal.service.ts
+++ b/packages/terminal-next/src/node/terminal.service.ts
@@ -52,7 +52,7 @@ export class TerminalServiceImpl implements ITerminalNodeService {
     // 如果有相同的setClient clientId被调用，则取消延时触发closeClient，否则会导致终端无响应
     const timeOutHandler = this.closeTimeOutMap.get(clientId);
     if (timeOutHandler) {
-      global.clearTimeout(timeOutHandler);
+      clearTimeout(timeOutHandler);
       this.closeTimeOutMap.delete(clientId);
     }
   }
@@ -77,7 +77,7 @@ export class TerminalServiceImpl implements ITerminalNodeService {
 
   public closeClient(clientId: string) {
     // 延时触发，因为WS本身有重连逻辑，因此通过延时触发来避免断开后不就重连但是回调方法都被dispose的问题
-    const closeTimer = global.setTimeout(
+    const closeTimer = setTimeout(
       () => {
         this.disposeClient(clientId);
         this.logger.debug(`Remove pty process from ${clientId} client`);
@@ -119,7 +119,7 @@ export class TerminalServiceImpl implements ITerminalNodeService {
     this.batchedPtyDataMap.delete(sessionId);
 
     if (this.batchedPtyDataTimer.has(sessionId)) {
-      global.clearTimeout(this.batchedPtyDataTimer.get(sessionId)!);
+      clearTimeout(this.batchedPtyDataTimer.get(sessionId)!);
       this.batchedPtyDataTimer.delete(sessionId);
     }
 
@@ -164,7 +164,7 @@ export class TerminalServiceImpl implements ITerminalNodeService {
           if (!this.batchedPtyDataTimer.has(sessionId)) {
             this.batchedPtyDataTimer.set(
               sessionId,
-              global.setTimeout(() => this.flushPtyData(clientId, sessionId), BATCH_DURATION_MS),
+              setTimeout(() => this.flushPtyData(clientId, sessionId), BATCH_DURATION_MS),
             );
           }
         } else {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

browser 里没有 global，如果用了 global.setTimeout 就得让用户用 global 的 polyfill

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 移除了 `global` 前缀，简化了多个功能的定时器调用（如 `setTimeout` 和 `clearTimeout`），提高了代码可读性。
	- 确保在不同环境中更准确地检查 `localStorage` 的可用性。

这些更改未影响现有功能，保持了应用的稳定性和性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->