### PR TITLE
feat: add option to render removed widget immediately

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -23,6 +23,11 @@ export interface IDiffPreviewerOptions {
    * 是否隐藏接受部分编辑的 widget，用于只展示 diff 的场景
    */
   hideAcceptPartialEditWidget?: boolean;
+
+  /**
+   * 默认情况下，removed widget 会在 `runWhenIdle` 内被添加，如果需要立即添加，可以设置为 true
+   */
+  renderRemovedWidgetImmediately?: boolean;
 }
 
 export interface IInlineDiffPreviewerNode extends IDisposable {

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -106,6 +106,7 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
       partialEditWidgetOptions: {
         hideAcceptPartialEditWidget: options.hideAcceptPartialEditWidget,
       },
+      renderRemovedWidgetImmediately: options.renderRemovedWidgetImmediately,
     });
   }
 

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -677,6 +677,9 @@ export class LivePreviewDiffDecorationModel extends Disposable {
 
   public touchRemovedWidget(states: IRemovedWidgetState[]) {
     runWhenIdle(() => {
+      if (this.disposed) {
+        return;
+      }
       this.clearRemovedWidgets();
       states.forEach(({ textLines, position }) => {
         this.showRemovedWidgetByLineNumber(position.lineNumber, textLines, {});

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -65,6 +65,7 @@ export interface ITotalCodeInfo {
 
 export interface IModelOptions {
   partialEditWidgetOptions?: IPartialEditWidgetOptions;
+  renderRemovedWidgetImmediately?: boolean;
 }
 
 @Injectable({ multiple: true })
@@ -676,15 +677,18 @@ export class LivePreviewDiffDecorationModel extends Disposable {
   }
 
   public touchRemovedWidget(states: IRemovedWidgetState[]) {
-    runWhenIdle(() => {
-      if (this.disposed) {
-        return;
-      }
+    const run = () => {
       this.clearRemovedWidgets();
       states.forEach(({ textLines, position }) => {
         this.showRemovedWidgetByLineNumber(position.lineNumber, textLines, {});
       });
-    });
+    };
+
+    if (this.options.renderRemovedWidgetImmediately) {
+      run();
+    } else {
+      runWhenIdle(run);
+    }
   }
 
   public touchPendingRange(range: LineRange) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

测试通过

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在 `IModelOptions` 和 `IDiffPreviewerOptions` 接口中新增可选属性 `renderRemovedWidgetImmediately`，允许立即渲染已移除的小部件。
	- 改进了 `InlineStreamDiffHandler` 类的 `setPreviewerOptions` 方法，增强了预览器选项的配置能力。
	- 更新了 `computeDiff` 方法，以处理超时场景，确保在时间限制下仍能提供有效的差异输出。

- **Bug 修复**
	- 增强了 `touchRemovedWidget` 方法的错误处理，防止在已处置实例上进行操作，从而减少运行时错误的可能性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->