### PR TITLE
feat(inline-diff): support hide accpet widget

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -491,20 +491,6 @@ export class AINativeBrowserContribution
         args: false,
         when: `editorFocus && ${InlineChatIsVisible.raw}`,
       });
-      keybindings.registerKeybinding({
-        command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
-        keybinding: 'ctrl+y',
-        args: true,
-        priority: 100,
-        when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
-      });
-      keybindings.registerKeybinding({
-        command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
-        keybinding: 'ctrl+n',
-        args: false,
-        priority: 100,
-        when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
-      });
 
       if (this.inlineChatFeatureRegistry.getInteractiveInputHandler()) {
         keybindings.registerKeybinding(
@@ -538,5 +524,20 @@ export class AINativeBrowserContribution
         );
       }
     }
+
+    keybindings.registerKeybinding({
+      command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
+      keybinding: 'ctrl+y',
+      args: true,
+      priority: 100,
+      when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
+    });
+    keybindings.registerKeybinding({
+      command: AI_INLINE_DIFF_PARTIAL_EDIT.id,
+      keybinding: 'ctrl+n',
+      args: false,
+      priority: 100,
+      when: `editorTextFocus && ${InlineDiffPartialEditsIsVisible.raw}`,
+    });
   }
 }

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -19,6 +19,10 @@ import { InlineDiffWidget } from './inline-diff-widget';
 
 export interface IDiffPreviewerOptions {
   disposeWhenEditorClosed: boolean;
+  /**
+   * 是否隐藏接受部分编辑的 widget，用于只展示 diff 的场景
+   */
+  hideAcceptPartialEditWidget?: boolean;
 }
 
 export interface IInlineDiffPreviewerNode extends IDisposable {

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
@@ -216,7 +216,12 @@ export class InlineDiffController extends BaseAIMonacoEditorController {
     if (inlineDiffMode === EInlineDiffPreviewMode.sideBySide) {
       this.previewer = this.injector.get(SideBySideInlineDiffWidget, [monacoEditor]);
     } else {
-      this.previewer = this.injector.get(LiveInlineDiffPreviewer, [monacoEditor]);
+      this.previewer = this.injector.get(LiveInlineDiffPreviewer, [
+        monacoEditor,
+        {
+          previewerOptions: options,
+        },
+      ]);
     }
 
     this.previewer.create(selection, options);

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
@@ -216,12 +216,7 @@ export class InlineDiffController extends BaseAIMonacoEditorController {
     if (inlineDiffMode === EInlineDiffPreviewMode.sideBySide) {
       this.previewer = this.injector.get(SideBySideInlineDiffWidget, [monacoEditor]);
     } else {
-      this.previewer = this.injector.get(LiveInlineDiffPreviewer, [
-        monacoEditor,
-        {
-          previewerOptions: options,
-        },
-      ]);
+      this.previewer = this.injector.get(LiveInlineDiffPreviewer, [monacoEditor]);
     }
 
     this.previewer.create(selection, options);

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -101,6 +101,12 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
 
   setPreviewerOptions(options: IDiffPreviewerOptions): void {
     this.previewerOptions = options;
+
+    this.livePreviewDiffDecorationModel.setPreviewerOptions({
+      partialEditWidgetOptions: {
+        hideAcceptPartialEditWidget: options.hideAcceptPartialEditWidget,
+      },
+    });
   }
 
   initialize(selection: Selection): void {

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.component.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.component.tsx
@@ -124,6 +124,13 @@ const PartialEditComponent = (props: {
   );
 };
 
+export interface IPartialEditWidgetOptions {
+  /**
+   * In some case, we don't want to show the accept and reject button
+   */
+  hideAcceptPartialEditWidget?: boolean;
+}
+
 @Injectable({ multiple: true })
 export class AcceptPartialEditWidget extends ReactInlineContentWidget {
   static ID = 'AcceptPartialEditWidgetID';
@@ -141,6 +148,10 @@ export class AcceptPartialEditWidget extends ReactInlineContentWidget {
   public readonly onDiscard: Event<void> = this._onDiscard.event;
 
   positionPreference = [ContentWidgetPositionPreference.EXACT];
+
+  constructor(protected readonly editor: ICodeEditor, protected editWidgetOptions?: IPartialEditWidgetOptions) {
+    super(editor);
+  }
 
   public addedLinesCount: number = 0;
   public deletedLinesCount: number = 0;
@@ -166,6 +177,10 @@ export class AcceptPartialEditWidget extends ReactInlineContentWidget {
   }
 
   public renderView(): React.ReactNode {
+    if (this.editWidgetOptions?.hideAcceptPartialEditWidget) {
+      return;
+    }
+
     const keyStrings = this.getSequenceKeyStrings();
     if (!keyStrings) {
       return;

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -29,6 +29,7 @@ import {
   AddedRangeDecoration,
   EPartialEdit,
   IPartialEditEvent,
+  IPartialEditWidgetOptions,
   IRemovedWidgetState,
   IRemovedZoneWidgetOptions,
   ITextLinesTokens,
@@ -53,6 +54,10 @@ export interface ITotalCodeInfo {
   unresolvedChangedLinesCount: number;
 }
 
+export interface IModelOptions {
+  partialEditWidgetOptions?: IPartialEditWidgetOptions;
+}
+
 @Injectable({ multiple: true })
 export class LivePreviewDiffDecorationModel extends Disposable {
   @Autowired(INJECTOR_TOKEN)
@@ -75,6 +80,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
   protected readonly _onPartialEditWidgetListChange = this.registerDispose(new Emitter<AcceptPartialEditWidget[]>());
   public readonly onPartialEditWidgetListChange: Event<AcceptPartialEditWidget[]> =
     this._onPartialEditWidgetListChange.event;
+
+  protected options: IModelOptions = {
+    partialEditWidgetOptions: {},
+  };
 
   protected model: ITextModel;
 
@@ -575,7 +584,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
   }
 
   private createPartialEditWidget(lineNumber: number): AcceptPartialEditWidget {
-    const acceptPartialEditWidget = this.injector.get(AcceptPartialEditWidget, [this.monacoEditor]);
+    const acceptPartialEditWidget = this.injector.get(AcceptPartialEditWidget, [
+      this.monacoEditor,
+      this.options.partialEditWidgetOptions,
+    ]);
     acceptPartialEditWidget.show({ position: { lineNumber, column: 1 } });
 
     const disposable = acceptPartialEditWidget.onDispose(() => {
@@ -701,5 +713,9 @@ export class LivePreviewDiffDecorationModel extends Disposable {
         this.monacoEditor.revealLineInCenterIfOutsideViewport(pos.lineNumber);
       }
     }
+  }
+
+  setPreviewerOptions(options: IModelOptions) {
+    this.options = options;
   }
 }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

支持隐藏 inline diff 的采纳按钮，适用于仅展示 diff 的时候

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 恢复了 `ctrl+y` 和 `ctrl+n` 快捷键用于 `AI_INLINE_DIFF_PARTIAL_EDIT` 命令。
  - 更新了差异预览器的选项配置，增强了灵活性。

- **改进**
  - 增加了新的接口和选项，允许更好地管理和配置预览器的行为。
  - 更新了多个类以支持新的预览选项和状态一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->