### PR TITLE
fix: immediately update with current component to handle initial badge

### DIFF
--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -214,13 +214,16 @@ export const IconTabView: React.FC<{ component: ComponentRegistryProvider }> = (
   }, [component]);
 
   useEffect(() => {
+    // Immediately update with current component to handle initial badge value
+    setComponent({ ...component });
+
     const dispose = component.onChange((newComponent) => {
       setComponent(newComponent);
     });
     return () => {
       dispose.dispose();
     };
-  }, []);
+  }, [component]); // Add component as dependency to re-run effect when it changes
 
   return (
     <div className={styles_icon_tab}>
@@ -246,12 +249,13 @@ export const TextTabView: React.FC<{ component: ComponentRegistryProvider }> = (
   const [component, setComponent] = React.useState<ComponentRegistryProvider>(defaultComponent);
   useEffect(() => {
     const dispose = component.onChange((newComponent) => {
-      setComponent(newComponent);
+      // Immediately update with current component to handle initial badge value
+      setComponent({ ...newComponent });
     });
     return () => {
       dispose.dispose();
     };
-  }, []);
+  }, [component]); // Add component as dependency to re-run effect when it changes
   return (
     <div className={styles.text_tab}>
       <div className={styles.bottom_tab_title}>{component.options?.title?.toUpperCase()}</div>


### PR DESCRIPTION
immediately update with current component to handle initial badge value

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

Fix the issue where the badge icon of the tab bar does not update when a change file appears.

![image](https://github.com/user-attachments/assets/a6c753a1-da56-42c0-b13f-b28ebfe3ef0a)


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了标签栏组件的状态管理，确保徽章值即时更新。
  - 增强了拖放事件的处理，提高了用户体验。

- **修复**
  - 优化了标签栏的可见性逻辑，以更好地响应状态变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->