### PR TITLE
style: improve inline diff partial edit

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.module.less
@@ -42,21 +42,30 @@
   .content {
     float: right;
     display: flex;
-    border-radius: 4px;
+    flex-direction: row;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
     overflow: hidden;
     margin-right: 12px;
     max-height: @line-height;
     height: @line-height;
     align-items: center;
+    opacity: 0.8;
   }
 
   .btn {
+    display: flex;
     pointer-events: auto;
     border: none;
-    font-size: 12px;
+    font-size: 10px;
     cursor: pointer;
     padding: 2px 6px;
-    height: @line-height;
+    align-items: center;
+    gap: 4px;
+
+    > span {
+      opacity: 1;
+    }
 
     &.accept_btn {
       background-color: var(--aiNative-inlineDiffAcceptPartialEdit);

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.component.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.component.tsx
@@ -5,7 +5,7 @@ import ReactDOMClient from 'react-dom/client';
 import { Autowired, Injectable } from '@opensumi/di';
 import { KeybindingRegistry, useDisposable } from '@opensumi/ide-core-browser';
 import { AI_INLINE_DIFF_PARTIAL_EDIT } from '@opensumi/ide-core-browser/lib/ai-native/command';
-import { Emitter, Event, IPosition, isDefined, isUndefined, uuid } from '@opensumi/ide-core-common';
+import { Emitter, Event, IPosition, isDefined, isUndefined, localize, uuid } from '@opensumi/ide-core-common';
 import {
   ICodeEditor,
   IEditorDecorationsCollection,
@@ -114,10 +114,12 @@ const PartialEditComponent = (props: {
     >
       <div className={styles.content}>
         <span className={cls(styles.accept_btn, styles.btn)} onClick={handleAccept}>
-          {keyStrings.acceptSequence}
+          {localize('aiNative.inline.diff.accept')}
+          <span>{keyStrings.acceptSequence}</span>
         </span>
         <span className={cls(styles.discard_btn, styles.btn)} onClick={handleDiscard}>
-          {keyStrings.discardSequence}
+          {localize('aiNative.inline.diff.reject')}
+          <span>{keyStrings.discardSequence}</span>
         </span>
       </div>
     </div>

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1457,8 +1457,9 @@ export const localizationBundle = {
     'aiNative.inline.chat.operate.loading.cancel': 'Esc to cancel',
     'aiNative.inline.chat.input.placeholder.default': 'Ask Copilot（shift + enter newline）',
     'aiNative.inline.hint.widget.placeholder': '{0} to inline chat',
-
     'aiNative.inline.problem.fix.title': 'Fix with AI',
+    'aiNative.inline.diff.accept': 'Accept',
+    'aiNative.inline.diff.reject': 'Reject',
 
     'aiNative.resolve.conflict.dialog.afresh': 'Are you sure you want to regenerate?',
     'aiNative.resolve.conflict.dialog.detection':

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1223,8 +1223,9 @@ export const localizationBundle = {
     'aiNative.inline.chat.operate.loading.cancel': '按 ESC 取消',
     'aiNative.inline.chat.input.placeholder.default': '可以问我任何问题，支持 shift + 回车换行',
     'aiNative.inline.hint.widget.placeholder': '按 {0} 唤起 Inline Chat',
-
     'aiNative.inline.problem.fix.title': 'AI 修复',
+    'aiNative.inline.diff.accept': '采纳',
+    'aiNative.inline.diff.reject': '拒绝',
 
     'aiNative.resolve.conflict.dialog.afresh': '你确定要重新生成吗？',
     'aiNative.resolve.conflict.dialog.detection':

--- a/packages/theme/src/common/color-tokens/ai-native.ts
+++ b/packages/theme/src/common/color-tokens/ai-native.ts
@@ -18,21 +18,21 @@ export const designInlineDiffRemovedRange = registerColor(
 
 export const designInlineDiffAcceptPartialEdit = registerColor(
   'aiNative.inlineDiffAcceptPartialEdit',
-  { dark: transparent(defaultInsertColor, 3), light: transparent(defaultInsertColor, 3), hcDark: null, hcLight: null },
+  { dark: '#89d185', light: '#89d185', hcDark: null, hcLight: null },
   '',
   true,
 );
 
 export const designInlineDiffAcceptPartialEditForeground = registerColor(
   'aiNative.inlineDiffAcceptPartialEdit.foreground',
-  { dark: '#fff', light: '#fff', hcDark: null, hcLight: null },
+  { dark: '#1f1f1f', light: '#1f1f1f', hcDark: null, hcLight: null },
   '',
   true,
 );
 
 export const designInlineDiffDiscardPartialEdit = registerColor(
   'aiNative.inlineDiffDiscardPartialEdit',
-  { dark: transparent(defaultRemoveColor, 3), light: transparent(defaultRemoveColor, 3), hcDark: null, hcLight: null },
+  { dark: '#f14c4c', light: '#f14c4c', hcDark: null, hcLight: null },
   '',
   true,
 );


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

before:
![image](https://github.com/user-attachments/assets/035da1c5-00a6-437b-930b-71d5fcb674e8)

after:
![image](https://github.com/user-attachments/assets/17d6749c-13d7-493f-89e1-c1256bb646fb)


### Changelog
改进 inline diff partial 样式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了本地化的按钮标签，支持接受和拒绝操作。
  
- **样式**
  - 更新了内联差异组件的样式，改善了视觉效果和布局。
  - 修改了内联差异的颜色定义，以增强视觉表现。

- **文档**
  - 更新了英文和中文的本地化文件，增加了接受和拒绝操作的翻译。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->