### PR TITLE
fix: rename log service dispose

### DIFF
--- a/packages/logs-core/__tests__/browser/log.service.test.ts
+++ b/packages/logs-core/__tests__/browser/log.service.test.ts
@@ -13,13 +13,13 @@ import {
 
 @Injectable()
 class MockLogServiceForClient implements ILogServiceForClient {
-  dispose(namespace: SupportLogNamespace): void {}
+  async disposeLogger(namespace: SupportLogNamespace): Promise<void> {}
   async setGlobalLogLevel(level: LogLevel): Promise<void> {}
   getGlobalLogLevel(): Promise<LogLevel> {
     return Promise.resolve(LogLevel.Verbose);
   }
   async disposeAll(): Promise<void> {
-    this.dispose(this.namespace);
+    this.disposeLogger(this.namespace);
   }
   async getLogFolder(): Promise<string> {
     return '';

--- a/packages/logs-core/src/browser/log.service.ts
+++ b/packages/logs-core/src/browser/log.service.ts
@@ -126,6 +126,6 @@ export class LogServiceClient implements ILogServiceClient {
     if (!this.logServiceForClient) {
       return;
     }
-    await this.logServiceForClient.dispose(this.namespace);
+    await this.logServiceForClient.disposeLogger(this.namespace);
   }
 }

--- a/packages/logs-core/src/common/log-core.ts
+++ b/packages/logs-core/src/common/log-core.ts
@@ -13,7 +13,7 @@ export interface ILogServiceForClient {
   error(namespace: SupportLogNamespace, message: string, pid?: number): void;
   critical(namespace: SupportLogNamespace, message: string, pid?: number): void;
 
-  dispose(namespace: SupportLogNamespace): void;
+  disposeLogger(namespace: SupportLogNamespace): Promise<void>;
 
   setGlobalLogLevel(level: LogLevel): Promise<void>;
   getGlobalLogLevel(): Promise<LogLevel>;

--- a/packages/logs-core/src/node/log.service.ts
+++ b/packages/logs-core/src/node/log.service.ts
@@ -331,7 +331,7 @@ export class LogServiceForClient extends RPCService<IRPCLogService> implements I
     logger.sendLog(LogLevel.Critical, message);
   }
 
-  dispose(namespace: SupportLogNamespace) {
+  async disposeLogger(namespace: SupportLogNamespace) {
     this.getLogger(namespace).dispose();
   }
 

--- a/tools/dev-tool/src/injector-helper.ts
+++ b/tools/dev-tool/src/injector-helper.ts
@@ -85,7 +85,7 @@ class MockLogServiceForClient {
   async log() {}
   async error() {}
   async critical() {}
-  async dispose() {}
+  async disposeLogger() {}
   async disposeAll() {
     this.hasDisposeAll = true;
   }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
log service dispose 定义了一个参数 namespace，用于前端 dispose logger，但链接中断时 injector 会 dispose 所有实例，导致 namespace 为 undefiend，此时会创建一个路径为 undefiend 的日志文件

### Changelog
更改 dispose 为 disposeLogger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 日志服务的处理方法已更新为异步，增强了日志处理的灵活性和清晰度。
	- 日志级别设置方法现在支持异步操作，提供更强的控制流。
  
- **修复**
	- 处理日志的释放操作方法名称已更改，以更准确地反映其功能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->