### PR TITLE
chore:  support editor hover preference

### DIFF
--- a/packages/editor/src/browser/preference/schema.ts
+++ b/packages/editor/src/browser/preference/schema.ts
@@ -198,7 +198,9 @@ export const EDITOR_DEFAULTS = {
     hover: {
       enabled: true,
       delay: 300,
+      hidingDelay: 300,
       sticky: true,
+      above: true,
     },
     links: true,
     contextmenu: true,
@@ -623,20 +625,6 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     minimum: 1,
     markdownDescription: '%editor.configuration.tabSize%',
   },
-  // 'editor.indentSize': {
-  // 	'anyOf': [
-  // 		{
-  // 			'type': 'string',
-  // 			'enum': ['tabSize']
-  // 		},
-  // 		{
-  // 			'type': 'number',
-  // 			'minimum': 1
-  // 		}
-  // 	],
-  // 	'default': 'tabSize',
-  // 	'markdownDescription': localize('indentSize', "The number of spaces used for indentation or 'tabSize' to use the value from `#editor.tabSize#`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.")
-  // },
   'editor.insertSpaces': {
     type: 'boolean',
     default: EDITOR_MODEL_DEFAULTS.insertSpaces,
@@ -694,6 +682,7 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
     default: EDITOR_DEFAULTS.viewInfo.minimap.maxColumn,
     description: '%editor.configuration.minimap.maxColumn%',
   },
+  // hover start
   'editor.hover.enabled': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.hover.enabled,
@@ -702,13 +691,24 @@ const monacoEditorSchema: PreferenceSchemaProperties = {
   'editor.hover.delay': {
     type: 'number',
     default: EDITOR_DEFAULTS.contribInfo.hover.delay,
-    description: localize('hover.delay', 'Controls the delay in milliseconds after which the hover is shown.'),
+    description: '%editor.configuration.hover.delay%',
   },
   'editor.hover.sticky': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.hover.sticky,
     description: '%editor.configuration.hover.sticky%',
   },
+  'editor.hover.hidingDelay': {
+    type: 'number',
+    default: EDITOR_DEFAULTS.contribInfo.hover.hidingDelay,
+    description: '%editor.configuration.hover.hidingDelay%',
+  },
+  'editor.hover.above': {
+    type: 'boolean',
+    default: EDITOR_DEFAULTS.contribInfo.hover.above,
+    description: '%editor.configuration.hover.above%',
+  },
+  // hover end
   'editor.find.seedSearchStringFromSelection': {
     type: 'boolean',
     default: EDITOR_DEFAULTS.contribInfo.find.seedSearchStringFromSelection,

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -681,6 +681,15 @@ export const localizationBundle = {
       'Show the inline suggestion toolbar when hovering over an inline suggestion.',
     'editor.configuration.inlineSuggest.showToolbar.never': 'Never show the inline suggestion toolbar.',
     // inlineSuggest end
+    // hover start
+    'editor.configuration.hover.enabled': 'Controls whether the hover is shown.',
+    'editor.configuration.hover.delay': 'Controls the delay in milliseconds after which the hover is shown.',
+    'editor.configuration.hover.sticky':
+      'Controls whether the hover should remain visible when mouse is moved over it.',
+    'editor.configuration.hover.hidingDelay':
+      'Controls the delay in milliseconds after which the hover is hidden. Requires `editor.hover.sticky` to be.',
+    'editor.configuration.hover.above': "Prefer showing hovers above the line, if there's space.",
+    // hover end
     'editor.configuration.experimental.stickyScroll':
       'Shows the nested current scopes during the scroll at the top of the editor.',
     'editor.configuration.customCodeActionMenu.showHeaders':
@@ -715,9 +724,6 @@ export const localizationBundle = {
       'Render the actual characters on a line as opposed to color blocks.',
     'editor.configuration.minimap.maxColumn':
       'Limit the width of the minimap to render at most a certain number of columns.',
-    'editor.configuration.hover.enabled': 'Controls whether the hover is shown.',
-    'editor.configuration.hover.sticky':
-      'Controls whether the hover should remain visible when mouse is moved over it.',
     'editor.configuration.find.seedSearchStringFromSelection':
       'Controls whether the search string in the Find Widget is seeded from the editor selection.',
     'editor.configuration.find.autoFindInSelection':

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1112,6 +1112,14 @@ export const localizationBundle = {
     'editor.configuration.inlineSuggest.showToolbar.onHover': '将鼠标悬停在内联建议上时显示内联建议工具栏。',
     'editor.configuration.inlineSuggest.showToolbar.never': '永不显示内联建议工具栏。',
     // inlineSuggest end
+    // hover start
+    'editor.configuration.hover.enabled': '控制是否在编辑器中启用代码提示。',
+    'editor.configuration.hover.delay': '控制代码提示显示的延迟时间（毫秒）。',
+    'editor.configuration.hover.sticky': '控制代码提示是否在鼠标悬停时保持可见。',
+    'editor.configuration.hover.hidingDelay':
+      '控制代码提示隐藏的延迟时间（毫秒）。需要 `editor.hover.sticky` 设置为 true 时生效。',
+    'editor.configuration.hover.above': '优先显示代码提示在行上方，如果行有空间。',
+    // hover end
     'editor.configuration.autoSave': '控制如何自动保存文件。',
     'editor.configuration.formatOnSave': '在保存时格式化文件',
     'editor.configuration.formatOnType': '控制编辑器是在键入后自动格式化该行。',

--- a/packages/preferences/src/browser/preference-settings.service.ts
+++ b/packages/preferences/src/browser/preference-settings.service.ts
@@ -691,6 +691,12 @@ export const defaultSettingSections: {
           id: 'editor.experimental.stickyScroll.enabled',
           localized: 'preference.editor.experimental.stickyScroll.enabled',
         },
+        // hover
+        { id: 'editor.hover.enabled' },
+        { id: 'editor.hover.delay' },
+        { id: 'editor.hover.sticky' },
+        { id: 'editor.hover.hidingDelay' },
+        { id: 'editor.hover.above' },
         // Guides
         { id: 'editor.guides.bracketPairs', localized: 'preference.editor.guides.bracketPairs' },
         { id: 'editor.guides.indentation', localized: 'preference.editor.guides.indentation' },


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

### Changelog
适配 editor hover 相关配置