### PR TITLE
style: improve editor context  menu style

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -437,7 +437,6 @@ export namespace EDITOR_COMMANDS {
     id: 'editor.splitToRight',
     category: CATEGORY,
     label: '%editor.splitToRight%',
-    iconClass: getIcon('embed'),
   };
 
   export const SPLIT_TO_TOP: Command = {

--- a/packages/editor/src/browser/editor.contribution.ts
+++ b/packages/editor/src/browser/editor.contribution.ts
@@ -35,6 +35,7 @@ import {
   ServiceNames,
   URI,
   formatLocalize,
+  getIcon,
   getLanguageIdFromMonaco,
   localize,
 } from '@opensumi/ide-core-browser';
@@ -61,7 +62,6 @@ import {
   IDocPersistentCacheProvider,
   IEditor,
   ILanguageService,
-  IResource,
   IResourceOpenOptions,
   ResourceService,
   SaveReason,
@@ -1321,6 +1321,7 @@ export class EditorContribution
 
     menus.registerMenuItem(MenuId.EditorTitle, {
       command: EDITOR_COMMANDS.SPLIT_TO_RIGHT.id,
+      iconClass: getIcon('embed'),
       group: 'navigation',
       when: 'resource',
       order: 5,


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

Before
![image](https://github.com/user-attachments/assets/5822030e-6416-4656-b101-b44237d49ff6)

After
<img width="1425" alt="image" src="https://github.com/user-attachments/assets/9aed2e16-9065-4b21-b769-49f9e05ca182" />

独立为需要展示图标的区域添加图标，增强样式统一性

### Changelog

 improve editor context  menu style


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了`SPLIT_TO_RIGHT`命令的图标显示，增强了菜单项的视觉表现。
  
- **bug修复**
  - 移除了`SPLIT_TO_RIGHT`命令中的`iconClass`属性，命令调用时不再显示相关图标。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->