### PR TITLE
fix: adjust the scope of the diffEditor.hideUnchangedRegions.enabled configuration to the user level

### DIFF
--- a/packages/editor/src/browser/diff/compare.ts
+++ b/packages/editor/src/browser/diff/compare.ts
@@ -7,6 +7,7 @@ import {
   Deferred,
   Domain,
   EDITOR_COMMANDS,
+  PreferenceScope,
   PreferenceService,
   URI,
   getIcon,
@@ -109,7 +110,7 @@ export class CompareEditorContribution implements MenuContribution, CommandContr
     commands.registerCommand(DIFF_EDITOR_COMMANDS.TOGGLE_COLLAPSE_UNCHANGED_REGIONS, {
       execute: () => {
         const enabled = this.preferenceService.get('diffEditor.hideUnchangedRegions.enabled');
-        this.preferenceService.set('diffEditor.hideUnchangedRegions.enabled', !enabled);
+        this.preferenceService.set('diffEditor.hideUnchangedRegions.enabled', !enabled, PreferenceScope.User);
       },
     });
   }


### PR DESCRIPTION
fix: adjust the scope of the diffEditor.hideUnchangedRegions.enabled configuration to the user level

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🪚 Refactors

### Background or solution

### Changelog

fix: adjust the scope of the diffEditor.hideUnchangedRegions.enabled configuration to the user level


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了用户范围的偏好设置选项，允许用户自定义“隐藏未更改区域”功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->