### PR TITLE
feat: support VSCode API: TestMessage.stackTrace

### DIFF
--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1675,7 +1675,6 @@ export interface TestMessageStackFrameDTO {
 }
 
 export namespace TestMessageStackFrame {
-  // TestMessageStackFrameDTO
   export function from(stackTrace: vscode.TestMessageStackFrame): any {
     return {
       label: stackTrace.label,

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1,4 +1,3 @@
-import * as languageProtocol from 'vscode-languageserver-protocol';
 import { Position as P, Range as R, SymbolKind as S, SymbolInformation } from 'vscode-languageserver-types';
 
 import { IChatFollowup, IChatReplyFollowup, IChatResponseCommandFollowup } from '@opensumi/ide-ai-native/lib/common';
@@ -1669,17 +1668,17 @@ export namespace TestMessage {
 }
 
 export interface TestMessageStackFrameDTO {
-  uri?: languageProtocol.DocumentUri;
-  position?: languageProtocol.Position;
+  uri: Uri | undefined;
+  position: vscode.Position | undefined;
   label: string;
 }
 
 export namespace TestMessageStackFrame {
-  export function from(stackTrace: vscode.TestMessageStackFrame): any {
+  export function from(stackTrace: vscode.TestMessageStackFrame): TestMessageStackFrameDTO {
     return {
       label: stackTrace.label,
       position: stackTrace.position,
-      uri: stackTrace?.uri?.toString(),
+      uri: stackTrace?.uri,
     };
   }
 }

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1,3 +1,4 @@
+import * as languageProtocol from 'vscode-languageserver-protocol';
 import { Position as P, Range as R, SymbolKind as S, SymbolInformation } from 'vscode-languageserver-types';
 
 import { IChatFollowup, IChatReplyFollowup, IChatResponseCommandFollowup } from '@opensumi/ide-ai-native/lib/common';
@@ -1665,6 +1666,12 @@ export namespace TestMessage {
     message.location = item.location ? location.to(item.location) : undefined;
     return message;
   }
+}
+
+export interface TestMessageStackFrameDTO {
+  uri?: languageProtocol.DocumentUri;
+  position?: languageProtocol.Position;
+  label: string;
 }
 
 export namespace TestMessageStackFrame {

--- a/packages/extension/src/common/vscode/converter.ts
+++ b/packages/extension/src/common/vscode/converter.ts
@@ -1651,6 +1651,7 @@ export namespace TestMessage {
       actual: message.actualOutput,
       contextValue: message.contextValue,
       location: message.location ? (location.from(message.location) as any) : undefined,
+      stackTrace: message.stackTrace && message.stackTrace.map((frame) => TestMessageStackFrame.from(frame)),
     };
   }
 
@@ -1663,6 +1664,17 @@ export namespace TestMessage {
     message.contextValue = item.contextValue;
     message.location = item.location ? location.to(item.location) : undefined;
     return message;
+  }
+}
+
+export namespace TestMessageStackFrame {
+  // TestMessageStackFrameDTO
+  export function from(stackTrace: vscode.TestMessageStackFrame): any {
+    return {
+      label: stackTrace.label,
+      position: stackTrace.position,
+      uri: stackTrace?.uri?.toString(),
+    };
   }
 }
 

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -3431,6 +3431,7 @@ export class TestMessage implements vscode.TestMessage {
   public location?: vscode.Location;
   /** proposed: */
   public contextValue?: string;
+  public stackTrace?: vscode.TestMessageStackFrame[] | undefined;
 
   public static diff(message: string | vscode.MarkdownString, expected: string, actual: string) {
     const msg = new TestMessage(message);
@@ -3440,6 +3441,10 @@ export class TestMessage implements vscode.TestMessage {
   }
 
   constructor(public message: string | vscode.MarkdownString) {}
+}
+
+export class TestMessageStackFrame implements vscode.TestMessageStackFrame {
+  constructor(public label: string, public uri?: vscode.Uri, public position?: Position) {}
 }
 
 export class TestCoverageCount implements vscode.TestCoverageCount {

--- a/packages/testing/src/common/testCollection.ts
+++ b/packages/testing/src/common/testCollection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 // Some code copied and modified from https://github.com/microsoft/vscode/tree/main/src/vs/workbench/contrib/testing/common
 
-import { Emitter, IMarkdownString, IPosition, IRange, Uri as URI, map } from '@opensumi/ide-core-common';
+import { Emitter, IMarkdownString, IPosition, IRange, Position, Uri as URI, map } from '@opensumi/ide-core-common';
 
 export type TestsDiffOp =
   | [op: TestDiffOpType.Add, item: InternalTestItem]
@@ -152,6 +152,12 @@ export interface ILocationDto {
   range: IRange;
 }
 
+export interface ITestMessageStackFrame {
+  label: string;
+  uri: URI | undefined;
+  position: Position | undefined;
+}
+
 export interface ITestErrorMessage {
   message: string | IMarkdownString;
   type: TestMessageType.Error;
@@ -159,6 +165,7 @@ export interface ITestErrorMessage {
   actual: string | undefined;
   contextValue: string | undefined;
   location: IRichLocation | undefined;
+  stackTrace: undefined | ITestMessageStackFrame[];
 }
 
 export type SerializedTestErrorMessage = Omit<ITestErrorMessage, 'location'> & { location?: ILocationDto };

--- a/packages/testing/src/common/testCollection.ts
+++ b/packages/testing/src/common/testCollection.ts
@@ -6,6 +6,8 @@
 
 import { Emitter, IMarkdownString, IPosition, IRange, Position, Uri as URI, map } from '@opensumi/ide-core-common';
 
+import type vscode from 'vscode';
+
 export type TestsDiffOp =
   | [op: TestDiffOpType.Add, item: InternalTestItem]
   | [op: TestDiffOpType.Update, item: ITestItemUpdate]
@@ -155,7 +157,7 @@ export interface ILocationDto {
 export interface ITestMessageStackFrame {
   label: string;
   uri: URI | undefined;
-  position: Position | undefined;
+  position: vscode.Position | undefined;
 }
 
 export interface ITestErrorMessage {

--- a/packages/types/vscode/typings/vscode.tests.d.ts
+++ b/packages/types/vscode/typings/vscode.tests.d.ts
@@ -605,6 +605,33 @@ declare module "vscode" {
     invalidateResults(): void;
   }
   /**
+   * A stack frame found in the {@link TestMessage.stackTrace}.
+   */
+  export class TestMessageStackFrame {
+    /**
+     * The location of this stack frame. This should be provided as a URI if the
+     * location of the call frame can be accessed by the editor.
+     */
+    uri?: Uri;
+
+    /**
+     * Position of the stack frame within the file.
+     */
+    position?: Position;
+
+    /**
+     * The name of the stack frame, typically a method or function name.
+     */
+    label: string;
+
+    /**
+     * @param label The name of the stack frame
+     * @param file The file URI of the stack frame
+     * @param position The position of the stack frame within the file
+     */
+    constructor(label: string, uri?: Uri, position?: Position);
+  }
+  /**
    * Message associated with the test state. Can be linked to a specific
    * source range -- useful for assertion failures, for example.
    */
@@ -655,6 +682,10 @@ declare module "vscode" {
      * - `message`: the {@link TestMessage} instance.
      */
     contextValue?: string;
+    /**
+     * The stack trace associated with the message or failure.
+     */
+    stackTrace?: TestMessageStackFrame[];
     /**
      * Creates a new TestMessage that will present as a diff in the editor.
      * @param message Message to display to the user.


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了 `TestMessageStackFrame` 类，增强了测试消息的堆栈跟踪信息。
  - `TestMessage` 类新增了 `stackTrace` 属性，以包含详细的堆栈跟踪数据。
  - 新增接口 `ITestMessageStackFrame`，以支持堆栈跟踪的结构化表示。

- **文档**
  - 为新类及其属性添加了文档注释，以确保清晰的用途和用法说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->