### PR TITLE
fix: direct debug adapter fix, and runInTerminal fix

### DIFF
--- a/packages/extension/src/browser/vscode/contributes/debuggers.ts
+++ b/packages/extension/src/browser/vscode/contributes/debuggers.ts
@@ -282,6 +282,10 @@ export class DebuggersContributionPoint extends VSCodeContributePoint<DebuggersC
         if (prop[name].properties) {
           recursionPropertiesDescription(prop[name].properties!);
         }
+        // 避免某些不规范的 json 配置打挂整个 debug 功能，做个防御
+        if (typeof prop[name] !== 'object') {
+          return;
+        }
         prop[name].description = replaceLocalizePlaceholder(prop[name].description, extension.id);
         prop[name].markdownDescription = replaceLocalizePlaceholder(prop[name].markdownDescription, extension.id);
       });

--- a/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
+++ b/packages/extension/src/hosted/api/vscode/debug/extension-debug-adapter-starter.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import { ChildProcess, SpawnOptions, fork, spawn } from 'child_process';
 import net from 'net';
+import { EventEmitter } from 'node:events';
+import stream from 'stream';
 
 import { DebugAdapterForkExecutable, DebugStreamConnection } from '@opensumi/ide-debug';
 
@@ -82,17 +84,99 @@ export function connectDebugAdapter(server: vscode.DebugAdapterServer): DebugStr
 }
 
 /**
+ * Custom MessageReader to parse DAP messages from the input stream
+ */
+class MessageReader extends EventEmitter {
+  private contentLength: number = -1;
+  private buffer: Buffer = Buffer.alloc(0);
+
+  constructor(private input: stream.Readable) {
+    super();
+    input.on('data', this.onData.bind(this));
+  }
+
+  private onData(data: Buffer) {
+    this.buffer = Buffer.concat([this.buffer, data]);
+
+    while (true) {
+      if (this.contentLength === -1) {
+        const headerEnd = this.buffer.indexOf('\r\n\r\n');
+        if (headerEnd === -1) {
+          break; // Not enough data
+        }
+        const header = this.buffer.slice(0, headerEnd).toString();
+        const match = header.match(/Content-Length: (\d+)/);
+        if (match) {
+          this.contentLength = parseInt(match[1], 10);
+          this.buffer = this.buffer.slice(headerEnd + 4);
+        } else {
+          this.emit('error', new Error('Invalid header'));
+          return;
+        }
+      }
+
+      if (this.buffer.length >= this.contentLength) {
+        const messageBytes = this.buffer.slice(0, this.contentLength);
+        this.buffer = this.buffer.slice(this.contentLength);
+        this.contentLength = -1;
+
+        const message = JSON.parse(messageBytes.toString());
+        this.emit('message', message);
+      } else {
+        break; // Not enough data
+      }
+    }
+  }
+}
+
+/**
+ * Custom MessageWriter to serialize DAP messages to the output stream
+ */
+class MessageWriter {
+  constructor(private output: stream.Writable) {}
+
+  write(message: any) {
+    const json = message;
+    const contentLength = Buffer.byteLength(message, 'utf8');
+    const header = `Content-Length: ${contentLength}\r\n\r\n`;
+    this.output.write(header + json);
+  }
+}
+
+/**
  * 直接调用插件自己实现的调试适配器
  * 这里通过 server 服务来拉起适配器
+ * Modify directDebugAdapter to directly interface with DebugStreamConnection
  */
 export function directDebugAdapter(id: string, da: vscode.DebugAdapter): DebugStreamConnection {
-  const server = net
-    .createServer(() => {
-      const session = new DirectDebugAdapter(id, da);
-      session.start();
-    })
-    .listen(0);
-  return connectDebugAdapter({ port: (server.address() as net.AddressInfo).port });
+  const input = new stream.PassThrough();
+  const output = new stream.PassThrough();
+
+  const adapter = new DirectDebugAdapter(id, da);
+  adapter.start();
+
+  const reader = new MessageReader(input);
+  const writer = new MessageWriter(output);
+
+  // Pass messages from the input stream to the adapter
+  reader.on('message', (message) => {
+    adapter.sendMessage(message);
+  });
+
+  // Send messages from the adapter to the output stream
+  adapter.onMessageReceived((message) => {
+    writer.write(message);
+  });
+
+  return {
+    input,
+    output,
+    dispose: () => {
+      input.destroy();
+      output.destroy();
+      adapter.dispose();
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
### Types

修复 DAP 支持 和 OpenSumi Debug 的错误
- 修复 directDebugAdapter 无法使用的问题
- 修复 DAP 调用 runInTerminal 后服务端无法拿到 pid 的问题

- [x] 🐛 Bug Fixes

### Background or solution

目前 OpenSumi Debug 对于 directDebugAdapter 的支持有问题，导致插件注册的 directDebugAdapter 无法正常对接 Debug 能力，表现是 DAP 的 IO 完全不通。重写了这部分 IO 对接逻辑后，问题被解决。

另外 RunInTerminal 也有问题，表现是 Debug 时拉起终端运行程序之后，DAP Server 感知不到 Server 被拉起来，同时也拿不到进程的 pid。发现问题在于 RunInTerminal 在 IDE 侧调用后没有 await，就直接返回空结果给 DAP Server。

### Changelog
- direct debug adapter fix
- runInTerminal no pid response fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了调试请求的响应处理，支持异步操作，提高了调试过程的可靠性。
  - 引入了新的消息读取和写入类，增强了调试适配器之间的消息通信。

- **错误修复**
  - 添加了防御性检查，确保调试器配置的 JSON 格式正确，避免运行时错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->