### PR TITLE
chore: add missing ajv dep for keymaps package

### DIFF
--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -17,7 +17,8 @@
     "url": "git@github.com:opensumi/core.git"
   },
   "dependencies": {
-    "@opensumi/ide-core-common": "workspace:*"
+    "@opensumi/ide-core-common": "workspace:*",
+    "ajv": "^6.10.0"
   },
   "devDependencies": {
     "@opensumi/ide-components": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,7 @@ __metadata:
     "@opensumi/ide-file-service": "workspace:*"
     "@opensumi/ide-preferences": "workspace:*"
     "@opensumi/ide-quick-open": "workspace:*"
+    ajv: "npm:^6.10.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🧹 Chores

### Background or solution
keymaps 服务实际上依赖了 ajv，添加以防止在某些情况下引用到错误的 ajv lib

https://github.com/opensumi/core/blob/main/packages/keymaps/src/browser/keymaps-parser.ts#L1
 
### Changelog
无


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在 `@opensumi/ide-keymaps` 包中新增了对 `ajv` 依赖的支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->