### PR TITLE
chore: improve code edits source trigger

### DIFF
--- a/packages/ai-native/src/browser/contrib/intelligent-completions/index.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/index.ts
@@ -1,3 +1,4 @@
+import { Disposable } from '@opensumi/ide-core-common';
 import { IRange, InlineCompletion } from '@opensumi/ide-monaco';
 
 import type { ILineChangeData } from './source/line-change.source';
@@ -17,14 +18,8 @@ export enum ECodeEditsSource {
 }
 
 export type ICodeEditsContextBean =
-  | {
-      typing: ECodeEditsSource.LinterErrors;
-      data: ILinterErrorData;
-    }
-  | {
-      typing: ECodeEditsSource.LineChange;
-      data: ILineChangeData;
-    };
+  | { typing: ECodeEditsSource.LinterErrors; data: ILinterErrorData }
+  | { typing: ECodeEditsSource.LineChange; data: ILineChangeData };
 
 export interface ICodeEdit {
   /**
@@ -38,4 +33,14 @@ export interface ICodeEdit {
 }
 export interface ICodeEditsResult {
   readonly items: ICodeEdit[];
+}
+
+export class CodeEditsResultValue extends Disposable {
+  constructor(private readonly raw: ICodeEditsResult) {
+    super();
+  }
+
+  public get items(): ICodeEdit[] {
+    return this.raw.items;
+  }
 }

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/source/line-change.source.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/source/line-change.source.ts
@@ -43,7 +43,7 @@ export class LineChangeCodeEditsSource extends BaseCodeEditsSource {
     }
 
     this.lastEditTime = currentTime;
-    this.launchProvider(this.monacoEditor, position, {
+    this.setBean({
       typing: ECodeEditsSource.LineChange,
       data: {
         preLineNumber: this.prePosition?.lineNumber,

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/source/lint-error.source.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/source/lint-error.source.ts
@@ -89,7 +89,7 @@ export class LintErrorCodeEditsSource extends BaseCodeEditsSource {
     if (markers.length) {
       const relativeWorkspacePath = await this.workspaceService.asRelativePath(resource.path);
 
-      this.launchProvider(this.monacoEditor, position, {
+      this.setBean({
         typing: ECodeEditsSource.LinterErrors,
         data: {
           relativeWorkspacePath: relativeWorkspacePath?.path ?? resource.path,


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

这里原有的逻辑是：
不同的触发行为都会先去请求用户注册的 provider api，拿到补全结果后再显示，如果这些触发行为同时被触发了（例如 lint_error 和 line_change）则按优先级来决定显示哪个补全结果
这样的逻辑就导致会频繁的调用 provider api

现在改进的逻辑是：
先按优先级决定要触发哪种行为，再根据行为去调用 provider api，保证只调用一次

### Changelog
改进 code edits api 的触发行为规则

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了 `CodeEditsResultValue` 和 `CodeEditsContextBean` 类，增强了代码编辑的处理能力。
	- 更新了智能完成控制器的逻辑，以提高多行编辑的处理效率。
- **改进**
	- 优化了代码编辑的上下文管理，简化了数据处理流程。
	- 增强了对 linter 错误数据的处理，确保了路径的有效性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->