### PR TITLE
chore: update xterm imports to use @xterm/xterm package (#4036)

### DIFF
--- a/packages/ai-native/package.json
+++ b/packages/ai-native/package.json
@@ -37,13 +37,13 @@
     "@opensumi/ide-theme": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
     "@opensumi/ide-workspace": "workspace:*",
+    "@xterm/xterm": "5.5.0",
     "ansi-regex": "^2.0.0",
     "dom-align": "^1.7.0",
     "js-tiktoken": "1.0.12",
     "react-chat-elements": "^12.0.10",
     "react-highlight": "^0.15.0",
-    "web-tree-sitter": "0.22.6",
-    "xterm": "5.3.0"
+    "web-tree-sitter": "0.22.6"
   },
   "devDependencies": {
     "@opensumi/ide-core-browser": "workspace:*"

--- a/packages/ai-native/src/browser/contrib/terminal/ai-terminal.service.ts
+++ b/packages/ai-native/src/browser/contrib/terminal/ai-terminal.service.ts
@@ -1,4 +1,4 @@
-import { IMarker } from 'xterm';
+import { IMarker } from '@xterm/xterm';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { AIActionItem } from '@opensumi/ide-core-browser/lib/components/ai-native';

--- a/packages/ai-native/src/browser/contrib/terminal/decoration/terminal-decoration.tsx
+++ b/packages/ai-native/src/browser/contrib/terminal/decoration/terminal-decoration.tsx
@@ -1,6 +1,6 @@
+import { IDecoration, IMarker, Terminal } from '@xterm/xterm';
 import React from 'react';
 import { Root, createRoot } from 'react-dom/client';
-import { IDecoration, IMarker, Terminal } from 'xterm';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { AIActionItem } from '@opensumi/ide-core-browser/lib/components/ai-native';

--- a/packages/ai-native/src/browser/contrib/terminal/ps1-terminal.service.tsx
+++ b/packages/ai-native/src/browser/contrib/terminal/ps1-terminal.service.tsx
@@ -1,7 +1,7 @@
+import { IDecoration, IDisposable, IMarker, Terminal } from '@xterm/xterm';
 import domAlign from 'dom-align';
 import React from 'react';
 import { Root, createRoot } from 'react-dom/client';
-import { IDecoration, IDisposable, IMarker, Terminal } from 'xterm';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { localize } from '@opensumi/ide-core-browser';

--- a/packages/terminal-next/__tests__/browser/client.test.ts
+++ b/packages/terminal-next/__tests__/browser/client.test.ts
@@ -21,7 +21,7 @@ import { injector } from './inject';
 import { createProxyServer, createWsServer } from './proxy';
 import { createBufferLineArray, delay } from './utils';
 
-import type { ITerminalAddon } from 'xterm';
+import type { ITerminalAddon } from '@xterm/xterm';
 
 function createDOMContainer() {
   const div = document.createElement('div');
@@ -41,12 +41,15 @@ class MockXTermAddonWebgl {
   }
 }
 
-jest.mock('xterm', () => {
+jest.mock('@xterm/xterm', () => {
   const Terminal = class MockXTerminal {
     private _text = '';
     public options = {};
     get cols() {
       return 0;
+    }
+    get onLineFeed() {
+      return Event.None;
     }
     get onResize() {
       return Event.None;
@@ -109,11 +112,11 @@ jest.mock('xterm', () => {
     }
   };
   return {
-    ...jest.requireActual('xterm'),
+    ...jest.requireActual('@xterm/xterm'),
     Terminal,
   };
 });
-jest.mock('xterm-addon-webgl', () => MockXTermAddonWebgl);
+jest.mock('@xterm/addon-webgl', () => MockXTermAddonWebgl);
 
 describe('Terminal Client', () => {
   let client: ITerminalClient;

--- a/packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/protocol-link-provider.test.ts
@@ -1,6 +1,7 @@
-import { ILink, Terminal } from 'xterm';
+import { ILink, Terminal } from '@xterm/xterm';
 
-import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+
 import { TerminalProtocolLinkProvider } from '../../../src/browser/links/protocol-link-provider';
 
 describe('Workbench - TerminalWebLinkProvider', () => {

--- a/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
@@ -1,8 +1,8 @@
-import { ILink, Terminal } from 'xterm';
+import { ILink, Terminal } from '@xterm/xterm';
 
 import { OperatingSystem, URI } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 
-import { createBrowserInjector } from '../../../../../tools/dev-tool/src/injector-helper';
 import { TerminalValidatedLocalLinkProvider } from '../../../src/browser/links/validated-local-link-provider';
 
 const unixLinks = ['/foo', '~/foo', './foo', '../foo', '/foo/bar', '/foo/bar+more', 'foo/bar', 'foo/bar+more'];

--- a/packages/terminal-next/__tests__/browser/mock.service.ts
+++ b/packages/terminal-next/__tests__/browser/mock.service.ts
@@ -1,5 +1,5 @@
+import { Terminal } from '@xterm/xterm';
 import WebSocket from 'ws';
-import { Terminal } from 'xterm';
 
 import { Injectable } from '@opensumi/di';
 import { WSChannel } from '@opensumi/ide-connection';

--- a/packages/terminal-next/__tests__/browser/terminal.hover.manager.test.ts
+++ b/packages/terminal-next/__tests__/browser/terminal.hover.manager.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { IViewportRange, Terminal } from 'xterm';
+import { IViewportRange, Terminal } from '@xterm/xterm';
 
 import { Injector } from '@opensumi/di';
 import { LayoutState } from '@opensumi/ide-core-browser/lib/layout/layout-state';

--- a/packages/terminal-next/__tests__/browser/utils.ts
+++ b/packages/terminal-next/__tests__/browser/utils.ts
@@ -1,4 +1,4 @@
-import { IBufferCell, IBufferLine } from 'xterm';
+import { IBufferCell, IBufferLine } from '@xterm/xterm';
 
 export async function delay(ms: number) {
   return new Promise<void>((resolve) => {

--- a/packages/terminal-next/package.json
+++ b/packages/terminal-next/package.json
@@ -22,13 +22,13 @@
     "@opensumi/ide-core-node": "workspace:*",
     "@opensumi/ide-file-service": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
+    "@xterm/addon-canvas": "0.7.0",
+    "@xterm/addon-fit": "0.10.0",
+    "@xterm/addon-search": "0.15.0",
+    "@xterm/addon-webgl": "0.18.0",
+    "@xterm/xterm": "5.5.0",
     "node-pty": "1.0.0",
-    "os-locale": "^4.0.0",
-    "xterm": "5.3.0",
-    "xterm-addon-canvas": "0.4.0",
-    "xterm-addon-fit": "0.8.0",
-    "xterm-addon-search": "0.12.0",
-    "xterm-addon-webgl": "0.15.0"
+    "os-locale": "^4.0.0"
   },
   "devDependencies": {
     "@opensumi/ide-components": "workspace:*",

--- a/packages/terminal-next/src/browser/component/terminal.view.tsx
+++ b/packages/terminal-next/src/browser/component/terminal.view.tsx
@@ -19,7 +19,7 @@ import ResizeView, { ResizeDirection } from './resize.view';
 import styles from './terminal.module.less';
 import TerminalWidget from './terminal.widget';
 
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 export default observer(() => {
   const controller = useInjectable<ITerminalController>(ITerminalController);

--- a/packages/terminal-next/src/browser/links/base.ts
+++ b/packages/terminal-next/src/browser/links/base.ts
@@ -1,6 +1,6 @@
 import { TerminalLink } from './link';
 
-import type { ILink, ILinkProvider } from 'xterm';
+import type { ILink, ILinkProvider } from '@xterm/xterm';
 
 export abstract class TerminalBaseLinkProvider implements ILinkProvider {
   private _activeLinks: TerminalLink[] | undefined;

--- a/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
+++ b/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
@@ -8,7 +8,7 @@ import { convertLinkRangeToBuffer, getXtermLineContent } from './helpers';
 import { TerminalLink } from './link';
 import { XtermLinkMatcherHandler } from './link-manager';
 
-import type { IBufferLine, IViewportRange, Terminal } from 'xterm';
+import type { IBufferLine, IViewportRange, Terminal } from '@xterm/xterm';
 
 /**
  * An adapter to convert a simple external link provider into an internal link provider that

--- a/packages/terminal-next/src/browser/links/helpers.ts
+++ b/packages/terminal-next/src/browser/links/helpers.ts
@@ -6,7 +6,7 @@
 
 import { IRange } from '@opensumi/ide-core-common/lib/types';
 
-import type { IBuffer, IBufferCellPosition, IBufferLine, IBufferRange, IViewportRange } from 'xterm';
+import type { IBuffer, IBufferCellPosition, IBufferLine, IBufferRange, IViewportRange } from '@xterm/xterm';
 
 export function convertLinkRangeToBuffer(lines: IBufferLine[], bufferWidth: number, range: IRange, startLine: number) {
   const bufferRange: IBufferRange = {

--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -1,4 +1,4 @@
-import { ILinkProvider, IViewportRange, Terminal } from 'xterm';
+import { ILinkProvider, IViewportRange, Terminal } from '@xterm/xterm';
 
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { IOpenerService, PreferenceService } from '@opensumi/ide-core-browser';

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -13,7 +13,7 @@ import {
 
 import { convertBufferRangeToViewport } from './helpers';
 
-import type { IBufferRange, ILink, ILinkDecorations, IViewportRange, Terminal } from 'xterm';
+import type { IBufferRange, ILink, ILinkDecorations, IViewportRange, Terminal } from '@xterm/xterm';
 
 // default delay time (ms) for showing tooltip when mouse is over a link
 const DEFAULT_HOVER_DELAY = 500;

--- a/packages/terminal-next/src/browser/links/protocol-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/protocol-link-provider.ts
@@ -7,7 +7,7 @@ import { TerminalBaseLinkProvider } from './base';
 import { convertLinkRangeToBuffer, getXtermLineContent } from './helpers';
 import { TerminalLink } from './link';
 
-import type { IBufferLine, IViewportRange, Terminal } from 'xterm';
+import type { IBufferLine, IViewportRange, Terminal } from '@xterm/xterm';
 
 @Injectable({ multiple: true })
 export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {

--- a/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
@@ -16,7 +16,7 @@ import { FOLDER_IN_WORKSPACE_LABEL, FOLDER_NOT_IN_WORKSPACE_LABEL, OPEN_FILE_LAB
 import { XtermLinkMatcherHandler } from './link-manager';
 
 import type { TerminalClient } from '../terminal.client';
-import type { IBufferLine, IViewportRange, Terminal } from 'xterm';
+import type { IBufferLine, IViewportRange, Terminal } from '@xterm/xterm';
 
 const pathPrefix = '(\\.\\.?|\\~)';
 const pathSeparatorClause = '\\/';

--- a/packages/terminal-next/src/browser/terminal.addon.ts
+++ b/packages/terminal-next/src/browser/terminal.addon.ts
@@ -1,4 +1,4 @@
-import { ITerminalAddon, Terminal } from 'xterm';
+import { ITerminalAddon, Terminal } from '@xterm/xterm';
 
 import { Disposable, Emitter } from '@opensumi/ide-core-common';
 

--- a/packages/terminal-next/src/browser/terminal.preference.ts
+++ b/packages/terminal-next/src/browser/terminal.preference.ts
@@ -1,5 +1,5 @@
+import { ITerminalOptions } from '@xterm/xterm';
 import pickBy from 'lodash/pickBy';
-import { ITerminalOptions } from 'xterm';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { PreferenceService } from '@opensumi/ide-core-browser';

--- a/packages/terminal-next/src/browser/terminal.theme.ts
+++ b/packages/terminal-next/src/browser/terminal.theme.ts
@@ -6,7 +6,7 @@ import { ITerminalTheme } from '../common';
 
 import * as TERMINAL_COLOR from './terminal.color';
 
-import type { ITheme } from 'xterm';
+import type { ITheme } from '@xterm/xterm';
 
 @Injectable()
 export class TerminalTheme extends Themable implements ITerminalTheme {

--- a/packages/terminal-next/src/browser/terminal.typeAhead.addon.ts
+++ b/packages/terminal-next/src/browser/terminal.typeAhead.addon.ts
@@ -22,7 +22,7 @@ import { CodeTerminalSettingId } from '../common/preference';
 import { Color, RGBA } from './terminal.typeAhead.ext';
 import { IXtermCore, XtermAttributes } from './xterm-private';
 
-import type { IBuffer, IBufferCell, IDisposable, ITerminalAddon, Terminal } from 'xterm';
+import type { IBuffer, IBufferCell, IDisposable, ITerminalAddon, Terminal } from '@xterm/xterm';
 
 export const DEFAULT_LOCAL_ECHO_EXCLUDE: ReadonlyArray<string> = ['vim', 'vi', 'nano', 'tmux'];
 

--- a/packages/terminal-next/src/browser/xterm-private.d.ts
+++ b/packages/terminal-next/src/browser/xterm-private.d.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { IBufferCell } from 'xterm';
+import { IBufferCell } from '@xterm/xterm';
 
 export type XtermAttributes = Omit<IBufferCell, 'getWidth' | 'getChars' | 'getCode'> & { clone?(): XtermAttributes };
 

--- a/packages/terminal-next/src/browser/xterm.ts
+++ b/packages/terminal-next/src/browser/xterm.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { ITerminalOptions, ITheme, Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { ISearchOptions, SearchAddon } from 'xterm-addon-search';
+import { FitAddon } from '@xterm/addon-fit';
+import { ISearchOptions, SearchAddon } from '@xterm/addon-search';
+import { ITerminalOptions, ITheme, Terminal } from '@xterm/xterm';
 
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { IClipboardService } from '@opensumi/ide-core-browser';
@@ -26,8 +26,8 @@ import {
   TERMINAL_OVERVIEW_RULER_FIND_MATCH_FOREGROUND_COLOR,
 } from './terminal.color';
 
-import type { CanvasAddon as CanvasAddonType } from 'xterm-addon-canvas';
-import type { WebglAddon as WebglAddonType } from 'xterm-addon-webgl';
+import type { CanvasAddon as CanvasAddonType } from '@xterm/addon-canvas';
+import type { WebglAddon as WebglAddonType } from '@xterm/addon-webgl';
 
 export interface XTermOptions {
   cwd?: string;
@@ -85,7 +85,7 @@ export class XTerm extends Disposable implements IXTerm {
     try {
       if (!this._canvasAddon) {
         // @ts-ignore
-        this._canvasAddon = new (await import('xterm-addon-canvas')).CanvasAddon();
+        this._canvasAddon = new (await import('@xterm/addon-canvas')).CanvasAddon();
       }
 
       this.addDispose(this._canvasAddon);
@@ -104,7 +104,7 @@ export class XTerm extends Disposable implements IXTerm {
     try {
       if (!this._webglAddon) {
         // @ts-ignore
-        this._webglAddon = new (await import('xterm-addon-webgl')).WebglAddon();
+        this._webglAddon = new (await import('@xterm/addon-webgl')).WebglAddon();
       }
 
       this.addDispose(this._webglAddon);

--- a/packages/terminal-next/src/common/client.ts
+++ b/packages/terminal-next/src/common/client.ts
@@ -1,4 +1,4 @@
-import { Terminal } from 'xterm';
+import { Terminal } from '@xterm/xterm';
 
 import { Deferred, Disposable, Event, IDisposable } from '@opensumi/ide-core-common';
 

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -1,6 +1,6 @@
+import { Terminal as XTerm } from '@xterm/xterm';
 import { IPty as INodePty } from 'node-pty';
 import * as pty from 'node-pty';
-import { Terminal as XTerm } from 'xterm';
 
 import { IThemeColor, MaybePromise, OperatingSystem, Uri } from '@opensumi/ide-core-common';
 

--- a/packages/terminal-next/src/common/service.ts
+++ b/packages/terminal-next/src/common/service.ts
@@ -1,4 +1,4 @@
-import { ITerminalOptions as IXtermTerminalOptions } from 'xterm';
+import { ITerminalOptions as IXtermTerminalOptions } from '@xterm/xterm';
 
 import { IDisposable, OperatingSystem } from '@opensumi/ide-core-common';
 

--- a/packages/terminal-next/src/common/theme.ts
+++ b/packages/terminal-next/src/common/theme.ts
@@ -1,4 +1,4 @@
-import { ITheme } from 'xterm';
+import { ITheme } from '@xterm/xterm';
 
 export const ITerminalTheme = Symbol('ITerminalTheme');
 export interface ITerminalTheme {

--- a/packages/terminal-next/src/common/xterm-private.d.ts
+++ b/packages/terminal-next/src/common/xterm-private.d.ts
@@ -1,4 +1,4 @@
-import { IBufferCell } from 'xterm';
+import { IBufferCell } from '@xterm/xterm';
 
 export type XTermAttributes = Omit<IBufferCell, 'getWidth' | 'getChars' | 'getCode'> & { clone?(): XTermAttributes };
 

--- a/packages/terminal-next/src/common/xterm.ts
+++ b/packages/terminal-next/src/common/xterm.ts
@@ -1,4 +1,4 @@
-import { ITerminalOptions, ITheme, Terminal } from 'xterm';
+import { ITerminalOptions, ITheme, Terminal } from '@xterm/xterm';
 
 import { SupportedOptions } from './preference';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,13 +2084,13 @@ __metadata:
     "@opensumi/ide-theme": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
+    "@xterm/xterm": "npm:5.5.0"
     ansi-regex: "npm:^2.0.0"
     dom-align: "npm:^1.7.0"
     js-tiktoken: "npm:1.0.12"
     react-chat-elements: "npm:^12.0.10"
     react-highlight: "npm:^0.15.0"
     web-tree-sitter: "npm:0.22.6"
-    xterm: "npm:5.3.0"
   languageName: unknown
   linkType: soft
 
@@ -2986,14 +2986,14 @@ __metadata:
     "@opensumi/ide-variable": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
     "@types/http-proxy": "npm:^1.17.2"
+    "@xterm/addon-canvas": "npm:0.7.0"
+    "@xterm/addon-fit": "npm:0.10.0"
+    "@xterm/addon-search": "npm:0.15.0"
+    "@xterm/addon-webgl": "npm:0.18.0"
+    "@xterm/xterm": "npm:5.5.0"
     http-proxy: "npm:^1.18.0"
     node-pty: "npm:1.0.0"
     os-locale: "npm:^4.0.0"
-    xterm: "npm:5.3.0"
-    xterm-addon-canvas: "npm:0.4.0"
-    xterm-addon-fit: "npm:0.8.0"
-    xterm-addon-search: "npm:0.12.0"
-    xterm-addon-webgl: "npm:0.15.0"
   languageName: unknown
   linkType: soft
 
@@ -4779,6 +4779,49 @@ __metadata:
   version: 0.8.10
   resolution: "@xmldom/xmldom@npm:0.8.10"
   checksum: 10/62400bc5e0e75b90650e33a5ceeb8d94829dd11f9b260962b71a784cd014ddccec3e603fe788af9c1e839fa4648d8c521ebd80d8b752878d3a40edabc9ce7ccf
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-canvas@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@xterm/addon-canvas@npm:0.7.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 10/63300bb472f9a06675af99375c02b63d1072765c52b2fed29c8dae310fe0be6858cc09bd0cc37dc2a58fed7dfe1c0808b25a02753d071e6d46b7efdb8f163bf0
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-fit@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@xterm/addon-fit@npm:0.10.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 10/8edfad561c0d0316c5883cbe2ce56109f105a2b2bf53b71d5f8c788e656a3205c1093a659dddcf4025a459e4b7ff8e07b6c6a19815c8711deeded560de5f1893
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-search@npm:0.15.0":
+  version: 0.15.0
+  resolution: "@xterm/addon-search@npm:0.15.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 10/f45475d837c5bcd5277aa24301464be5f786311dc086d8eb650fe67839347b9922291556643cedde881bc41d99c6a6d4a1498fafda98396d355613a471f59e8d
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-webgl@npm:0.18.0":
+  version: 0.18.0
+  resolution: "@xterm/addon-webgl@npm:0.18.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 10/ba3250afd41ea32b5f302d63b20e7dec107aec64c3c1fbc0142215bf5167f63a5907423e260712bd1c637ad549db267aa1e0afc2080472354ac25d8c7f2c2281
+  languageName: node
+  linkType: hard
+
+"@xterm/xterm@npm:5.5.0":
+  version: 5.5.0
+  resolution: "@xterm/xterm@npm:5.5.0"
+  checksum: 10/d4cdc402de81a83a3e0ef93f38072cb8f54abe4d65865f2e29b92cbc2593f86d052f6b993895c9e5dec97f47548f504e90bcea0aad6845917c09b03f2f3a4629
   languageName: node
   linkType: hard
 
@@ -20164,49 +20207,6 @@ __metadata:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
-  languageName: node
-  linkType: hard
-
-"xterm-addon-canvas@npm:0.4.0":
-  version: 0.4.0
-  resolution: "xterm-addon-canvas@npm:0.4.0"
-  peerDependencies:
-    xterm: ^5.0.0
-  checksum: 10/f1448dd22dbe982fff712a1cb124920a31b1c15acfe506ab1a0f8f10f2e4be9b2a39d53d76efee3250cbafaa48e261b4cbc9ce5a27e55c3b63ce35de59f6003f
-  languageName: node
-  linkType: hard
-
-"xterm-addon-fit@npm:0.8.0":
-  version: 0.8.0
-  resolution: "xterm-addon-fit@npm:0.8.0"
-  peerDependencies:
-    xterm: ^5.0.0
-  checksum: 10/5af2041b442f7c804eda2e6f62e3b68b5159b0ae6bd96e2aa8d85b26441df57291cbfed653d1196d4af5d9b94bfc39993df8b409a25c35e0d36bdaf6f5cdfe5f
-  languageName: node
-  linkType: hard
-
-"xterm-addon-search@npm:0.12.0":
-  version: 0.12.0
-  resolution: "xterm-addon-search@npm:0.12.0"
-  peerDependencies:
-    xterm: ^5.0.0
-  checksum: 10/569c1a76408544d18350e57b912cece7beeb420b3952abd3ab403358dabb7327e6cfc0e5423cf5d47868aec138e50dbeaa0126eeb0eee6be0806f92c508f3a0d
-  languageName: node
-  linkType: hard
-
-"xterm-addon-webgl@npm:0.15.0":
-  version: 0.15.0
-  resolution: "xterm-addon-webgl@npm:0.15.0"
-  peerDependencies:
-    xterm: ^5.0.0
-  checksum: 10/c93e58629931735120a4ca49264775fed9369b72380fc6f4d55eea8760a2ca0483e2d5730618f71e4fae8c128e610024a24728f207961098d2188e1067eacdfa
-  languageName: node
-  linkType: hard
-
-"xterm@npm:5.3.0":
-  version: 5.3.0
-  resolution: "xterm@npm:5.3.0"
-  checksum: 10/3690b6a6d744f1d2932279975bb8e6c786e70c675531045016ecfe0f9b7957e2fc6811b815335f3e0e84b40ffae654f6ee4afe55a5768534744497e62252dd50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

Migrate xterm to @xterm/xterm and update related addon packages accordingly

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 更新了终端功能的依赖，采用了新的 `@xterm` 包，提升了终端的性能和功能。
  - 增加了对多个新依赖的支持，如 `@xterm/addon-canvas` 和 `@xterm/addon-fit`。

- **修复**
  - 修正了终端服务中的命令建议和提示的逻辑，提升了用户交互体验。

- **文档**
  - 更新了相关的导入路径，确保一致性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->