### PR TITLE
fix(pty): cannot run bash with bash integration

### DIFF
--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -195,9 +195,8 @@ export class PtyService extends Disposable implements IPtyService {
       }
       if (Array.isArray(options.args)) {
         // bash 的参数中，如果有 --init-file 则不再添加
-        // --init-file 要放在最前面，如 `bash -l --init-file /path/to/init.sh` 就会报错。
-        //                           `bash --init-file /path/to/init.sh -l` 就不会报错。
         if (!options.args.includes('--init-file')) {
+          // --init-file 要放在最前面，bash 的启动参数必须要 long options 在前面，否则会启动失败
           options.args.unshift('--init-file', bashIntegrationPath);
         }
       }

--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -194,7 +194,12 @@ export class PtyService extends Disposable implements IPtyService {
         options.args = [];
       }
       if (Array.isArray(options.args)) {
-        options.args.push('--init-file', bashIntegrationPath);
+        // bash 的参数中，如果有 --init-file 则不再添加
+        // --init-file 要放在最前面，如 `bash -l --init-file /path/to/init.sh` 就会报错。
+        //                           `bash --init-file /path/to/init.sh -l` 就不会报错。
+        if (!options.args.includes('--init-file')) {
+          options.args.unshift('--init-file', bashIntegrationPath);
+        }
       }
     }
 


### PR DESCRIPTION
### Types


- [x] 🐛 Bug Fixes


### Background or solution

开启 bash integration 的时候 Bash 无法启动

bash 启动时，long option 必须放在 option 之前

![CleanShot 2024-10-11 at 10 43 00@2x](https://github.com/user-attachments/assets/4bb5953e-3dd8-4689-865a-07c563975b4b)


### Changelog
