### PR TITLE
feat: empty implement VSCode proposed API: registerMultiDocumentHighlightProvider

### DIFF
--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -1460,6 +1460,29 @@ export class WorkspaceEdit implements vscode.WorkspaceEdit {
 }
 
 @es5ClassCompat
+export class MultiDocumentHighlight {
+  /**
+   * The URI of the document containing the highlights.
+   */
+  uri: Uri;
+
+  /**
+   * The highlights for the document.
+   */
+  highlights: DocumentHighlight[];
+
+  /**
+   * Creates a new instance of MultiDocumentHighlight.
+   * @param uri The URI of the document containing the highlights.
+   * @param highlights The highlights for the document.
+   */
+  constructor(uri: Uri, highlights: DocumentHighlight[]) {
+    this.uri = uri;
+    this.highlights = highlights;
+  }
+}
+
+@es5ClassCompat
 export class DocumentLink {
   range: Range;
   target?: Uri;

--- a/packages/extension/src/hosted/api/vscode/ext.host.language.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.language.ts
@@ -361,6 +361,16 @@ export function createLanguagesApiFactory(
     ): vscode.Disposable {
       return extHostLanguages.registerDocumentPasteEditProvider(extension, selector, provider, metadata);
     },
+    /**
+     * @monaco-todo: wait until API is available in Monaco (1.85.0+)
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    registerMultiDocumentHighlightProvider(
+      selector: vscode.DocumentSelector,
+      provider: vscode.MultiDocumentHighlightProvider,
+    ): vscode.Disposable {
+      return toDisposable(() => {});
+    },
   };
 }
 

--- a/packages/types/vscode.d.ts
+++ b/packages/types/vscode.d.ts
@@ -43,6 +43,7 @@
 /// <reference path='./vscode/typings/vscode.proposed.chatAgents2Additions.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.chatVariables.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.interactive.d.ts' />
+/// <reference path='./vscode/typings/vscode.proposed.multiDocumentHighlightProvider.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.inlineCompletionsAdditions.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.codeActionAI.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.codeActionRanges.d.ts' />

--- a/packages/types/vscode/typings/vscode.language.d.ts
+++ b/packages/types/vscode/typings/vscode.language.d.ts
@@ -2447,6 +2447,7 @@ declare module 'vscode' {
 		 * @param token A cancellation token.
 		 * @returns A set of text edits or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined`, `null`, or an empty array.
+     * @monaco-todo the current monaco version does not yet use this API
 		 */
 		provideDocumentRangesFormattingEdits?(document: TextDocument, ranges: Range[], options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]>;
   }

--- a/packages/types/vscode/typings/vscode.proposed.multiDocumentHighlightProvider.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.multiDocumentHighlightProvider.d.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	/**
+	 * Represents a collection of document highlights from multiple documents.
+	 */
+	export class MultiDocumentHighlight {
+
+		/**
+		 * The URI of the document containing the highlights.
+		 */
+		uri: Uri;
+
+		/**
+		 * The highlights for the document.
+		 */
+		highlights: DocumentHighlight[];
+
+		/**
+		 * Creates a new instance of MultiDocumentHighlight.
+		 * @param uri The URI of the document containing the highlights.
+		 * @param highlights The highlights for the document.
+		 */
+		constructor(uri: Uri, highlights: DocumentHighlight[]);
+	}
+
+	export interface MultiDocumentHighlightProvider {
+
+		/**
+		 * Provide a set of document highlights, like all occurrences of a variable or
+		 * all exit-points of a function.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param otherDocuments An array of additional valid documents for which highlights should be provided.
+		 * @param token A cancellation token.
+		 * @returns A Map containing a mapping of the Uri of a document to the document highlights or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined`, `null`, or an empty map.
+		 */
+		provideMultiDocumentHighlights(document: TextDocument, position: Position, otherDocuments: TextDocument[], token: CancellationToken): ProviderResult<MultiDocumentHighlight[]>;
+	}
+
+	namespace languages {
+
+		/**
+		 * Register a multi document highlight provider.
+		 *
+		 * Multiple providers can be registered for a language. In that case providers are sorted
+		 * by their {@link languages.match score} and groups sequentially asked for document highlights.
+		 * The process stops when a provider returns a `non-falsy` or `non-failure` result.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A multi-document highlight provider.
+		 * @returns A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerMultiDocumentHighlightProvider(selector: DocumentSelector, provider: MultiDocumentHighlightProvider): Disposable;
+	}
+
+}


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
Empty implement VSCode proposed API: registerMultiDocumentHighlightProvider

这个 API 依赖 monaco > 1.85 ，因此暂时空实现

cc @Ricbet 

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了 `MultiDocumentHighlight` 类，用于处理多个文档的高亮显示。
  - 新增 `registerMultiDocumentHighlightProvider` 方法，允许注册多文档高亮提供者。
  - 新增 `registerDocumentDropEditProvider` 和 `registerEvaluatableExpressionProvider` 方法，提供文档编辑和可评估表达式的支持。
  - 添加 `onDidChangeDiagnostics` 事件，监控诊断信息的变化。
  - 扩展了 `getDiagnostics` 方法，支持获取所有资源的诊断信息。

- **文档**
  - 更新了 TypeScript 类型定义，包含新的多文档高亮相关功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->