### PR TITLE
fix: inline chat lower level than findwidget

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
-import { IAIInlineChatService, StackingLevelStr, useInjectable } from '@opensumi/ide-core-browser';
+import { IAIInlineChatService, StackingLevel, useInjectable } from '@opensumi/ide-core-browser';
 import { AIAction } from '@opensumi/ide-core-browser/lib/components/ai-native';
 import { InteractiveInput } from '@opensumi/ide-core-browser/lib/components/ai-native/interactive-input/index';
 import { MenuNode } from '@opensumi/ide-core-browser/lib/menu/next/base';
@@ -261,7 +261,7 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
   override getDomNode(): HTMLElement {
     const domNode = super.getDomNode();
     requestAnimationFrame(() => {
-      domNode.style.zIndex = StackingLevelStr.OverlayTop;
+      domNode.style.zIndex = (StackingLevel.FindWidget - 1).toString();
     });
     return domNode;
   }

--- a/packages/core-browser/src/design/rule.ts
+++ b/packages/core-browser/src/design/rule.ts
@@ -35,6 +35,11 @@ export const StackingLevel = Object.freeze({
 
   EditorFloatingContainer: 20,
 
+  /**
+   * Find 控件的 zIndex 是 25
+   */
+  FindWidget: 25,
+
   // #region 中级弹窗区域
   Popup: 100,
   // #endregion


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

### Changelog
修复 findWidget 部件被 inline chat 遮挡的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在堆叠级别中添加了新的 `FindWidget` 属性，z-index 值为 25，确保其在现有组件之上。
- **改动**
	- 更新了 `getDomNode()` 方法中的 z-index 计算方式，使用新的堆叠级别引用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->