### PR TITLE
chore(ext-service): remove unused method

### DIFF
--- a/packages/extension/__tests__/node/extension.service.test.ts
+++ b/packages/extension/__tests__/node/extension.service.test.ts
@@ -157,7 +157,7 @@ describe('Extension Service', () => {
     });
 
     it('should create connect listenPath', async () => {
-      const listenPath = await extensionService.getElectronMainThreadListenPath2(mockExtClientId);
+      const listenPath = await extensionService.getElectronMainThreadListenPath(mockExtClientId);
       expect(path.dirname(listenPath)).toBe(path.join(os.tmpdir(), 'sumi-ipc'));
     });
     it('should create ext server listen option', async () => {

--- a/packages/extension/src/browser/extension.service.ts
+++ b/packages/extension/src/browser/extension.service.ts
@@ -412,7 +412,7 @@ export class ExtensionServiceImpl extends WithEventBus implements ExtensionServi
           break;
         }
       case ERestartPolicy.Always:
-        this.progressService.withProgress(
+        await this.progressService.withProgress(
           {
             location: ProgressLocation.Notification,
             title: localize('extension.exthostRestarting.content'),

--- a/packages/extension/src/common/extension.ts
+++ b/packages/extension/src/common/extension.ts
@@ -93,7 +93,6 @@ export interface IExtensionNodeService {
   ensureProcessReady(clientId: string): Promise<boolean>;
   getExtProcessId(clientId: string): Promise<number | null>;
   getElectronMainThreadListenPath(clientId: string): Promise<string>;
-  getElectronMainThreadListenPath2(clientId: string): Promise<string>;
   getExtServerListenOption(clientId: string);
   getExtension(
     extensionPath: string,

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -524,7 +524,7 @@ export const localizationBundle = {
     'preference.general.language': 'Language',
     'preference.general.language.change.refresh.info':
       'After changing the language, it should be restarted to take effect. Will it be refreshed immediately?',
-    'preference.general.language.change.refresh.now': 'Now',
+    'preference.general.language.change.refresh.now': 'Refresh',
     'preference.general.language.change.refresh.later': 'Later',
 
     'preference.debug.internalConsoleOptions': 'Controls when the internal debug console should open.',

--- a/packages/terminal-next/src/browser/terminal.controller.ts
+++ b/packages/terminal-next/src/browser/terminal.controller.ts
@@ -380,7 +380,7 @@ export class TerminalController extends WithEventBus implements ITerminalControl
              * 等待预先连接成功
              */
             client.attached.promise.then(() => {
-              widget.name = client.name;
+              widget.rename(client.name);
               // client.term.writeln('\x1b[2mTerminal restored\x1b[22m');
 
               /**


### PR DESCRIPTION
### Types


- [x] 🧹 Chores

### Background or solution

一些 cleanup

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了语言设置中刷新操作的本地化字符串，从“现在”更改为“刷新”。
  
- **改进**
	- 优化了扩展服务的重启逻辑，确保在页面可见时才执行重启。
	- 统一了日志记录，使用新的日志标签替代旧的实例ID。
  
- **修复**
	- 移除了未使用的方法，简化了接口结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->