### PR TITLE
style: improve statusbar popover style

### DIFF
--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -45,6 +45,7 @@ export interface IPopoverProps {
   zIndex?: number;
   onClickAction?: (args: any) => void;
   onVisibleChange?: (visible: boolean) => void;
+  getTooltipContainer?: (triggerNode: HTMLElement) => HTMLElement;
   [key: string]: any;
 }
 
@@ -65,6 +66,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   zIndex = 1000,
   onClickAction,
   onVisibleChange,
+  getTooltipContainer,
   ...restProps
 }) => {
   const handleActionClick = useCallback(
@@ -117,6 +119,7 @@ export const Popover: React.FC<IPopoverProps> = ({
       overlayClassName={overlayClassName}
       prefixCls='kt-popover'
       overlayStyle={overlayStyle}
+      getTooltipContainer={getTooltipContainer}
       overlay={overlayContent}
       zIndex={zIndex}
     >

--- a/packages/components/src/popover/styles.less
+++ b/packages/components/src/popover/styles.less
@@ -79,9 +79,9 @@
 .@{prefix}-popover-placement-top .@{prefix}-popover-arrow,
 .@{prefix}-popover-placement-topLeft .@{prefix}-popover-arrow,
 .@{prefix}-popover-placement-topRight .@{prefix}-popover-arrow {
-  bottom: 4px;
-  margin-left: -5px;
-  border-width: 5px 5px 0;
+  margin-left: -6px;
+  margin-bottom: 1px;
+  border-width: 6px 6px 0;
   border-top-color: var(--kt-popover-background);
 }
 

--- a/packages/core-browser/src/services/status-bar-service.ts
+++ b/packages/core-browser/src/services/status-bar-service.ts
@@ -56,7 +56,7 @@ export interface StatusBarEntry {
    * 标识当前状态栏组件 contextmenu 显示的名称，如果没有使用 text 代替
    */
   name?: string;
-  // 状态栏项的对其方式
+  // 状态栏项的对齐方式
   alignment: StatusBarAlignment;
   // 状态栏项的颜色
   color?: IThemeColor | string;
@@ -80,19 +80,11 @@ export interface StatusBarEntry {
   role?: string;
   // 状态栏项的位置，可以是左侧或右侧
   side?: 'left' | 'right';
-  /**
-   * 是否默认展示，可以通过右键菜单控制
-   */
+  // 是否默认展示，可以通过右键菜单控制
   hidden?: boolean;
-
-  /**
-   * 鼠标移上去 Content 的内容
-   */
+  // 鼠标移上去 Content 的内容
   hoverContents?: StatusBarHoverContent[];
-
-  /**
-   * 点击事件
-   */
+  // 点击事件
   onClick?: (e: any) => void;
 }
 

--- a/packages/core-browser/src/services/status-bar-service.ts
+++ b/packages/core-browser/src/services/status-bar-service.ts
@@ -56,25 +56,43 @@ export interface StatusBarEntry {
    * 标识当前状态栏组件 contextmenu 显示的名称，如果没有使用 text 代替
    */
   name?: string;
+  // 状态栏项的对其方式
   alignment: StatusBarAlignment;
+  // 状态栏项的颜色
   color?: IThemeColor | string;
+  // 状态栏项的背景颜色
   backgroundColor?: IThemeColor | string;
+  // 状态栏项的CSS类名称
   className?: string;
+  // 状态栏项的工具提示文本或Markdown字符串
   tooltip?: string | IMarkdownString;
+  // 状态栏项关联的命令ID
   command?: string;
+  // 命令参数数组
   arguments?: any[];
+  // 状态栏项的优先级
   priority?: number;
+  // 状态栏项的图标类名称
   iconClass?: string;
+  // 状态栏项的ARIA标签
   ariaLabel?: string;
+  // 状态栏项的角色属性
   role?: string;
+  // 状态栏项的位置，可以是左侧或右侧
+  side?: 'left' | 'right';
   /**
    * 是否默认展示，可以通过右键菜单控制
    */
   hidden?: boolean;
+
   /**
    * 鼠标移上去 Content 的内容
    */
   hoverContents?: StatusBarHoverContent[];
+
+  /**
+   * 点击事件
+   */
   onClick?: (e: any) => void;
 }
 

--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -73,6 +73,7 @@ export const StatusBarItem = memo((props: StatusBarEntry) => {
     hoverContents,
     color: propsColor,
     backgroundColor: propsBackgroundColor,
+    side,
   } = props;
 
   const themeService = useInjectable<IThemeService>(IThemeService);
@@ -129,7 +130,9 @@ export const StatusBarItem = memo((props: StatusBarEntry) => {
         content={popoverContent}
         trigger={PopoverTriggerType.hover}
         delay={0.2}
-        position={PopoverPosition.top}
+        position={
+          side === 'left' ? PopoverPosition.topLeft : side === 'right' ? PopoverPosition.topRight : PopoverPosition.top
+        }
         disable={disablePopover}
       >
         <div className={styles.popover_item}>

--- a/packages/status-bar/src/browser/status-bar.module.less
+++ b/packages/status-bar/src/browser/status-bar.module.less
@@ -81,6 +81,8 @@
 .element {
   span:global(.codicon),
   span:global(.kt-icon) {
+    display: flex;
+    justify-content: center;
     align-items: center;
     font-size: 1em;
     margin: 0 2px;

--- a/packages/status-bar/src/browser/status-bar.view.tsx
+++ b/packages/status-bar/src/browser/status-bar.view.tsx
@@ -46,6 +46,7 @@ export const StatusBarView = memo(
           {statusBar.leftEntries.length
             ? statusBar.leftEntries.map((entry: StatusBarEntry, index: number) => (
                 <StatusBarItem
+                  side='left'
                   key={`${entry.entryId}-${index}`}
                   {...{ ...entry, color: foregroundColor ?? entry.color }}
                 />
@@ -56,6 +57,7 @@ export const StatusBarView = memo(
           {statusBar.rightEntries.length
             ? statusBar.rightEntries.map((entry: StatusBarEntry, index: number) => (
                 <StatusBarItem
+                  side='right'
                   key={`${entry.entryId}-${index}`}
                   {...{ ...entry, color: foregroundColor ?? entry.color }}
                 />


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution
Before：
<img width="58" alt="image" src="https://github.com/user-attachments/assets/a4cf795b-a3f9-4797-9d40-e1a1be0629e6">

After：

<img width="396" alt="image" src="https://github.com/user-attachments/assets/ed42618e-c475-4456-a46e-bff483a5134e">

修复底部 Popover 展示内容被遮挡问题
### Changelog

improve statusbar popover style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
	- 在 `Popover` 组件中添加了可选属性 `getTooltipContainer`，允许用户自定义工具提示容器。
	- 在状态栏中引入多个新属性，增强状态栏项的自定义和交互能力，包括 `alignment`、`color`、`tooltip` 等。
	- 在 `StatusBarItem` 组件中添加 `side` 属性，以控制 `Popover` 的显示位置。

- **样式**
	- 优化了 `Popover` 组件箭头的样式，以提升视觉对齐。
	- 更新了状态栏组件的样式，使图标元素居中显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->