### PR TITLE
style: improve notice toast style

### DIFF
--- a/packages/components/src/message/style.less
+++ b/packages/components/src/message/style.less
@@ -30,6 +30,17 @@
     background: var(--notifications-background);
     color: var(--notifications-foreground);
   }
+  &-custom-content {
+    display: flex;
+    align-items: flex-start;
+    align-items: center;
+    :global(.anticon) {
+      height: 21px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
 
   &-success .@{iconfont-css-prefix} {
     color: @success-color;

--- a/packages/components/src/message/style.less
+++ b/packages/components/src/message/style.less
@@ -33,8 +33,8 @@
   &-custom-content {
     display: flex;
     align-items: flex-start;
-    align-items: center;
-    :global(.anticon) {
+    justify-content: center;
+    .anticon {
       height: 21px;
       display: flex;
       align-items: center;


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

Before:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/d8a06c18-3192-4a0d-9dd3-79d1e0c4b4e4">

After:
<img width="135" alt="image" src="https://github.com/user-attachments/assets/d1e0f0ed-fe95-4d21-92cd-341008343778">

### Changelog

improve notice toast style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在消息组件中添加了自定义内容的新CSS类，支持更灵活的布局和对齐方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->