### PR TITLE
feat: revert an API that will be removed in a future version of VSCode

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.scm.ts
@@ -635,24 +635,25 @@ class ExtHostSourceControl implements vscode.SourceControl {
         }),
       );
 
-      this._historyProviderDisposable.value.add(
-        historyProvider.onDidChangeActionButton(() => {
-          this._historyProviderActionButtonDisposable.value = new DisposableStore();
-          const internal =
-            historyProvider.actionButton !== undefined
-              ? {
-                  command: this._commands.converter.toInternal(
-                    historyProvider.actionButton.command,
-                    this._historyProviderActionButtonDisposable.value,
-                  )!,
-                  description: historyProvider.actionButton.description,
-                  enabled: historyProvider.actionButton.enabled,
-                }
-              : undefined;
-
-          this.#proxy.$onDidChangeHistoryProviderActionButton(this.handle, internal ?? null);
-        }),
-      );
+      if (historyProvider.onDidChangeActionButton) {
+        this._historyProviderDisposable.value.add(
+          historyProvider.onDidChangeActionButton(() => {
+            this._historyProviderActionButtonDisposable.value = new DisposableStore();
+            const internal =
+              historyProvider.actionButton !== undefined
+                ? {
+                    command: this._commands.converter.toInternal(
+                      historyProvider.actionButton.command,
+                      this._historyProviderActionButtonDisposable.value,
+                    )!,
+                    description: historyProvider.actionButton.description,
+                    enabled: historyProvider.actionButton.enabled,
+                  }
+                : undefined;
+            this.#proxy.$onDidChangeHistoryProviderActionButton(this.handle, internal ?? null);
+          }),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] Other Changes

### Background or solution
The onDidChangeActionButton API was added to accommodate VSCode version 1.84, but it was removed in later versions, resulting in errors when upgrading the extension. Therefore, this adaptation of the API has been removed.

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能变更**
	- 仅在可用时注册操作按钮状态更新的事件监听器，以防止潜在错误。
	- `ISCMHistoryProvider` 接口中移除了 `onDidChangeActionButton` 事件属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->