### PR TITLE
chore: revert vscode engine version

### DIFF
--- a/packages/core-common/src/const/application.ts
+++ b/packages/core-common/src/const/application.ts
@@ -10,4 +10,4 @@ export namespace DEFAULT_ALIPAY_CLOUD_REGISTRY {
   export const MASTER_KEY = 'i6rkupqyvC6Bc6CiO0yVLNqq';
 }
 
-export const DEFAULT_VSCODE_ENGINE_VERSION = '1.90.0';
+export const DEFAULT_VSCODE_ENGINE_VERSION = '1.68.0';


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution
Revert vscode engine version

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了默认的 VSCode 引擎版本，从 `'1.90.0'` 更改为 `'1.68.0'`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->