### PR TITLE
fix: when using language pack extensions, extensions that use i10n do not load correctly

### DIFF
--- a/packages/extension/__mocks__/extension.service.client.ts
+++ b/packages/extension/__mocks__/extension.service.client.ts
@@ -49,6 +49,6 @@ export class MockExtNodeClientService implements IExtensionNodeClientService {
     return Promise.resolve();
   }
   getLanguagePack(languageId: string) {
-    return undefined;
+    return Promise.resolve(undefined);
   }
 }

--- a/packages/extension/src/browser/vscode/api/main.thread.localization.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.localization.ts
@@ -31,7 +31,7 @@ export class MainThreadLocalization implements IMainThreadLocalization {
   async $fetchBuiltInBundleUri(id: string, language: string): Promise<Uri | undefined> {
     try {
       // 当插件为内置插件时，从 Language Packs 中获取
-      const languagePack = this.extensionNodeClient.getLanguagePack(language || this.currentLanguage);
+      const languagePack = await this.extensionNodeClient.getLanguagePack(language || this.currentLanguage);
       if (languagePack && languagePack.translations[id]) {
         return Uri.file(languagePack.translations[id]);
       }

--- a/packages/extension/src/browser/vscode/contributes/configuration.ts
+++ b/packages/extension/src/browser/vscode/contributes/configuration.ts
@@ -12,6 +12,8 @@ import { LifeCyclePhase } from '@opensumi/ide-core-common';
 import { Contributes, LifeCycle, VSCodeContributePoint } from '../../../common';
 import { AbstractExtInstanceManagementService } from '../../types';
 
+import { LocalizationsContributionPoint } from './localization';
+
 export interface ConfigurationSnippets {
   body: {
     title: string;
@@ -35,7 +37,11 @@ export class ConfigurationContributionPoint extends VSCodeContributePoint<Prefer
   @Autowired(AbstractExtInstanceManagementService)
   protected readonly extensionManageService: AbstractExtInstanceManagementService;
 
-  contribute() {
+  @Autowired(LocalizationsContributionPoint)
+  protected readonly localizationsContributionPoint: LocalizationsContributionPoint;
+
+  async contribute() {
+    await this.localizationsContributionPoint.whenContributed;
     for (const contrib of this.contributesMap) {
       const { extensionId, contributes } = contrib;
       const extension = this.extensionManageService.getExtensionInstanceByExtId(extensionId);

--- a/packages/extension/src/browser/vscode/contributes/configuration.ts
+++ b/packages/extension/src/browser/vscode/contributes/configuration.ts
@@ -41,7 +41,11 @@ export class ConfigurationContributionPoint extends VSCodeContributePoint<Prefer
   protected readonly localizationsContributionPoint: LocalizationsContributionPoint;
 
   async contribute() {
-    await this.localizationsContributionPoint.whenContributed;
+    //  当语言包插件被使用的时候，需要等待LocalizationsContributionPoint执行完成。否则配置项的多语言初始化的还是默认语言（英文）。
+    if (this.localizationsContributionPoint.hasUncontributedPoint()) {
+      await this.localizationsContributionPoint.whenContributed;
+    }
+
     for (const contrib of this.contributesMap) {
       const { extensionId, contributes } = contrib;
       const extension = this.extensionManageService.getExtensionInstanceByExtId(extensionId);

--- a/packages/extension/src/browser/vscode/contributes/configuration.ts
+++ b/packages/extension/src/browser/vscode/contributes/configuration.ts
@@ -7,7 +7,7 @@ import {
   PreferenceSchemaProvider,
   PreferenceService,
 } from '@opensumi/ide-core-browser';
-import { LifeCyclePhase } from '@opensumi/ide-core-common';
+import { ILogger, LifeCyclePhase } from '@opensumi/ide-core-common';
 
 import { Contributes, LifeCycle, VSCodeContributePoint } from '../../../common';
 import { AbstractExtInstanceManagementService } from '../../types';
@@ -40,10 +40,17 @@ export class ConfigurationContributionPoint extends VSCodeContributePoint<Prefer
   @Autowired(LocalizationsContributionPoint)
   protected readonly localizationsContributionPoint: LocalizationsContributionPoint;
 
+  @Autowired(ILogger)
+  private readonly logger: ILogger;
+
   async contribute() {
     //  当语言包插件被使用的时候，需要等待LocalizationsContributionPoint执行完成。否则配置项的多语言初始化的还是默认语言（英文）。
     if (this.localizationsContributionPoint.hasUncontributedPoint()) {
-      await this.localizationsContributionPoint.whenContributed;
+      try {
+        await this.localizationsContributionPoint.whenContributed;
+      } catch (error) {
+        this.logger.error('Failed to wait contribute localizations.', error);
+      }
     }
 
     for (const contrib of this.contributesMap) {

--- a/packages/extension/src/browser/vscode/contributes/localization.ts
+++ b/packages/extension/src/browser/vscode/contributes/localization.ts
@@ -93,6 +93,7 @@ export class LocalizationsContributionPoint extends VSCodeContributePoint<Locali
         if (localization.translations) {
           const languageId = normalizeLanguageId(localization.languageId);
           if (languageId !== getLanguageId()) {
+            this._whenContributed.resolve();
             return;
           }
           promises.push(

--- a/packages/extension/src/browser/vscode/contributes/localization.ts
+++ b/packages/extension/src/browser/vscode/contributes/localization.ts
@@ -9,7 +9,7 @@ import {
   path,
   registerLocalizationBundle,
 } from '@opensumi/ide-core-browser';
-import { LifeCyclePhase } from '@opensumi/ide-core-common';
+import { Deferred, LifeCyclePhase } from '@opensumi/ide-core-common';
 import { IExtensionStoragePathServer } from '@opensumi/ide-extension-storage';
 import { IFileServiceClient } from '@opensumi/ide-file-service/lib/common';
 
@@ -62,6 +62,12 @@ export class LocalizationsContributionPoint extends VSCodeContributePoint<Locali
 
   @Autowired(AbstractExtInstanceManagementService)
   private readonly extensionManageService: AbstractExtInstanceManagementService;
+
+  private _whenContributed = new Deferred<void>();
+
+  get whenContributed(): Promise<void> {
+    return this._whenContributed.promise;
+  }
 
   private storagePath: string;
 
@@ -119,6 +125,7 @@ export class LocalizationsContributionPoint extends VSCodeContributePoint<Locali
     }
 
     await Promise.all(promises);
+    this._whenContributed.resolve();
   }
 
   async registerLanguage(translate: TranslationFormat, extensionPath: string) {

--- a/packages/extension/src/browser/vscode/contributes/localization.ts
+++ b/packages/extension/src/browser/vscode/contributes/localization.ts
@@ -82,51 +82,56 @@ export class LocalizationsContributionPoint extends VSCodeContributePoint<Locali
   }
 
   async contribute() {
-    const promises: Promise<void>[] = [];
-    const currentLanguage: string = this.preferenceService.get(GeneralSettingsId.Language) || getLanguageId();
-    const currentExtensions = this.extensionManageService.getExtensionInstances();
+    try {
+      const promises: Promise<void>[] = [];
+      const currentLanguage: string = this.preferenceService.get(GeneralSettingsId.Language) || getLanguageId();
+      const currentExtensions = this.extensionManageService.getExtensionInstances();
 
-    for (const contrib of this.contributesMap) {
-      const { extensionId, contributes } = contrib;
-      const extension = this.extensionManageService.getExtensionInstanceByExtId(extensionId);
-      for await (const localization of contributes) {
-        if (localization.translations) {
-          const languageId = normalizeLanguageId(localization.languageId);
-          if (languageId !== getLanguageId()) {
-            this._whenContributed.resolve();
-            return;
+      for (const contrib of this.contributesMap) {
+        const { extensionId, contributes } = contrib;
+        const extension = this.extensionManageService.getExtensionInstanceByExtId(extensionId);
+        for await (const localization of contributes) {
+          if (localization.translations) {
+            const languageId = normalizeLanguageId(localization.languageId);
+            if (languageId !== getLanguageId()) {
+              continue;
+            }
+
+            promises.push(
+              ...localization.translations.map(async (translate) => {
+                if (currentExtensions.findIndex((e) => e.id === translate.id) === -1) {
+                  return;
+                }
+                const contents = await this.registerLanguage(translate, extension!.path);
+                registerLocalizationBundle(
+                  {
+                    languageId,
+                    languageName: localization.languageName,
+                    localizedLanguageName: localization.localizedLanguageName,
+                    contents,
+                  },
+                  translate.id,
+                );
+              }),
+            );
+
+            if (!this.storagePath) {
+              this.storagePath = (await this.extensionStoragePathServer.getLastStoragePath()) || '';
+            }
+
+            promises.push(
+              this.extensionNodeService.updateLanguagePack(currentLanguage, extension!.path, this.storagePath),
+            );
           }
-          promises.push(
-            ...localization.translations.map(async (translate) => {
-              if (currentExtensions.findIndex((e) => e.id === translate.id) === -1) {
-                return;
-              }
-              const contents = await this.registerLanguage(translate, extension!.path);
-              registerLocalizationBundle(
-                {
-                  languageId,
-                  languageName: localization.languageName,
-                  localizedLanguageName: localization.localizedLanguageName,
-                  contents,
-                },
-                translate.id,
-              );
-            }),
-          );
-
-          if (!this.storagePath) {
-            this.storagePath = (await this.extensionStoragePathServer.getLastStoragePath()) || '';
-          }
-
-          promises.push(
-            this.extensionNodeService.updateLanguagePack(currentLanguage, extension!.path, this.storagePath),
-          );
         }
       }
-    }
 
-    await Promise.all(promises);
-    this._whenContributed.resolve();
+      await Promise.all(promises);
+      this._whenContributed.resolve();
+    } catch (error) {
+      this.logger.error('Failed to contribute localizations:', error);
+      this._whenContributed.reject(error);
+    }
   }
 
   async registerLanguage(translate: TranslationFormat, extensionPath: string) {

--- a/packages/extension/src/common/extension.ts
+++ b/packages/extension/src/common/extension.ts
@@ -128,7 +128,7 @@ export interface IExtensionNodeClientService {
   updateLanguagePack(languageId: string, languagePackPath: string, storagePath: string): Promise<void>;
   setupNLSConfig(languageId: string, storagePath: string): Promise<void>;
   getOpenVSXRegistry(): Promise<string>;
-  getLanguagePack(languageId: string): IExtensionLanguagePack | undefined;
+  getLanguagePack(languageId: string): Promise<IExtensionLanguagePack | undefined>;
   pid(): Promise<number | null>;
 }
 

--- a/packages/extension/src/node/extension.service.client.ts
+++ b/packages/extension/src/node/extension.service.client.ts
@@ -246,6 +246,6 @@ export class ExtensionServiceClientImpl
 
   public getLanguagePack(languageId: string) {
     const languagePacks = this.languagePackCache?.[languageId];
-    return languagePacks;
+    return Promise.resolve(languagePacks);
   }
 }

--- a/packages/startup/entry/web-lite/lite-module/extension/index.ts
+++ b/packages/startup/entry/web-lite/lite-module/extension/index.ts
@@ -30,7 +30,7 @@ export class ExtensionClientService implements IExtensionNodeClientService {
   getOpenVSXRegistry(): Promise<string> {
     throw new Error('Method not implemented.');
   }
-  getLanguagePack(languageId: string): IExtensionLanguagePack | undefined {
+  getLanguagePack(languageId: string): Promise<IExtensionLanguagePack | undefined> {
     throw new Error('Method not implemented.');
   }
   restartExtProcessByClient(): void {

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -1,6 +1,5 @@
 const os = require('os');
 const path = require('path');
-const querystring = require('querystring');
 const pipeline = require('stream').pipeline;
 
 const retry = require('async-retry');
@@ -66,10 +65,9 @@ const parallelRunPromise = (lazyPromises, n) => {
   return new Promise(addWorking);
 };
 
-async function downloadExtension(url, namespace, extensionName) {
+async function downloadExtension(url, namespace, extensionName, version) {
   const tmpPath = path.join(os.tmpdir(), 'extension');
-  const [tempFileName, queryStr] = path.basename(url).split('?');
-  const { version = '' } = querystring.parse(queryStr);
+  const [tempFileName] = path.basename(url).split('?');
   const tmpZipFile = path.join(tmpPath, `${tempFileName}-${version}`);
   await fs.mkdirp(tmpPath);
 
@@ -160,7 +158,7 @@ const installExtension = async (namespace, name, version) => {
     // 下载解压插件容易出错，因此这里加一个重试逻辑
     await retry(
       async () => {
-        const { targetDirName, tmpZipFile } = await downloadExtension(downloadUrl, namespace, name);
+        const { targetDirName, tmpZipFile } = await downloadExtension(downloadUrl, namespace, name, version);
         await unzipFile(targetDir, targetDirName, tmpZipFile);
         rimraf.sync(tmpZipFile);
       },


### PR DESCRIPTION
### Types
- [ ] 🐛 Bug Fixes

### Background or solution
1、使用插件：vscode-language-pack-zh-hans-1.96.0、json-language-features-1.88.1
2、切换语言使用zh-cn。
3、打开settings里的json相关配置描述，显示的是英文的。
3、编写一个有语法错误的json。显示的语言是英文的。

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 更新了多个方法以支持异步操作，确保更好的性能和响应性。
	- 在配置贡献中集成了本地化处理，以改善用户体验。
  
- **修复**
	- 修改了语言包获取方法的返回类型，确保一致性和可靠性。

- **文档**
	- 更新了方法签名以反映异步处理的变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->