### PR TITLE
fix: debug stop render

### DIFF
--- a/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-toolbar.view.tsx
@@ -128,7 +128,7 @@ export const DebugToolbarView = (props: DebugToolbarViewProps) => {
         return (
           <DebugAction
             run={doStop}
-            enabled={autorunState !== DebugState.Inactive}
+            enabled={state !== DebugState.Inactive}
             icon={'disconnect'}
             label={localize('debug.action.disattach')}
           />
@@ -137,7 +137,7 @@ export const DebugToolbarView = (props: DebugToolbarViewProps) => {
       return (
         <DebugAction
           run={doStop}
-          enabled={autorunState !== DebugState.Inactive}
+          enabled={state !== DebugState.Inactive}
           icon={'stop'}
           label={localize('debug.action.stop')}
         />


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复 debug 的停止按钮不可用的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了调试工具栏的停止和继续操作的启用逻辑。
	- 改进了会话选择事件的处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->