### PR TITLE
feat: support VSCode API: DocumentDropEdit

### DIFF
--- a/packages/types/vscode/typings/vscode.d.ts
+++ b/packages/types/vscode/typings/vscode.d.ts
@@ -4581,26 +4581,46 @@ declare module 'vscode' {
   }
 
   /**
-	 * Provider which handles dropping of resources into a text editor.
-	 *
-	 * This allows users to drag and drop resources (including resources from external apps) into the editor. While dragging
-	 * and dropping files, users can hold down `shift` to drop the file into the editor instead of opening it.
-	 * Requires `editor.dropIntoEditor.enabled` to be on.
-	 */
-	export interface DocumentDropEditProvider {
-		/**
-		 * Provide edits which inserts the content being dragged and dropped into the document.
-		 *
-		 * @param document The document in which the drop occurred.
-		 * @param position The position in the document where the drop occurred.
-		 * @param dataTransfer A {@link DataTransfer} object that holds data about what is being dragged and dropped.
-		 * @param token A cancellation token.
-		 *
-		 * @returns A {@link DocumentDropEdit} or a thenable that resolves to such. The lack of a result can be
-		 * signaled by returning `undefined` or `null`.
-		 */
-		provideDocumentDropEdits(document: TextDocument, position: Position, dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentDropEdit>;
-	}
+   * An edit operation applied {@link DocumentDropEditProvider on drop}.
+   */
+  export class DocumentDropEdit {
+    /**
+     * The text or snippet to insert at the drop location.
+     */
+    insertText: string | SnippetString;
+
+    /**
+     * An optional additional edit to apply on drop.
+     */
+    additionalEdit?: WorkspaceEdit;
+
+    /**
+     * @param insertText The text or snippet to insert at the drop location.
+     */
+    constructor(insertText: string | SnippetString);
+  }
+
+  /**
+   * Provider which handles dropping of resources into a text editor.
+   *
+   * This allows users to drag and drop resources (including resources from external apps) into the editor. While dragging
+   * and dropping files, users can hold down `shift` to drop the file into the editor instead of opening it.
+   * Requires `editor.dropIntoEditor.enabled` to be on.
+   */
+  export interface DocumentDropEditProvider {
+    /**
+     * Provide edits which inserts the content being dragged and dropped into the document.
+     *
+     * @param document The document in which the drop occurred.
+     * @param position The position in the document where the drop occurred.
+     * @param dataTransfer A {@link DataTransfer} object that holds data about what is being dragged and dropped.
+     * @param token A cancellation token.
+     *
+     * @returns A {@link DocumentDropEdit} or a thenable that resolves to such. The lack of a result can be
+     * signaled by returning `undefined` or `null`.
+     */
+    provideDocumentDropEdits(document: TextDocument, position: Position, dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentDropEdit>;
+  }
 
   //#endregion Semantic Tokens
 

--- a/packages/types/vscode/typings/vscode.proposed.dropMetadata.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.dropMetadata.d.ts
@@ -30,13 +30,6 @@ declare module 'vscode' {
 		kind: DocumentPasteEditKind;
 
 		/**
-		 * The mime type from the {@link DataTransfer} that this edit applies.
-		 *
-		 * TODO: Should this be taken from `dropMimeTypes` instead?
-		 */
-		handledMimeType?: string;
-
-		/**
 		 * Controls the ordering or multiple paste edits. If this provider yield to edits, it will be shown lower in the list.
 		 */
 		yieldTo?: ReadonlyArray<DocumentPasteEditKind>;


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
相关代码在 https://github.com/opensumi/core/pull/4136 这里空实现了，这里补个类型

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了 `DocumentDropEdit` 类，用于处理文本编辑器中的拖放内容。
  - 更新了 `DocumentDropEditProvider` 接口，增加了 `provideDocumentDropEdits` 方法，以支持内容的拖放编辑。

- **变更**
  - 移除了 `DocumentDropEdit` 接口中的 `handledMimeType` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->