### PR TITLE
feat: support VSCode API: provideDocumentRangesFormattingEdits

### DIFF
--- a/packages/types/vscode/typings/vscode.language.d.ts
+++ b/packages/types/vscode/typings/vscode.language.d.ts
@@ -2375,6 +2375,25 @@ declare module 'vscode' {
      * signaled by returning `undefined`, `null`, or an empty array.
      */
     provideDocumentRangeFormattingEdits(document: TextDocument, range: Range, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]>;
+
+    /**
+		 * Provide formatting edits for multiple ranges in a document.
+		 *
+		 * This function is optional but allows a formatter to perform faster when formatting only modified ranges or when
+		 * formatting a large number of selections.
+		 *
+		 * The given ranges are hints and providers can decide to format a smaller
+		 * or larger range. Often this is done by adjusting the start and end
+		 * of the range to full syntax nodes.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param ranges The ranges which should be formatted.
+		 * @param options Options controlling formatting.
+		 * @param token A cancellation token.
+		 * @returns A set of text edits or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined`, `null`, or an empty array.
+		 */
+		provideDocumentRangesFormattingEdits?(document: TextDocument, ranges: Range[], options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]>;
   }
 
   /**


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
目前使用的 monaco 版本还不支持这个函数，因此这里暂时空实现，等后续升级 monaco 版本时再提供实现

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `DocumentRangeFormattingEditProvider` 接口中新增了可选方法 `provideDocumentRangesFormattingEdits`，允许一次性格式化文档中的多个范围，提高了格式化请求的效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->