### PR TITLE
fix: diff editor model not exist error

### DIFF
--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -303,10 +303,6 @@ export interface AppConfig {
    * This is useful when your scenario is one-time use, and you can control the opening of the editor tab yourself.
    */
   disableRestoreEditorGroupState?: boolean;
-  /**
-   * 启用 Diff 编辑器状态恢复逻辑
-   */
-  enableRestoreDiffEditorState?: boolean;
 }
 
 export interface ICollaborationClientOpts {

--- a/packages/editor/src/browser/editor-collection.service.ts
+++ b/packages/editor/src/browser/editor-collection.service.ts
@@ -9,7 +9,6 @@ import {
   Emitter as EventEmitter,
   ILineChange,
   ISelection,
-  LRUCache,
   OnEvent,
   URI,
   WithEventBus,
@@ -32,7 +31,7 @@ import {
   IUndoStopOptions,
   ResourceDecorationNeedChangeEvent,
 } from '../common';
-import { IEditorDocumentModel, IEditorDocumentModelRef } from '../common/editor';
+import { IEditorDocumentModel, IEditorDocumentModelRef, isTextEditorViewState } from '../common/editor';
 
 import { MonacoEditorDecorationApplier } from './decoration-applier';
 import { EditorDocumentModelContentChangedEvent, IEditorDocumentModelService } from './doc-model/types';
@@ -514,7 +513,7 @@ export class BrowserCodeEditor extends BaseMonacoEditorWrapper implements ICodeE
   protected restoreState() {
     if (this.currentUri) {
       const state = this.editorState.get(this.currentUri.toString());
-      if (state) {
+      if (isTextEditorViewState(state)) {
         this.monacoEditor.restoreViewState(state);
       }
     }
@@ -608,8 +607,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
 
   public onRefOpen = this._onRefOpen.event;
 
-  private diffEditorModelCache = new LRUCache<string, monaco.editor.IDiffEditorViewModel>(100);
-
   protected saveCurrentState() {
     if (this.currentUri) {
       const state = this.monacoDiffEditor.saveViewState();
@@ -619,10 +616,13 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     }
   }
 
-  protected restoreState() {
+  protected restoreState(options: IResourceOpenOptions) {
     if (this.currentUri) {
       const state = this.editorState.get(this.currentUri.toString());
-      if (state) {
+      if (isTextEditorViewState(state)) {
+        if (options.range || options.originalRange) {
+          state.modified!.cursorState = []; // 避免重复的选中态
+        }
         this.monacoDiffEditor.restoreViewState(state);
       }
     }
@@ -641,13 +641,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     );
   }
 
-  disposeModel(originalUri: string, modifiedUri: string) {
-    if (this.diffEditorModelCache.size > 0) {
-      const key = `${originalUri}-${modifiedUri}`;
-      this.diffEditorModelCache.delete(key);
-    }
-  }
-
   async compare(
     originalDocModelRef: IEditorDocumentModelRef,
     modifiedDocModelRef: IEditorDocumentModelRef,
@@ -662,17 +655,7 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
     }
     const original = this.originalDocModel.getMonacoModel();
     const modified = this.modifiedDocModel.getMonacoModel();
-    const key = `${original.uri.toString()}-${modified.uri.toString()}`;
-    let model: monaco.editor.IDiffEditorViewModel | undefined;
-    if (this.appConfig.enableRestoreDiffEditorState) {
-      model = this.diffEditorModelCache.get(key);
-    }
-
-    if (!model) {
-      model = this.monacoDiffEditor.createViewModel({ original, modified });
-      this.diffEditorModelCache.set(key, model);
-    }
-
+    const model = this.monacoDiffEditor.createViewModel({ original, modified });
     this.monacoDiffEditor.setModel(model);
 
     if (rawUri) {
@@ -687,11 +670,14 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
         }),
       });
     }
+    await model?.waitForDiff();
+
+    // 需要等待 Diff 渲染，否则无法获取当前的 Diff 代码折叠状态
+    this.restoreState(options);
 
     if (options.range || options.originalRange) {
       const range = (options.range || options.originalRange) as monaco.IRange;
       const currentEditor = options.range ? this.modifiedEditor.monacoEditor : this.originalEditor.monacoEditor;
-      await model?.waitForDiff();
       // 必须使用 setTimeout, 因为两边的 editor 出现时机问题，diffEditor 是异步显示和渲染
       setTimeout(() => {
         currentEditor.revealRangeInCenter(range);
@@ -706,8 +692,6 @@ export class BrowserDiffEditor extends WithEventBus implements IDiffEditor {
           currentEditor.revealRangeInCenter(range);
         });
       });
-    } else {
-      this.restoreState();
     }
     this._onRefOpen.fire(originalDocModelRef);
     this._onRefOpen.fire(modifiedDocModelRef);

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -1568,7 +1568,6 @@ export class EditorGroup extends WithEventBus implements IGridEditorGroup {
       const query = uri.getParsedQuery();
       this.doDisposeDocRef(new URI(query.original));
       this.doDisposeDocRef(new URI(query.modified));
-      this.diffEditor?.disposeModel(query.original, query.modified);
     } else if (uri.scheme === 'mergeEditor') {
       this.mergeEditor && this.mergeEditor.dispose();
     } else {

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -22,6 +22,8 @@ import { IDocModelUpdateOptions } from './types';
 
 import type {
   EOL,
+  ICodeEditorViewState,
+  IDiffEditorViewState,
   IEditorOptions,
   ICodeEditor as IMonacoCodeEditor,
   ITextModel,
@@ -317,8 +319,6 @@ export interface IDiffEditor extends IDisposable {
   getLineChanges(): ILineChange[] | null;
 
   onRefOpen: Event<IEditorDocumentModelRef>;
-
-  disposeModel(originalUri: string, modifiedUri: string): void;
 }
 
 @Injectable()
@@ -989,3 +989,23 @@ export function getSimpleEditorOptions(): IEditorOptions {
  * in case the column does not exist yet.
  */
 export type EditorGroupColumn = number;
+
+export function isTextEditorViewState(candidate: unknown): candidate is ICodeEditorViewState | IDiffEditorViewState {
+  const viewState = candidate as (ICodeEditorViewState | IDiffEditorViewState) | undefined;
+  if (!viewState) {
+    return false;
+  }
+
+  const diffEditorViewState = viewState as IDiffEditorViewState;
+  if (diffEditorViewState.modified) {
+    return isTextEditorViewState(diffEditorViewState.modified);
+  }
+
+  const codeEditorViewState = viewState as ICodeEditorViewState;
+
+  return !!(
+    codeEditorViewState.contributionsState &&
+    codeEditorViewState.viewState &&
+    Array.isArray(codeEditorViewState.cursorState)
+  );
+}


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

原有 Diff Editor 状态恢复失效主要是存在时序问题

即在新的 Diff Model 未渲染，不存在折叠代码等数据时进行恢复，最终导致恢复失败。

本次修复移除了多余的逻辑，让 Diff 编辑器的状态恢复时序回归正常留存，避免了 Model 丢失/未更新等问题出现

### Changelog

修复 Diff 编辑器的状态恢复逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 移除 `AppConfig` 接口中的 `enableRestoreDiffEditorState` 属性，简化配置选项。
  - 更新编辑器类以增强状态管理和选项处理，特别是在差异编辑上下文中。
  - 新增方法以改进资源管理和状态恢复，确保编辑器组反映最后已知状态。
  - 新增 `getLineChanges` 方法，以便在差异编辑器中检索行变更。

- **修复**
  - 更新事件处理逻辑，以确保正确的编辑器上下文维护。

- **文档**
  - 添加新的类型和接口，改善编辑器状态和行变更的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->