### PR TITLE
feat: partially supported the VSCode TerminalExitReason API

### DIFF
--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.terminal.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.terminal.test.ts
@@ -190,7 +190,7 @@ describe('ext host terminal test', () => {
 
     expect(mockCreateTerminal).toHaveBeenCalled();
 
-    const mockSetStatus = jest.spyOn(terminal4, 'setExitCode');
+    const mockSetStatus = jest.spyOn(terminal4, 'setExitStatus');
 
     // 要等待前台创建完 terminal 示例后，pty 事件绑定完再 fire
     setTimeout(() => {

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -2869,6 +2869,14 @@ export enum TaskRevealKind {
   Never = 3,
 }
 
+export enum TerminalExitReason {
+  Unknown = 0,
+  Shutdown = 1,
+  Process = 2,
+  User = 3,
+  Extension = 4,
+}
+
 export enum UIKind {
   Desktop = 1,
   Web = 2,

--- a/packages/extension/src/hosted/api/vscode/ext.host.terminal.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.terminal.ts
@@ -38,6 +38,7 @@ import {
   IMainThreadTerminal,
   MainThreadAPIIdentifier,
 } from '../../../common/vscode';
+import { TerminalExitReason } from '../../../common/vscode/ext-types';
 
 import type vscode from 'vscode';
 
@@ -136,7 +137,8 @@ export class ExtHostTerminal implements IExtHostTerminal {
       return;
     }
 
-    terminal.setExitCode(e.code);
+    // 目前 OpenSumi 不是很好打通完整的 Terminal 关闭原因，先用 Unknown 打通接口
+    terminal.setExitStatus(e.code, TerminalExitReason.Unknown);
     this.closeTerminalEvent.fire(terminal);
 
     this.terminalsMap.delete(terminalId);
@@ -213,7 +215,7 @@ export class ExtHostTerminal implements IExtHostTerminal {
 
     this.disposables.add(
       p.onProcessExit((e: number | undefined) => {
-        terminal.setExitCode(e);
+        terminal.setExitStatus(e, TerminalExitReason.Process);
       }),
     );
 
@@ -750,8 +752,8 @@ export class Terminal implements vscode.Terminal {
     this.created(id);
   }
 
-  public setExitCode(code: number | undefined) {
-    this._exitStatus = Object.freeze({ code });
+  public setExitStatus(code: number | undefined, reason: vscode.TerminalExitReason) {
+    this._exitStatus = Object.freeze({ code, reason });
   }
 
   public setName(name: string) {

--- a/packages/types/vscode/typings/vscode.d.ts
+++ b/packages/types/vscode/typings/vscode.d.ts
@@ -2952,7 +2952,42 @@ declare module 'vscode' {
      *   without providing an exit code.
      */
     readonly code: number | undefined;
+
+    /**
+		 * The reason that triggered the exit of a terminal.
+		 */
+		readonly reason: TerminalExitReason;
   }
+
+	/**
+	 * Terminal exit reason kind.
+	 */
+	export enum TerminalExitReason {
+		/**
+		 * Unknown reason.
+		 */
+		Unknown = 0,
+
+		/**
+		 * The window closed/reloaded.
+		 */
+		Shutdown = 1,
+
+		/**
+		 * The shell process exited.
+		 */
+		Process = 2,
+
+		/**
+		 * The user closed the terminal.
+		 */
+		User = 3,
+
+		/**
+		 * An extension disposed the terminal.
+		 */
+		Extension = 4,
+	}
 
   export interface Terminal {
 


### PR DESCRIPTION
### Types

兼容 vscode TerminalExitReason API，目前适配了 onProcessExit 的场景，其他场景采用兼容 API 的实现，确保插件的正常工作。 

- [x] 🎉 New Features

