### PR TITLE
fix: markdown html link render error

### DIFF
--- a/packages/ai-native/src/browser/components/ChatMarkdown.tsx
+++ b/packages/ai-native/src/browser/components/ChatMarkdown.tsx
@@ -35,11 +35,6 @@ export const ChatMarkdown = (props: MarkdownProps) => {
       typeof props.markdown === 'string' ? new MarkdownString(props.markdown) : props.markdown;
 
     const renderer: MarkdownReactRenderer = new MarkdownReactRenderer();
-    renderer.link = (href: string, text: ReactNode): React.ReactElement => (
-        <a rel='noopener' target='_blank' href={href} title={href}>
-          {text}
-        </a>
-      );
     renderer.code = (code, lang) => {
       const language = postProcessCodeBlockLanguageId(lang);
 

--- a/packages/components/src/markdown-react/parse.tsx
+++ b/packages/components/src/markdown-react/parse.tsx
@@ -1,5 +1,5 @@
 import { marked } from 'marked';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { HeadingLevels, MarkdownReactRenderer } from './render';
 
@@ -19,7 +19,7 @@ export class MarkdownReactParser extends marked.Renderer {
     return tokens.map((token) => {
       switch (token.type) {
         case 'html': {
-          return <div dangerouslySetInnerHTML={{ __html: token.raw }} />;
+          return this.renderer.html(token.text);
         }
 
         case 'space': {
@@ -106,11 +106,21 @@ export class MarkdownReactParser extends marked.Renderer {
     });
   }
 
+  private unescapeInfo = new Map<string, string>([
+    ['&quot;', '"'],
+    ['&nbsp;', ' '],
+    ['&amp;', '&'],
+    ['&#39;', "'"],
+    ['&lt;', '<'],
+    ['&gt;', '>'],
+  ]);
+
   parseInline(tokens: marked.Token[] = []): ReactNode[] {
     return tokens.map((token) => {
       switch (token.type) {
         case 'text': {
-          return this.renderer.text(unescape(token.text));
+          const text = token.text.replace(/&(#\d+|[a-zA-Z]+);/g, (m) => this.unescapeInfo.get(m) ?? m);
+          return this.renderer.text(text);
         }
 
         case 'strong': {

--- a/packages/components/src/markdown-react/render.tsx
+++ b/packages/components/src/markdown-react/render.tsx
@@ -1,4 +1,4 @@
-import { ElementType, ReactElement, ReactNode, createElement } from 'react';
+import React, { ElementType, ReactElement, ReactNode, createElement } from 'react';
 
 export type HeadingLevels = 1 | 2 | 3 | 4 | 5 | 6;
 export interface TableFlags {
@@ -11,7 +11,6 @@ export type RendererMethods = keyof MarkdownReactRenderer;
 
 export interface ReactRendererOptions {
   baseURL?: string;
-  openLinksInNewTab?: boolean;
   langPrefix?: string;
   renderer?: CustomReactRenderer;
 }
@@ -59,8 +58,7 @@ export class MarkdownReactRenderer {
 
   link(href: string, text: ReactNode) {
     const url = this.joinBase(href, this.options.baseURL);
-    const target = this.options.openLinksInNewTab ? '_blank' : null;
-    return this.node('a', text, { href: url, target });
+    return this.node('a', text, { href: url, target: '_blank' });
   }
 
   image(src: string, alt: string, title: string | null = null) {
@@ -130,8 +128,8 @@ export class MarkdownReactRenderer {
     return text;
   }
 
-  html(html: ReactNode) {
-    return html;
+  html(text: string) {
+    return <div dangerouslySetInnerHTML={{ __html: text }} />;
   }
 
   hr() {

--- a/packages/components/src/markdown-react/render.tsx
+++ b/packages/components/src/markdown-react/render.tsx
@@ -58,7 +58,7 @@ export class MarkdownReactRenderer {
 
   link(href: string, text: ReactNode) {
     const url = this.joinBase(href, this.options.baseURL);
-    return this.node('a', text, { href: url, target: '_blank', rel: 'noopener' });
+    return this.node('a', text, { href: url, target: '_blank', rel: 'noopener noreferrer' });
   }
 
   image(src: string, alt: string, title: string | null = null) {

--- a/packages/components/src/markdown-react/render.tsx
+++ b/packages/components/src/markdown-react/render.tsx
@@ -58,7 +58,7 @@ export class MarkdownReactRenderer {
 
   link(href: string, text: ReactNode) {
     const url = this.joinBase(href, this.options.baseURL);
-    return this.node('a', text, { href: url, target: '_blank' });
+    return this.node('a', text, { href: url, target: '_blank', rel: 'noopener' });
   }
 
   image(src: string, alt: string, title: string | null = null) {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution


### Changelog
修复 markdown react 组件渲染 html 标签异常的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 简化了Markdown链接的渲染过程，恢复了默认的链接处理方式。
	- 改进了HTML和文本令牌的处理，增强了渲染控制。

- **Bug修复**
	- 更新了HTML内容的渲染方式，增强了安全性。

- **文档**
	- 更新了MarkdownReactRenderer和MarkdownReactParser的相关逻辑，确保更清晰的代码结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->