### PR TITLE
feat: Implementing an Empty Function for registerDocumentDropEditProvider and registerDocumentPasteEditProvider

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.language.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.language.ts
@@ -1867,21 +1867,27 @@ export class ExtHostLanguages implements IExtHostLanguages {
     return result;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   registerDocumentDropEditProvider(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     extension: IExtensionDescription,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     selector: vscode.DocumentSelector,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     provider: vscode.DocumentDropEditProvider,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     metadata?: vscode.DocumentDropEditProviderMetadata,
   ) {
     return toDisposable(() => {});
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   registerDocumentPasteEditProvider(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     extension: IExtensionDescription,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     selector: vscode.DocumentSelector,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     provider: vscode.DocumentPasteEditProvider,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     metadata: vscode.DocumentPasteProviderMetadata,
   ) {
     return toDisposable(() => {});

--- a/packages/extension/src/hosted/api/vscode/ext.host.language.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.language.ts
@@ -61,6 +61,7 @@ import {
   Uri,
   UriComponents,
   disposableTimeout,
+  toDisposable,
 } from '@opensumi/ide-core-common';
 import { InlineValue } from '@opensumi/ide-debug/lib/common/inline-values';
 import { IPosition } from '@opensumi/ide-monaco/lib/common';
@@ -345,6 +346,20 @@ export function createLanguagesApiFactory(
     },
     createLanguageStatusItem(id: string, selector: vscode.DocumentSelector): vscode.LanguageStatusItem {
       return extHostLanguages.createLanguageStatusItem(extension, id, selector);
+    },
+    registerDocumentDropEditProvider(
+      selector: vscode.DocumentSelector,
+      provider: vscode.DocumentDropEditProvider,
+      metadata?: vscode.DocumentDropEditProviderMetadata,
+    ): vscode.Disposable {
+      return extHostLanguages.registerDocumentDropEditProvider(extension, selector, provider, metadata);
+    },
+    registerDocumentPasteEditProvider(
+      selector: vscode.DocumentSelector,
+      provider: vscode.DocumentPasteEditProvider,
+      metadata: vscode.DocumentPasteProviderMetadata,
+    ): vscode.Disposable {
+      return extHostLanguages.registerDocumentPasteEditProvider(extension, selector, provider, metadata);
     },
   };
 }
@@ -1850,5 +1865,25 @@ export class ExtHostLanguages implements IExtHostLanguages {
     };
     updateAsync();
     return result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  registerDocumentDropEditProvider(
+    extension: IExtensionDescription,
+    selector: vscode.DocumentSelector,
+    provider: vscode.DocumentDropEditProvider,
+    metadata?: vscode.DocumentDropEditProviderMetadata,
+  ) {
+    return toDisposable(() => {});
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  registerDocumentPasteEditProvider(
+    extension: IExtensionDescription,
+    selector: vscode.DocumentSelector,
+    provider: vscode.DocumentPasteEditProvider,
+    metadata: vscode.DocumentPasteProviderMetadata,
+  ) {
+    return toDisposable(() => {});
   }
 }

--- a/packages/types/vscode.d.ts
+++ b/packages/types/vscode.d.ts
@@ -49,3 +49,5 @@
 /// <reference path='./vscode/typings/vscode.proposed.newSymbolNamesProvider.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.env.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.terminalDataWriteEvent.d.ts' />
+/// <reference path='./vscode/typings/vscode.proposed.documentPaste.d.ts' />
+/// <reference path='./vscode/typings/vscode.proposed.dropMetadata.d.ts' />

--- a/packages/types/vscode/typings/vscode.d.ts
+++ b/packages/types/vscode/typings/vscode.d.ts
@@ -4044,6 +4044,28 @@ declare module 'vscode' {
     provideDocumentRangeSemanticTokens(document: TextDocument, range: Range, token: CancellationToken): ProviderResult<SemanticTokens>;
   }
 
+  /**
+	 * Provider which handles dropping of resources into a text editor.
+	 *
+	 * This allows users to drag and drop resources (including resources from external apps) into the editor. While dragging
+	 * and dropping files, users can hold down `shift` to drop the file into the editor instead of opening it.
+	 * Requires `editor.dropIntoEditor.enabled` to be on.
+	 */
+	export interface DocumentDropEditProvider {
+		/**
+		 * Provide edits which inserts the content being dragged and dropped into the document.
+		 *
+		 * @param document The document in which the drop occurred.
+		 * @param position The position in the document where the drop occurred.
+		 * @param dataTransfer A {@link DataTransfer} object that holds data about what is being dragged and dropped.
+		 * @param token A cancellation token.
+		 *
+		 * @returns A {@link DocumentDropEdit} or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideDocumentDropEdits(document: TextDocument, position: Position, dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentDropEdit>;
+	}
+
   //#endregion Semantic Tokens
 
   /**

--- a/packages/types/vscode/typings/vscode.language.d.ts
+++ b/packages/types/vscode/typings/vscode.language.d.ts
@@ -484,6 +484,16 @@ declare module 'vscode' {
     export function registerDocumentRangeSemanticTokensProvider(selector: DocumentSelector, provider: DocumentRangeSemanticTokensProvider, legend: SemanticTokensLegend): Disposable;
 
     /**
+		 * Registers a new {@link DocumentDropEditProvider}.
+		 *
+		 * @param selector A selector that defines the documents this provider applies to.
+		 * @param provider A drop provider.
+		 *
+		 * @returns A {@link Disposable} that unregisters this provider when disposed of.
+		 */
+		export function registerDocumentDropEditProvider(selector: DocumentSelector, provider: DocumentDropEditProvider): Disposable;
+
+    /**
      * Register a provider that locates evaluatable expressions in text documents.
      * VS Code will evaluate the expression in the active debug session and will show the result in the debug hover.
      *

--- a/packages/types/vscode/typings/vscode.proposed.documentPaste.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.documentPaste.d.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/30066/
+
+	/**
+	 * The reason why paste edits were requested.
+	 */
+	export enum DocumentPasteTriggerKind {
+		/**
+		 * Pasting was requested as part of a normal paste operation.
+		 */
+		Automatic = 0,
+
+		/**
+		 * Pasting was requested by the user with the `paste as` command.
+		 */
+		PasteAs = 1,
+	}
+
+	/**
+	 * Additional information about the paste operation.
+	 */
+
+	export interface DocumentPasteEditContext {
+		/**
+		 * Requested kind of paste edits to return.
+		 */
+		readonly only: DocumentPasteEditKind | undefined;
+
+		/**
+		 * The reason why paste edits were requested.
+		 */
+		readonly triggerKind: DocumentPasteTriggerKind;
+	}
+
+	/**
+	 * Provider invoked when the user copies or pastes in a {@linkcode TextDocument}.
+	 */
+	interface DocumentPasteEditProvider<T extends DocumentPasteEdit = DocumentPasteEdit> {
+
+		/**
+		 * Optional method invoked after the user copies text in a file.
+		 *
+		 * This allows the provider to attach copy metadata to the {@link DataTransfer}
+		 * which is then passed back to providers in {@linkcode provideDocumentPasteEdits}.
+		 *
+		 * Note that currently any changes to the {@linkcode DataTransfer} are isolated to the current editor session.
+		 * This means that added metadata cannot be seen by other applications.
+		 *
+		 * @param document Document where the copy took place.
+		 * @param ranges Ranges being copied in {@linkcode document}.
+		 * @param dataTransfer The data transfer associated with the copy. You can store additional values on this for later use in  {@linkcode provideDocumentPasteEdits}.
+		 * This object is only valid for the duration of this method.
+		 * @param token A cancellation token.
+		 *
+		 * @return Optional thenable that resolves when all changes to the `dataTransfer` are complete.
+		 */
+		prepareDocumentPaste?(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): void | Thenable<void>;
+
+		/**
+		 * Invoked before the user pastes into a document.
+		 *
+		 * Returned edits can replace the standard pasting behavior.
+		 *
+		 * @param document Document being pasted into
+		 * @param ranges Range in the {@linkcode document} to paste into.
+		 * @param dataTransfer The {@link DataTransfer data transfer} associated with the paste. This object is only valid for the duration of the paste operation.
+		 * @param context Additional context for the paste.
+		 * @param token A cancellation token.
+		 *
+		 * @return Set of potential {@link DocumentPasteEdit edits} that apply the paste. Return `undefined` to use standard pasting.
+		 */
+		provideDocumentPasteEdits?(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, context: DocumentPasteEditContext, token: CancellationToken): ProviderResult<T[]>;
+
+		/**
+		 * Optional method which fills in the {@linkcode DocumentPasteEdit.additionalEdit} before the edit is applied.
+		 *
+		 * This is called once per edit and should be used if generating the complete edit may take a long time.
+		 * Resolve can only be used to change {@link DocumentPasteEdit.additionalEdit}.
+		 *
+		 * @param pasteEdit The {@linkcode DocumentPasteEdit} to resolve.
+		 * @param token A cancellation token.
+		 *
+		 * @returns The resolved paste edit or a thenable that resolves to such. It is OK to return the given
+		 * `pasteEdit`. If no result is returned, the given `pasteEdit` is used.
+		 */
+		resolveDocumentPasteEdit?(pasteEdit: T, token: CancellationToken): ProviderResult<T>;
+	}
+
+	/**
+	 * An edit applied on paste.
+	 */
+	class DocumentPasteEdit {
+
+		/**
+		 * Human readable label that describes the edit.
+		 */
+		title: string;
+
+		/**
+		 * {@link DocumentPasteEditKind Kind} of the edit.
+		 *
+		 * Used to identify specific types of edits.
+		 */
+		kind: DocumentPasteEditKind;
+
+		/**
+		 * The text or snippet to insert at the pasted locations.
+		 */
+		insertText: string | SnippetString;
+
+		/**
+		 * An optional additional edit to apply on paste.
+		 */
+		additionalEdit?: WorkspaceEdit;
+
+		/**
+		 * Controls the ordering of paste edits provided by multiple providers.
+		 *
+		 * If this edit yields to another, it will be shown lower in the list of paste edit.
+		 */
+		yieldTo?: readonly DocumentPasteEditKind[];
+
+		/**
+		 * Create a new paste edit.
+		 *
+		 * @param insertText The text or snippet to insert at the pasted locations.
+		 * @param title Human readable label that describes the edit.
+		 * @param kind {@link DocumentPasteEditKind Kind} of the edit.
+		 */
+		constructor(insertText: string | SnippetString, title: string, kind: DocumentPasteEditKind);
+	}
+
+
+	/**
+	 * TODO: Share with code action kind?
+	 */
+	class DocumentPasteEditKind {
+		static readonly Empty: DocumentPasteEditKind;
+
+		// TODO: Add `Text` any others?
+
+		private constructor(value: string);
+
+		readonly value: string;
+
+		append(...parts: string[]): CodeActionKind;
+		intersects(other: CodeActionKind): boolean;
+		contains(other: CodeActionKind): boolean;
+	}
+
+	interface DocumentPasteProviderMetadata {
+		/**
+		 * List of {@link DocumentPasteEditKind kinds} that the provider may return in {@linkcode DocumentPasteEditProvider.provideDocumentPasteEdits provideDocumentPasteEdits}.
+		 *
+		 * The provider will only be invoked when one of these kinds is being requested. For normal pasting, all providers will be invoked.
+		 */
+		readonly providedPasteEditKinds: readonly DocumentPasteEditKind[];
+
+		/**
+		 * Mime types that {@linkcode DocumentPasteEditProvider.prepareDocumentPaste prepareDocumentPaste} may add on copy.
+		 */
+		readonly copyMimeTypes?: readonly string[];
+
+		/**
+		 * Mime types that {@linkcode DocumentPasteEditProvider.provideDocumentPasteEdits provideDocumentPasteEdits} should be invoked for.
+		 *
+		 * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.
+		 *
+		 * Use `text/uri-list` for resources dropped from the explorer or other tree views in the workbench.
+		 *
+		 * Use `files` to indicate that the provider should be invoked if any {@link DataTransferFile files} are present in the {@linkcode DataTransfer}.
+		 * Note that {@linkcode DataTransferFile} entries are only created when dropping content from outside the editor, such as
+		 * from the operating system.
+		 */
+		readonly pasteMimeTypes?: readonly string[];
+	}
+
+	namespace languages {
+		/**
+		 * Registers a new {@linkcode DocumentPasteEditProvider}.
+		 *
+		 * @param selector A selector that defines the documents this provider applies to.
+		 * @param provider A paste editor provider.
+		 * @param metadata Additional metadata about the provider.
+		 *
+		 * @returns A {@link Disposable} that unregisters this provider when disposed of.
+		 */
+		export function registerDocumentPasteEditProvider(selector: DocumentSelector, provider: DocumentPasteEditProvider, metadata: DocumentPasteProviderMetadata): Disposable;
+	}
+}

--- a/packages/types/vscode/typings/vscode.proposed.dropMetadata.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.dropMetadata.d.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/179430
+
+
+	/**
+	 * TODO:
+	 * - Add ctor(insertText: string | SnippetString, title?: string, kind?: DocumentPasteEditKind); Can't be done as this is an extension to an existing class
+	 * - Update provider to return multiple edits
+	 */
+
+	export interface DocumentDropEdit {
+		/**
+		 * Human readable label that describes the edit.
+		 */
+		title?: string;
+
+		/**
+		 * {@link DocumentPasteEditKind Kind} of the edit.
+		 *
+		 * Used to identify specific types of edits.
+		 *
+		 * TODO: use own type?
+		 */
+		kind: DocumentPasteEditKind;
+
+		/**
+		 * The mime type from the {@link DataTransfer} that this edit applies.
+		 *
+		 * TODO: Should this be taken from `dropMimeTypes` instead?
+		 */
+		handledMimeType?: string;
+
+		/**
+		 * Controls the ordering or multiple paste edits. If this provider yield to edits, it will be shown lower in the list.
+		 */
+		yieldTo?: ReadonlyArray<DocumentPasteEditKind>;
+	}
+
+	export interface DocumentDropEditProviderMetadata {
+		readonly providedDropEditKinds?: readonly DocumentPasteEditKind[];
+
+		/**
+		 * List of {@link DataTransfer} mime types that the provider can handle.
+		 *
+		 * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.
+		 *
+		 * Use `text/uri-list` for resources dropped from the explorer or other tree views in the workbench.
+		 *
+		 * Use `files` to indicate that the provider should be invoked if any {@link DataTransferFile files} are present in the {@link DataTransfer}.
+		 * Note that {@link DataTransferFile} entries are only created when dropping content from outside the editor, such as
+		 * from the operating system.
+		 */
+		readonly dropMimeTypes: readonly string[];
+	}
+}


### PR DESCRIPTION
### Types
- [x] 🎉 New Features

### Background or solution
registerDocumentDropEditProvider 与 registerDocumentPasteEditProvider 两个 API 先空实现

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了文档拖放和粘贴编辑提供者的注册方法，增强了文本编辑器的交互能力。
	- 引入了新的接口和枚举，以支持文档拖放和粘贴操作的处理。
- **文档**
	- 扩展了 Visual Studio Code 扩展开发环境中的类型定义，提供了新的文档粘贴和拖放元数据功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->