### PR TITLE
feat: add zsh integration support

### DIFF
--- a/packages/terminal-next/src/node/pty.ts
+++ b/packages/terminal-next/src/node/pty.ts
@@ -186,8 +186,8 @@ export class PtyService extends Disposable implements IPtyService {
       ) as { [key: string]: string };
     }
 
-    // HACK: 这里的处理逻辑有些黑，后续需要整体去整理下 Shell Intergration，然后整体优化一下
-    // 如果是启动 bash，则使用 init file 植入 Intergration 能力
+    // HACK: 这里的处理逻辑有些黑，后续需要整体去整理下 Shell Integration，然后整体优化一下
+    // 如果是启动 bash，则使用 init file 植入 Integration 能力
     if (options.executable?.includes('bash')) {
       const bashIntegrationPath = await this.shellIntegrationService.initBashInitFile();
       if (!options.args) {
@@ -200,6 +200,18 @@ export class PtyService extends Disposable implements IPtyService {
           options.args.unshift('--init-file', bashIntegrationPath);
         }
       }
+    }
+
+    // ZSH 相关的能力注入
+    if (options.executable?.includes('zsh')) {
+      const zshDotFilesPath = await this.shellIntegrationService.initZshDotFiles();
+
+      if (!ptyEnv) {
+        ptyEnv = {};
+      }
+
+      ptyEnv['USER_ZDOTDIR'] = ptyEnv['ZDOTDIR'] || os.homedir() || '~';
+      ptyEnv['ZDOTDIR'] = zshDotFilesPath;
     }
 
     this._ptyOptions['env'] = ptyEnv;

--- a/packages/terminal-next/src/node/shell-integration.service.ts
+++ b/packages/terminal-next/src/node/shell-integration.service.ts
@@ -11,6 +11,9 @@ export interface IShellIntegrationService {
 
   // 获取 Bash 注入文件的 Content 内容
   getBashIntegrationContent(): Promise<string>;
+
+  // 初始化 zsh 注入的配置，并且返回配置的路径
+  initZshDotFiles(): Promise<string>;
 }
 
 // 未来适配 OpenSumi 的时候需要调整
@@ -73,5 +76,130 @@ export class ShellIntegrationService implements IShellIntegrationService {
     await fs.mkdirp(shellIntegrationDirPath);
     await fs.writeFile(bashIntegrationPath, await this.getBashIntegrationContent());
     return bashIntegrationPath;
+  }
+
+  // ZSH 的智能化基于 ZDOTDIR 能力运行
+  async initZshDotFiles(): Promise<string> {
+    const zDotDir = path.join(os.tmpdir(), 'sumi-integration-zsh');
+    await this.writeZshConfigShellScripts(zDotDir);
+    return zDotDir;
+  }
+
+  private async writeZshConfigShellScripts(outputDir: string) {
+    // 定义文件内容
+    const shellIntegrationEnv = String.raw`
+if [[ -f $USER_ZDOTDIR/.zshenv ]]; then
+    SUMI_ZDOTDIR=$ZDOTDIR
+    ZDOTDIR=$USER_ZDOTDIR
+
+    # prevent recursion
+    if [[ $USER_ZDOTDIR != $SUMI_ZDOTDIR ]]; then
+        . $USER_ZDOTDIR/.zshenv
+    fi
+
+    USER_ZDOTDIR=$ZDOTDIR
+    ZDOTDIR=$SUMI_ZDOTDIR
+fi
+`;
+
+    const shellIntegrationLogin = String.raw`
+if [[ -f $USER_ZDOTDIR/.zlogin ]]; then
+    ZDOTDIR=$USER_ZDOTDIR
+    . $ZDOTDIR/.zlogin
+fi
+`;
+
+    // 处理 zProfile 的情况，需要临时切回用户的 zshrc 目录配置执行 zProfile，然后记得要切回来，否则 zshrc hack 不生效
+    const shellIntegrationProfile = String.raw`
+if [[ -f $USER_ZDOTDIR/.zprofile ]]; then
+    SUMI_ZDOTDIR=$ZDOTDIR
+    ZDOTDIR=$USER_ZDOTDIR
+    . $USER_ZDOTDIR/.zprofile
+    ZDOTDIR=$SUMI_ZDOTDIR
+fi
+`;
+
+    const shellIntegrationRc = `
+builtin autoload -U add-zsh-hook
+
+if [[ -f $USER_ZDOTDIR/.zshrc ]]; then
+    ZDOTDIR=$USER_ZDOTDIR
+    . $USER_ZDOTDIR/.zshrc
+fi
+
+__is_prompt_start() {
+    builtin printf '\\e]6973;PS\\a'
+}
+
+__is_prompt_end() {
+    builtin printf '\\e]6973;PE\\a'
+}
+
+__is_escape_value() {
+    builtin emulate -L zsh
+
+    # Process text byte by byte, not by codepoint.
+    builtin local LC_ALL=C str="$1" i byte token out=''
+
+    for (( i = 0; i < \${#str}; ++i )); do
+        byte="\${str:$i:1}"
+
+        # Escape backslashes and semi-colons
+        if [ "$byte" = "\\\\" ]; then
+            token="\\\\\\\\"
+        elif [ "$byte" = ";" ]; then
+            token="\\\\x3b"
+        elif [ "$byte" = $'\\n' ]; then
+            token="\\\\x0a"
+        elif [ "$byte" = $'\\e' ]; then
+            token="\\\\x1b"
+        elif [ "$byte" = $'\\a' ]; then
+            token="\\\\x07"
+        else
+            token="$byte"
+        fi
+
+        out+="$token"
+    done
+
+    builtin print -r "$out"
+}
+
+__is_update_cwd() {
+    builtin printf '\\e]6973;CWD;%s\\a' "$(__is_escape_value "\${PWD}")"
+}
+
+__is_update_prompt() {
+    __is_prior_prompt="$PS1"
+    if [[ $ISTERM_TESTING == "1" ]]; then
+        __is_prior_prompt="> "
+    fi
+    PS1="%{\$(__is_prompt_start)%}\$__is_prior_prompt%{\$(__is_prompt_end)%}"
+}
+
+__is_precmd() {
+    if [[ $PS1 != *"\$(__is_prompt_start)"* ]]; then
+        __is_update_prompt
+    fi
+    __is_update_cwd
+}
+
+__is_update_prompt
+add-zsh-hook precmd __is_precmd
+`;
+
+    const files = [
+      { name: '.zshenv', content: shellIntegrationEnv },
+      { name: '.zlogin', content: shellIntegrationLogin },
+      { name: '.zprofile', content: shellIntegrationProfile },
+      { name: '.zshrc', content: shellIntegrationRc },
+    ];
+
+    await fs.mkdir(outputDir, { recursive: true });
+
+    for (const file of files) {
+      const filePath = path.join(outputDir, file.name);
+      await fs.writeFile(filePath, file.content, 'utf-8');
+    }
   }
 }


### PR DESCRIPTION
### Types

feat: add zsh integration support

增加了 ZSH 终端智能能力的支持，现在 ZSH 也可以使用 AI 自然语言生成命令等一系列能力。

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

终端自然语言生成代码能力之前只支持了 bash

### Changelog
- feat: add zsh integration support



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了对 Zsh 的支持，新增了初始化 Zsh 配置文件的功能。
  - 添加了 `initZshDotFiles` 方法，以初始化 Zsh 配置目录并返回路径。

- **文档**
  - 更新了注释以提高代码的可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->