### PR TITLE
fix: quick pick update options

### DIFF
--- a/packages/core-browser/src/menu/next/menu-service.ts
+++ b/packages/core-browser/src/menu/next/menu-service.ts
@@ -161,10 +161,16 @@ class Menu extends Disposable implements IMenu {
         // menu.enabledWhen 的优先级高于 Command.isEnabled
         // 若设置了 menu.enabledWhen 则忽略 Command.isEnabled
         const commandEnablement = command ? this.commandRegistry.isEnabled(menuCommand.id, ...args) : true;
-        const disabled =
-          item.enabledWhen !== undefined
-            ? !this.contextKeyService.match(item.enabledWhen, options.contextDom)
-            : !commandEnablement;
+        let disabled = true;
+
+        if (item.enabledWhen !== undefined) {
+          disabled = !this.contextKeyService.match(item.enabledWhen, options.contextDom);
+        } else if (command?.enablement) {
+          // 若 command 设置了 enablement 则匹配 enablement
+          disabled = !this.contextKeyService.match(command.enablement, options.contextDom);
+        } else {
+          disabled = !commandEnablement;
+        }
 
         // menu.toggledWhen 的优先级高于 Command.isToggled
         // 若设置了 menu.toggledWhen 则忽略 Command.isToggled

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -464,6 +464,7 @@ export interface QuickPickService {
   show(elements: string[], options?: QuickPickOptions): Promise<string | undefined>;
   show<T>(elements: QuickPickItem<T>[], options?: QuickPickOptions): Promise<T | undefined>;
   show<T>(elements: (string | QuickPickItem<T>)[], options?: QuickPickOptions): Promise<T | string | undefined>;
+  updateOptions(options: QuickPickOptions): void;
   hide(reason?: HideReason): void;
   readonly onDidAccept: Event<void>;
   readonly onDidChangeActiveItems: Event<QuickOpenItem[]>;

--- a/packages/core-browser/src/quick-open/index.ts
+++ b/packages/core-browser/src/quick-open/index.ts
@@ -361,10 +361,16 @@ export namespace QuickOpenOptions {
      * 内容更新后保持滚动区域不变
      */
     keepScrollPosition?: boolean;
+
     /**
      * 是否显示 progress
      */
     busy?: boolean;
+
+    /**
+     * 总是保持显示，除非主动调用 hide
+     */
+    alwaysOpen?: boolean;
   }
   export const defaultOptions: Resolved = Object.freeze({
     enabled: true,

--- a/packages/extension/src/browser/vscode/api/main.thread.quickopen.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.quickopen.ts
@@ -137,6 +137,10 @@ export class MainThreadQuickOpen extends Disposable implements IMainThreadQuickO
     }
   }
 
+  $updateQuickPick(options: QuickPickOptions): void {
+    this.quickPickService.updateOptions(options);
+  }
+
   $hideInputBox(id: number) {
     if (this.createdInputBox.has(id)) {
       const box = this.createdInputBox.get(id);

--- a/packages/extension/src/common/vscode/window.ts
+++ b/packages/extension/src/common/vscode/window.ts
@@ -44,6 +44,7 @@ export interface IMainThreadQuickOpen {
   $hideQuickPick(): void;
   $showQuickInput(options: QuickInputOptions, validateInput: boolean): Promise<string | undefined>;
   $hideQuickInput(): void;
+  $updateQuickPick(options: QuickPickOptions): void;
   $createOrUpdateInputBox(id: number, options: QuickInputOptions): void;
   $hideInputBox(id: number): void;
   $disposeInputBox(id: number): void;

--- a/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.quickopen.ts
@@ -195,6 +195,7 @@ export class ExtHostQuickOpen implements IExtHostQuickOpen {
         value: (options as QuickPickOptions).value,
         busy: (options as QuickPickOptions).busy,
         enabled: (options as QuickPickOptions).enabled,
+        alwaysOpen: true, // 插件调用的 quick pick 不自动关闭，和 vscode 交互保持一致
       },
     );
 

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -326,7 +326,7 @@ export class KaitianQuickOpenControllerOpts implements IKaitianQuickOpenControll
   }
 
   updateOptions(options?: QuickOpenOptions) {
-    this.options = QuickOpenOptions.resolve(options);
+    this.options = QuickOpenOptions.resolve(options, this.options);
   }
 
   /**

--- a/packages/quick-open/src/browser/quick-open.type.ts
+++ b/packages/quick-open/src/browser/quick-open.type.ts
@@ -90,6 +90,7 @@ export interface QuickOpenInputOptions extends QuickOpenTabOptions {
   canSelectMany?: boolean;
   keepScrollPosition?: boolean;
   busy?: boolean;
+  enabled?: boolean;
 }
 
 export interface IQuickOpenWidget extends QuickOpenTabOptions {

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -587,10 +587,7 @@ export const QuickOpenView = () => {
           if (!item) {
             return;
           }
-          const hide = item.run(QuickOpenMode.OPEN);
-          if (hide) {
-            widget.hide(HideReason.ELEMENT_SELECTED);
-          }
+          item.run(QuickOpenMode.OPEN);
           break;
         }
         case Key.TAB.keyCode: {

--- a/packages/quick-open/src/browser/quick-open.view.tsx
+++ b/packages/quick-open/src/browser/quick-open.view.tsx
@@ -587,7 +587,10 @@ export const QuickOpenView = () => {
           if (!item) {
             return;
           }
-          item.run(QuickOpenMode.OPEN);
+          const hide = item.run(QuickOpenMode.OPEN);
+          if (hide) {
+            widget.hide(HideReason.ELEMENT_SELECTED);
+          }
           break;
         }
         case Key.TAB.keyCode: {

--- a/packages/quick-open/src/browser/quick-open.widget.tsx
+++ b/packages/quick-open/src/browser/quick-open.widget.tsx
@@ -129,11 +129,15 @@ export class QuickOpenWidget implements IQuickOpenWidget {
   }
 
   updateOptions(options: Partial<QuickOpenInputOptions>) {
-    Object.keys(options).forEach((key) => {
-      const privateKey = `_${key}`;
-      if (Object.hasOwn(this, privateKey)) {
-        this[privateKey] = options[key];
-      }
+    transaction((tx) => {
+      if ('placeholder' in options) {this.inputPlaceholder.set(options.placeholder, tx);}
+      if ('password' in options) {this.isPassword.set(!!options.password, tx);}
+      if ('inputEnable' in options) {this.inputEnable.set(!!options.inputEnable, tx);}
+      if ('valueSelection' in options) {this.valueSelection.set(options.valueSelection, tx);}
+      if ('canSelectMany' in options) {this.canSelectMany.set(!!options.canSelectMany, tx);}
+      if ('keepScrollPosition' in options) {this.keepScrollPosition.set(!!options.keepScrollPosition, tx);}
+      if ('busy' in options) {this.busy.set(!!options.busy, tx);}
+      if ('enabled' in options) {this.inputEnable.set(!!options.enabled, tx);}
     });
   }
 

--- a/packages/quick-open/src/browser/quick-pick.service.ts
+++ b/packages/quick-open/src/browser/quick-pick.service.ts
@@ -62,6 +62,10 @@ export class QuickPickServiceImpl implements QuickPickService {
     });
   }
 
+  updateOptions(options: QuickPickOptions): void {
+    this.quickOpenService.updateOptions(options);
+  }
+
   hide(reason?: HideReason): void {
     this.quickOpenService.hide(reason);
   }

--- a/packages/quick-open/src/browser/quick-pick.service.ts
+++ b/packages/quick-open/src/browser/quick-pick.service.ts
@@ -22,13 +22,20 @@ export class QuickPickServiceImpl implements QuickPickService {
   @Autowired(QuickOpenService)
   protected readonly quickOpenService: QuickOpenService;
 
+  private isAlwaysOpen = false;
+
   show(elements: string[], options?: QuickPickOptions): Promise<string | undefined>;
   show<T>(elements: QuickPickItem<T>[], options?: QuickPickOptions): Promise<T | undefined>;
-  show<T>(elements: QuickPickItem<T>[], options?: QuickPickOptions & { canPickMany: true }): Promise<T[] | undefined>;
+  show<T>(
+    elements: QuickPickItem<T>[],
+    options?: QuickPickOptions & { canPickMany: true; alwaysOpen?: boolean },
+  ): Promise<T[] | undefined>;
   async show<T>(
     elements: (string | QuickPickItem<T>)[],
-    options?: QuickPickOptions & { canPickMany: true },
+    options?: QuickPickOptions & { canPickMany: true; alwaysOpen?: boolean },
   ): Promise<T | T[] | undefined> {
+    this.isAlwaysOpen = !!options?.alwaysOpen;
+
     return new Promise<T | T[] | undefined>((resolve) => {
       const items = this.toItems(elements, resolve);
       if (options && this.quickTitleBar.shouldShowTitleBar(options.title, options.step, options.buttons)) {
@@ -114,11 +121,15 @@ export class QuickPickServiceImpl implements QuickPickService {
           return false;
         }
         resolve(value);
-        this.onDidAcceptEmitter.fire(undefined);
-        return true;
+        this.fireOnDidAccept();
+        return !this.isAlwaysOpen;
       },
       value,
     };
+  }
+
+  fireOnDidAccept(): void {
+    this.onDidAcceptEmitter.fire(undefined);
   }
 
   private readonly onDidAcceptEmitter: Emitter<void> = new Emitter();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

### Changelog
修复插件注册的 quick pick 设置 options 无效的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了动态更新快速选择服务选项的能力。
  - 新增属性 `busy` 和 `alwaysOpen`，增强快速打开功能的可配置性。
  - 引入 `BaseQuickInput` 抽象类，简化快速输入管理。
  
- **Bug 修复**
  - 改进了菜单项的启用状态判断逻辑，增强了灵活性和鲁棒性。

- **文档**
  - 代码注释已从中文翻译为英文，提升逻辑清晰度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->