### PR TITLE
chore: enable local worker file in development mode

### DIFF
--- a/packages/express-file-server/src/node/express-file-server.contribution.ts
+++ b/packages/express-file-server/src/node/express-file-server.contribution.ts
@@ -30,6 +30,18 @@ export class ExpressFileServerContribution implements ServerAppContribution {
           return;
         }
 
+        if (process.env.NODE_ENV === 'development' && uriPath.startsWith('/monaco/worker')) {
+          const filePath = path.resolve(__dirname, `../../../${uriPath}`);
+          const contentType = ALLOW_MIME[path.extname(filePath).slice(1)];
+          if (!contentType) {
+            ctx.status = 404;
+            return;
+          }
+          ctx.set('Content-Type', contentType);
+          ctx.body = fs.createReadStream(filePath);
+          return;
+        }
+
         const filePath = URI.parse(`file://${uriPath}`).codeUri.fsPath;
         const whitelist = this.getWhiteList();
         const contentType = ALLOW_MIME[path.extname(filePath).slice(1)];

--- a/packages/monaco/src/browser/monaco.contribution.ts
+++ b/packages/monaco/src/browser/monaco.contribution.ts
@@ -301,7 +301,17 @@ export class MonacoClientContribution
     };
 
     const getWorker = (moduleId, label) => {
-      const url = getWorkerUrl(moduleId, label);
+      let url: string;
+
+      /**
+       * 开发模式下，直接使用本地文件
+       */
+      if (process.env.NODE_ENV === 'development') {
+        url = 'assets/monaco/worker/editor.worker.bundle.js';
+      } else {
+        url = getWorkerUrl(moduleId, label);
+      }
+
       /**
        * monaco 0.53 版本开始，创建 worker 线程时都指定了 type 为 module，而我们模块格式不兼容
        * 所以需要覆写 getWorker 函数，手动创建 worker 线程


### PR DESCRIPTION
### Types

- [x] 🧹 Chores


### Background or solution

### Changelog
开发模式下直接加载本地的 monaco worker 文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在开发模式下，添加了对Monaco工作者的本地文件路径支持。
  - 增强了文件服务逻辑，支持开发模式下的特定请求处理。

- **类型安全**
  - 增强了`getWorker`和`getWorkerUrl`方法的类型安全，明确声明了`url`变量的类型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->