### PR TITLE
feat(ext): support `sumiContributesOverride` field

### DIFF
--- a/packages/core-browser/src/ai-native/ai-config.service.ts
+++ b/packages/core-browser/src/ai-native/ai-config.service.ts
@@ -4,7 +4,7 @@ import { IAINativeCapabilities } from '@opensumi/ide-core-common';
 import { LayoutViewSizeConfig } from '../layout/constants';
 import { AppConfig } from '../react-providers/config-provider';
 
-const DEFAULT_CAPABILITIES: Required<IAINativeCapabilities> = {
+export const DEFAULT_CAPABILITIES: Required<IAINativeCapabilities> = {
   supportsMarkers: true,
   supportsChatAssistant: true,
   supportsInlineChat: true,

--- a/packages/extension/src/browser/vscode/contributes/view-containers.ts
+++ b/packages/extension/src/browser/vscode/contributes/view-containers.ts
@@ -36,16 +36,18 @@ export class ViewContainersContributionPoint extends VSCodeContributePoint<ViewC
 
   private disposableCollection: DisposableCollection = new DisposableCollection();
 
-  private convertLocationToSide(location: LocationKey): 'left' | 'bottom' | typeof AI_CHAT_VIEW_ID {
+  private convertLocationToSide(
+    location: LocationKey,
+  ): ['left' | 'bottom' | typeof AI_CHAT_VIEW_ID, 'vertical' | 'horizontal'] {
     switch (location) {
       case 'activitybar': {
-        return 'left';
+        return ['left', 'vertical'];
       }
       case 'ai-chat': {
-        return AI_CHAT_VIEW_ID;
+        return [AI_CHAT_VIEW_ID, 'vertical'];
       }
       default:
-        return 'bottom';
+        return ['bottom', 'horizontal'];
     }
   }
 
@@ -57,7 +59,7 @@ export class ViewContainersContributionPoint extends VSCodeContributePoint<ViewC
         continue;
       }
       for (const location of Object.keys(contributes)) {
-        const side: string = this.convertLocationToSide(location as LocationKey);
+        const [side, alignment] = this.convertLocationToSide(location as LocationKey);
 
         for (const container of contributes[location]) {
           const handlerId = this.mainlayoutService.collectTabbarComponent(
@@ -71,7 +73,7 @@ export class ViewContainersContributionPoint extends VSCodeContributePoint<ViewC
               fromExtension: true,
               // 插件注册的视图容器无view时默认都隐藏tab
               hideIfEmpty: true,
-              alignment: side === 'left' ? 'vertical' : 'horizontal',
+              alignment,
             },
             side,
           );

--- a/packages/extension/src/node/extension.scanner.ts
+++ b/packages/extension/src/node/extension.scanner.ts
@@ -124,6 +124,8 @@ export class ExtensionScanner {
       packageJSON.sumiContributes = packageJSON.kaitianContributes;
     }
 
+    packageJSON.contributes = packageJSON.contributes || {};
+
     // merge for `sumiContributes` and `contributes`
     // `sumiContributesOverride` is used for override the `contributes`
     if (packageJSON.sumiContributesOverride) {

--- a/packages/extension/src/node/extension.scanner.ts
+++ b/packages/extension/src/node/extension.scanner.ts
@@ -125,6 +125,11 @@ export class ExtensionScanner {
     }
 
     // merge for `sumiContributes` and `contributes`
+    // `sumiContributesOverride` is used for override the `contributes`
+    if (packageJSON.sumiContributesOverride) {
+      packageJSON.contributes = Object.assign(packageJSON.contributes, packageJSON.sumiContributesOverride);
+    }
+    // `sumiContributes` is used for merge the `contributes`
     packageJSON.contributes = mergeContributes(packageJSON.sumiContributes, packageJSON.contributes);
 
     const extension = {

--- a/packages/startup/entry/sample-modules/overrides/extension/extension-node.service.ts
+++ b/packages/startup/entry/sample-modules/overrides/extension/extension-node.service.ts
@@ -7,6 +7,7 @@ export class OverrideExtensionNodeService extends NodeExtProcessService {
         VSCODE_NLS: JSON.stringify({
           locale: 'zh-CN',
         }),
+        CF_RUNTIME: 'codefuse-ide',
       },
     };
   }

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -1,3 +1,4 @@
+import { AI_CHAT_LOGO_AVATAR_ID } from '@opensumi/ide-ai-native';
 import { SlotLocation } from '@opensumi/ide-core-browser';
 import { DESIGN_MENUBAR_CONTAINER_VIEW_ID, DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
 import { AIModules } from '@opensumi/ide-startup/lib/browser/common-modules';
@@ -14,7 +15,7 @@ renderApp(
       },
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {
-          modules: [MENU_BAR_FEATURE_TIP],
+          modules: [MENU_BAR_FEATURE_TIP, AI_CHAT_LOGO_AVATAR_ID],
         },
         [SlotLocation.top]: {
           modules: [DESIGN_MENUBAR_CONTAINER_VIEW_ID],

--- a/packages/startup/entry/web/render-app.tsx
+++ b/packages/startup/entry/web/render-app.tsx
@@ -28,6 +28,8 @@ import { RemoteOpenerModule } from '@opensumi/ide-remote-opener/lib/browser';
 import { CommonBrowserModules } from '../../src/browser/common-modules';
 import { SampleModule } from '../sample-modules';
 import { AILayout } from '@opensumi/ide-ai-native/lib/browser/layout/ai-layout';
+import { DESIGN_MENU_BAR_RIGHT } from '@opensumi/ide-design';
+import { AI_CHAT_LOGO_AVATAR_ID } from '@opensumi/ide-ai-native';
 
 const CLIENT_ID = 'W_' + uuid();
 
@@ -94,6 +96,9 @@ export const getDefaultClientAppOpts = ({
       },
       [SlotLocation.action]: {
         modules: ['@opensumi/ide-toolbar-action'],
+      },
+      [DESIGN_MENU_BAR_RIGHT]: {
+        modules: [AI_CHAT_LOGO_AVATAR_ID],
       },
       ...layoutConfig,
     },


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features


### Background or solution

之前我们的 `sumiContributes` 会和用户的 `contributes` merge 掉，本次推出的 sumiContributesOverride 则是直接 override 掉对应的字段，这样就可以让某些插件在 VSCode 下注册到 location A，在 opensumi 下注册到 location B:

![CleanShot 2024-10-15 at 12 46 54@2x](https://github.com/user-attachments/assets/0bd9f10f-af19-4ba7-b54e-3fd6c75b69e9)


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 添加了新的环境变量 `CF_RUNTIME`，用于扩展节点服务。
  - 更新了布局配置，增加了 `AI_CHAT_LOGO_AVATAR_ID` 到菜单栏功能。

- **改进**
  - 修改了 `convertLocationToSide` 方法，返回更详细的布局信息。
  - 更新了 `getExtension` 方法，增强了对扩展的处理逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->