### PR TITLE
fix: debug console enter invalid

### DIFF
--- a/packages/debug/src/browser/view/console/debug-console.contribution.ts
+++ b/packages/debug/src/browser/view/console/debug-console.contribution.ts
@@ -158,7 +158,6 @@ export class DebugConsoleContribution
       command: DEBUG_COMMANDS.CONSOLE_ENTER_EVALUATE.id,
       keybinding: 'enter',
       when: `${CONTEXT_IN_DEBUG_REPL.raw} && ${CONTEXT_IN_DEBUG_MODE.raw}`,
-      priority: 0,
     });
     bindings.registerKeybinding({
       command: DEBUG_COMMANDS.CONSOLE_INPUT_DOWN_ARROW.id,


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复调试控制台 enter 无效问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 调整了调试控制台的键绑定注册，优化了键绑定的执行顺序。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->