### PR TITLE
style: improve notification buttons style

### DIFF
--- a/packages/components/src/notification/notification.less
+++ b/packages/components/src/notification/notification.less
@@ -252,7 +252,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       padding: 0 5px;
-      box-sizing: border-box;
+      box-sizing: content-box;
       display: inline-block;
     }
   }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

Before:
<img width="204" alt="image" src="https://github.com/user-attachments/assets/856734df-0263-438c-ab60-3c6570c4c2a5">

After:
<img width="334" alt="image" src="https://github.com/user-attachments/assets/274a6d26-5f88-4ba6-aad0-52b7d86f4c27">

### Changelog

improve notification buttons style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式更新**
	- 通知组件按钮的样式进行了调整，`box-sizing` 属性从 `border-box` 更改为 `content-box`，可能影响按钮的布局和内边距行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->