### PR TITLE
fix: when context key cause different menu bars change at same time. only one menu bar refreshed

### DIFF
--- a/packages/core-browser/src/menu/next/menubar-service.ts
+++ b/packages/core-browser/src/menu/next/menubar-service.ts
@@ -59,9 +59,23 @@ export class MenubarServiceImpl extends Disposable implements AbstractMenubarSer
     // 监听 menubar 刷新事件
     this.addDispose(Event.debounce(this.menuRegistry.onDidChangeMenubar, () => {}, 50)(this._build, this));
 
+    const menuIds = new Set<string>();
     // 监听内部的 onMenuChange 刷新单个 menubarItem 下的所有节点
     this.addDispose(
-      Event.debounce(this.onMenuChange, (l, menuId: string) => menuId, 50)(this._rebuildSingleRootMenus, this),
+      Event.debounce(
+        this.onMenuChange,
+        (l, menuId: string) => {
+          menuIds.add(menuId);
+          return menuId;
+        },
+        50,
+      )(() => {
+        const changedMenuIds = [...menuIds.values()];
+        menuIds.clear();
+        changedMenuIds.forEach((menuId) => {
+          this._rebuildSingleRootMenus(menuId);
+        });
+      }, this),
     );
 
     this.addDispose(this._onDidMenuBarChange);


### PR DESCRIPTION

### Types

- [ ] 🐛 Bug Fixes

### Background or solution

复现步骤：
1、定义一个context key.设置两个不同的menubar下的menu item的when为该context key。
2、更改该context key的值。
现象：只有一个menubar被刷新。
期待结果：两个menubar应该都被刷新。

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了菜单更新处理，支持批量处理多个菜单变更，提高了菜单结构的刷新效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->