### PR TITLE
feat: support detect EOL from file content

### DIFF
--- a/packages/editor/src/browser/doc-model/editor-document-model-service.ts
+++ b/packages/editor/src/browser/doc-model/editor-document-model-service.ts
@@ -307,11 +307,10 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
       throw new Error(`No document provider found for ${uri.toString()}`);
     }
 
-    const [content, readonly, languageId, eol, alwaysDirty, closeAutoSave, disposeEvenDirty] = await Promise.all([
+    const [content, readonly, languageId, alwaysDirty, closeAutoSave, disposeEvenDirty] = await Promise.all([
       provider.provideEditorDocumentModelContent(uri, encoding),
       provider.isReadonly ? provider.isReadonly(uri) : undefined,
       provider.preferLanguageForUri ? provider.preferLanguageForUri(uri) : undefined,
-      provider.provideEOL ? provider.provideEOL(uri) : undefined,
       provider.isAlwaysDirty ? provider.isAlwaysDirty(uri) : false,
       provider.closeAutoSave ? provider.closeAutoSave(uri) : false,
       provider.disposeEvenDirty ? provider.disposeEvenDirty(uri) : false,
@@ -321,6 +320,8 @@ export class EditorDocumentModelServiceImpl extends WithEventBus implements IEdi
     if (!encoding && provider.provideEncoding) {
       encoding = await provider.provideEncoding(uri);
     }
+
+    const eol = provider.provideEOL ? await provider.provideEOL(uri) : EOL.LF;
 
     const savable = !!provider.saveDocumentModel;
 

--- a/packages/editor/src/browser/fs-resource/fs-editor-doc.ts
+++ b/packages/editor/src/browser/fs-resource/fs-editor-doc.ts
@@ -130,21 +130,21 @@ export class BaseFileSystemEditorDocumentProvider implements IEditorDocumentMode
   }
 
   private async getEol(uri: URI, content: string) {
-    const contentToDetect = content.slice(0, 2000);
+    const MAX_DETECT_LENGTH = 2000;
     let cr = 0;
     let lf = 0;
     let crlf = 0;
-    const len = contentToDetect.length;
+    const len = Math.min(MAX_DETECT_LENGTH, content.length);
     for (let i = 0; i < len; i++) {
-      if (contentToDetect[i] === '\r') {
-        if (contentToDetect[i + 1] === '\n') {
+      if (content[i] === '\r') {
+        if (content[i + 1] === '\n') {
           crlf++;
           // 跳过后续 \n
           i++;
         } else {
           cr++;
         }
-      } else if (contentToDetect[i] === '\n') {
+      } else if (content[i] === '\n') {
         lf++;
       }
     }

--- a/packages/monaco/src/common/types.ts
+++ b/packages/monaco/src/common/types.ts
@@ -35,7 +35,6 @@ export type IEvent<T> = (listener: (e: T) => any, thisArg?: any) => IDisposable;
  */
 export const enum EOL {
   LF = '\n',
-
   CRLF = '\r\n',
 }
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

实现比较简陋，合理的应该是在文件流式读取时，分片截取部分便能识别出文件的 EOL 序列

用户设置为 auto 时，默认采用检测出的值

### Changelog

support detect EOL from file content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了对不同URI的行结束符（EOL）字符设置的缓存机制，提高了文档内容读取的效率。
  - 更新了文档读取方法以返回EOL信息，增强了用户体验。

- **修复**
  - 简化了文档模型内容的处理逻辑，减少了初始Promise解析时的并发调用，提高了性能。

- **文档**
  - 更新了EOL枚举，移除了不再使用的LF值，仅保留CRLF。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->