### PR TITLE
feat: add support for VSCode API: TextEditorOptions.indentSize

### DIFF
--- a/packages/types/sumi-worker/worker.editor.d.ts
+++ b/packages/types/sumi-worker/worker.editor.d.ts
@@ -141,6 +141,14 @@ declare module 'sumi-worker' {
     tabSize?: number | string;
 
     /**
+     * The number of spaces to insert when {@link TextEditorOptions.insertSpaces insertSpaces} is true.
+     *
+     * When getting a text editor's options, this property will always be a number (resolved).
+     * When setting a text editor's options, this property is optional and it can be a number or `"tabSize"`.
+     */
+    indentSize?: number | string;
+
+    /**
      * When pressing Tab insert [n](#TextEditorOptions.tabSize) spaces.
      * When getting a text editor's options, this property will always be a boolean (resolved).
      * When setting a text editor's options, this property is optional and it can be a boolean or `"auto"`.

--- a/packages/types/vscode/typings/vscode.editor.d.ts
+++ b/packages/types/vscode/typings/vscode.editor.d.ts
@@ -142,6 +142,14 @@ declare module 'vscode' {
     tabSize?: number | string;
 
     /**
+     * The number of spaces to insert when {@link TextEditorOptions.insertSpaces insertSpaces} is true.
+     *
+     * When getting a text editor's options, this property will always be a number (resolved).
+     * When setting a text editor's options, this property is optional and it can be a number or `"tabSize"`.
+     */
+    indentSize?: number | string;
+
+    /**
      * When pressing Tab insert [n](#TextEditorOptions.tabSize) spaces.
      * When getting a text editor's options, this property will always be a boolean (resolved).
      * When setting a text editor's options, this property is optional and it can be a boolean or `"auto"`.


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
这个 API 是最早是 proposed 的，在之前的代码中已经被实现了：https://github.com/opensumi/core/blob/main/packages/extension/src/hosted/api/vscode/editor/editor.host.ts#L618

这次只是将 typings 暴露出来

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 在 `TextEditorOptions` 接口中新增可选属性 `indentSize`，允许用户配置插入空格的数量或使用 `"tabSize"` 字符串，增强文本编辑器的可配置性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->