### PR TITLE
Refactor/support watch by unrecursive config patch 3—4 5

### DIFF
--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -302,6 +302,16 @@ export interface AppConfig {
    * 启用 Diff 编辑器状态恢复逻辑
    */
   enableRestoreDiffEditorState?: boolean;
+  notebookServerHost?: string;
+  /**
+   * The authentication token for requests.  Use an empty string to disable.
+   */
+  notebookServerToken?: string;
+
+  /**
+   * Unrecursive directories
+   */
+  unRecursiveDirectories?: string[];
 }
 
 export interface ICollaborationClientOpts {

--- a/packages/core-common/src/types/file.ts
+++ b/packages/core-common/src/types/file.ts
@@ -157,7 +157,7 @@ export interface FileSystemProvider {
    * @param options Configures the watch.
    * @returns A disposable that tells the provider to stop watching the `uri`.
    */
-  watch(uri: Uri, options: { excludes?: string[] }): number | Promise<number>;
+  watch(uri: Uri, options: { excludes?: string[]; recursive?: boolean }): number | Promise<number>;
 
   unwatch?(watcherId: number): void | Promise<void>;
 

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -339,6 +339,9 @@ export class FileServiceClient implements IFileServiceClient, IDisposable {
 
   // 添加监听文件
   async watchFileChanges(uri: URI, excludes?: string[]): Promise<IFileServiceWatcher> {
+    const unRecursiveDirectories = this.appConfig.unRecursiveDirectories || [];
+    const isUnRecursive = unRecursiveDirectories.some((dir) => uri.toString().startsWith(dir));
+
     const _uri = this.convertUri(uri.toString());
     const originWatcher = this.uriWatcherMap.get(_uri.toString());
     if (originWatcher) {
@@ -356,6 +359,7 @@ export class FileServiceClient implements IFileServiceClient, IDisposable {
 
     const watcherId = await provider.watch(_uri.codeUri, {
       excludes,
+      recursive: !isUnRecursive,
     });
 
     this.watcherDisposerMap.set(id, {

--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -340,7 +340,7 @@ export class FileServiceClient implements IFileServiceClient, IDisposable {
   // 添加监听文件
   async watchFileChanges(uri: URI, excludes?: string[]): Promise<IFileServiceWatcher> {
     const unRecursiveDirectories = this.appConfig.unRecursiveDirectories || [];
-    const isUnRecursive = unRecursiveDirectories.some((dir) => uri.toString().startsWith(dir));
+    const isUnRecursive = unRecursiveDirectories.some((dir) => uri.path.toString().startsWith(dir));
 
     const _uri = this.convertUri(uri.toString());
     const originWatcher = this.uriWatcherMap.get(_uri.toString());

--- a/packages/file-service/src/node/disk-file-system.provider.ts
+++ b/packages/file-service/src/node/disk-file-system.provider.ts
@@ -68,7 +68,15 @@ export interface IWatcher {
 export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvider> implements IDiskFileProvider {
   private fileChangeEmitter = new Emitter<FileChangeEvent>();
 
-  private watcherServer: UnRecursiveFileSystemWatcher | FileSystemWatcherServer;
+  /**
+   * recursive file system watcher
+   */
+  private recursiveFileSystemWatcher?: FileSystemWatcherServer;
+
+  /**
+   * unrecursive file system watcher
+   */
+  private unrecursiveFileSystemWatcher?: UnRecursiveFileSystemWatcher;
 
   readonly onDidChangeFile: Event<FileChangeEvent> = this.fileChangeEmitter.event;
   protected watcherServerDisposeCollection: DisposableCollection;
@@ -95,7 +103,6 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     super();
     this.logger = this.loggerManager.getLogger(SupportLogNamespace.Node);
     this.recursive = recursive;
-    this.initWatchServer();
   }
 
   get whenReady() {
@@ -131,15 +138,22 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
    * @param {{ excludes: string[] }}
    * @memberof DiskFileSystemProvider
    */
-  async watch(uri: UriComponents, options?: { excludes?: string[] }): Promise<number> {
+  async watch(uri: UriComponents, options?: { excludes?: string[]; recursive?: boolean }): Promise<number> {
     await this.whenReady;
     const _uri = Uri.revive(uri);
-    const id = await this.watcherServer.watchFileChanges(_uri.toString(), {
+
+    const watcherServer = this.getOrCreateWatcherServer(options?.excludes, options?.recursive);
+
+    if (!watcherServer) {
+      return -1;
+    }
+
+    const id = await watcherServer.watchFileChanges(_uri.toString(), {
       excludes: options?.excludes ?? [],
     });
     const disposable = {
       dispose: () => {
-        this.watcherServer.unwatchFileChanges(id);
+        watcherServer?.unwatchFileChanges(id);
       },
     };
     this.watcherCollection.set(_uri.toString(), { id, options, disposable });
@@ -157,7 +171,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
   async stat(uri: UriComponents, options?: IFileStatOptions): Promise<FileStat> {
     const _uri = Uri.revive(uri);
     try {
-      const stat = await this.doGetStat(_uri, 1, options);
+      const stat = await this.doGetStat(_uri, 0, options);
       if (stat) {
         return stat;
       }
@@ -367,7 +381,7 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     // 每次调用之后都需要重新初始化 WatcherServer，保证最新的规则生效
     this.logger.log('Set watcher exclude:', watchExcludes);
     this.watchFileExcludes = watchExcludes;
-    this.initWatchServer(this.watchFileExcludes);
+    this.getOrCreateWatcherServer(this.watchFileExcludes);
   }
 
   getWatchFileExcludes() {
@@ -378,20 +392,33 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     return Array.from(new Set(this.watchFileExcludes.concat(excludes || [])));
   }
 
-  protected initWatchServer(excludes?: string[]) {
+  protected getOrCreateWatcherServer(excludes?: string[], recursive?: boolean) {
     if (!this.injector) {
-      return;
+      return undefined;
     }
+
+    if (this.isInitialized) {
+      // 当服务已经初始化一次后，重新初始化时需要重新绑定原有的监听服务
+      this.rewatch();
+    }
+
     if (this.watcherServerDisposeCollection) {
       this.watcherServerDisposeCollection.dispose();
     }
+
     this.watcherServerDisposeCollection = new DisposableCollection();
-    if (this.recursive) {
-      this.watcherServer = this.injector.get(FileSystemWatcherServer, [excludes]);
+    const useRecursiveServer = recursive ?? this.recursive;
+    let watcherServer: FileSystemWatcherServer | UnRecursiveFileSystemWatcher;
+
+    if (useRecursiveServer) {
+      watcherServer = this.recursiveFileSystemWatcher || this.injector.get(FileSystemWatcherServer, [excludes]);
+      this.recursiveFileSystemWatcher = watcherServer;
     } else {
-      this.watcherServer = this.injector.get(UnRecursiveFileSystemWatcher, [excludes]);
+      watcherServer = this.unrecursiveFileSystemWatcher || this.injector.get(UnRecursiveFileSystemWatcher, [excludes]);
+      this.unrecursiveFileSystemWatcher = watcherServer;
     }
-    this.watcherServer.setClient({
+
+    watcherServer.setClient({
       onDidFilesChanged: (events: DidFilesChangedParams) => {
         this.logger.log(events.changes, 'events.change');
         if (events.changes.length > 0) {
@@ -409,16 +436,14 @@ export class DiskFileSystemProvider extends RPCService<IRPCDiskFileSystemProvide
     });
     this.watcherServerDisposeCollection.push({
       dispose: () => {
-        this.watcherServer.dispose();
+        watcherServer.dispose();
       },
     });
-    if (this.isInitialized) {
-      // 当服务已经初始化一次后，重新初始化时需要重新绑定原有的监听服务
-      this.rewatch();
-    } else {
-      this._whenReadyDeferred.resolve();
-    }
+
+    this._whenReadyDeferred.resolve();
     this.isInitialized = true;
+
+    return watcherServer;
   }
 
   private async rewatch() {

--- a/packages/file-service/src/node/file-service.ts
+++ b/packages/file-service/src/node/file-service.ts
@@ -95,7 +95,7 @@ export class FileService implements IFileService {
     return this.toDisposable;
   }
 
-  async watchFileChanges(uri: string, options?: { excludes: string[] }): Promise<number> {
+  async watchFileChanges(uri: string, options?: { excludes: string[]; recursive?: boolean }): Promise<number> {
     const id = this.watcherId++;
     const _uri = this.getUri(uri);
     const provider = await this.getProvider(_uri.scheme);
@@ -103,6 +103,7 @@ export class FileService implements IFileService {
 
     const watcherId = await provider.watch(_uri.codeUri, {
       excludes: (options && options.excludes) || [],
+      recursive: options && options.recursive !== undefined ? options.recursive : this.options.recursive,
     });
     this.watcherDisposerMap.set(id, {
       dispose: () => provider.unwatch!(watcherId),

--- a/packages/file-service/src/node/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/recursive/file-service-watcher.ts
@@ -295,7 +295,7 @@ export class FileSystemWatcherServer extends Disposable implements IFileSystemWa
   }
 
   setClient(client: FileSystemWatcherClient | undefined) {
-    if (this.client && this.disposed) {
+    if (this.disposed) {
       return;
     }
     this.client = client;

--- a/packages/file-service/src/node/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/recursive/file-service-watcher.ts
@@ -295,7 +295,7 @@ export class FileSystemWatcherServer extends Disposable implements IFileSystemWa
   }
 
   setClient(client: FileSystemWatcherClient | undefined) {
-    if (client && this.disposed) {
+    if (this.client && this.disposed) {
       return;
     }
     this.client = client;

--- a/packages/file-service/src/node/un-recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/un-recursive/file-service-watcher.ts
@@ -244,7 +244,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
   }
 
   setClient(client: FileSystemWatcherClient | undefined) {
-    if (this.client && this.toDispose.disposed) {
+    if (this.toDispose.disposed) {
       return;
     }
     this.client = client;

--- a/packages/file-service/src/node/un-recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/un-recursive/file-service-watcher.ts
@@ -244,7 +244,7 @@ export class UnRecursiveFileSystemWatcher implements IFileSystemWatcherServer {
   }
 
   setClient(client: FileSystemWatcherClient | undefined) {
-    if (client && this.toDispose.disposed) {
+    if (this.client && this.toDispose.disposed) {
       return;
     }
     this.client = client;


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 增加了应用配置选项，包括 notebook 服务器主机、认证令牌和不递归处理的目录。
  - `watch` 方法支持递归参数，允许更灵活的文件监控。
  
- **Bug 修复**
  - 修改了 `setClient` 方法的逻辑，简化了客户端设置的条件。

- **文档**
  - 更新了部分注释，提升了代码可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->