### PR TITLE
fix: correct width calculation in resize component

### DIFF
--- a/packages/core-browser/src/components/resize/resize.tsx
+++ b/packages/core-browser/src/components/resize/resize.tsx
@@ -258,34 +258,33 @@ export const ResizeHandleHorizontal = (props: ResizeHandleProps) => {
       const currentPrev = prevElement.current!.clientWidth;
       const currentNext = nextElement.current!.clientWidth;
 
-      const nextTotolWidth = +nextElement.current!.style.width!.replace('%', '');
-      const prevTotalWidth = +prevElement.current!.style.width!.replace('%', '');
-      fastdom.mutate(() => {
-        const totalSize = currentPrev + currentNext;
-        if (props.flexMode) {
-          const prevWidth = props.flexMode === ResizeFlexMode.Prev ? size : totalSize - size;
-          const nextWidth = props.flexMode === ResizeFlexMode.Next ? size : totalSize - size;
-          flexModeSetSize(prevWidth, nextWidth, true);
-        } else {
-          const currentTotalWidth = nextTotolWidth + prevTotalWidth;
+      const totalSize = currentPrev + currentNext;
+      if (props.flexMode) {
+        const prevWidth = props.flexMode === ResizeFlexMode.Prev ? size : totalSize - size;
+        const nextWidth = props.flexMode === ResizeFlexMode.Next ? size : totalSize - size;
+        flexModeSetSize(prevWidth, nextWidth, true);
+      } else {
+        const nextTotolWidth = +nextElement.current!.style.width!.replace('%', '');
+        const prevTotalWidth = +prevElement.current!.style.width!.replace('%', '');
 
-          if (isLatter) {
-            nextElement.current!.style.width = currentTotalWidth * (size / totalSize) + '%';
-            prevElement.current!.style.width = currentTotalWidth * (1 - size / totalSize) + '%';
-          } else {
-            prevElement.current!.style.width = currentTotalWidth * (size / totalSize) + '%';
-            nextElement.current!.style.width = currentTotalWidth * (1 - size / totalSize) + '%';
-          }
-        }
+        const currentTotalWidth = nextTotolWidth + prevTotalWidth;
+
         if (isLatter) {
-          handleZeroSize(totalSize - size, size);
+          nextElement.current!.style.width = currentTotalWidth * (size / totalSize) + '%';
+          prevElement.current!.style.width = currentTotalWidth * (1 - size / totalSize) + '%';
         } else {
-          handleZeroSize(size, totalSize - size);
+          prevElement.current!.style.width = currentTotalWidth * (size / totalSize) + '%';
+          nextElement.current!.style.width = currentTotalWidth * (1 - size / totalSize) + '%';
         }
-        if (props.onResize) {
-          props.onResize(prevElement.current!, nextElement.current!);
-        }
-      });
+      }
+      if (isLatter) {
+        handleZeroSize(totalSize - size, size);
+      } else {
+        handleZeroSize(size, totalSize - size);
+      }
+      if (props.onResize) {
+        props.onResize(prevElement.current!, nextElement.current!);
+      }
     });
   };
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

fastdom 改造导致的时序问题，该问题会导致首次进入 IDE 面板初始化异常，资源管理面板无法正常初始化合适宽度
<img width="579" alt="image" src="https://github.com/user-attachments/assets/867da190-8fcf-4cd9-9e0a-b60259ae6c50">

移除内层包裹解决

### Changelog

correct width calculation in resize component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了水平和垂直调整组件的大小调整逻辑，提升了用户体验。
- **错误修复**
	- 增强了大小调整功能的鲁棒性，确保元素在调整时不会超出定义的限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->