### PR TITLE
WIP: refactor: make watcher service more stable

### DIFF
--- a/packages/file-service/__tests__/browser/file-service-client.test.ts
+++ b/packages/file-service/__tests__/browser/file-service-client.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import temp from 'temp';
 
-import { DisposableCollection, FileUri, UTF8 } from '@opensumi/ide-core-common';
+import { DisposableCollection, FileUri, UTF8, injectGDataStores } from '@opensumi/ide-core-common';
 import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { FileService } from '@opensumi/ide-file-service/lib/node';
 import { DiskFileSystemProvider } from '@opensumi/ide-file-service/lib/node/disk-file-system.provider';
@@ -29,6 +29,7 @@ describe('FileServiceClient should be work', () => {
       useClass: DiskFileSystemProvider,
     },
   );
+  injectGDataStores(injector);
 
   beforeAll(() => {
     // @ts-ignore

--- a/packages/file-service/__tests__/node/file-node-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-node-watcher.test.ts
@@ -1,31 +1,46 @@
 import * as fse from 'fs-extra';
 import temp from 'temp';
 
-import { FileUri, sleep } from '@opensumi/ide-core-node';
+import { Disposable, FileUri, URI, sleep } from '@opensumi/ide-core-node';
 import { createNodeInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 
 import { DidFilesChangedParams, FileChangeType } from '../../src/common/index';
+import { FileChangeCollectionManager, FileChangeCollectionManagerOptions } from '../../src/node/file-change-collection';
 import { UnRecursiveFileSystemWatcher } from '../../src/node/un-recursive/file-service-watcher';
 
 const sleepTime = 1000;
 
+async function generateWatcher(track: typeof temp, watchPathCb: (root: URI) => string) {
+  const injector = createNodeInjector([]);
+  const root = FileUri.create(await fse.realpath(await track.mkdir('unRecursive-test')));
+  injector.addProviders({
+    token: FileChangeCollectionManagerOptions,
+    useValue: { debounceTimeout: 0 },
+  });
+  const fileChangeCollectionManager = injector.get(FileChangeCollectionManager);
+  const watcherServer = injector.get(UnRecursiveFileSystemWatcher);
+  fse.mkdirpSync(FileUri.fsPath(root.resolve('for_rename_folder')));
+  fse.writeFileSync(FileUri.fsPath(root.resolve('for_rename')), 'rename');
+  const watcherId = await watcherServer.watchFileChanges(watchPathCb(root));
+
+  const setClient = (client: { onDidFilesChanged: (event: DidFilesChangedParams) => void }) =>
+    watcherServer.addDispose(fileChangeCollectionManager.setClientForTest(watcherId, client));
+  watcherServer.addDispose(
+    Disposable.create(() => {
+      // eslint-disable-next-line no-console
+      console.log('dispose watcher id', watcherId);
+      watcherServer.unwatchFileChanges(watcherId);
+    }),
+  );
+  return { root, watcherServer, setClient };
+}
+
 describe('unRecursively watch for folder additions, deletions, rename,and updates', () => {
   const track = temp.track();
-  async function generateWatcher() {
-    const injector = createNodeInjector([]);
-    const root = FileUri.create(fse.realpathSync(await temp.mkdir('unRecursive-test')));
-    const watcherServer = injector.get(UnRecursiveFileSystemWatcher);
-    fse.mkdirpSync(FileUri.fsPath(root.resolve('for_rename_folder')));
-    fse.writeFileSync(FileUri.fsPath(root.resolve('for_rename')), 'rename');
-    await watcherServer.watchFileChanges(root.toString());
-    return { root, watcherServer };
-  }
-  const watcherServerList: UnRecursiveFileSystemWatcher[] = [];
-  afterAll(async () => {
+  const rootPathCb = (root: URI) => root.toString();
+
+  afterAll(() => {
     track.cleanupSync();
-    watcherServerList.forEach((watcherServer) => {
-      watcherServer.dispose();
-    });
   });
   it('Rename the files under the folder', async () => {
     const addUris = new Set<string>();
@@ -43,8 +58,8 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
 
     const expectedAddUris = [root.resolve('for_rename_renamed').toString()];
 
@@ -54,7 +69,7 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
     await sleep(sleepTime);
     expect([...addUris]).toEqual(expectedAddUris);
     expect([...deleteUris]).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
   it('Add the files under the folder', async () => {
     const addUris = new Set<string>();
@@ -72,8 +87,8 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
 
     const expectedAddUris = [root.resolve('README.md').toString()];
 
@@ -84,7 +99,7 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
 
     expect(Array.from(addUris)).toEqual(expectedAddUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
   it('Update the files under the folder', async () => {
     const updatedUris = new Set<string>();
@@ -101,15 +116,15 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
     const expectedDeleteUris = [];
     const expectedUpdatedUris = [root.resolve('for_rename').toString()];
     fse.writeFileSync(root.resolve('for_rename').codeUri.fsPath.toString(), '');
     await sleep(sleepTime);
     expect(Array.from(updatedUris)).toEqual(expectedUpdatedUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
   it('Delete the files under the folder', async () => {
     const addUris = new Set<string>();
@@ -127,8 +142,9 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
+
     const expectedDeleteUris = [root.resolve('for_rename').toString()];
     const expectedAddUris = [];
     await fse.unlink(root.resolve('for_rename').codeUri.fsPath.toString());
@@ -136,7 +152,7 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
 
     expect(Array.from(addUris)).toEqual(expectedAddUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
   it('Rename the watched folder', async () => {
     const addUris = new Set<string>();
@@ -154,8 +170,8 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
 
     const expectedAddUris = [];
     const expectedDeleteUris = [];
@@ -168,7 +184,7 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
 
     expect([...addUris]).toEqual(expectedAddUris);
     expect([...deleteUris]).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
   it('Add the watched folder', async () => {
     const addUris = new Set<string>();
@@ -185,8 +201,8 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
 
     const expectedAddUris = [];
 
@@ -197,7 +213,7 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
 
     expect(Array.from(addUris)).toEqual(expectedAddUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
 
   it('Delete the watched folder', async () => {
@@ -216,8 +232,9 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
+
     const expectedDeleteUris = [];
     const expectedAddUris = [];
     await fse.remove(root.resolve('for_rename_folder').codeUri.fsPath.toString());
@@ -225,26 +242,16 @@ describe('unRecursively watch for folder additions, deletions, rename,and update
 
     expect(Array.from(addUris)).toEqual(expectedAddUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
 });
 
 describe('Delete and update monitored files', () => {
   const track = temp.track();
-  async function generateWatcher() {
-    const injector = createNodeInjector([]);
-    const root = FileUri.create(fse.realpathSync(await temp.mkdir('unRecursive-test')));
-    const watcherServer = injector.get(UnRecursiveFileSystemWatcher);
-    fse.writeFileSync(FileUri.fsPath(root.resolve('for_rename')), 'rename');
-    await watcherServer.watchFileChanges(root.toString() + '/for_rename');
-    return { root, watcherServer };
-  }
-  const watcherServerList: UnRecursiveFileSystemWatcher[] = [];
-  afterAll(async () => {
+  const rootPathCb = (root: URI) => root.toString() + '/for_rename';
+
+  afterAll(() => {
     track.cleanupSync();
-    watcherServerList.forEach((watcherServer) => {
-      watcherServer.dispose();
-    });
   });
 
   it('Delete watched files', async () => {
@@ -263,8 +270,8 @@ describe('Delete and update monitored files', () => {
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
 
     const expectedDeleteUris = [root.resolve('for_rename').toString()];
 
@@ -273,7 +280,7 @@ describe('Delete and update monitored files', () => {
     await sleep(sleepTime);
     expect(Array.from(addUris)).toEqual(expectedAddUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
 
   it('Update watched files', async () => {
@@ -292,14 +299,14 @@ describe('Delete and update monitored files', () => {
         });
       },
     };
-    const { root, watcherServer } = await generateWatcher();
-    watcherServer.setClient(watcherClient);
+    const { root, watcherServer, setClient } = await generateWatcher(track, rootPathCb);
+    setClient(watcherClient);
     const expectedDeleteUris = [];
     const expectedUpdatedUris = [root.resolve('for_rename').toString()];
     await fse.writeFile(root.resolve('for_rename').codeUri.fsPath.toString(), 'for');
     await sleep(sleepTime);
     expect(Array.from(updatedUris)).toEqual(expectedUpdatedUris);
     expect(Array.from(deleteUris)).toEqual(expectedDeleteUris);
-    watcherServerList.push(watcherServer);
+    watcherServer.dispose();
   });
 });

--- a/packages/file-service/src/common/tokens.ts
+++ b/packages/file-service/src/common/tokens.ts
@@ -1,5 +1,4 @@
 export const FileServicePath = 'FileService';
 export const DiskFileServicePath = 'DiskFileService';
-export const ShadowFileServicePath = 'ShadowFileService';
 export const FileWatcherServicePath = 'FileWatcherService';
 export const FileExtServicePath = 'FileExtServicePath';

--- a/packages/file-service/src/node/data-store/index.ts
+++ b/packages/file-service/src/node/data-store/index.ts
@@ -1,0 +1,9 @@
+import { RefCountedDisposable } from '@opensumi/ide-core-common';
+
+export const WatchInsData = 'WatchIns';
+export interface WatchInsData {
+  watcherId: number;
+  path: string;
+
+  disposable: RefCountedDisposable;
+}

--- a/packages/file-service/src/node/disk-file.remote-service.ts
+++ b/packages/file-service/src/node/disk-file.remote-service.ts
@@ -1,0 +1,9 @@
+import { RemoteService } from '@opensumi/ide-core-common';
+
+import { DiskFileServicePath } from '../common';
+import { DiskFileServiceProtocol } from '../common/protocols/disk-file-service';
+
+import { DiskFileSystemProvider } from './disk-file-system.provider';
+
+@RemoteService(DiskFileServicePath, DiskFileServiceProtocol)
+export class DiskFileRemoteService extends DiskFileSystemProvider {}

--- a/packages/file-service/src/node/index.ts
+++ b/packages/file-service/src/node/index.ts
@@ -1,18 +1,11 @@
 import { Injectable, Injector } from '@opensumi/di';
 import { NodeModule } from '@opensumi/ide-core-node';
 
-import {
-  DiskFileServicePath,
-  FileServicePath,
-  FileSystemProvider,
-  IDiskFileProvider,
-  IFileService,
-  IShadowFileProvider,
-  ShadowFileServicePath,
-} from '../common';
-import { DiskFileServiceProtocol } from '../common/protocols/disk-file-service';
+import { FileServicePath, FileSystemProvider, IDiskFileProvider, IFileService } from '../common';
 
 import { DiskFileSystemProvider } from './disk-file-system.provider';
+import { DiskFileRemoteService } from './disk-file.remote-service';
+import { FileChangeCollectionManager } from './file-change-collection';
 import { getSafeFileservice } from './file-service';
 
 export * from './file-service';
@@ -32,18 +25,16 @@ export class FileServiceModule extends NodeModule {
   providers = [
     { token: IFileService, useFactory: (injector: Injector) => getSafeFileservice(injector) },
     { token: IDiskFileProvider, useFactory: (injector: Injector) => getFileservice(injector, DiskFileSystemProvider) },
+    // 单例 FileChangeCollectionManager
+    {
+      token: FileChangeCollectionManager,
+      useClass: FileChangeCollectionManager,
+    },
   ];
 
+  remoteServices = [DiskFileRemoteService];
+
   backServices = [
-    {
-      servicePath: DiskFileServicePath,
-      token: IDiskFileProvider,
-      protocol: DiskFileServiceProtocol,
-    },
-    {
-      servicePath: ShadowFileServicePath,
-      token: IShadowFileProvider,
-    },
     {
       servicePath: FileServicePath,
       token: IFileService,

--- a/packages/file-service/src/node/recursive/drivers/base.ts
+++ b/packages/file-service/src/node/recursive/drivers/base.ts
@@ -1,0 +1,6 @@
+import { FileChangeType } from '@opensumi/ide-core-common';
+
+export interface DriverFileChange {
+  path: string;
+  type: FileChangeType;
+}

--- a/packages/file-service/src/node/recursive/drivers/fs-watcher.ts
+++ b/packages/file-service/src/node/recursive/drivers/fs-watcher.ts
@@ -1,0 +1,26 @@
+import fs, { watch } from 'fs-extra';
+
+import { DriverFileChange } from './base';
+
+export async function watchByFSWatcher(
+  realPath: string,
+  options: {
+    onError: (err: Error) => void;
+    onEvents: (events: DriverFileChange[]) => void;
+    excludes?: string[];
+    recursive?: boolean;
+  },
+) {
+  const watcher = watch(realPath, { recursive: options?.recursive });
+
+  watcher.on('error', (code: number, signal: string) => {
+    watcher.close();
+
+    options.onError(new Error(`Failed to watch ${realPath} for changes using fs.watch() (${code}, ${signal})`));
+  });
+
+  const stat = await fs.lstat(realPath);
+  const isDirectory = stat.isDirectory();
+  if (isDirectory) {
+  }
+}

--- a/packages/file-service/src/node/recursive/drivers/nsfw.ts
+++ b/packages/file-service/src/node/recursive/drivers/nsfw.ts
@@ -1,0 +1,155 @@
+import paths from 'path';
+
+import fs from 'fs-extra';
+import uniqBy from 'lodash/uniqBy';
+
+import { FileChangeType, isLinux, parseGlob } from '@opensumi/ide-core-common';
+
+import { INsfw } from '../../../common';
+import { shouldIgnorePath } from '../../shared';
+
+import { DriverFileChange } from './base';
+
+function requireNSFWModule(): typeof import('nsfw') {
+  return require('nsfw');
+}
+
+export const watchByNSFW = async (
+  realPath: string,
+  options: {
+    onError: (err: Error) => void;
+    onEvents: (events: DriverFileChange[]) => void;
+    // todo: support dynamic excludes
+    excludes?: string[];
+  },
+) => {
+  const nsfw = requireNSFWModule();
+
+  const excludesFn = compileExcludePattern(options.excludes);
+
+  const watcher: INsfw.NSFW = await nsfw(
+    realPath,
+    async (events: INsfw.ChangeEvent[]) => {
+      if (events.length > 5000) {
+        return;
+      }
+
+      const filterEvents = events.filter((event) => {
+        // 如果是 RENAME，不会产生临时文件
+        if (event.action === INsfw.actions.RENAMED) {
+          return true;
+        }
+
+        return !shouldIgnorePath(event.file);
+      });
+
+      const mergedEvents = uniqBy(filterEvents, (event) => {
+        if (event.action === INsfw.actions.RENAMED) {
+          const deletedPath = paths.join(event.directory, event.oldFile!);
+          const newPath = paths.join(event.newDirectory || event.directory, event.newFile!);
+          return deletedPath + newPath;
+        }
+
+        return event.action + paths.join(event.directory, event.file!);
+      });
+
+      const result = [] as DriverFileChange[];
+
+      await Promise.all(
+        mergedEvents.map(async (event) => {
+          switch (event.action) {
+            case INsfw.actions.RENAMED:
+              {
+                const deletedPath = await resolvePath(event.directory, event.oldFile!);
+                if (excludesFn(deletedPath)) {
+                  return;
+                }
+
+                result.push({ path: deletedPath, type: FileChangeType.DELETED });
+
+                if (event.newDirectory) {
+                  const path = await resolvePath(event.newDirectory, event.newFile!);
+                  if (excludesFn(path)) {
+                    return;
+                  }
+
+                  result.push({ path, type: FileChangeType.ADDED });
+                } else {
+                  const path = await resolvePath(event.directory, event.newFile!);
+                  if (excludesFn(path)) {
+                    return;
+                  }
+
+                  result.push({ path, type: FileChangeType.ADDED });
+                }
+              }
+              break;
+            default:
+              {
+                const path = await resolvePath(event.directory, event.file!);
+                if (excludesFn(path)) {
+                  return;
+                }
+
+                switch (event.action) {
+                  case INsfw.actions.CREATED:
+                    result.push({ path, type: FileChangeType.ADDED });
+                    break;
+                  case INsfw.actions.DELETED:
+                    result.push({ path, type: FileChangeType.DELETED });
+                    break;
+                  case INsfw.actions.MODIFIED:
+                    result.push({ path, type: FileChangeType.UPDATED });
+                    break;
+                }
+              }
+              break;
+          }
+        }),
+      );
+    },
+    {
+      errorCallback: (err) => {
+        options.onError(err);
+      },
+    },
+  );
+
+  await watcher.start();
+
+  return {
+    dispose: async () => {
+      await watcher.stop();
+    },
+  };
+};
+
+function compileExcludePattern(excludes?: string[]): (path: string) => boolean {
+  const matches = excludes?.map((pattern) => parseGlob(pattern));
+  return (path: string) => {
+    if (!matches || matches.length < 1) {
+      return false;
+    }
+
+    return matches.some((match) => match(path));
+  };
+}
+
+async function resolvePath(directory: string, file: string): Promise<string> {
+  const path = paths.join(directory, file);
+  // 如果是 linux 则获取一下真实 path，以防返回的是软连路径被过滤
+  if (isLinux) {
+    try {
+      return await fs.realpath.native(path);
+    } catch (_e) {
+      try {
+        // file does not exist try to resolve directory
+        return paths.join(await fs.realpath.native(directory), file);
+      } catch (_e) {
+        // directory does not exist fall back to symlink
+        return path;
+      }
+    }
+  }
+  return path;
+}

--- a/packages/file-service/src/node/recursive/drivers/parcel.ts
+++ b/packages/file-service/src/node/recursive/drivers/parcel.ts
@@ -1,0 +1,69 @@
+import ParcelWatcher from '@parcel/watcher';
+
+import { FileChangeType } from '@opensumi/ide-core-common';
+import { isLinux, isWindows } from '@opensumi/ide-utils';
+
+import { shouldIgnorePath } from '../../shared';
+
+import { DriverFileChange } from './base';
+
+const PARCEL_WATCHER_BACKEND = isWindows ? 'windows' : isLinux ? 'inotify' : 'fs-events';
+
+/**
+ * 过滤 `write-file-atomic` 写入生成的临时文件
+ * @param events
+ */
+function trimChangeEvent(events: ParcelWatcher.Event[]): ParcelWatcher.Event[] {
+  events = events.filter((event: ParcelWatcher.Event) => !shouldIgnorePath(event.path));
+  return events;
+}
+
+export const watchByParcelWatcher = async (
+  realPath: string,
+  options: {
+    onError: (err: Error) => void;
+    onEvents: (events: DriverFileChange[]) => void;
+    excludes?: string[];
+  },
+) => {
+  const handle = await ParcelWatcher.subscribe(
+    realPath,
+    (err, events: ParcelWatcher.Event[]) => {
+      if (err) {
+        return options.onError(err);
+      }
+
+      events = trimChangeEvent(events);
+
+      // 对于超过 5000 数量的 events 做屏蔽优化，避免潜在的卡死问题
+      if (events.length > 5000) {
+        // FIXME: 研究此处屏蔽的影响，考虑下阈值应该设置多少，或者更加优雅的方式
+        return;
+      }
+
+      const result = [] as DriverFileChange[];
+      for (const event of events) {
+        switch (event.type) {
+          case 'create':
+            result.push({ path: event.path, type: FileChangeType.ADDED });
+            break;
+          case 'delete':
+            result.push({ path: event.path, type: FileChangeType.DELETED });
+            break;
+          case 'update':
+            result.push({ path: event.path, type: FileChangeType.UPDATED });
+            break;
+        }
+      }
+
+      options.onEvents(result);
+    },
+    {
+      backend: PARCEL_WATCHER_BACKEND,
+      ignore: options?.excludes,
+    },
+  );
+  return {
+    dispose: () => handle.unsubscribe(),
+  };
+};

--- a/packages/file-tree-next/__tests__/browser/file-tree.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.test.ts
@@ -5,18 +5,17 @@ import temp from 'temp';
 
 import { TreeNodeEvent, TreeNodeType } from '@opensumi/ide-components';
 import {
+  AppConfig,
   CorePreferences,
   EDITOR_COMMANDS,
   Emitter,
   IContextKeyService,
+  ILogger,
   PreferenceService,
 } from '@opensumi/ide-core-browser';
-import { ILogger } from '@opensumi/ide-core-browser';
-import { AppConfig } from '@opensumi/ide-core-browser';
 import { MockContextKeyService } from '@opensumi/ide-core-browser/__mocks__/context-key';
 import { MockedStorageProvider } from '@opensumi/ide-core-browser/__mocks__/storage';
 import {
-  CommandRegistry,
   Deferred,
   Disposable,
   FileUri,
@@ -25,9 +24,12 @@ import {
   OS,
   StorageProvider,
   URI,
+  injectGDataStores,
 } from '@opensumi/ide-core-common';
 import { IDecorationsService } from '@opensumi/ide-decoration';
 import { FileDecorationsService } from '@opensumi/ide-decoration/lib/browser/decorationsService';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileServicePath, FileStat, IDiskFileProvider, IFileServiceClient } from '@opensumi/ide-file-service';
 import { FileServiceClient } from '@opensumi/ide-file-service/lib/browser/file-service-client';
@@ -41,10 +43,7 @@ import { IThemeService } from '@opensumi/ide-theme';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { MockWorkspaceService } from '@opensumi/ide-workspace/lib/common/mocks';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
-import { FileTreeNextModule } from '../../src';
-import { PasteTypes } from '../../src';
+import { FileTreeNextModule, PasteTypes } from '../../src';
 import { FileTreeContribution } from '../../src/browser/file-tree-contribution';
 import styles from '../../src/browser/file-tree-node.module.less';
 import { FileTreeService } from '../../src/browser/file-tree.service';
@@ -210,6 +209,8 @@ describe('FileTree should be work while on single workspace model', () => {
         useValue: mockMainLayoutService,
       },
     );
+    injectGDataStores(injector);
+
     const fileServiceClient: FileServiceClient = injector.get(IFileServiceClient);
     fileServiceClient.registerProvider('file', injector.get(IDiskFileProvider));
 
@@ -317,7 +318,7 @@ describe('FileTree should be work while on single workspace model', () => {
     it('Style decoration should be right while click the item', async () => {
       const { handleItemClick, decorations } = fileTreeModelService;
 
-      let retracted = jest.fn();
+      const retracted = jest.fn();
       injector.mockCommand(RETRACT_BOTTOM_PANEL.id, () => {
         mockMainLayoutService.bottomExpanded = false;
         retracted();

--- a/packages/keymaps/__tests__/browser/keymaps.service.test.ts
+++ b/packages/keymaps/__tests__/browser/keymaps.service.test.ts
@@ -19,6 +19,9 @@ import {
 } from '@opensumi/ide-core-browser';
 import { MockProgressService } from '@opensumi/ide-core-browser/__mocks__/progress-service';
 import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
+import { injectGDataStores } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { IDiskFileProvider, IFileServiceClient } from '@opensumi/ide-file-service';
 import { FileServiceClientModule } from '@opensumi/ide-file-service/lib/browser';
 import { FileServiceContribution } from '@opensumi/ide-file-service/lib/browser/file-service-contribution';
@@ -27,9 +30,6 @@ import { KeymapsModule } from '@opensumi/ide-keymaps/lib/browser';
 import { KeymapService } from '@opensumi/ide-keymaps/lib/browser/keymaps.service';
 import { IUserStorageService } from '@opensumi/ide-preferences';
 import { UserStorageContribution, UserStorageServiceImpl } from '@opensumi/ide-preferences/lib/browser/userstorage';
-
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 
 @Injectable()
 export class AddonModule extends BrowserModule {
@@ -110,6 +110,7 @@ describe('KeymapsService should be work', () => {
         },
       },
     );
+    injectGDataStores(injector);
 
     // 覆盖文件系统中的getCurrentUserHome方法，便于用户设置测试
     injector.mock(IFileServiceClient, 'getCurrentUserHome', () => ({

--- a/packages/preferences/__tests__/browser/preference-service.test.ts
+++ b/packages/preferences/__tests__/browser/preference-service.test.ts
@@ -26,6 +26,9 @@ import {
   isObject,
   isString,
 } from '@opensumi/ide-core-browser';
+import { injectGDataStores } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { IDiskFileProvider, IFileServiceClient } from '@opensumi/ide-file-service';
 import { FileServiceClientModule } from '@opensumi/ide-file-service/lib/browser';
 import { FileServiceContribution } from '@opensumi/ide-file-service/lib/browser/file-service-contribution';
@@ -33,9 +36,6 @@ import { DiskFileSystemProvider } from '@opensumi/ide-file-service/lib/node/disk
 import { PreferencesModule } from '@opensumi/ide-preferences/lib/browser';
 import { UserStorageContribution } from '@opensumi/ide-preferences/lib/browser/userstorage';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
-
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 
 @Injectable()
 export class AddonModule extends BrowserModule {
@@ -146,6 +146,7 @@ describe('PreferenceService should be work', () => {
       token: IDiskFileProvider,
       useClass: DiskFileSystemProvider,
     });
+    injectGDataStores(injector);
 
     // 覆盖文件系统中的getCurrentUserHome方法，便于用户设置测试
     injector.mock(IFileServiceClient, 'getCurrentUserHome', () => ({


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution



### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了 `generateToken` 函数，用于生成基于类型的令牌。
  - 添加了 `FileChangeCollectionManager` 类以管理文件更改集合。
  - 新增 `FileSystemWatcherServer` 和 `UnRecursiveFileSystemWatcher` 类以改进文件监视功能。
  - 新增 `watchByFSWatcher`、`watchByNSFW` 和 `watchByParcelWatcher` 函数，提供多种文件监视选项。

- **功能改进**
  - 更新了 `InMemoryDataStore` 类以增强灵活性和功能性，支持更复杂的键管理。
  - 文件监视器的管理和事件处理得到了改进，提升了资源管理效率。
  - `FileChangeCollection` 类新增 `reset` 方法以清除存储的更改。
  - 平台检测逻辑简化，macOS 检测被禁用。

- **文档**
  - 更新了相关文档以反映新功能和改进。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->