### PR TITLE
feat: empty impl VSCode TestCoverage API

### DIFF
--- a/packages/extension/src/browser/vscode/api/main.thread.tests.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.tests.ts
@@ -190,10 +190,6 @@ export class MainThreadTestsImpl extends Disposable implements IMainThreadTestin
     this.withTestResult(runId, (r) => r.appendOutput(output, taskId, location, testId));
   }
 
-  $signalCoverageAvailable(runId: string, taskId: string): void {
-    this.logger.warn('$signalCoverageAvailable', runId, taskId);
-  }
-
   $startedTestRunTask(runId: string, task: ITestRunTask): void {
     this.withTestResult(runId, (r) => r.addTask(task));
   }

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1790,48 +1790,6 @@ export namespace TestResults {
     };
   }
 }
-
-export namespace TestCoverage {
-  function fromCoveredCount(count: vscode.CoveredCount): ICoveredCount {
-    return { covered: count.covered, total: count.covered };
-  }
-
-  function fromLocation(location: vscode.Range | vscode.Position) {
-    return 'line' in location ? Position.from(location) : Range.from(location);
-  }
-
-  export function fromDetailed(coverage: vscode.DetailedCoverage): CoverageDetails {
-    if ('branches' in coverage) {
-      return {
-        count: coverage.executionCount,
-        location: fromLocation(coverage.location),
-        type: DetailType.Statement,
-        branches: coverage.branches.length
-          ? coverage.branches.map((b) => ({
-              count: b.executionCount,
-              location: b.location && fromLocation(b.location),
-            }))
-          : undefined,
-      };
-    } else {
-      return {
-        type: DetailType.Function,
-        count: coverage.executionCount,
-        location: fromLocation(coverage.location),
-      };
-    }
-  }
-
-  export function fromFile(coverage: vscode.FileCoverage): IFileCoverage {
-    return {
-      uri: coverage.uri,
-      statement: fromCoveredCount(coverage.statementCoverage),
-      branch: coverage.branchCoverage && fromCoveredCount(coverage.branchCoverage),
-      function: coverage.functionCoverage && fromCoveredCount(coverage.functionCoverage),
-      details: coverage.detailedCoverage?.map(fromDetailed),
-    };
-  }
-}
 // #endregion
 
 export interface IURITransformer {

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -3435,6 +3435,112 @@ export class TestMessage implements vscode.TestMessage {
   constructor(public message: string | vscode.MarkdownString) {}
 }
 
+export class TestCoverageCount implements vscode.TestCoverageCount {
+  constructor(public covered: number, public total: number) {
+    validateTestCoverageCount(this);
+  }
+}
+
+export function validateTestCoverageCount(cc?: vscode.TestCoverageCount) {
+  if (!cc) {
+    return;
+  }
+
+  if (cc.covered > cc.total) {
+    throw new Error(`The total number of covered items (${cc.covered}) cannot be greater than the total (${cc.total})`);
+  }
+
+  if (cc.total < 0) {
+    throw new Error(`The number of covered items (${cc.total}) cannot be negative`);
+  }
+}
+
+export class FileCoverage implements vscode.FileCoverage {
+  public static fromDetails(uri: vscode.Uri, details: vscode.FileCoverageDetail[]): vscode.FileCoverage {
+    const statements = new TestCoverageCount(0, 0);
+    const branches = new TestCoverageCount(0, 0);
+    const decl = new TestCoverageCount(0, 0);
+
+    for (const detail of details) {
+      if ('branches' in detail) {
+        statements.total += 1;
+        statements.covered += detail.executed ? 1 : 0;
+
+        for (const branch of detail.branches) {
+          branches.total += 1;
+          branches.covered += branch.executed ? 1 : 0;
+        }
+      } else {
+        decl.total += 1;
+        decl.covered += detail.executed ? 1 : 0;
+      }
+    }
+
+    const coverage = new FileCoverage(
+      uri,
+      statements,
+      branches.total > 0 ? branches : undefined,
+      decl.total > 0 ? decl : undefined,
+    );
+
+    coverage.detailedCoverage = details;
+
+    return coverage;
+  }
+
+  detailedCoverage?: vscode.FileCoverageDetail[];
+
+  constructor(
+    public readonly uri: vscode.Uri,
+    public statementCoverage: vscode.TestCoverageCount,
+    public branchCoverage?: vscode.TestCoverageCount,
+    public declarationCoverage?: vscode.TestCoverageCount,
+    public includesTests: vscode.TestItem[] = [],
+  ) {}
+}
+
+export class StatementCoverage implements vscode.StatementCoverage {
+  // back compat until finalization:
+  get executionCount() {
+    return +this.executed;
+  }
+  set executionCount(n: number) {
+    this.executed = n;
+  }
+
+  constructor(
+    public executed: number | boolean,
+    public location: Position | Range,
+    public branches: vscode.BranchCoverage[] = [],
+  ) {}
+}
+
+export class BranchCoverage implements vscode.BranchCoverage {
+  // back compat until finalization:
+  get executionCount() {
+    return +this.executed;
+  }
+  set executionCount(n: number) {
+    this.executed = n;
+  }
+
+  constructor(public executed: number | boolean, public location: Position | Range, public label?: string) {}
+}
+
+export class DeclarationCoverage implements vscode.DeclarationCoverage {
+  // back compat until finalization:
+  get executionCount() {
+    return +this.executed;
+  }
+  set executionCount(n: number) {
+    this.executed = n;
+  }
+
+  constructor(public readonly name: string, public executed: number | boolean, public location: Position | Range) {}
+}
+
+export type FileCoverageDetail = StatementCoverage | DeclarationCoverage;
+
 @es5ClassCompat
 export class TestTag implements vscode.TestTag {
   constructor(public readonly id: string) {}

--- a/packages/extension/src/common/vscode/tests.ts
+++ b/packages/extension/src/common/vscode/tests.ts
@@ -39,18 +39,6 @@ export interface IExtHostTests {
   $publishTestResults(results: ISerializedTestResults[]): void;
   /** Expands a test item's children, by the given number of levels. */
   $expandTest(testId: string, levels: number): Promise<void>;
-  /** Requests file coverage for a test run. Errors if not available. */
-  $provideFileCoverage(runId: string, taskId: string, token: CancellationToken): Promise<IFileCoverage[]>;
-  /**
-   * Requests coverage details for the file index in coverage data for the run.
-   * Requires file coverage to have been previously requested via $provideFileCoverage.
-   */
-  $resolveFileCoverage(
-    runId: string,
-    taskId: string,
-    fileIndex: number,
-    token: CancellationToken,
-  ): Promise<CoverageDetails[]>;
   /** Configures a test run config. */
   $configureRunProfile(controllerId: string, configId: number): void;
   /** Asks the controller to refresh its tests */
@@ -103,8 +91,6 @@ export interface IMainThreadTesting {
   $appendTestMessagesInRun(runId: string, taskId: string, testId: string, messages: SerializedTestMessage[]): void;
   /** Appends raw output to the test run.. */
   $appendOutputToRun(runId: string, taskId: string, output: string, location?: ILocationDto, testId?: string): void;
-  /** Triggered when coverage is added to test results. */
-  $signalCoverageAvailable(runId: string, taskId: string): void;
   /** Signals a task in a test run started. */
   $startedTestRunTask(runId: string, task: ITestRunTask): void;
   /** Signals a task in a test run ended. */

--- a/packages/testing/src/common/testCollection.ts
+++ b/packages/testing/src/common/testCollection.ts
@@ -186,6 +186,7 @@ export interface ITestRunTask {
   id: string;
   name: string | undefined;
   running: boolean;
+  ctrlId: string;
 }
 
 export interface ITestTag {

--- a/packages/types/vscode/typings/vscode.tests.d.ts
+++ b/packages/types/vscode/typings/vscode.tests.d.ts
@@ -130,6 +130,29 @@ declare module "vscode" {
     loadDetailedCoverage?: (testRun: TestRun, fileCoverage: FileCoverage, token: CancellationToken) => Thenable<FileCoverageDetail[]>;
 
     /**
+     * An extension-provided function that provides detailed statement and
+     * function-level coverage for a single test in a file. This is the per-test
+     * sibling of {@link TestRunProfile.loadDetailedCoverage}, called only if
+     * a test item is provided in {@link FileCoverage.includesTests} and only
+     * for files where such data is reported.
+     *
+     * Often {@link TestRunProfile.loadDetailedCoverage} will be called first
+     * when a user opens a file, and then this method will be called if they
+     * drill down into specific per-test coverage information. This method
+     * should then return coverage data only for statements and declarations
+     * executed by the specific test during the run.
+     *
+     * The {@link FileCoverage} object passed to this function is the same
+     * instance emitted on {@link TestRun.addCoverage} calls associated with this profile.
+     *
+     * @param testRun The test run that generated the coverage data.
+     * @param fileCoverage The file coverage object to load detailed coverage for.
+     * @param fromTestItem The test item to request coverage information for.
+     * @param token A cancellation token that indicates the operation should be cancelled.
+     */
+    loadDetailedCoverageForTest?: (testRun: TestRun, fileCoverage: FileCoverage, fromTestItem: TestItem, token: CancellationToken) => Thenable<FileCoverageDetail[]>;
+
+    /**
      * Deletes the run profile.
      */
     dispose(): void;
@@ -812,43 +835,6 @@ declare module "vscode" {
     Errored = 6
   }
   //#endregion
-
-  //#region Test Coverage
-
-  export interface TestRun {
-    /**
-     * Test coverage provider for this result. An extension can defer setting
-     * this until after a run is complete and coverage is available.
-     */
-    coverageProvider?: TestCoverageProvider
-    // ...
-  }
-
-  /**
-   * Provides information about test coverage for a test result.
-   * Methods on the provider will not be called until the test run is complete
-   */
-  export interface TestCoverageProvider<T extends FileCoverage = FileCoverage> {
-    /**
-     * Returns coverage information for all files involved in the test run.
-     * @param token A cancellation token.
-     * @return Coverage metadata for all files involved in the test.
-     */
-    provideFileCoverage(token: CancellationToken): ProviderResult<T[]>;
-
-    /**
-     * Give a FileCoverage to fill in more data, namely {@link FileCoverage.detailedCoverage}.
-     * The editor will only resolve a FileCoverage once, and onyl if detailedCoverage
-     * is undefined.
-     *
-     * @param coverage A coverage object obtained from {@link provideFileCoverage}
-     * @param token A cancellation token.
-     * @return The resolved file coverage, or a thenable that resolves to one. It
-     * is OK to return the given `coverage`. When no result is returned, the
-     * given `coverage` will be used.
-     */
-    resolveFileCoverage?(coverage: T, token: CancellationToken): ProviderResult<T>;
-  }
 
   /**
    * A class that contains information about a covered resource. A count can

--- a/packages/types/vscode/typings/vscode.tests.d.ts
+++ b/packages/types/vscode/typings/vscode.tests.d.ts
@@ -117,6 +117,18 @@ declare module "vscode" {
       request: TestRunRequest,
       token: CancellationToken
     ) => Thenable<void> | void;
+
+    /**
+     * An extension-provided function that provides detailed statement and
+     * function-level coverage for a file. The editor will call this when more
+     * detail is needed for a file, such as when it's opened in an editor or
+     * expanded in the **Test Coverage** view.
+     *
+     * The {@link FileCoverage} object passed to this function is the same instance
+     * emitted on {@link TestRun.addCoverage} calls associated with this profile.
+     */
+    loadDetailedCoverage?: (testRun: TestRun, fileCoverage: FileCoverage, token: CancellationToken) => Thenable<FileCoverageDetail[]>;
+
     /**
      * Deletes the run profile.
      */
@@ -411,11 +423,21 @@ declare module "vscode" {
      */
     appendOutput(output: string, location?: Location, test?: TestItem): void;
     /**
+     * Adds coverage for a file in the run.
+     */
+    addCoverage(fileCoverage: FileCoverage): void;
+    /**
      * Signals that the end of the test run. Any tests included in the run whose
      * states have not been updated will have their state reset.
      */
     end(): void;
+    /**
+     * An event fired when the editor is no longer interested in data
+     * associated with the test run.
+     */
+    onDidDispose: Event<void>;
   }
+
   /**
    * Collection of test items, found in {@link TestItem.children} and
    * {@link TestController.items}.


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
空实现 VSCode TestCoverage 相关 API

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 引入了多个与测试覆盖率和内联建议相关的新类和函数。
  - `TestRunProfile` 接口新增可选方法，允许提供详细的覆盖信息。
  - `TestRun` 接口新增 `addCoverage` 方法，用于追加文件的覆盖数据。

- **功能变更**
  - 移除了与覆盖率信号相关的方法，影响测试框架中的文件覆盖请求功能。
  - 更新了多个接口和类以增强类型安全性和一致性。

- **接口更新**
  - `ITestRunTask` 接口新增 `ctrlId` 属性，改进控制器标识功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->