### PR TITLE
feat: support intelligent completions  always visible preference

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -77,7 +77,6 @@ import { ChatProxyService } from './chat/chat-proxy.service';
 import { AIChatView } from './chat/chat.view';
 import { CodeActionSingleHandler } from './contrib/code-action/code-action.handler';
 import { AIInlineCompletionsProvider } from './contrib/inline-completions/completeProvider';
-import { InlineCompletionSingleHandler } from './contrib/inline-completions/inline-completions.handler';
 import { AICompletionsService } from './contrib/inline-completions/service/ai-completions.service';
 import { IntelligentCompletionsController } from './contrib/intelligent-completions/intelligent-completions.controller';
 import { ProblemFixController } from './contrib/problem-fix/problem-fix.controller';
@@ -203,9 +202,6 @@ export class AINativeBrowserContribution
   @Autowired(RenameSingleHandler)
   private readonly renameSingleHandler: RenameSingleHandler;
 
-  @Autowired(InlineCompletionSingleHandler)
-  private readonly inlineCompletionSingleHandler: InlineCompletionSingleHandler;
-
   @Autowired(CodeActionSingleHandler)
   private readonly codeActionSingleHandler: CodeActionSingleHandler;
 
@@ -272,8 +268,7 @@ export class AINativeBrowserContribution
 
   onDidStart() {
     runWhenIdle(() => {
-      const { supportsInlineCompletion, supportsRenameSuggestions, supportsInlineChat } =
-        this.aiNativeConfigService.capabilities;
+      const { supportsRenameSuggestions, supportsInlineChat } = this.aiNativeConfigService.capabilities;
       const prefChatVisibleType = this.preferenceService.getValid(AINativeSettingSectionsId.ChatVisibleType);
 
       if (prefChatVisibleType === 'always') {
@@ -284,10 +279,6 @@ export class AINativeBrowserContribution
 
       if (supportsRenameSuggestions) {
         this.renameSingleHandler.load();
-      }
-
-      if (supportsInlineCompletion) {
-        this.inlineCompletionSingleHandler.load();
       }
 
       if (supportsInlineChat) {
@@ -338,19 +329,23 @@ export class AINativeBrowserContribution
 
     if (this.aiNativeConfigService.capabilities.supportsInlineCompletion) {
       registry.registerSettingSection(AI_NATIVE_SETTING_GROUP_ID, {
-        title: localize('preference.ai.native.inlineCompletions.title'),
+        title: localize('preference.ai.native.intelligentCompletions.title'),
         preferences: [
           {
-            id: AINativeSettingSectionsId.InlineCompletionsCacheEnabled,
-            localized: 'preference.ai.native.inlineCompletions.cache.enabled',
+            id: AINativeSettingSectionsId.IntelligentCompletionsCacheEnabled,
+            localized: 'preference.ai.native.intelligentCompletions.cache.enabled',
           },
           {
-            id: AINativeSettingSectionsId.InlineCompletionsDebounceTime,
-            localized: 'preference.ai.native.inlineCompletions.debounceTime',
+            id: AINativeSettingSectionsId.IntelligentCompletionsDebounceTime,
+            localized: 'preference.ai.native.intelligentCompletions.debounceTime',
           },
           {
-            id: AINativeSettingSectionsId.InlineCompletionsPromptEngineeringEnabled,
-            localized: 'preference.ai.native.inlineCompletions.promptEngineering.enabled',
+            id: AINativeSettingSectionsId.IntelligentCompletionsPromptEngineeringEnabled,
+            localized: 'preference.ai.native.intelligentCompletions.promptEngineering.enabled',
+          },
+          {
+            id: AINativeSettingSectionsId.IntelligentCompletionsAlwaysVisible,
+            localized: 'preference.ai.native.intelligentCompletions.always.visible',
           },
         ],
       });
@@ -383,7 +378,6 @@ export class AINativeBrowserContribution
         const { monacoEditor } = editor;
 
         this.codeActionSingleHandler.mountEditor(editor.monacoEditor);
-        this.inlineCompletionSingleHandler.mountEditor(editor.monacoEditor);
 
         return monacoEditor.onDidScrollChange(() => {
           if (this.ctxMenuRenderer.visible) {

--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -345,7 +345,7 @@ export class AINativeBrowserContribution
           },
           {
             id: AINativeSettingSectionsId.IntelligentCompletionsAlwaysVisible,
-            localized: 'preference.ai.native.intelligentCompletions.always.visible',
+            localized: 'preference.ai.native.intelligentCompletions.alwaysVisible',
           },
         ],
       });

--- a/packages/ai-native/src/browser/contrib/inline-completions/completeProvider.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/completeProvider.ts
@@ -65,13 +65,13 @@ export class AIInlineCompletionsProvider extends WithEventBus {
     super();
 
     this.inlineComletionsDebounceTime = this.preferenceService.getValid(
-      AINativeSettingSectionsId.InlineCompletionsDebounceTime,
+      AINativeSettingSectionsId.IntelligentCompletionsDebounceTime,
       150,
     );
 
     this.addDispose(
       this.preferenceService.onSpecificPreferenceChange(
-        AINativeSettingSectionsId.InlineCompletionsDebounceTime,
+        AINativeSettingSectionsId.IntelligentCompletionsDebounceTime,
         ({ newValue }) => {
           this.inlineComletionsDebounceTime = newValue;
         },

--- a/packages/ai-native/src/browser/contrib/inline-completions/model/inlineCompletionRequestTask.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/model/inlineCompletionRequestTask.ts
@@ -67,13 +67,13 @@ export class InlineCompletionRequestTask extends Disposable {
     this.isCancelFlag = false;
 
     this.isEnablePromptEngineering = this.preferenceService.getValid(
-      AINativeSettingSectionsId.InlineCompletionsPromptEngineeringEnabled,
+      AINativeSettingSectionsId.IntelligentCompletionsPromptEngineeringEnabled,
       this.isEnablePromptEngineering,
     );
 
     this._disposables.add(
       this.preferenceService.onSpecificPreferenceChange(
-        AINativeSettingSectionsId.InlineCompletionsPromptEngineeringEnabled,
+        AINativeSettingSectionsId.IntelligentCompletionsPromptEngineeringEnabled,
         ({ newValue }) => {
           this.isEnablePromptEngineering = newValue;
         },
@@ -143,7 +143,6 @@ export class InlineCompletionRequestTask extends Disposable {
       return [];
     }
 
-    this.aiCompletionsService.updateStatusBarItem('running', true);
     const requestStartTime = Date.now();
 
     let completeResult: IIntelligentCompletionsResult | undefined;
@@ -157,7 +156,9 @@ export class InlineCompletionRequestTask extends Disposable {
       completeResult = cacheData;
     } else {
       try {
+        this.aiCompletionsService.updateStatusBarItem('running', true);
         completeResult = await this.aiCompletionsService.complete(requestBean);
+        this.aiCompletionsService.hideStatusBarItem();
       } catch (error) {
         this.aiCompletionsService.reporterEnd(relationId, {
           success: false,

--- a/packages/ai-native/src/browser/contrib/inline-completions/model/inlineCompletionRequestTask.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/model/inlineCompletionRequestTask.ts
@@ -158,7 +158,6 @@ export class InlineCompletionRequestTask extends Disposable {
       try {
         this.aiCompletionsService.updateStatusBarItem('running', true);
         completeResult = await this.aiCompletionsService.complete(requestBean);
-        this.aiCompletionsService.hideStatusBarItem();
       } catch (error) {
         this.aiCompletionsService.reporterEnd(relationId, {
           success: false,
@@ -167,6 +166,8 @@ export class InlineCompletionRequestTask extends Disposable {
         });
         this.aiCompletionsService.hideStatusBarItem();
         return [];
+      } finally {
+        this.aiCompletionsService.hideStatusBarItem();
       }
     }
 

--- a/packages/ai-native/src/browser/contrib/inline-completions/promptCache.ts
+++ b/packages/ai-native/src/browser/contrib/inline-completions/promptCache.ts
@@ -36,13 +36,13 @@ export class PromptCache implements IDisposable {
   protected _isCacheEnabled = false;
   constructor() {
     this._isCacheEnabled = this.preferenceService.getValid(
-      AINativeSettingSectionsId.InlineCompletionsCacheEnabled,
+      AINativeSettingSectionsId.IntelligentCompletionsCacheEnabled,
       true,
     );
 
     this._disposables.add(
       this.preferenceService.onSpecificPreferenceChange(
-        AINativeSettingSectionsId.InlineCompletionsCacheEnabled,
+        AINativeSettingSectionsId.IntelligentCompletionsCacheEnabled,
         (e) => {
           this._isCacheEnabled = e.newValue;
         },

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.source.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.source.ts
@@ -1,49 +1,49 @@
 import debounce from 'lodash/debounce';
 
-import { Autowired, Injectable } from '@opensumi/di';
-import { IDisposable } from '@opensumi/ide-core-browser';
+import { Autowired, INJECTOR_TOKEN, Injectable, Injector, Optional } from '@opensumi/di';
 import { AI_INLINE_COMPLETION_VISIBLE } from '@opensumi/ide-core-browser/lib/ai-native/command';
-import {
-  CommandService,
-  CommandServiceImpl,
-  Disposable,
-  IEventBus,
-  Sequencer,
-  runWhenIdle,
-} from '@opensumi/ide-core-common';
+import { Disposable, IDisposable } from '@opensumi/ide-core-common';
+import { CommandService, CommandServiceImpl, IEventBus, Sequencer, runWhenIdle } from '@opensumi/ide-core-common';
 import { EditorSelectionChangeEvent } from '@opensumi/ide-editor/lib/browser';
 import { ICodeEditor, InlineCompletions, Position, Range } from '@opensumi/ide-monaco';
 import { monacoApi } from '@opensumi/ide-monaco/lib/browser/monaco-api';
+import { empty } from '@opensumi/ide-utils/lib/strings';
 import { InlineCompletionContextKeys } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys';
 
-import { BaseAIMonacoContribHandler } from '../base';
-import { IIntelligentCompletionsResult } from '../intelligent-completions/intelligent-completions';
 
-import { AIInlineCompletionsProvider } from './completeProvider';
-import { AICompletionsService } from './service/ai-completions.service';
+import { AIInlineCompletionsProvider } from '../inline-completions/completeProvider';
+import { AICompletionsService } from '../inline-completions/service/ai-completions.service';
 
-@Injectable()
-export class InlineCompletionSingleHandler extends BaseAIMonacoContribHandler {
+import { IIntelligentCompletionsResult } from './intelligent-completions';
+
+
+@Injectable({ multiple: true })
+export class InlineCompletionsSource extends Disposable {
+  @Autowired(INJECTOR_TOKEN)
+  protected readonly injector: Injector;
+
   @Autowired(IEventBus)
   private eventBus: IEventBus;
 
   @Autowired(CommandService)
   private commandService: CommandServiceImpl;
 
-  @Autowired(AIInlineCompletionsProvider)
   private readonly aiInlineCompletionsProvider: AIInlineCompletionsProvider;
-
-  @Autowired(AICompletionsService)
-  private aiCompletionsService: AICompletionsService;
+  private readonly aiCompletionsService: AICompletionsService;
 
   private sequencer = new Sequencer();
   private preDidShowItems: InlineCompletions | undefined;
 
-  private registerInlineCompletionFeature(monacoEditor: ICodeEditor): IDisposable {
-    // 判断用户是否选择了一块区域或者移动光标 取消掉请补全求
+  constructor(@Optional() private readonly monacoEditor: ICodeEditor) {
+    super();
+
+    this.aiInlineCompletionsProvider = this.injector.get(AIInlineCompletionsProvider);
+    this.aiCompletionsService = this.injector.get(AICompletionsService);
+
+    // 判断用户是否选择了一块区域或者移动光标 取消掉请补全请求
     const selectionChange = () => {
       this.aiCompletionsService.hideStatusBarItem();
-      const selection = monacoEditor.getSelection();
+      const selection = this.monacoEditor.getSelection();
       if (!selection) {
         return;
       }
@@ -60,51 +60,13 @@ export class InlineCompletionSingleHandler extends BaseAIMonacoContribHandler {
       trailing: true,
     });
 
-    this.disposables.push(
-      this.eventBus.on(EditorSelectionChangeEvent, (e) => {
-        if (e.payload.source === 'mouse') {
-          debouncedSelectionChange();
-        } else {
-          debouncedSelectionChange.cancel();
-          selectionChange();
-        }
-      }),
-      monacoEditor.onDidChangeModelContent((e) => {
-        const changes = e.changes;
-        for (const change of changes) {
-          if (change.text === '') {
-            this.aiInlineCompletionsProvider.isDelEvent = true;
-            this.aiInlineCompletionsProvider.cancelRequest();
-          } else {
-            this.aiInlineCompletionsProvider.isDelEvent = false;
-          }
-        }
-      }),
-      monacoEditor.onDidBlurEditorText(() => {
-        this.commandService.executeCommand(AI_INLINE_COMPLETION_VISIBLE.id, false);
-      }),
-    );
-
-    return this;
-  }
-
-  private editorDispose: Disposable = new Disposable();
-  mountEditor(monacoEditor: ICodeEditor) {
-    super.mountEditor(monacoEditor);
-
-    if (this.editorDispose) {
-      this.editorDispose.dispose();
-    }
-
-    this.editorDispose = new Disposable();
-
     const inlineVisibleKey = new Set([InlineCompletionContextKeys.inlineSuggestionVisible.key]);
-    this.editorDispose.addDispose(
-      monacoEditor.contextKeyService.onDidChangeContext((e) => {
+    this.addDispose(
+      this.monacoEditor.contextKeyService.onDidChangeContext((e) => {
         // inline completion 真正消失时
         if (e.affectsSome(inlineVisibleKey)) {
           const inlineSuggestionVisible = InlineCompletionContextKeys.inlineSuggestionVisible.getValue(
-            monacoEditor.contextKeyService,
+            this.monacoEditor.contextKeyService,
           );
           if (!inlineSuggestionVisible && this.preDidShowItems) {
             runWhenIdle(() => {
@@ -116,23 +78,44 @@ export class InlineCompletionSingleHandler extends BaseAIMonacoContribHandler {
       }),
     );
 
-    return this.editorDispose;
+    this.addDispose(
+      this.eventBus.on(EditorSelectionChangeEvent, (e) => {
+        if (e.payload.source === 'mouse') {
+          debouncedSelectionChange();
+        } else {
+          debouncedSelectionChange.cancel();
+          selectionChange();
+        }
+      }),
+    );
+
+    this.addDispose(
+      this.monacoEditor.onDidChangeModelContent((e) => {
+        const changes = e.changes;
+        for (const change of changes) {
+          if (change.text === empty) {
+            this.aiInlineCompletionsProvider.isDelEvent = true;
+            this.aiInlineCompletionsProvider.cancelRequest();
+          } else {
+            this.aiInlineCompletionsProvider.isDelEvent = false;
+          }
+        }
+      }),
+    );
+
+    this.addDispose(
+      this.monacoEditor.onDidBlurEditorText(() => {
+        this.commandService.executeCommand(AI_INLINE_COMPLETION_VISIBLE.id, false);
+      }),
+    );
   }
 
-  doContribute(): IDisposable {
-    if (this.monacoEditor) {
-      this.registerInlineCompletionFeature(this.monacoEditor);
-    }
-
+  public fetch(): IDisposable {
     let prePosition: Position | undefined;
 
     return monacoApi.languages.registerInlineCompletionsProvider('*', {
-      groupId: 'ai-native-inline-completions',
+      groupId: 'ai-native-intelligent-completions',
       provideInlineCompletions: async (model, position, context, token) => {
-        if (!this.shouldHandle(model.uri)) {
-          return;
-        }
-
         /**
          * 如果新字符在 inline completion 的 ghost text 内，则走缓存，不重新请求
          */

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.ts
@@ -9,10 +9,6 @@ export interface IIntelligentCompletionsResult<T = any> {
    */
   readonly enableMultiLine?: boolean | undefined;
   /**
-   * 总是保持显示，优先级高于下拉补全的内联提示
-   */
-  readonly alwaysVisible?: boolean | undefined;
-  /**
    * 定义的额外信息
    */
   extra?: T;

--- a/packages/ai-native/src/browser/preferences/schema.ts
+++ b/packages/ai-native/src/browser/preferences/schema.ts
@@ -34,17 +34,21 @@ export const aiNativePreferenceSchema: PreferenceSchema = {
       enum: ['never', 'always', 'default'],
       default: 'default',
     },
-    [AINativeSettingSectionsId.InlineCompletionsPromptEngineeringEnabled]: {
+    [AINativeSettingSectionsId.IntelligentCompletionsPromptEngineeringEnabled]: {
       type: 'boolean',
       default: true,
     },
-    [AINativeSettingSectionsId.InlineCompletionsDebounceTime]: {
+    [AINativeSettingSectionsId.IntelligentCompletionsDebounceTime]: {
       type: 'number',
       default: 150,
     },
-    [AINativeSettingSectionsId.InlineCompletionsCacheEnabled]: {
+    [AINativeSettingSectionsId.IntelligentCompletionsCacheEnabled]: {
       type: 'boolean',
       default: true,
+    },
+    [AINativeSettingSectionsId.IntelligentCompletionsAlwaysVisible]: {
+      type: 'boolean',
+      default: false,
     },
   },
 };

--- a/packages/core-common/src/settings/ai-native.ts
+++ b/packages/core-common/src/settings/ai-native.ts
@@ -15,7 +15,7 @@ export enum AINativeSettingSectionsId {
   IntelligentCompletionsPromptEngineeringEnabled = 'ai.native.intelligentCompletions.promptEngineering.enabled',
   IntelligentCompletionsDebounceTime = 'ai.native.intelligentCompletions.debounceTime',
   IntelligentCompletionsCacheEnabled = 'ai.native.intelligentCompletions.cache.enabled',
-  IntelligentCompletionsAlwaysVisible = 'ai.native.intelligentCompletions.always.visible',
+  IntelligentCompletionsAlwaysVisible = 'ai.native.intelligentCompletions.alwaysVisible',
 }
 export const AI_NATIVE_SETTING_GROUP_ID = 'AI-Native';
 export const AI_NATIVE_SETTING_GROUP_TITLE = 'AI Native';

--- a/packages/core-common/src/settings/ai-native.ts
+++ b/packages/core-common/src/settings/ai-native.ts
@@ -12,9 +12,10 @@ export enum AINativeSettingSectionsId {
   /**
    * Whether to enable prompt engineering, some LLM models may not perform well on prompt engineering.
    */
-  InlineCompletionsPromptEngineeringEnabled = 'ai.native.inlineCompletions.promptEngineering.enabled',
-  InlineCompletionsDebounceTime = 'ai.native.inlineCompletions.debounceTime',
-  InlineCompletionsCacheEnabled = 'ai.native.inlineCompletions.cache.enabled',
+  IntelligentCompletionsPromptEngineeringEnabled = 'ai.native.intelligentCompletions.promptEngineering.enabled',
+  IntelligentCompletionsDebounceTime = 'ai.native.intelligentCompletions.debounceTime',
+  IntelligentCompletionsCacheEnabled = 'ai.native.intelligentCompletions.cache.enabled',
+  IntelligentCompletionsAlwaysVisible = 'ai.native.intelligentCompletions.always.visible',
 }
 export const AI_NATIVE_SETTING_GROUP_ID = 'AI-Native';
 export const AI_NATIVE_SETTING_GROUP_TITLE = 'AI Native';

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1494,7 +1494,7 @@ export const localizationBundle = {
       'Whether to enable prompt engineering, some LLM models may not perform well on prompt engineering.',
     'preference.ai.native.intelligentCompletions.debounceTime': 'Debounce time for intelligent completions',
     'preference.ai.native.intelligentCompletions.cache.enabled': 'Whether to enable cache for intelligent completions',
-    'preference.ai.native.intelligentCompletions.always.visible': 'Whether to always show intelligent completions',
+    'preference.ai.native.intelligentCompletions.alwaysVisible': 'Whether to always show intelligent completions',
     // #endregion AI Native
 
     // #endregion merge editor

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1485,14 +1485,16 @@ export const localizationBundle = {
       'Does Inline Chat related code actions automatically appear when code are selected?',
     'preference.ai.native.chat.visible.type': 'Control how the chat panel is displayed by default',
 
-    'preference.ai.native.inlineCompletions.title': 'Inline Completions',
-    'preference.ai.native.inlineCompletions.promptEngineering.enabled':
-      'Whether to enable prompt engineering, some LLM models may not perform well on prompt engineering.',
-    'preference.ai.native.inlineCompletions.debounceTime': 'Debounce time for inline completions',
     'preference.ai.native.inlineDiff.preview.mode': 'Inline Diff preview mode',
     'preference.ai.native.inlineDiff.preview.mode.sideBySide': 'Displayed in the editor as left and right diff panels',
     'preference.ai.native.inlineDiff.preview.mode.inlineLive': 'Displayed in the editor through streaming rendering',
-    'preference.ai.native.inlineCompletions.cache.enabled': 'Whether to enable cache for inline completions',
+
+    'preference.ai.native.intelligentCompletions.title': 'Intelligent Completions',
+    'preference.ai.native.intelligentCompletions.promptEngineering.enabled':
+      'Whether to enable prompt engineering, some LLM models may not perform well on prompt engineering.',
+    'preference.ai.native.intelligentCompletions.debounceTime': 'Debounce time for intelligent completions',
+    'preference.ai.native.intelligentCompletions.cache.enabled': 'Whether to enable cache for intelligent completions',
+    'preference.ai.native.intelligentCompletions.always.visible': 'Whether to always show intelligent completions',
     // #endregion AI Native
 
     // #endregion merge editor

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1259,7 +1259,7 @@ export const localizationBundle = {
       '是否启用提示词工程，一些 LLM 模型在提示词工程上可能表现不佳。',
     'preference.ai.native.intelligentCompletions.debounceTime': '智能补全的延迟时间（毫秒）',
     'preference.ai.native.intelligentCompletions.cache.enabled': '是否启用智能补全的缓存',
-    'preference.ai.native.intelligentCompletions.always.visible': '是否总是展示智能补全',
+    'preference.ai.native.intelligentCompletions.alwaysVisible': '是否总是展示智能补全',
     // #endregion AI Native
 
     'webview.webviewTagUnavailable': '非 Electron 环境不支持 webview 标签，请使用 iframe 标签',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1249,14 +1249,17 @@ export const localizationBundle = {
     'preference.ai.native.inlineChat.codeAction.enabled':
       '是否启用在选中代码片段时显示 Inline Chat 相关的 Code Actions?',
     'preference.ai.native.chat.visible.type': '控制 Chat 面板默认的展示方式',
-    'preference.ai.native.inlineCompletions.title': '内联补全',
-    'preference.ai.native.inlineCompletions.promptEngineering.enabled':
-      '是否启用提示词工程，一些 LLM 模型在提示词工程上可能表现不佳。',
-    'preference.ai.native.inlineCompletions.debounceTime': '内联补全的延迟时间（毫秒）',
+
     'preference.ai.native.inlineDiff.preview.mode': 'Inline Diff 的预览模式',
     'preference.ai.native.inlineDiff.preview.mode.sideBySide': '在编辑器当中以左右 diff 面板的方式展示',
     'preference.ai.native.inlineDiff.preview.mode.inlineLive': '在编辑器当中以流式渲染的方式展示',
-    'preference.ai.native.inlineCompletions.cache.enabled': '是否启用内联补全的缓存',
+
+    'preference.ai.native.intelligentCompletions.title': '智能补全',
+    'preference.ai.native.intelligentCompletions.promptEngineering.enabled':
+      '是否启用提示词工程，一些 LLM 模型在提示词工程上可能表现不佳。',
+    'preference.ai.native.intelligentCompletions.debounceTime': '智能补全的延迟时间（毫秒）',
+    'preference.ai.native.intelligentCompletions.cache.enabled': '是否启用智能补全的缓存',
+    'preference.ai.native.intelligentCompletions.always.visible': '是否总是展示智能补全',
     // #endregion AI Native
 
     'webview.webviewTagUnavailable': '非 Electron 环境不支持 webview 标签，请使用 iframe 标签',

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -494,7 +494,6 @@ export class AINativeContribution implements AINativeCoreContribution {
             },
           ],
           enableMultiLine: true,
-          alwaysVisible: true,
         };
       } catch (error) {
         if (error.name === 'AbortError') {

--- a/packages/startup/entry/sample-modules/ai-native/ai.back.service.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai.back.service.ts
@@ -47,13 +47,6 @@ export class AIBackService implements IAIBackService<ReqeustResponse, ChatReadab
   @Autowired(INodeLogger)
   protected readonly logger: INodeLogger;
 
-  async requestCompletion(input: IAICompletionOption, cancelToken?: CancellationToken) {
-    return {
-      sessionId: input.sessionId,
-      codeModelList: [{ content: 'Hello OpenSumi!' }],
-    };
-  }
-
   async request(input: string, options: IAIBackServiceOption, cancelToken?: CancellationToken) {
     await sleep(1000);
 


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

智能补全与下拉补全同时显示的问题由 preference 管控比较好。
删除了原来的 alwaysVisible api 的设计。

现在即使是插件或者其他模块注册的 inline completion provider 都能一直显示出来，不会因下拉补全的出现而消失

### Changelog
新增 intelligentCompletions.always.visible 配置


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入智能补全功能，替代原有的行内补全。
  - 新增设置选项“智能补全始终可见”。

- **变更**
  - 更新了设置标识符，反映从行内补全到智能补全的转变。
  - 移除行内补全相关的属性和方法，简化了代码结构。

- **本地化**
  - 更新了语言包，替换行内补全的键为智能补全的键。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->