### PR TITLE
fix: slash command unseen

### DIFF
--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -515,6 +515,7 @@ export const AIChatView = observer(() => {
       await renderUserMessage({
         relationId,
         message,
+        command,
         agentId,
       });
 
@@ -532,6 +533,7 @@ export const AIChatView = observer(() => {
         relationId,
         message,
         agentId,
+        command,
         request,
         msgId,
       });


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes
### Background or solution

### Changelog
修复 slash command 的标识符不显示的问题