### PR TITLE
feat: support QuickPickItem.iconPath

### DIFF
--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -125,6 +125,7 @@ export interface QuickOpenItemOptions {
    * 图标
    */
   iconClass?: string;
+  iconPath?: URI | { light: URI; dark: URI } | ThemeIcon;
   /**
    * 对应绑定的快捷键
    */
@@ -197,6 +198,9 @@ export class QuickOpenItem {
   }
   getIconClass(): string | undefined {
     return this.options.iconClass;
+  }
+  getIconPath(): URI | { light: URI; dark: URI } | ThemeIcon | undefined {
+    return this.options.iconPath;
   }
   getKeybinding(): Keybinding | undefined {
     return this.options.keybinding;
@@ -401,6 +405,7 @@ export interface QuickPickItem<T> {
   value: T;
   description?: string;
   detail?: string;
+  iconPath?: URI | { light: URI; dark: URI } | ThemeIcon;
   iconClass?: string;
   buttons?: QuickInputButton[];
 }

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -95,6 +95,7 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
           pickItems.push({
             label: item.label,
             groupLabel,
+            iconPath: item.iconPath as QuickPickItem<number>['iconPath'],
             description: item.description,
             detail: item.detail,
             value: index, // handle

--- a/packages/quick-open/src/browser/quick-open-item.service.ts
+++ b/packages/quick-open/src/browser/quick-open-item.service.ts
@@ -1,7 +1,8 @@
 import { Autowired, Injectable } from '@opensumi/di';
+import { getExternalIcon } from '@opensumi/ide-core-browser';
 import { IQuickPickItemButtonEvent, QuickInputButton } from '@opensumi/ide-core-browser/lib/quick-open';
 import { StaticResourceService } from '@opensumi/ide-core-browser/lib/static-resource';
-import { Emitter, Event } from '@opensumi/ide-core-common';
+import { Emitter, Event, ThemeIcon, URI } from '@opensumi/ide-core-common';
 import { IIconService, IThemeService, IconType } from '@opensumi/ide-theme';
 
 import { iconPath2URI } from '../common/icon';
@@ -35,7 +36,18 @@ export class QuickOpenItemService {
       return [];
     }
     return buttons.map((btn, i) => {
-      const iconUri = iconPath2URI(btn.iconPath, this.themeService.getCurrentThemeSync().type);
+      if (ThemeIcon.isThemeIcon(btn.iconPath)) {
+        return {
+          ...btn,
+          iconClass: getExternalIcon(btn.iconPath.id),
+          handle: i,
+        };
+      }
+
+      const iconUri = iconPath2URI(
+        btn.iconPath as URI | { light: URI; dark: URI },
+        this.themeService.getCurrentThemeSync().type,
+      );
       const iconPath = iconUri && this.staticResourceService.resolveStaticResource(iconUri).toString();
       const iconClass = iconPath && this.iconService.fromIcon('', iconPath, IconType.Background);
       return {
@@ -44,5 +56,27 @@ export class QuickOpenItemService {
         handle: i,
       };
     });
+  }
+
+  getIconClass(data: { iconPath?: URI | { light: URI; dark: URI } | ThemeIcon; iconClass?: string }) {
+    const { iconClass, iconPath } = data;
+
+    if (iconClass) {
+      return iconClass;
+    }
+
+    if (!iconPath) {
+      return undefined;
+    }
+
+    if (ThemeIcon.isThemeIcon(iconPath)) {
+      return getExternalIcon(iconPath.id);
+    }
+
+    const iconUri = iconPath2URI(iconPath, this.themeService.getCurrentThemeSync().type);
+    const iconPathString = iconUri && this.staticResourceService.resolveStaticResource(iconUri).toString();
+    const iconCls = iconPath && this.iconService.fromIcon('', iconPathString, IconType.Background);
+
+    return iconCls;
   }
 }

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -186,6 +186,17 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
 
   const showBorder = React.useMemo(() => data.showBorder(), [data]);
 
+  const iconPath = React.useMemo(() => data.getIconPath(), [data]);
+
+  const finalIconClass = React.useMemo(
+    () =>
+      quickOpenItemService.getIconClass({
+        iconPath,
+        iconClass,
+      }),
+    [iconClass, iconPath],
+  );
+
   const buttons = React.useMemo(() => quickOpenItemService.getButtons(data.getButtons()), [data]);
 
   const [labelHighlights, descriptionHighlights, detailHighlights] = React.useMemo(() => data.getHighlights(), [data]);
@@ -257,7 +268,7 @@ const QuickOpenItemView: React.FC<IQuickOpenItemProps> = observer(({ data, index
       {/* tabIndex is needed here, pls see https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null */}
       <div tabIndex={0} className={styles.item_label_container} onMouseDown={runQuickOpenItem}>
         <div className={styles.item_label}>
-          {iconClass && <span className={cls(styles.item_icon, iconClass)}></span>}
+          {finalIconClass && <span className={cls(styles.item_icon, finalIconClass)}></span>}
           <HighlightLabel
             className={styles.item_label_name}
             labelClassName={styles.label_icon_container}

--- a/packages/quick-open/src/browser/quick-pick.service.ts
+++ b/packages/quick-open/src/browser/quick-pick.service.ts
@@ -89,6 +89,7 @@ export class QuickPickServiceImpl implements QuickPickService {
     const groupLabel = typeof element === 'string' ? undefined : element.groupLabel;
     const showBorder = typeof element === 'string' ? undefined : element.showBorder;
     const buttons = typeof element === 'string' ? undefined : element.buttons;
+    const iconPath = typeof element === 'string' ? undefined : element.iconPath;
     const [icon, text] = getIconClass(label);
 
     if (icon) {
@@ -103,6 +104,7 @@ export class QuickPickServiceImpl implements QuickPickService {
       groupLabel,
       showBorder,
       buttons,
+      iconPath,
       run: (mode) => {
         if (mode !== Mode.OPEN) {
           return false;

--- a/packages/quick-open/src/browser/quick-title-bar.ts
+++ b/packages/quick-open/src/browser/quick-title-bar.ts
@@ -1,9 +1,10 @@
 import { action, computed, makeObservable, observable } from 'mobx';
 
 import { Autowired, Injectable } from '@opensumi/di';
+import { getExternalIcon } from '@opensumi/ide-core-browser';
 import { QuickTitleButton, QuickTitleButtonSide } from '@opensumi/ide-core-browser/lib/quick-open';
 import { StaticResourceService } from '@opensumi/ide-core-browser/lib/static-resource';
-import { Emitter, Event, isUndefined } from '@opensumi/ide-core-common';
+import { Emitter, Event, ThemeIcon, URI, isUndefined } from '@opensumi/ide-core-common';
 import './quick-title-bar.less';
 import { IIconService, IThemeService, IconType } from '@opensumi/ide-theme';
 
@@ -75,7 +76,18 @@ export class QuickTitleBar {
       return [];
     }
     return this._buttons.map((btn, i) => {
-      const iconUri = iconPath2URI(btn.iconPath, this.themeService.getCurrentThemeSync().type);
+      if (ThemeIcon.isThemeIcon(btn.iconPath)) {
+        return {
+          ...btn,
+          iconClass: getExternalIcon(btn.iconPath.id),
+          handle: i,
+        };
+      }
+
+      const iconUri = iconPath2URI(
+        btn.iconPath as URI | { light: URI; dark: URI },
+        this.themeService.getCurrentThemeSync().type,
+      );
       const iconPath = iconUri && this.staticResourceService.resolveStaticResource(iconUri).toString();
       const iconClass = iconPath && this.iconService.fromIcon('', iconPath, IconType.Background);
       return {

--- a/packages/quick-open/src/common/icon.ts
+++ b/packages/quick-open/src/common/icon.ts
@@ -1,8 +1,10 @@
 import { URI } from '@opensumi/ide-core-common';
 
-export function iconPath2URI(iconPath: any, themeType?: string): URI | undefined {
+export function iconPath2URI(iconPath: URI | { light: URI; dark: URI }, themeType?: string): URI | undefined {
   if (URI.isUri(iconPath)) {
-    return iconPath;
+    const tmpIconPath = iconPath as URI;
+
+    return Object.prototype.hasOwnProperty.call(tmpIconPath, 'codeUri') ? tmpIconPath : new URI(tmpIconPath.toString());
   }
 
   if ((iconPath.dark || iconPath.light) && themeType) {

--- a/packages/quick-open/src/common/icon.ts
+++ b/packages/quick-open/src/common/icon.ts
@@ -2,9 +2,7 @@ import { URI } from '@opensumi/ide-core-common';
 
 export function iconPath2URI(iconPath: URI | { light: URI; dark: URI }, themeType?: string): URI | undefined {
   if (URI.isUri(iconPath)) {
-    const tmpIconPath = iconPath as URI;
-
-    return Object.prototype.hasOwnProperty.call(tmpIconPath, 'codeUri') ? tmpIconPath : new URI(tmpIconPath.toString());
+    return 'codeUri' in iconPath ? iconPath : new URI((iconPath as URI).toString());
   }
 
   if ((iconPath.dark || iconPath.light) && themeType) {

--- a/packages/types/vscode/typings/vscode.quickpick.d.ts
+++ b/packages/types/vscode/typings/vscode.quickpick.d.ts
@@ -32,6 +32,11 @@ declare module 'vscode' {
     kind?: QuickPickItemKind;
 
     /**
+     * The icon path or {@link ThemeIcon} for the QuickPickItem.
+     */
+    iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+
+    /**
      * A human readable string which is rendered less prominent.
      */
     description?: string;


### PR DESCRIPTION
### Types
- [x] 🎉 New Features

### Background or solution
Support VSCode API: QuickPickItem.iconPath

![image](https://github.com/user-attachments/assets/ee9ad166-c01c-47ba-bdc6-2b80f4a68220)


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 为快速选择项和快速打开项添加了可选的 `iconPath` 属性，允许指定图标路径。
	- 更新了快速选择和输入框方法，以支持图标的展示和输入验证的改进。

- **改进**
	- 增强了图标处理逻辑，支持 `ThemeIcon` 和其他图标类型的区分。
	- 提升了快速选择服务的灵活性，允许更广泛的配置选项。
	- 改进了 `iconPath2URI` 函数的类型安全性和逻辑处理。

- **文档**
	- 更新了相关接口的类型定义，以反映新的图标路径属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->