### PR TITLE
fix: right panel container view

### DIFF
--- a/packages/ai-native/src/browser/layout/tabbar.view.tsx
+++ b/packages/ai-native/src/browser/layout/tabbar.view.tsx
@@ -123,7 +123,7 @@ const AILeftTabbarRenderer: React.FC = () => {
       return (
         <>
           {visibleContainers.length > 0 && <HorizontalVertical margin={'8px auto 0px'} width={'60%'} />}
-          {visibleContainers.map((component) => renderContainers(component, currentContainerId))}
+          {visibleContainers.map((component) => renderContainers(component, tabbarService, currentContainerId))}
         </>
       );
     },

--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -54,7 +54,11 @@ export interface ITabbarViewProps {
   canHideTabbar?: boolean;
   renderOtherVisibleContainers?: React.FC<{
     props: ITabbarViewProps;
-    renderContainers: (component: ComponentRegistryInfo, currentContainerId: string) => JSX.Element | null;
+    renderContainers: (
+      component: ComponentRegistryInfo,
+      tabbarService: TabbarService,
+      currentContainerId: string,
+    ) => JSX.Element | null;
   }>;
 }
 
@@ -109,7 +113,7 @@ export const TabbarViewBase: React.FC<ITabbarViewProps> = (props) => {
   });
 
   const renderContainers = React.useCallback(
-    (component: ComponentRegistryInfo, currentContainerId?: string) => {
+    (component: ComponentRegistryInfo, tabbarService: TabbarService, currentContainerId?: string) => {
       const containerId = component.options?.containerId;
       if (!containerId) {
         return null;
@@ -164,13 +168,13 @@ export const TabbarViewBase: React.FC<ITabbarViewProps> = (props) => {
         </li>
       );
     },
-    [tabbarService],
+    [],
   );
 
   return (
     <div className={cls([styles_tab_bar, className])}>
       <div className={styles_bar_content} style={{ flexDirection: Layout.getTabbarDirection(direction) }}>
-        {visibleContainers.map((component) => renderContainers(component, currentContainerId))}
+        {visibleContainers.map((component) => renderContainers(component, tabbarService, currentContainerId))}
         {renderOtherVisibleContainers({ props, renderContainers })}
         {hideContainers.length ? (
           <li
@@ -308,7 +312,11 @@ export const RightTabbarRenderer: React.FC<{ barSize?: number; style?: React.CSS
 export const LeftTabbarRenderer: React.FC<{
   renderOtherVisibleContainers?: React.FC<{
     props: ITabbarViewProps;
-    renderContainers: (component: ComponentRegistryInfo, currentContainerId: string) => JSX.Element | null;
+    renderContainers: (
+      component: ComponentRegistryInfo,
+      tabbarService: TabbarService,
+      currentContainerId: string,
+    ) => JSX.Element | null;
   }>;
   isRenderExtraTopMenus?: boolean;
   renderExtraMenus?: React.ReactNode;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

因为 tabbarService 是多例的，根据不同的 location 会实例化一个。
之前的代码会导致其他调用方都只会走到 left 这个 tabbarService，从而导致异常

### Changelog
修复 right 面板不展示的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了标签栏组件的渲染逻辑，增强了与标签栏服务的交互。
	- 引入了更灵活的容器渲染方式，支持动态状态管理。
- **改进**
	- 标签栏服务现在在多个组件中传递，提升了状态更新和拖放事件的处理能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->