### PR TITLE
fix: quickopen auto focus previous active element

### DIFF
--- a/packages/addons/src/browser/file-search.contribution.ts
+++ b/packages/addons/src/browser/file-search.contribution.ts
@@ -250,7 +250,6 @@ export class FileSearchQuickCommandHandler {
       this.prevEditorState = {};
     }
     this.prevSelected = undefined;
-    this.commandService.executeCommand(EDITOR_COMMANDS.FOCUS.id);
     this.cancelIndicator.cancel();
   }
 

--- a/packages/quick-open/src/browser/prefix-quick-open.service.ts
+++ b/packages/quick-open/src/browser/prefix-quick-open.service.ts
@@ -19,7 +19,7 @@
 import React from 'react';
 
 import { Autowired, Injectable } from '@opensumi/di';
-import { QuickOpenActionProvider, localize } from '@opensumi/ide-core-browser';
+import { EDITOR_COMMANDS, QuickOpenActionProvider, localize } from '@opensumi/ide-core-browser';
 import { CorePreferences } from '@opensumi/ide-core-browser/lib/core-preferences';
 import {
   IQuickOpenHandlerRegistry,
@@ -31,7 +31,7 @@ import {
   QuickOpenTab,
   QuickOpenTabConfig,
 } from '@opensumi/ide-core-browser/lib/quick-open';
-import { Disposable, DisposableCollection, IDisposable, ILogger } from '@opensumi/ide-core-common';
+import { CommandService, Disposable, DisposableCollection, IDisposable, ILogger } from '@opensumi/ide-core-common';
 
 import { QuickOpenTabs } from './components/quick-open-tabs';
 import { QuickTitleBar } from './quick-title-bar';
@@ -155,7 +155,10 @@ export class PrefixQuickOpenServiceImpl implements PrefixQuickOpenService {
   protected readonly quickTitleBar: QuickTitleBar;
 
   @Autowired(CorePreferences)
-  private readonly corePreferences: CorePreferences;
+  protected readonly corePreferences: CorePreferences;
+
+  @Autowired(CommandService)
+  protected readonly commandService: CommandService;
 
   private activePrefix = '';
 
@@ -251,6 +254,7 @@ export class PrefixQuickOpenServiceImpl implements PrefixQuickOpenService {
         if (handler.onClose) {
           handler.onClose(canceled);
         }
+        this.commandService.executeCommand(EDITOR_COMMANDS.FOCUS.id);
       },
       renderTab: () =>
         React.createElement(QuickOpenTabs, {

--- a/packages/quick-open/src/browser/quick-open.command.service.ts
+++ b/packages/quick-open/src/browser/quick-open.command.service.ts
@@ -107,10 +107,6 @@ export class QuickCommandHandler implements QuickOpenHandler {
     };
   }
 
-  onClose() {
-    this.commandService.executeCommand(EDITOR_COMMANDS.FOCUS.id);
-  }
-
   private getItems() {
     const items: QuickOpenItem[] = [];
     const { recent, other } = this.getCommands();

--- a/packages/quick-open/src/browser/quick-open.help.service.ts
+++ b/packages/quick-open/src/browser/quick-open.help.service.ts
@@ -52,10 +52,6 @@ export class HelpQuickOpenHandler implements QuickOpenHandler {
     return {};
   }
 
-  onClose() {
-    this.commandService.executeCommand(EDITOR_COMMANDS.FOCUS.id);
-  }
-
   protected comparePrefix(a: string, b: string): number {
     return a.toLowerCase().localeCompare(b.toLowerCase());
   }

--- a/packages/quick-open/src/browser/quick-open.service.tsx
+++ b/packages/quick-open/src/browser/quick-open.service.tsx
@@ -55,7 +55,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
   protected _widget: QuickOpenWidget | undefined;
   protected opts: KaitianQuickOpenControllerOpts;
   protected container: HTMLElement;
-  protected previousActiveElement: Element | undefined;
+  protected previousActiveElement: Element | undefined | null;
 
   @Autowired(KeybindingRegistry)
   protected keybindingRegistry: KeybindingRegistry;
@@ -103,6 +103,7 @@ export class MonacoQuickOpenService implements QuickOpenService {
   }
 
   open(model: IKaitianQuickOpenModel, options?: Partial<QuickOpenOptions.Resolved> | undefined): void {
+    this.previousActiveElement = document.activeElement;
     const opts = new KaitianQuickOpenControllerOpts(model, this.keybindingRegistry, options);
     this.progressDispose = this.progressService.registerProgressIndicator(VIEW_CONTAINERS.QUICKPICK_PROGRESS);
     this.hideDecoration();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

fixed #4271

### Changelog
fix: quickopen auto focus previous active element


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 修改了快速打开界面的关闭行为，取消了自动聚焦编辑器的功能。
	- 更新了快速打开服务中活动元素的处理方式，允许其显式为null。
	- 在处理程序关闭时，增强了与编辑器聚焦的交互流程。

- **Bug 修复**
	- 移除了多个类中的关闭方法，简化了关闭命令面板时的控制流。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->