### PR TITLE
fix: open recent workspace in web

### DIFF
--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -58,7 +58,10 @@ export class WindowService implements IWindowService {
       }
       const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${encodeURIComponent(workspacePath)}`;
       if (options.newWindow) {
-          window.open(url)
+          const newWindow = window.open(url);
+          if (!newWindow) {
+            throw new Error('无法打开新窗口，请检查浏览器是否阻止弹出窗口');
+          }
       } else {
           parent.window.location.href = url;
       }

--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -57,13 +57,13 @@ export class WindowService implements IWindowService {
         workspacePath = workspaceUri.path.toString();
       }
       if (!workspacePath) {
-        throw new Error('工作区路径无效');
+        throw new Error('Invalid workspace path');
       }
       const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${encodeURIComponent(workspacePath)}`;
       if (options.newWindow) {
           const newWindow = window.open(url);
           if (!newWindow) {
-            throw new Error('无法打开新窗口，请检查浏览器是否阻止弹出窗口');
+            throw new Error('Unable to open new window, please check if your browser blocks pop-ups');
           }
       } else {
           parent.window.location.href = url;

--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -49,9 +49,8 @@ export class WindowService implements IWindowService {
         });
       }
     } else {
-      let workspacePath = workspace.toString().replace("file://", "");
+      const workspacePath = workspace.toString().replace("file://", "");
       const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${workspacePath}`
-      console.log('This from web, url is: ' + url);
       if (options.newWindow) {
           window.open(url)
       } else {

--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -49,10 +49,10 @@ export class WindowService implements IWindowService {
         });
       }
     } else {
-      const workspaceUri = new URI(workspace);
+      const workspaceUri = new URI(workspace.toString());
       let workspacePath: string;
       if (workspaceUri.scheme === 'file') {
-        workspacePath = workspaceUri.fsPath;
+        workspacePath = workspaceUri.codeUri.fsPath;
       } else {
         workspacePath = workspaceUri.path.toString();
       }

--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -49,8 +49,14 @@ export class WindowService implements IWindowService {
         });
       }
     } else {
-      const workspacePath = workspace.toString().replace("file://", "");
-      const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${workspacePath}`
+      const workspaceUri = new URI(workspace);
+      let workspacePath: string;
+      if (workspaceUri.scheme === 'file') {
+        workspacePath = workspaceUri.fsPath;
+      } else {
+        workspacePath = workspaceUri.path.toString();
+      }
+      const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${encodeURIComponent(workspacePath)}`;
       if (options.newWindow) {
           window.open(url)
       } else {

--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -56,6 +56,9 @@ export class WindowService implements IWindowService {
       } else {
         workspacePath = workspaceUri.path.toString();
       }
+      if (!workspacePath) {
+        throw new Error('工作区路径无效');
+      }
       const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${encodeURIComponent(workspacePath)}`;
       if (options.newWindow) {
           const newWindow = window.open(url);

--- a/packages/core-browser/src/window/window.service.ts
+++ b/packages/core-browser/src/window/window.service.ts
@@ -49,7 +49,14 @@ export class WindowService implements IWindowService {
         });
       }
     } else {
-      throw new Error('Method not implemented.');
+      let workspacePath = workspace.toString().replace("file://", "");
+      const url = `${window.location.protocol}//${window.location.host}?workspaceDir=${workspacePath}`
+      console.log('This from web, url is: ' + url);
+      if (options.newWindow) {
+          window.open(url)
+      } else {
+          parent.window.location.href = url;
+      }
     }
   }
 


### PR DESCRIPTION
Failed to open the recent project on the welcome page using Chrome browser (non electron)

### [Types](

- [ ] 🐛 Bug Fixes

### Background or solution
关联issuse #4138 
### Changelog

- isElectronRenderer为false的时候增加浏览器处理逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 改进了工作区打开功能，支持在非Electron环境中构建URL并根据选项打开新窗口或更新当前窗口位置。
	- 引入了日志记录功能，以便在执行`openWorkspace`方法时记录调试和错误信息。

- **错误修复**
	- 修复了在非Electron环境中调用`openWorkspace`方法时的错误处理逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->