### PR TITLE
fix: avoid rpc proxy leak

### DIFF
--- a/packages/connection/src/common/capturer.ts
+++ b/packages/connection/src/common/capturer.ts
@@ -71,7 +71,7 @@ export class Capturer implements IDisposable {
     }
   };
 
-  constructor(protected source: string) {
+  constructor(public source: string) {
     this.prefix = randomString(6);
     this.capturer = getCapturer();
 

--- a/packages/connection/src/common/rpc/connection.ts
+++ b/packages/connection/src/common/rpc/connection.ts
@@ -375,4 +375,10 @@ export class SumiConnection implements IDisposable {
   private traceRequestError(requestId: number, method: string, args: any[], error: any) {
     this.capturer.captureSendRequestFail(requestId, method, error);
   }
+
+  toJSON() {
+    throw new Error(
+      "You're trying to serialize a SumiConnection instance, which is not allowed.\nPlease check your code, and remove the rpc proxy reference.",
+    );
+  }
 }

--- a/packages/connection/src/common/rpc/multiplexer.ts
+++ b/packages/connection/src/common/rpc/multiplexer.ts
@@ -112,10 +112,17 @@ export class SumiConnectionMultiplexer extends SumiConnection implements IRPCPro
         if (typeof name === 'symbol') {
           return null;
         }
+
         // charCodeAt(0) === 36 means starts with $
-        if (!target[name] && name.charCodeAt(0) === 36) {
-          const rpcName = SumiConnectionMultiplexer.getRPCName(rpcId, name);
-          target[name] = (...args: any[]) => this.sendRequest(rpcName, ...args);
+        if (!target[name]) {
+          if (name.charCodeAt(0) === 36) {
+            const rpcName = SumiConnectionMultiplexer.getRPCName(rpcId, name);
+            target[name] = (...args: any[]) => this.sendRequest(rpcName, ...args);
+          } else if (name === 'toJSON') {
+            target[name] = () => {
+              throw new Error('Cannot serialize a rpc protocol proxy object');
+            };
+          }
         }
 
         return target[name];

--- a/packages/extension/src/browser/vscode/api/main.thread.commands.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.commands.ts
@@ -13,7 +13,7 @@ export interface IExtCommandHandler extends IDisposable {
 }
 @Injectable({ multiple: true })
 export class MainThreadCommands implements IMainThreadCommands {
-  private readonly proxy: IExtHostCommands;
+  readonly #proxy: IExtHostCommands;
 
   private readonly commands = new Map<string, IExtCommandHandler>();
 
@@ -34,9 +34,9 @@ export class MainThreadCommands implements IMainThreadCommands {
   private disposable = new Disposable();
 
   constructor(@Optional(IRPCProtocol) private rpcProtocol: IRPCProtocol) {
-    this.proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostCommands);
-    this.proxy.$registerBuiltInCommands();
-    this.proxy.$registerCommandConverter();
+    this.#proxy = this.rpcProtocol.getProxy(ExtHostAPIIdentifier.ExtHostCommands);
+    this.#proxy.$registerBuiltInCommands();
+    this.#proxy.$registerCommandConverter();
     this.registerUriArgProcessor();
   }
 
@@ -83,7 +83,7 @@ export class MainThreadCommands implements IMainThreadCommands {
   }
 
   $registerCommand(id: string): void {
-    const proxy = this.proxy;
+    const proxy = this.#proxy;
 
     const execute = (...args) => {
       args = args.map((arg) => this.argumentProcessors.reduce((r, p) => p.processArgument(r), arg));
@@ -129,7 +129,7 @@ export class MainThreadCommands implements IMainThreadCommands {
       return this.commands.get(id)!.execute(...args);
     } else {
       args = args.map((arg) => this.argumentProcessors.reduce((r, p) => p.processArgument(r), arg));
-      return this.proxy.$executeContributedCommand(id, ...args);
+      return this.#proxy.$executeContributedCommand(id, ...args);
     }
   }
 

--- a/packages/extension/src/hosted/api/vscode/doc/ext-data.host.ts
+++ b/packages/extension/src/hosted/api/vscode/doc/ext-data.host.ts
@@ -31,7 +31,8 @@ export function regExpLeadsToEndlessLoop(regexp: RegExp): boolean {
 }
 
 export class ExtHostDocumentData extends MirrorTextModel {
-  private _proxy: IMainThreadDocumentsShape;
+  readonly #proxy: IMainThreadDocumentsShape;
+
   private _languageId: string;
   private _isDirty: boolean;
   private _document: vscode.TextDocument;
@@ -48,7 +49,7 @@ export class ExtHostDocumentData extends MirrorTextModel {
     isDirty: boolean,
   ) {
     super(uri, lines, eol, versionId);
-    this._proxy = proxy;
+    this.#proxy = proxy;
     this._languageId = languageId;
     this._isDirty = isDirty;
   }
@@ -147,7 +148,7 @@ export class ExtHostDocumentData extends MirrorTextModel {
     if (this._isDisposed) {
       return Promise.reject(new Error('Document has been closed'));
     }
-    return this._proxy.$trySaveDocument(this._uri.toString());
+    return this.#proxy.$trySaveDocument(this._uri.toString());
   }
 
   private _getTextInRange(_range: vscode.Range): string {

--- a/packages/extension/src/hosted/api/vscode/ext.host.command.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.command.ts
@@ -110,8 +110,7 @@ export function createCommandsApiFactory(
 }
 
 export class ExtHostCommands implements IExtHostCommands {
-  protected readonly proxy: IMainThreadCommands;
-  protected readonly rpcProtocol: IRPCProtocol;
+  readonly #proxy: IMainThreadCommands;
   protected readonly logger = getDebugLogger();
   protected readonly commands = new Map<string, CommandHandler<any>>();
   protected readonly argumentProcessors: ArgumentProcessor[] = [];
@@ -119,8 +118,7 @@ export class ExtHostCommands implements IExtHostCommands {
   public converter: CommandsConverter;
 
   constructor(rpcProtocol: IRPCProtocol, private buildInCommands?: IBuiltInCommand[]) {
-    this.rpcProtocol = rpcProtocol;
-    this.proxy = this.rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadCommands);
+    this.#proxy = rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadCommands);
     this.registerUriArgProcessor();
   }
 
@@ -247,13 +245,13 @@ export class ExtHostCommands implements IExtHostCommands {
       this.commands.set(id, handler);
     }
     if (global) {
-      this.proxy.$registerCommand(id);
+      this.#proxy.$registerCommand(id);
     }
 
     return Disposable.create(() => {
       if (this.commands.delete(id)) {
         if (global) {
-          this.proxy.$unregisterCommand(id);
+          this.#proxy.$unregisterCommand(id);
         }
       }
     });
@@ -301,7 +299,7 @@ export class ExtHostCommands implements IExtHostCommands {
       // automagically convert some argument types
       args = this.convertArguments(args);
 
-      return this.proxy
+      return this.#proxy
         .$executeCommandWithExtensionInfo<T>(id, extensionInfo, ...args)
         .then((result) => revive(result, 0));
     }
@@ -316,7 +314,7 @@ export class ExtHostCommands implements IExtHostCommands {
       // automagically convert some argument types
       args = this.convertArguments(args);
 
-      return this.proxy.$executeCommand<T>(id, ...args).then((result) => revive(result, 0));
+      return this.#proxy.$executeCommand<T>(id, ...args).then((result) => revive(result, 0));
     }
   }
 
@@ -369,7 +367,7 @@ export class ExtHostCommands implements IExtHostCommands {
   async getCommands(filterUnderscoreCommands = false): Promise<string[]> {
     this.logger.log('ExtHostCommands#getCommands', filterUnderscoreCommands);
 
-    const result = await this.proxy.$getCommands();
+    const result = await this.#proxy.$getCommands();
     if (filterUnderscoreCommands) {
       return result.filter((command) => command[0] !== '_');
     }
@@ -392,16 +390,17 @@ export class ExtHostCommands implements IExtHostCommands {
 }
 
 export class CommandsConverter {
+  readonly #commands: ExtHostCommands;
+
   private readonly _delegatingCommandId: string;
-  private readonly _commands: ExtHostCommands;
   private readonly _cache = new Map<number, vscode.Command>();
   private _cachIdPool = 0;
 
   // --- conversion between internal and api commands
   constructor(commands: ExtHostCommands, private readonly _lookupApiCommand: (id: string) => ApiCommand | undefined) {
     this._delegatingCommandId = `_vscode_delegate_cmd_${Date.now().toString(36)}`;
-    this._commands = commands;
-    this._commands.registerCommand(true, this._delegatingCommandId, this._executeConvertedCommand, this);
+    this.#commands = commands;
+    this.#commands.registerCommand(true, this._delegatingCommandId, this._executeConvertedCommand, this);
   }
 
   toInternal(command: vscode.Command | undefined, disposables: DisposableStore): CommandDto | undefined {
@@ -459,6 +458,6 @@ export class CommandsConverter {
     if (!actualCmd) {
       return Promise.reject('actual command NOT FOUND');
     }
-    return this._commands.executeCommand(actualCmd.command, ...(actualCmd.arguments || []));
+    return this.#commands.executeCommand(actualCmd.command, ...(actualCmd.arguments || []));
   }
 }

--- a/packages/extension/src/hosted/api/vscode/ext.host.output.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.output.ts
@@ -57,23 +57,23 @@ const OUTPUT_BATCH_DURATION_MS = 5;
 export class OutputChannelImpl implements types.OutputChannel {
   private disposed: boolean;
 
-  private proxy: IMainThreadOutput;
+  readonly #proxy: IMainThreadOutput;
 
   private batchedOutputLine = '';
 
   private batchedTimer: NodeJS.Timeout | null = null;
 
-  constructor(readonly name: string, private rpcProtocol: IRPCProtocol) {
-    this.proxy = this.rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadOutput);
+  constructor(readonly name: string, rpcProtocol: IRPCProtocol) {
+    this.#proxy = rpcProtocol.getProxy(MainThreadAPIIdentifier.MainThreadOutput);
   }
 
   replace(value: string): void {
-    this.proxy.$replace(this.name, value);
+    this.#proxy.$replace(this.name, value);
   }
 
   dispose(): void {
     if (!this.disposed) {
-      this.proxy.$dispose(this.name).then(() => {
+      this.#proxy.$dispose(this.name).then(() => {
         this.disposed = true;
       });
     }
@@ -100,11 +100,11 @@ export class OutputChannelImpl implements types.OutputChannel {
 
   clear(): void {
     this.validate();
-    this.proxy.$clear(this.name);
+    this.#proxy.$clear(this.name);
   }
 
   protected flushOutputString() {
-    this.proxy.$append(this.name, this.batchedOutputLine);
+    this.#proxy.$append(this.name, this.batchedOutputLine);
     this.batchedOutputLine = '';
     if (this.batchedTimer) {
       clearTimeout(this.batchedTimer);
@@ -114,16 +114,16 @@ export class OutputChannelImpl implements types.OutputChannel {
 
   show(preserveFocus: boolean | undefined): void {
     this.validate();
-    this.proxy.$reveal(this.name, !!preserveFocus);
+    this.#proxy.$reveal(this.name, !!preserveFocus);
   }
 
   hide(): void {
     this.validate();
-    this.proxy.$close(this.name);
+    this.#proxy.$close(this.name);
   }
 
   setLanguageId(languageId: string): void {
-    this.proxy.$setLanguageId(this.name, languageId);
+    this.#proxy.$setLanguageId(this.name, languageId);
   }
 
   protected validate(): void {

--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -201,15 +201,17 @@ function historyItemGroupEquals(
   );
 }
 
-function getInputBoxActionButtonIcon(actionButton?: vscode.SourceControlInputBoxActionButton): UriComponents | { light: UriComponents; dark: UriComponents } | vscode.ThemeIcon | undefined {
-	if (!actionButton?.icon) {
-		return undefined;
-	} else if (URI.isUri(actionButton.icon)) {
-		return actionButton.icon;
-	} else {
-		const icon = actionButton.icon as { light: URI; dark: URI };
-		return { light: icon.light, dark: icon.dark };
-	}
+function getInputBoxActionButtonIcon(
+  actionButton?: vscode.SourceControlInputBoxActionButton,
+): UriComponents | { light: UriComponents; dark: UriComponents } | vscode.ThemeIcon | undefined {
+  if (!actionButton?.icon) {
+    return undefined;
+  } else if (URI.isUri(actionButton.icon)) {
+    return actionButton.icon;
+  } else {
+    const icon = actionButton.icon as { light: URI; dark: URI };
+    return { light: icon.light, dark: icon.dark };
+  }
 }
 
 export type IValidateInput = (
@@ -218,6 +220,9 @@ export type IValidateInput = (
 ) => vscode.ProviderResult<vscode.SourceControlInputBoxValidation | undefined | null>;
 
 export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
+  readonly #proxy: IMainThreadSCMShape;
+  readonly #commands: ExtHostCommands;
+
   private _value = '';
 
   get value(): string {
@@ -225,7 +230,7 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
   }
 
   set value(value: string) {
-    this._proxy.$setInputBoxValue(this._sourceControlHandle, value);
+    this.#proxy.$setInputBoxValue(this._sourceControlHandle, value);
     this.updateValue(value);
   }
 
@@ -243,7 +248,7 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
     }
 
     this._enabled = enabled;
-    this._proxy.$setInputBoxEnablement(this._sourceControlHandle, enabled);
+    this.#proxy.$setInputBoxEnablement(this._sourceControlHandle, enabled);
   }
 
   private _onDidChange = new Emitter<string>();
@@ -259,7 +264,7 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
   }
 
   set placeholder(placeholder: string) {
-    this._proxy.$setInputBoxPlaceholder(this._sourceControlHandle, placeholder);
+    this.#proxy.$setInputBoxPlaceholder(this._sourceControlHandle, placeholder);
     this._placeholder = placeholder;
   }
 
@@ -276,7 +281,7 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
     }
 
     this._validateInput = fn;
-    this._proxy.$setValidationProviderIsEnabled(this._sourceControlHandle, !!fn);
+    this.#proxy.$setValidationProviderIsEnabled(this._sourceControlHandle, !!fn);
   }
 
   private _visible = true;
@@ -288,37 +293,40 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
   set visible(visible: boolean) {
     visible = !!visible;
     this._visible = visible;
-    this._proxy.$setInputBoxVisibility(this._sourceControlHandle, visible);
+    this.#proxy.$setInputBoxVisibility(this._sourceControlHandle, visible);
   }
 
   private _actionButton: vscode.SourceControlInputBoxActionButton | undefined;
-	private _actionButtonDisposables = new MutableDisposable<DisposableStore>();
+  private _actionButtonDisposables = new MutableDisposable<DisposableStore>();
 
-	get actionButton(): vscode.SourceControlInputBoxActionButton | undefined {
-		return this._actionButton;
-	}
+  get actionButton(): vscode.SourceControlInputBoxActionButton | undefined {
+    return this._actionButton;
+  }
 
-	set actionButton(actionButton: vscode.SourceControlInputBoxActionButton | undefined) {
-		this._actionButtonDisposables.value = new DisposableStore();
+  set actionButton(actionButton: vscode.SourceControlInputBoxActionButton | undefined) {
+    this._actionButtonDisposables.value = new DisposableStore();
 
-		this._actionButton = actionButton;
+    this._actionButton = actionButton;
 
-		const internal = actionButton !== undefined ?
-			{
-				command: this._commands.converter.toInternal(actionButton.command, this._actionButtonDisposables.value)!,
-				icon: getInputBoxActionButtonIcon(actionButton),
-				enabled: actionButton.enabled,
-			} : undefined;
-		this._proxy.$setInputBoxActionButton(this._sourceControlHandle, internal ?? null);
-	}
+    const internal =
+      actionButton !== undefined
+        ? {
+            command: this.#commands.converter.toInternal(actionButton.command, this._actionButtonDisposables.value)!,
+            icon: getInputBoxActionButtonIcon(actionButton),
+            enabled: actionButton.enabled,
+          }
+        : undefined;
+    this.#proxy.$setInputBoxActionButton(this._sourceControlHandle, internal ?? null);
+  }
 
   constructor(
     private _extension: IExtensionDescription,
-    private _proxy: IMainThreadSCMShape,
+    _proxy: IMainThreadSCMShape,
     private _sourceControlHandle: number,
-    private _commands: ExtHostCommands,
+    _commands: ExtHostCommands,
   ) {
-    // noop
+    this.#proxy = _proxy;
+    this.#commands = _commands;
   }
 
   $onInputBoxValueChange(value: string): void {
@@ -363,7 +371,7 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
   }
   set label(label: string) {
     this._label = label;
-    this._proxy.$updateGroupLabel(this._sourceControlHandle, this.handle, label);
+    this.#proxy.$updateGroupLabel(this._sourceControlHandle, this.handle, label);
   }
 
   private _hideWhenEmpty: boolean | undefined = undefined;
@@ -372,7 +380,7 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
   }
   set hideWhenEmpty(hideWhenEmpty: boolean | undefined) {
     this._hideWhenEmpty = hideWhenEmpty;
-    this._proxy.$updateGroup(this._sourceControlHandle, this.handle, { hideWhenEmpty });
+    this.#proxy.$updateGroup(this._sourceControlHandle, this.handle, { hideWhenEmpty });
   }
 
   get resourceStates(): vscode.SourceControlResourceState[] {
@@ -384,15 +392,16 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
   }
 
   readonly handle = ExtHostSourceControlResourceGroup._handlePool++;
-
+  readonly #proxy: IMainThreadSCMShape;
   constructor(
-    private _proxy: IMainThreadSCMShape,
+    _proxy: IMainThreadSCMShape,
     private _commands: ExtHostCommands,
     private _sourceControlHandle: number,
     private _id: string,
     private _label: string,
   ) {
-    this._proxy.$registerGroup(_sourceControlHandle, this.handle, _id, _label);
+    this.#proxy = _proxy;
+    this.#proxy.$registerGroup(_sourceControlHandle, this.handle, _id, _label);
   }
 
   getResourceState(handle: number): vscode.SourceControlResourceState | undefined {
@@ -487,7 +496,7 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
   }
 
   dispose(): void {
-    this._proxy.$unregisterGroup(this._sourceControlHandle, this.handle);
+    this.#proxy.$unregisterGroup(this._sourceControlHandle, this.handle);
     this._onDidDispose.fire();
   }
 }
@@ -545,7 +554,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
         enabled: actionButton.enabled ?? true,
       };
     }
-    this._proxy.$updateSourceControl(this.handle, { actionButton: internal ?? null });
+    this.#proxy.$updateSourceControl(this.handle, { actionButton: internal ?? null });
   }
 
   get id(): string {
@@ -577,7 +586,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
     }
 
     this._count = count;
-    this._proxy.$updateSourceControl(this.handle, { count });
+    this.#proxy.$updateSourceControl(this.handle, { count });
   }
 
   private _quickDiffProvider: vscode.QuickDiffProvider | undefined = undefined;
@@ -588,7 +597,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
 
   set quickDiffProvider(quickDiffProvider: vscode.QuickDiffProvider | undefined) {
     this._quickDiffProvider = quickDiffProvider;
-    this._proxy.$updateSourceControl(this.handle, { hasQuickDiffProvider: !!quickDiffProvider });
+    this.#proxy.$updateSourceControl(this.handle, { hasQuickDiffProvider: !!quickDiffProvider });
   }
 
   private _historyProvider: vscode.SourceControlHistoryProvider | undefined;
@@ -604,7 +613,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
     this._historyProvider = historyProvider;
     this._historyProviderDisposable.value = new DisposableStore();
 
-    this._proxy.$updateSourceControl(this.handle, { hasHistoryProvider: !!historyProvider });
+    this.#proxy.$updateSourceControl(this.handle, { hasHistoryProvider: !!historyProvider });
 
     if (historyProvider) {
       this._historyProviderDisposable.value.add(
@@ -619,7 +628,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
           }
 
           this._historyProviderCurrentHistoryItemGroup = historyProvider?.currentHistoryItemGroup;
-          this._proxy.$onDidChangeHistoryProviderCurrentHistoryItemGroup(
+          this.#proxy.$onDidChangeHistoryProviderCurrentHistoryItemGroup(
             this.handle,
             this._historyProviderCurrentHistoryItemGroup,
           );
@@ -641,7 +650,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
                 }
               : undefined;
 
-          this._proxy.$onDidChangeHistoryProviderActionButton(this.handle, internal ?? null);
+          this.#proxy.$onDidChangeHistoryProviderActionButton(this.handle, internal ?? null);
         }),
       );
     }
@@ -655,7 +664,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
 
   set commitTemplate(commitTemplate: string | undefined) {
     this._commitTemplate = commitTemplate;
-    this._proxy.$updateSourceControl(this.handle, { commitTemplate });
+    this.#proxy.$updateSourceControl(this.handle, { commitTemplate });
   }
 
   private _acceptInputDisposables = new MutableDisposable<DisposableStore>();
@@ -671,7 +680,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
     this._acceptInputCommand = acceptInputCommand;
 
     const internal = this._commands.converter.toInternal(acceptInputCommand, this._acceptInputDisposables.value);
-    this._proxy.$updateSourceControl(this.handle, { acceptInputCommand: internal });
+    this.#proxy.$updateSourceControl(this.handle, { acceptInputCommand: internal });
   }
 
   private _statusBarDisposables = new MutableDisposable<DisposableStore>();
@@ -693,7 +702,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
     const internal = (statusBarCommands || []).map((c) =>
       this._commands.converter.toInternal(c, this._statusBarDisposables.value!),
     ) as CommandDto[];
-    this._proxy.$updateSourceControl(this.handle, { statusBarCommands: internal });
+    this.#proxy.$updateSourceControl(this.handle, { statusBarCommands: internal });
   }
 
   private _selected = false;
@@ -707,22 +716,26 @@ class ExtHostSourceControl implements vscode.SourceControl {
 
   private handle: number = ExtHostSourceControl._handlePool++;
 
+  readonly #proxy: IMainThreadSCMShape;
+
   constructor(
     _extension: IExtensionDescription,
-    private _proxy: IMainThreadSCMShape,
+    _proxy: IMainThreadSCMShape,
     private _commands: ExtHostCommands,
     private _id: string,
     private _label: string,
     private _rootUri?: vscode.Uri,
   ) {
-    this._inputBox = new ExtHostSCMInputBox(_extension, this._proxy, this.handle, this._commands);
-    this._proxy.$registerSourceControl(this.handle, _id, _label, _rootUri);
+    this.#proxy = _proxy;
+
+    this._inputBox = new ExtHostSCMInputBox(_extension, this.#proxy, this.handle, this._commands);
+    this.#proxy.$registerSourceControl(this.handle, _id, _label, _rootUri);
   }
 
   private updatedResourceGroups = new Set<ExtHostSourceControlResourceGroup>();
 
   createResourceGroup(id: string, label: string): ExtHostSourceControlResourceGroup {
-    const group = new ExtHostSourceControlResourceGroup(this._proxy, this._commands, this.handle, id, label);
+    const group = new ExtHostSourceControlResourceGroup(this.#proxy, this._commands, this.handle, id, label);
 
     const updateListener = group.onDidUpdateResourceStates(() => {
       this.updatedResourceGroups.add(group);
@@ -754,7 +767,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
     });
 
     if (splices.length > 0) {
-      this._proxy.$spliceResourceStates(this.handle, splices);
+      this.#proxy.$spliceResourceStates(this.handle, splices);
     }
 
     this.updatedResourceGroups.clear();
@@ -774,7 +787,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
     this._statusBarDisposables.dispose();
 
     this._groups.forEach((group) => group.dispose());
-    this._proxy.$unregisterSourceControl(this.handle);
+    this.#proxy.$unregisterSourceControl(this.handle);
   }
 }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

git 插件如果要传输 SourceControl，现在会序列化失败

![image](https://github.com/user-attachments/assets/049cf6cd-8e94-47a3-9414-832b147da42a)


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `Capturer` 类的 `source` 属性现在可以从外部访问，增强了可用性。
  - 在 `SumiConnection` 类中添加了 `toJSON` 方法，调用时会抛出错误，指示不允许序列化。

- **代码改进**
  - 多个类的属性访问权限已从保护改为私有，增强了封装性。
  - 代码格式进行了调整，提高了可读性。

- **修复**
  - 更新了与私有字段的引用，确保一致性和代码可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->