### PR TITLE
fix: rewrite content minimum width

### DIFF
--- a/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
+++ b/packages/ai-native/src/browser/widget/rewrite/rewrite-widget.tsx
@@ -129,6 +129,7 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
 
       const lineCount = currentLineNumber - range.startLineNumber;
       const spaceWidth = virtualEditor!.getOption(monaco.editor.EditorOption.fontInfo).spaceWidth;
+      const contentLeft = virtualEditor!.getOption(monaco.editor.EditorOption.layoutInfo).contentLeft;
       let maxColumnWidth = 0;
       const tabSize = virtualModel.getOptions().tabSize;
       Array.from(
@@ -149,7 +150,7 @@ const TextBoxProvider = React.memo((props: ITextBoxProviderProps) => {
         }
       });
 
-      setEditorSize({ width: maxColumnWidth * spaceWidth, height: lineHeight * (lineCount + 1) });
+      setEditorSize({ width: maxColumnWidth * spaceWidth + contentLeft * 2, height: lineHeight * (lineCount + 1) });
     },
     [editorSize, editor],
   );


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

before:
![image](https://github.com/user-attachments/assets/7b076969-830a-4f8a-a119-c1bebfcc2ce6)


after:
![image](https://github.com/user-attachments/assets/6848c25b-f8ac-464e-be46-f572f1d99d4d)


### Changelog
限制 rewrite 面板的最小宽度

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了虚拟编辑器的布局，确保文本变化的视觉表现更加准确。
	- 更新了装饰的渲染逻辑，使其更好地与新的布局计算集成。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->