### PR TITLE
WIP: support inline completion highlight

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -352,6 +352,10 @@ export class AINativeBrowserContribution
             id: AINativeSettingSectionsId.IntelligentCompletionsAlwaysVisible,
             localized: 'preference.ai.native.intelligentCompletions.alwaysVisible',
           },
+          {
+            id: AINativeSettingSectionsId.IntelligentCompletionsHighlight,
+            localized: 'preference.ai.native.intelligentCompletions.highlight',
+          },
         ],
       });
       registry.registerSettingSection(AI_NATIVE_SETTING_GROUP_ID, {

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/decoration/ghost-text-tokenization.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/decoration/ghost-text-tokenization.decoration.ts
@@ -27,7 +27,7 @@ import styles from '../intelligent-completions.module.less';
 import { GHOST_TEXT_DESCRIPTION } from './multi-line.decoration';
 
 interface LineData {
-  content: string; // Must not contain a linebreak!
+  content: string;
   decorations: LineDecoration[];
 }
 
@@ -361,12 +361,15 @@ export class AdditionalLinesWidget extends Disposable {
 
             return {
               content: text.content,
-              decorations: text.decorations.map((dec) => new LineDecoration(
-                  dec.startColumn,
-                  dec.endColumn,
-                  styles.inline_completion_ghost_text_decoration,
-                  dec.type,
-                )),
+              decorations: text.decorations.map(
+                (dec) =>
+                  new LineDecoration(
+                    dec.startColumn,
+                    dec.endColumn,
+                    styles.inline_completion_ghost_text_decoration,
+                    dec.type,
+                  ),
+              ),
               lineTokens: virtualModel.tokenization.getLineTokens(line),
             };
           })

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/decoration/ghost-text.decoration.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/decoration/ghost-text.decoration.ts
@@ -1,0 +1,386 @@
+import { DisposableStore, Event, isDefined } from '@opensumi/ide-core-common';
+import { EditorOption, ICodeEditor, IModelDeltaDecoration, ITextModel, Range } from '@opensumi/ide-monaco';
+import {
+  IObservable,
+  autorun,
+  autorunOpts,
+  derived,
+  derivedDisposable,
+  observableFromEvent,
+  observableSignalFromEvent,
+  observableValue,
+} from '@opensumi/ide-monaco/lib/common/observable';
+import { Disposable, toDisposable } from '@opensumi/monaco-editor-core/esm/vs/base/common/lifecycle';
+import { ILanguageSelection } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languages/language';
+import { InjectedTextCursorStops, PositionAffinity } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model';
+import { IModelService } from '@opensumi/monaco-editor-core/esm/vs/editor/common/services/model';
+import { LineDecoration } from '@opensumi/monaco-editor-core/esm/vs/editor/common/viewLayout/lineDecorations';
+import { InlineDecorationType } from '@opensumi/monaco-editor-core/esm/vs/editor/common/viewModel';
+import { GhostTextReplacement } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/ghostText';
+import { ColumnRange } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/utils';
+import { StandaloneServices } from '@opensumi/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
+
+import { renderLines } from '../../../widget/ghost-text-widget';
+import { IGhostTextWidgetModelEnhanced } from '../index';
+import styles from '../intelligent-completions.module.less';
+
+import { GHOST_TEXT_DESCRIPTION } from './multi-line.decoration';
+
+interface LineData {
+  content: string; // Must not contain a linebreak!
+  decorations: LineDecoration[];
+}
+
+export class GhostTextTokenization extends Disposable {
+  private readonly isDisposed = observableValue(this, false);
+  private readonly currentTextModel = observableFromEvent(this.editor.onDidChangeModel, () => this.editor.getModel());
+
+  constructor(private readonly editor: ICodeEditor, private readonly model: IGhostTextWidgetModelEnhanced) {
+    super();
+    this._register(
+      toDisposable(() => {
+        this.isDisposed.set(true, undefined);
+      }),
+    );
+
+    const disposable = new DisposableStore();
+    const decorationsCollection = this.editor.createDecorationsCollection();
+
+    disposable.add(
+      autorunOpts(
+        { debugName: () => `Apply tokenization decorations from ${this.decorations.debugName}` },
+        (reader) => {
+          const d = this.decorations.read(reader);
+          decorationsCollection.set(d);
+        },
+      ),
+    );
+    disposable.add({
+      dispose: () => {
+        decorationsCollection.clear();
+      },
+    });
+
+    this._register(disposable);
+  }
+
+  // 创建一个虚拟的 monaco editor model
+  private readonly virtualModel = derivedDisposable(this, (reader) => {
+    const textModel = this.currentTextModel.read(reader);
+    if (!textModel) {
+      return undefined;
+    }
+
+    const controllerModel = this.model.targetCompletionModel.read(reader);
+    const inlineCompletion = controllerModel!.selectedInlineCompletion.read(reader);
+
+    if (!inlineCompletion) {
+      return undefined;
+    }
+
+    const modelService = StandaloneServices.get(IModelService);
+    const languageSelection: ILanguageSelection = { languageId: textModel.getLanguageId(), onDidChange: Event.None };
+
+    const replacement = inlineCompletion.toSingleTextEdit(reader);
+    const virtualModel = modelService.createModel('', languageSelection);
+    virtualModel.setValue(textModel.getValue());
+
+    /**
+     * 将补全的所有内容填写在虚拟 model 中，然后强制更新 tokenization，此时就能从虚拟 model 中拿到对应的 tokenization 信息
+     */
+    virtualModel.pushEditOperations(null, [replacement], () => null);
+    return virtualModel;
+  }).recomputeInitiallyAndOnChange(this._store);
+
+  private readonly uiState = derived(this, (reader) => {
+    if (this.isDisposed.read(reader)) {
+      return undefined;
+    }
+
+    const textModel = this.currentTextModel.read(reader);
+    if (textModel !== this.model.targetTextModel.read(reader)) {
+      return undefined;
+    }
+
+    const ghostText = this.model.ghostText.read(reader);
+    if (!ghostText) {
+      return undefined;
+    }
+
+    const replacedRange = ghostText instanceof GhostTextReplacement ? ghostText.columnRange : undefined;
+    const inlineTexts: { column: number; text: string; preview: boolean }[] = [];
+    const additionalLines: LineData[] = [];
+
+    const addToAdditionalLines = (lines: readonly string[], className: string | undefined) => {
+      if (additionalLines.length > 0) {
+        const lastLine = additionalLines[additionalLines.length - 1];
+        if (className) {
+          lastLine.decorations.push(
+            new LineDecoration(
+              lastLine.content.length + 1,
+              lastLine.content.length + 1 + lines[0].length,
+              className,
+              InlineDecorationType.Regular,
+            ),
+          );
+        }
+        lastLine.content += lines[0];
+
+        lines = lines.slice(1);
+      }
+      for (const line of lines) {
+        additionalLines.push({
+          content: line,
+          decorations: className
+            ? [new LineDecoration(1, line.length + 1, className, InlineDecorationType.Regular)]
+            : [],
+        });
+      }
+    };
+
+    const textBufferLine = textModel.getLineContent(ghostText.lineNumber);
+
+    let hiddenTextStartColumn: number | undefined;
+    let lastIdx = 0;
+    for (const part of ghostText.parts) {
+      let lines = part.lines;
+      if (hiddenTextStartColumn === undefined) {
+        inlineTexts.push({
+          column: part.column,
+          text: lines[0],
+          preview: part.preview,
+        });
+        lines = lines.slice(1);
+      } else {
+        addToAdditionalLines([textBufferLine.substring(lastIdx, part.column - 1)], undefined);
+      }
+
+      if (lines.length > 0) {
+        addToAdditionalLines(lines, GHOST_TEXT_DESCRIPTION);
+        if (hiddenTextStartColumn === undefined && part.column <= textBufferLine.length) {
+          hiddenTextStartColumn = part.column;
+        }
+      }
+
+      lastIdx = part.column - 1;
+    }
+    if (hiddenTextStartColumn !== undefined) {
+      addToAdditionalLines([textBufferLine.substring(lastIdx)], undefined);
+    }
+
+    const hiddenRange =
+      hiddenTextStartColumn !== undefined
+        ? new ColumnRange(hiddenTextStartColumn, textBufferLine.length + 1)
+        : undefined;
+
+    return {
+      replacedRange,
+      inlineTexts,
+      additionalLines,
+      hiddenRange,
+      lineNumber: ghostText.lineNumber,
+      additionalReservedLineCount: this.model.minReservedLineCount.read(reader),
+      targetTextModel: textModel,
+    };
+  });
+
+  private readonly decorations = derived(this, (reader) => {
+    const uiState = this.uiState.read(reader);
+    const virtualModel = this.virtualModel.read(reader);
+    if (!uiState || !virtualModel) {
+      return [];
+    }
+
+    const { replacedRange, hiddenRange, inlineTexts, lineNumber } = uiState;
+
+    const decorations: IModelDeltaDecoration[] = [];
+
+    if (replacedRange) {
+      decorations.push({
+        range: replacedRange.toRange(lineNumber),
+        options: { inlineClassName: 'inline-completion-text-to-replace', description: 'GhostTextReplacement' },
+      });
+    }
+
+    if (hiddenRange) {
+      decorations.push({
+        range: hiddenRange.toRange(lineNumber),
+        options: { inlineClassName: 'ghost-text-hidden', description: 'ghost-text-hidden' },
+      });
+    }
+
+    if (inlineTexts.length < 1) {
+      return decorations;
+    }
+
+    virtualModel.tokenization.forceTokenization(lineNumber);
+
+    const token = virtualModel.tokenization.getLineTokens(lineNumber);
+    const dom = document.createElement('div');
+    renderLines(
+      dom,
+      this.editor.getOption(EditorOption.tabIndex),
+      [
+        {
+          content: inlineTexts[0].text,
+          decorations: [],
+          lineTokens: token,
+        },
+      ],
+      this.editor.getOptions(),
+    );
+
+    /**
+     * 这里主要是为了从虚拟 model 中拿到对应行的 className，然后转成 decorations 的 className
+     */
+    const findViewLineDOMs = Array.from(dom.querySelectorAll('.view-line > span > span'));
+
+    findViewLineDOMs.forEach((dom, idx) => {
+      const className = dom.className;
+      const text = dom.textContent || '';
+      decorations.push({
+        range: Range.fromPositions({ lineNumber, column: inlineTexts[0].column }),
+        options: {
+          description: GHOST_TEXT_DESCRIPTION,
+          after: {
+            content: text,
+            inlineClassName: styles.inline_completion_ghost_text_decoration + ' ' + className,
+            cursorStops: InjectedTextCursorStops.Left,
+          },
+          showIfCollapsed: true,
+        },
+      });
+    });
+
+    return decorations;
+  });
+
+  private readonly additionalLinesWidget = this._register(
+    new AdditionalLinesWidget(
+      this.editor,
+      derived((reader) => {
+        const uiState = this.uiState.read(reader);
+        const virtualModel = this.virtualModel.read(reader);
+        if (!uiState || !virtualModel) {
+          return undefined;
+        }
+
+        return {
+          lineNumber: uiState.lineNumber,
+          additionalLines: uiState.additionalLines,
+          targetTextModel: uiState.targetTextModel,
+          virtualModel,
+        };
+      }),
+    ),
+  );
+
+  public ownsViewZone(viewZoneId: string): boolean {
+    return this.additionalLinesWidget.viewZoneId === viewZoneId;
+  }
+}
+
+export class AdditionalLinesWidget extends Disposable {
+  private _viewZoneId: string | undefined = undefined;
+  public get viewZoneId(): string | undefined {
+    return this._viewZoneId;
+  }
+
+  private readonly editorOptionsChanged = observableSignalFromEvent(
+    'editorOptionChanged',
+    Event.filter(
+      this.editor.onDidChangeConfiguration,
+      (e) =>
+        e.hasChanged(EditorOption.disableMonospaceOptimizations) ||
+        e.hasChanged(EditorOption.stopRenderingLineAfter) ||
+        e.hasChanged(EditorOption.renderWhitespace) ||
+        e.hasChanged(EditorOption.renderControlCharacters) ||
+        e.hasChanged(EditorOption.fontLigatures) ||
+        e.hasChanged(EditorOption.fontInfo) ||
+        e.hasChanged(EditorOption.lineHeight),
+    ),
+  );
+
+  constructor(
+    private readonly editor: ICodeEditor,
+    private readonly lines: IObservable<
+      | { targetTextModel: ITextModel; lineNumber: number; additionalLines: LineData[]; virtualModel: ITextModel }
+      | undefined
+    >,
+  ) {
+    super();
+
+    this._register(
+      autorun((reader) => {
+        const lines = this.lines.read(reader);
+        this.editorOptionsChanged.read(reader);
+
+        if (lines) {
+          this.updateLines(lines.lineNumber, lines.additionalLines, lines.virtualModel);
+        } else {
+          this.clear();
+        }
+      }),
+    );
+  }
+
+  public override dispose(): void {
+    super.dispose();
+    this.clear();
+  }
+
+  private clear(): void {
+    this.editor.changeViewZones((changeAccessor) => {
+      if (this._viewZoneId) {
+        changeAccessor.removeZone(this._viewZoneId);
+        this._viewZoneId = undefined;
+      }
+    });
+  }
+
+  private updateLines(lineNumber: number, additionalLines: LineData[], virtualModel: ITextModel): void {
+    const textModel = this.editor.getModel();
+    if (!textModel) {
+      return;
+    }
+
+    const { tabSize } = textModel.getOptions();
+
+    this.editor.changeViewZones((changeAccessor) => {
+      if (this._viewZoneId) {
+        changeAccessor.removeZone(this._viewZoneId);
+        this._viewZoneId = undefined;
+      }
+
+      if (additionalLines.length > 0) {
+        const domNode = document.createElement('div');
+        const lineDatas = additionalLines
+          .map((text, index) => {
+            const line = lineNumber + index + 1;
+            virtualModel.tokenization.forceTokenization(line);
+
+            return {
+              content: text.content,
+              decorations: text.decorations.map((dec) => new LineDecoration(
+                  dec.startColumn,
+                  dec.endColumn,
+                  styles.inline_completion_ghost_text_decoration,
+                  dec.type,
+                )),
+              lineTokens: virtualModel.tokenization.getLineTokens(line),
+            };
+          })
+          .filter(isDefined);
+
+        renderLines(domNode, tabSize, lineDatas, this.editor.getOptions());
+
+        this._viewZoneId = changeAccessor.addZone({
+          afterLineNumber: lineNumber,
+          heightInLines: additionalLines.length,
+          domNode,
+          afterColumnAffinity: PositionAffinity.Right,
+        });
+      }
+    });
+  }
+}

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/index.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/index.ts
@@ -1,8 +1,16 @@
 import { Disposable, ECodeEditsSourceTyping } from '@opensumi/ide-core-common';
-import { IPosition, IRange, InlineCompletion } from '@opensumi/ide-monaco';
+import { IDisposable, IPosition, IRange, InlineCompletion } from '@opensumi/ide-monaco';
+import { ISettableObservable } from '@opensumi/ide-monaco/lib/common/observable';
+import { IGhostTextWidgetModel } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/ghostTextWidget';
+import { InlineCompletionsModel } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel';
+
 
 import type { ILineChangeData } from './source/line-change.source';
 import type { ILinterErrorData } from './source/lint-error.source';
+
+export interface IGhostTextWidgetModelEnhanced extends IGhostTextWidgetModel {
+  readonly targetCompletionModel: ISettableObservable<InlineCompletionsModel | undefined, void> & IDisposable;
+}
 
 export interface IIntelligentCompletionsResult<T = any> {
   readonly items: InlineCompletion[];

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.controller.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.controller.ts
@@ -42,7 +42,7 @@ import { REWRITE_DECORATION_INLINE_ADD, RewriteWidget } from '../../widget/rewri
 import { BaseAIMonacoEditorController } from '../base';
 
 import { AdditionsDeletionsDecorationModel } from './decoration/additions-deletions.decoration';
-import { GhostTextTokenization } from './decoration/ghost-text.decoration';
+import { GhostTextTokenization } from './decoration/ghost-text-tokenization.decoration';
 import { MultiLineDecorationModel } from './decoration/multi-line.decoration';
 import {
   IMultiLineDiffChangeResult,
@@ -167,7 +167,8 @@ export class IntelligentCompletionsController extends BaseAIMonacoEditorControll
             IObservable<GhostTextOrReplacement, unknown>[],
             unknown
           >,
-          (ghostText, store) => store.add(
+          (ghostText, store) =>
+            store.add(
               (inlineCompletionsController['_instantiationService'] as IInstantiationService).createInstance(
                 GhostTextTokenization,
                 this.monacoEditor,

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.module.less
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.module.less
@@ -5,3 +5,10 @@
 .suggestion_additions_background {
   background-color: var(--aiNative-multiLineEditsAdditionsBackground) !important;
 }
+
+.inline_completion_ghost_text_decoration {
+  background-color: var(--vscode-editorGhostText-background);
+  border: 1px solid var(--vscode-editorGhostText-border);
+  opacity: 0.34;
+  font-style: italic;
+}

--- a/packages/ai-native/src/browser/preferences/schema.ts
+++ b/packages/ai-native/src/browser/preferences/schema.ts
@@ -50,6 +50,10 @@ export const aiNativePreferenceSchema: PreferenceSchema = {
       type: 'boolean',
       default: false,
     },
+    [AINativeSettingSectionsId.IntelligentCompletionsHighlight]: {
+      type: 'boolean',
+      default: false,
+    },
     [AINativeSettingSectionsId.CodeEditsLintErrors]: {
       type: 'boolean',
       default: false,

--- a/packages/core-common/src/settings/ai-native.ts
+++ b/packages/core-common/src/settings/ai-native.ts
@@ -16,6 +16,7 @@ export enum AINativeSettingSectionsId {
   IntelligentCompletionsDebounceTime = 'ai.native.intelligentCompletions.debounceTime',
   IntelligentCompletionsCacheEnabled = 'ai.native.intelligentCompletions.cache.enabled',
   IntelligentCompletionsAlwaysVisible = 'ai.native.intelligentCompletions.alwaysVisible',
+  IntelligentCompletionsHighlight = 'ai.native.intelligentCompletions.highlight',
 
   /**
    * Code edits settings

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1495,6 +1495,8 @@ export const localizationBundle = {
     'preference.ai.native.intelligentCompletions.debounceTime': 'Debounce time for intelligent completions',
     'preference.ai.native.intelligentCompletions.cache.enabled': 'Whether to enable cache for intelligent completions',
     'preference.ai.native.intelligentCompletions.alwaysVisible': 'Whether to always show intelligent completions',
+    'preference.ai.native.intelligentCompletions.highlight':
+      'Whether to enable syntax highlighting for intelligent completions',
 
     'preference.ai.native.codeEdits.title': 'Code Edits',
     'preference.ai.native.codeEdits.lintErrors': 'Whether to enable intelligent rewriting of Lint Errors',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1260,6 +1260,7 @@ export const localizationBundle = {
     'preference.ai.native.intelligentCompletions.debounceTime': '智能补全的延迟时间（毫秒）',
     'preference.ai.native.intelligentCompletions.cache.enabled': '是否启用智能补全的缓存',
     'preference.ai.native.intelligentCompletions.alwaysVisible': '是否总是展示智能补全',
+    'preference.ai.native.intelligentCompletions.highlight': '是否启用智能补全的语法高亮',
 
     'preference.ai.native.codeEdits.title': '智能改写',
     'preference.ai.native.codeEdits.lintErrors': '是否开启对 Lint Error 类型的智能改写',


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution


https://github.com/user-attachments/assets/3bdf99ff-f895-4499-932a-ae04809f102c

- [x] 内联补全高亮
- [x] 配置开关
- [x] 修复 column 变化时的高亮 token 错位问题

### Changelog
内联补全支持代码高亮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了智能补全高亮设置，用户可以自定义是否启用此功能。
	- 引入了 `GhostTextTokenization` 和 `AdditionalLinesWidget` 类，增强了代码编辑器中的内联补全功能。

- **样式**
	- 新增 CSS 类 `.inline_completion_ghost_text_decoration`，用于样式化编辑器中的幽灵文本。

- **本地化**
	- 添加了英语和中文的本地化条目，以支持智能补全高亮设置的语言选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->