### PR TITLE
fix: improve keybinding performance

### DIFF
--- a/packages/monaco/src/browser/monaco.contribution.ts
+++ b/packages/monaco/src/browser/monaco.contribution.ts
@@ -79,7 +79,7 @@ import { IInstantiationService } from '@opensumi/monaco-editor-core/esm/vs/platf
 import * as monacoKeybindings from '@opensumi/monaco-editor-core/esm/vs/platform/keybinding/common/keybindingsRegistry';
 
 import { editor } from '../common';
-import { DELEGATE_COMMANDS } from '../common/command';
+import { DELEGATE_COMMANDS, SKIP_UNREGISTER_MONACO_KEYBINDINGS } from '../common/command';
 
 import {
   EditorExtensionsRegistry,
@@ -596,13 +596,15 @@ export class MonacoClientContribution
           // monaco内优先级计算时为双优先级相加，第一优先级权重 * 100
           priority: (item.weight1 ? item.weight1 * 100 : 0) + (item.weight2 || 0),
         };
-        // 注册快捷键前先卸载 Monaco 内对应命令的快捷键实现
-        monacoKeybindingsRegistry.registerKeybindingRule({
-          id: `-${command}`,
-          weight: item.weight1,
-          primary: this.toMonacoKeybindingNumber(KeySequence.parse(rawKeybinding)),
-          when,
-        });
+        if (!SKIP_UNREGISTER_MONACO_KEYBINDINGS.includes(command)) {
+          // 注册快捷键前先卸载 Monaco 内对应命令的快捷键实现
+          monacoKeybindingsRegistry.registerKeybindingRule({
+            id: `-${command}`,
+            weight: item.weight1,
+            primary: this.toMonacoKeybindingNumber(KeySequence.parse(rawKeybinding)),
+            when,
+          });
+        }
         // 将 Monaco 内默认快捷键注册进 OpenSumi 中
         keybindings.registerKeybinding(keybinding);
       }

--- a/packages/monaco/src/browser/monaco.service.ts
+++ b/packages/monaco/src/browser/monaco.service.ts
@@ -173,20 +173,6 @@ export default class MonacoServiceImpl extends Disposable implements MonacoServi
       ).toKeybinding();
       return new MonacoResolvedKeybinding(MonacoResolvedKeybinding.keySequence(keybinding), this.keybindingRegistry);
     };
-
-    const oldLookup = keybindingService.lookupKeybinding;
-    keybindingService.lookupKeybinding = (commandId: string, context) => {
-      const resolvedKeybinding = oldLookup.call(keybindingService, commandId, context);
-      if (resolvedKeybinding) {
-        return resolvedKeybinding;
-      }
-
-      const keybindings = this.keybindingRegistry.getKeybindingsForCommand(commandId);
-
-      if (keybindings && keybindings.length) {
-        return new MonacoResolvedKeybinding(keybindings[0].resolved!, this.keybindingRegistry);
-      }
-    };
   }
 
   public registerOverride(serviceName: ServiceNames, service: any) {

--- a/packages/monaco/src/common/command.ts
+++ b/packages/monaco/src/common/command.ts
@@ -3,3 +3,6 @@ export const DELEGATE_COMMANDS = {
   REDO: 'redo',
   SELECT_ALL: 'editor.action.selectAll',
 };
+
+// 不卸载 Monaco 内默认快捷键的命令白名单
+export const SKIP_UNREGISTER_MONACO_KEYBINDINGS = ['acceptRenameInput', 'acceptRenameInputWithPreview'];


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

之前是为了解决 rename 的输入框快捷键不展示的问题，而代理 monaco 的 lookupKeybinding 函数，但该函数在遇到非常多 monaco 的实例时（例如 notebook）会有性能问题。
本次修复将该 lookupKeybinding 去除，并使用其他方式解决 rename 的快捷键展示问题

### Changelog
改进 keybinding 的性能问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 引入了新的常量 `SKIP_UNREGISTER_MONACO_KEYBINDINGS`，用于指定不应注销其默认键绑定的命令。
  - 更新了键绑定注册逻辑，增强了对命令的控制。

- **变更**
  - `MonacoServiceImpl` 类中的方法进行了更新，部分方法已被弃用，建议使用新的服务注册方法。

- **错误处理**
  - 在打开 URI 时，增强了错误处理机制，确保问题能够被记录和报告。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->