### PR TITLE
feat: empty implement testing 1.84 api

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.tests.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tests.ts
@@ -210,6 +210,10 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
     this.withTestResult(runId, (r) => r.markComplete());
   }
 
+  $markTestRetired(testIds: string[] | undefined): void {
+    this.logger.warn('Method not implemented.');
+  }
+
   private withTestResult<T>(runId: string, fn: (run: ITestResult) => T): T | undefined {
     const r = this.resultService.getResult(runId);
     return r && r instanceof TestResultImpl ? fn(r) : undefined;

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1625,6 +1625,7 @@ export namespace TestMessage {
       type: TestMessageType.Error,
       expected: message.expectedOutput,
       actual: message.actualOutput,
+      contextValue: message.contextValue,
       location: message.location ? (location.from(message.location) as any) : undefined,
     };
   }
@@ -1635,6 +1636,7 @@ export namespace TestMessage {
     );
     message.actualOutput = item.actual;
     message.expectedOutput = item.expected;
+    message.contextValue = item.contextValue;
     message.location = item.location ? location.to(item.location) : undefined;
     return message;
   }

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -3330,6 +3330,8 @@ export class TestMessage implements vscode.TestMessage {
   public expectedOutput?: string;
   public actualOutput?: string;
   public location?: vscode.Location;
+  /** proposed: */
+  public contextValue?: string;
 
   public static diff(message: string | vscode.MarkdownString, expected: string, actual: string) {
     const msg = new TestMessage(message);

--- a/packages/extension/src/common/vscode/tests.ts
+++ b/packages/extension/src/common/vscode/tests.ts
@@ -113,4 +113,6 @@ export interface IMainThreadTesting {
   $startedExtensionTestRun(req: ExtensionRunTestsRequest): void;
   /** Signals that an extension-provided test run finished. */
   $finishedExtensionTestRun(runId: string): void;
+  /** Marks a test (or controller) as retired in all results. */
+  $markTestRetired(testIds: string[] | undefined): void;
 }

--- a/packages/testing/src/common/testCollection.ts
+++ b/packages/testing/src/common/testCollection.ts
@@ -93,6 +93,7 @@ export interface ITestRunProfile {
   isDefault: boolean;
   tag: string | null;
   hasConfigurationHandler: boolean;
+  supportsContinuousRun: boolean;
 }
 
 /**
@@ -156,6 +157,7 @@ export interface ITestErrorMessage {
   type: TestMessageType.Error;
   expected: string | undefined;
   actual: string | undefined;
+  contextValue: string | undefined;
   location: IRichLocation | undefined;
 }
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

- [x] Support TestController.invalidateTestResults
- [x] Support TestMessage.contextValue
- [x] Support TestRunProfile.supportsContinuousRun
- [x] Support TestRunRequest.continuous
- [ ] Support TestRunRequest.preserveFocus // 1.87 版本中已删除


### Changelog
空实现 1.84 版本的 testing 插件 api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了 `$markTestRetired` 方法，用于标记测试或控制器为已退役。
	- 在 `TestMessage` 中新增 `contextValue` 属性，以提供更详细的错误报告。
	- 引入 `supportsContinuousRun` 属性，支持持续测试执行。
	- 新增 `invalidateTestResults` 方法，允许标记测试结果为过时。

- **文档**
	- 更新了 `runHandler` 方法的文档，说明支持持续运行的配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->