### PR TITLE
feat: support VSCode API: Workspace.save and Workspace.saveAs

### DIFF
--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -285,7 +285,7 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
   }
 
   async saveAs(uri: URI): Promise<URI | undefined> {
-    if (!this._currentEditorGroup) {
+    if (!this._currentEditorGroup || this._currentEditorGroup.currentResource?.deleted) {
       return undefined;
     }
 

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -267,7 +267,7 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
   }
 
   async saveAs(uri: URI): Promise<URI | undefined> {
-    if (this._currentEditorGroup) {
+    if (this._currentEditorGroup && uri) {
       const defaultPath = uri.path.toString() !== '/' ? path.dirname(uri.path.toString()) : this.appConfig.workspaceDir;
       const result = await this.windowDialogService.showSaveDialog({
         saveLabel: 'SaveAs File:',

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -261,22 +261,22 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
   }
 
   async save(uri: URI): Promise<URI | undefined> {
-    if (!this.editorGroups.length || !uri) {
+    if (!this.editorGroups.length) {
       return undefined;
     }
 
-    for (const editorGroup of this.editorGroups) {
-      const res = editorGroup.resources.find((resource) => {
-        if (resource.uri.isEqual(uri)) {
-          return resource;
+    try {
+      for (const editorGroup of this.editorGroups) {
+        const res = editorGroup.resources.find((resource) => resource.uri.isEqual(uri));
+        if (res) {
+          await editorGroup.saveResource(res);
         }
-      });
-      if (res) {
-        editorGroup.saveResource(res);
       }
-    }
 
-    return uri;
+      return uri;
+    } catch (error) {
+      throw new Error(`Save Failed: ${error.message}`);
+    }
   }
 
   private getDefaultSavePath(uri: URI): string {
@@ -285,7 +285,7 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
   }
 
   async saveAs(uri: URI): Promise<URI | undefined> {
-    if (!this._currentEditorGroup || !uri) {
+    if (!this._currentEditorGroup) {
       return undefined;
     }
 

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -260,9 +260,16 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
     return documents;
   }
 
-  async save() {
-    if (this._currentEditorGroup) {
-      await this._currentEditorGroup.saveCurrent();
+  async save(uri: URI) {
+    for (const editorGroup of this.editorGroups) {
+      const res = editorGroup.resources.find((resource) => {
+        if (resource.uri.isEqual(uri)) {
+          return resource;
+        }
+      });
+      if (res) {
+        editorGroup.saveResource(res);
+      }
     }
   }
 

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -266,17 +266,28 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
     }
   }
 
+  private getDefaultSavePath(uri: URI): string {
+    const defaultPath = uri.path.toString() !== '/' ? path.dirname(uri.path.toString()) : this.appConfig.workspaceDir;
+    return isWindows ? defaultPath.replace(/\\/g, '/') : defaultPath;
+  }
+
   async saveAs(uri: URI): Promise<URI | undefined> {
-    if (this._currentEditorGroup && uri) {
-      const defaultPath = uri.path.toString() !== '/' ? path.dirname(uri.path.toString()) : this.appConfig.workspaceDir;
+    if (!this._currentEditorGroup || !uri) {
+      return undefined;
+    }
+
+    try {
+      const defaultPath = this.getDefaultSavePath(uri);
       const result = await this.windowDialogService.showSaveDialog({
         saveLabel: 'SaveAs File:',
         showNameInput: true,
         defaultFileName: this._currentEditorGroup.currentResource?.name,
-        defaultUri: URI.file(isWindows ? defaultPath.replaceAll('\\', '/') : defaultPath),
+        defaultUri: URI.file(defaultPath),
         saveAs: true,
       });
       return result;
+    } catch (error) {
+      throw new Error(`SaveAs Failed: ${error.message}`);
     }
   }
 

--- a/packages/editor/src/browser/workbench-editor.service.ts
+++ b/packages/editor/src/browser/workbench-editor.service.ts
@@ -260,7 +260,11 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
     return documents;
   }
 
-  async save(uri: URI) {
+  async save(uri: URI): Promise<URI | undefined> {
+    if (!this.editorGroups.length || !uri) {
+      return undefined;
+    }
+
     for (const editorGroup of this.editorGroups) {
       const res = editorGroup.resources.find((resource) => {
         if (resource.uri.isEqual(uri)) {
@@ -271,6 +275,8 @@ export class WorkbenchEditorServiceImpl extends WithEventBus implements Workbenc
         editorGroup.saveResource(res);
       }
     }
+
+    return uri;
   }
 
   private getDefaultSavePath(uri: URI): string {

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -549,14 +549,8 @@ export abstract class WorkbenchEditorService {
    */
   abstract openUris(uri: URI[]): Promise<void>;
 
-  /**
-   * 保存
-   */
   abstract save(): Promise<void>;
 
-  /**
-   * 保存
-   */
   abstract saveAs(uri: URI): Promise<URI | undefined>;
 
   /**

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -549,7 +549,7 @@ export abstract class WorkbenchEditorService {
    */
   abstract openUris(uri: URI[]): Promise<void>;
 
-  abstract save(uri: URI): Promise<void>;
+  abstract save(uri: URI): Promise<URI | undefined>;
 
   abstract saveAs(uri: URI): Promise<URI | undefined>;
 

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -549,7 +549,7 @@ export abstract class WorkbenchEditorService {
    */
   abstract openUris(uri: URI[]): Promise<void>;
 
-  abstract save(): Promise<void>;
+  abstract save(uri: URI): Promise<void>;
 
   abstract saveAs(uri: URI): Promise<URI | undefined>;
 

--- a/packages/editor/src/common/editor.ts
+++ b/packages/editor/src/common/editor.ts
@@ -550,6 +550,16 @@ export abstract class WorkbenchEditorService {
   abstract openUris(uri: URI[]): Promise<void>;
 
   /**
+   * 保存
+   */
+  abstract save(): Promise<void>;
+
+  /**
+   * 保存
+   */
+  abstract saveAs(uri: URI): Promise<URI | undefined>;
+
+  /**
    * 保存全部
    * @param includeUntitled 是否对新文件进行保存询问, 默认false
    */

--- a/packages/editor/src/common/mocks/workbench-editor.service.ts
+++ b/packages/editor/src/common/mocks/workbench-editor.service.ts
@@ -31,7 +31,7 @@ export class MockWorkbenchEditorService extends WorkbenchEditorService {
     throw new Error('Method not implemented.');
   }
 
-  save(): Promise<void> {
+  save(uri: URI): Promise<URI | undefined> {
     throw new Error('Method not implemented.');
   }
 

--- a/packages/editor/src/common/mocks/workbench-editor.service.ts
+++ b/packages/editor/src/common/mocks/workbench-editor.service.ts
@@ -31,6 +31,14 @@ export class MockWorkbenchEditorService extends WorkbenchEditorService {
     throw new Error('Method not implemented.');
   }
 
+  save(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
+  saveAs(uri: URI): Promise<URI | undefined> {
+    throw new Error('Method not implemented.');
+  }
+
   saveAll(includeUntitled?: boolean): Promise<void> {
     throw new Error('Method not implemented.');
   }

--- a/packages/extension/__tests__/browser/extension-service/extension-service-mock-helper.ts
+++ b/packages/extension/__tests__/browser/extension-service/extension-service-mock-helper.ts
@@ -332,7 +332,7 @@ class MockWorkbenchEditorService implements WorkbenchEditorService {
   openUris(uri: URI[]): Promise<void> {
     throw new Error('Method not implemented.');
   }
-  save(): Promise<void> {
+  save(uri: URI): Promise<URI | undefined> {
     throw new Error('Method not implemented.');
   }
   saveAs(uri: URI): Promise<URI | undefined> {

--- a/packages/extension/__tests__/browser/extension-service/extension-service-mock-helper.ts
+++ b/packages/extension/__tests__/browser/extension-service/extension-service-mock-helper.ts
@@ -332,6 +332,12 @@ class MockWorkbenchEditorService implements WorkbenchEditorService {
   openUris(uri: URI[]): Promise<void> {
     throw new Error('Method not implemented.');
   }
+  save(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  saveAs(uri: URI): Promise<URI | undefined> {
+    throw new Error('Method not implemented.');
+  }
   saveAll(includeUntitled?: boolean | undefined): Promise<void> {
     throw new Error('Method not implemented.');
   }

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -128,20 +128,28 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
   }
 
   async $save(uri: URI): Promise<URI | undefined> {
+    if (!uri) {
+      return undefined;
+    }
+
     try {
       const saveUri = URI.file(uri.path.toString());
       return await this.editorService.save(saveUri);
     } catch (error) {
-      this.logger.error(error);
+      this.logger.error(`Save Failed: ${error.message}`);
       return undefined;
     }
   }
 
   async $saveAs(uri: URI): Promise<URI | undefined> {
+    if (!uri) {
+      return undefined;
+    }
+
     try {
       return await this.editorService.saveAs(uri);
     } catch (error) {
-      this.logger.error(error);
+      this.logger.error(`SaveAs Failed: ${error.message}`);
       return undefined;
     }
   }

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -127,6 +127,25 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
     }
   }
 
+  async $save(uri: URI): Promise<URI | undefined> {
+    try {
+      await this.editorService.save();
+      return uri;
+    } catch (error) {
+      this.logger.error(error);
+      return undefined;
+    }
+  }
+
+  async $saveAs(uri: URI): Promise<URI | undefined> {
+    try {
+      return await this.editorService.saveAs(uri);
+    } catch (error) {
+      this.logger.error(error);
+      return undefined;
+    }
+  }
+
   async $saveAll(): Promise<boolean> {
     try {
       await this.editorService.saveAll();

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -129,7 +129,8 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
 
   async $save(uri: URI): Promise<URI | undefined> {
     try {
-      await this.editorService.save();
+      const saveUri = URI.file(uri.path.toString());
+      await this.editorService.save(saveUri);
       return uri;
     } catch (error) {
       this.logger.error(error);

--- a/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.workspace.ts
@@ -130,8 +130,7 @@ export class MainThreadWorkspace extends WithEventBus implements IMainThreadWork
   async $save(uri: URI): Promise<URI | undefined> {
     try {
       const saveUri = URI.file(uri.path.toString());
-      await this.editorService.save(saveUri);
-      return uri;
+      return await this.editorService.save(saveUri);
     } catch (error) {
       this.logger.error(error);
       return undefined;

--- a/packages/extension/src/common/vscode/workspace.ts
+++ b/packages/extension/src/common/vscode/workspace.ts
@@ -11,6 +11,8 @@ import type { EndOfLineSequence } from '@opensumi/ide-monaco/lib/browser/monaco-
 import type vscode from 'vscode';
 
 export interface IMainThreadWorkspace extends IDisposable {
+  $save(uri: URI): Promise<URI | undefined>;
+  $saveAs(uri: URI): Promise<URI | undefined>;
   $saveAll(): Promise<boolean>;
   $tryApplyWorkspaceEdit(dto: model.WorkspaceEditDto, metadata?: model.WorkspaceEditMetadataDto): Promise<boolean>;
   $updateWorkspaceFolders(

--- a/packages/extension/src/hosted/api/vscode/ext.host.workspace.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.workspace.ts
@@ -1,5 +1,14 @@
 import { IRPCProtocol } from '@opensumi/ide-connection';
-import { CancellationToken, Emitter, Event, MessageType, Schemes, path, toDisposable } from '@opensumi/ide-core-common';
+import {
+  CancellationToken,
+  Emitter,
+  Event,
+  MessageType,
+  Schemes,
+  URI,
+  path,
+  toDisposable,
+} from '@opensumi/ide-core-common';
 import { FileStat } from '@opensumi/ide-file-service';
 
 import {
@@ -118,6 +127,8 @@ export function createWorkspaceApiFactory(
       disposables?: vscode.Disposable[],
     ) => extHostFileSystemEvent.getOnWillRenameFileEvent(extension)(listener, thisArg, disposables),
     onDidRenameFile: extHostWorkspace.onDidRenameFile,
+    save: (uri) => extHostWorkspace.save(uri),
+    saveAs: (uri) => extHostWorkspace.saveAs(uri),
     saveAll: () => extHostWorkspace.saveAll(),
     findFiles: (include, exclude, maxResults?, token?) =>
       extHostWorkspace.findFiles(
@@ -408,6 +419,14 @@ export class ExtHostWorkspace implements IExtHostWorkspace {
   applyEdit(edit: WorkspaceEdit, metadata?: vscode.WorkspaceEditMetadata): Promise<boolean> {
     const dto = TypeConverts.WorkspaceEdit.from(edit, this.extHostDoc);
     return this.proxy.$tryApplyWorkspaceEdit(dto, metadata);
+  }
+
+  save(uri: URI): Promise<URI | undefined> {
+    return this.proxy.$save(uri);
+  }
+
+  saveAs(uri: URI): Promise<URI | undefined> {
+    return this.proxy.$saveAs(uri);
   }
 
   saveAll(): Promise<boolean> {

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
@@ -4,11 +4,15 @@ import { Schemes, URI } from '@opensumi/ide-core-browser';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileStat, IFileServiceClient } from '@opensumi/ide-file-service';
+import { EditorFile } from '@opensumi/ide-opened-editor/lib/browser/opened-editor-node.define';
+import { OpenedEditorModelService } from '@opensumi/ide-opened-editor/lib/browser/services/opened-editor-model.service';
+import { OpenedEditorService } from '@opensumi/ide-opened-editor/lib/browser/services/opened-editor-tree.service';
 import { IDialogService } from '@opensumi/ide-overlay';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
-import { IFileTreeAPI } from '../../common';
+import { IFileTreeAPI, IFileTreeService } from '../../common';
 import { Directory } from '../../common/file-tree-node.define';
+import { FileTreeService } from '../file-tree.service';
 import { FileTreeModelService } from '../services/file-tree-model.service';
 
 import { FileDialogContextKey } from './file-dialog.contextkey';
@@ -38,6 +42,12 @@ export class FileTreeDialogService extends Tree {
 
   @Autowired(FileTreeModelService)
   protected fileTreeModelService: FileTreeModelService;
+
+  @Autowired(OpenedEditorModelService)
+  private readonly openedEditorModelService: OpenedEditorModelService;
+
+  @Autowired(OpenedEditorService)
+  private readonly openedEditorService: OpenedEditorService;
 
   private workspaceRoot: FileStat;
 
@@ -155,9 +165,12 @@ export class FileTreeDialogService extends Tree {
         focus: true,
         replace: true,
         forceClose: true,
+        disableNavigate: false,
       };
       await this.workbenchEditorService.open(openUri, EDITOR_OPTIONS);
-      this.fileTreeModelService.handleTreeFocus();
+      let node = this.openedEditorService.getEditorNodeByUri(openUri, this.workbenchEditorService.currentEditorGroup);
+      await this.fileTreeModelService.clearFileSelectedDecoration();
+      await this.openedEditorModelService.activeFileActivedDecoration(node as EditorFile);
     } catch (error) {
       throw new Error(`Failed to open saveAs file: ${error.message}`);
     }

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
@@ -4,9 +4,6 @@ import { Schemes, URI } from '@opensumi/ide-core-browser';
 import { LabelService } from '@opensumi/ide-core-browser/lib/services';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileStat, IFileServiceClient } from '@opensumi/ide-file-service';
-import { EditorFile } from '@opensumi/ide-opened-editor/lib/browser/opened-editor-node.define';
-import { OpenedEditorModelService } from '@opensumi/ide-opened-editor/lib/browser/services/opened-editor-model.service';
-import { OpenedEditorService } from '@opensumi/ide-opened-editor/lib/browser/services/opened-editor-tree.service';
 import { IDialogService } from '@opensumi/ide-overlay';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
@@ -43,11 +40,8 @@ export class FileTreeDialogService extends Tree {
   @Autowired(FileTreeModelService)
   protected fileTreeModelService: FileTreeModelService;
 
-  @Autowired(OpenedEditorModelService)
-  private readonly openedEditorModelService: OpenedEditorModelService;
-
-  @Autowired(OpenedEditorService)
-  private readonly openedEditorService: OpenedEditorService;
+  @Autowired(IFileTreeService)
+  private readonly fileTreeService: FileTreeService;
 
   private workspaceRoot: FileStat;
 
@@ -168,9 +162,11 @@ export class FileTreeDialogService extends Tree {
         disableNavigate: false,
       };
       await this.workbenchEditorService.open(openUri, EDITOR_OPTIONS);
-      let node = this.openedEditorService.getEditorNodeByUri(openUri, this.workbenchEditorService.currentEditorGroup);
       await this.fileTreeModelService.clearFileSelectedDecoration();
-      await this.openedEditorModelService.activeFileActivedDecoration(node as EditorFile);
+      const file = this.fileTreeService.getNodeByPathOrUri(openUri);
+      if (file) {
+        await this.fileTreeModelService.activeFileDecoration(file);
+      }
     } catch (error) {
       throw new Error(`Failed to open saveAs file: ${error.message}`);
     }

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.service.ts
@@ -9,6 +9,7 @@ import { IWorkspaceService } from '@opensumi/ide-workspace';
 
 import { IFileTreeAPI } from '../../common';
 import { Directory } from '../../common/file-tree-node.define';
+import { FileTreeModelService } from '../services/file-tree-model.service';
 
 import { FileDialogContextKey } from './file-dialog.contextkey';
 
@@ -34,6 +35,9 @@ export class FileTreeDialogService extends Tree {
 
   @Autowired(IDialogService)
   protected dialogService: IDialogService;
+
+  @Autowired(FileTreeModelService)
+  protected fileTreeModelService: FileTreeModelService;
 
   private workspaceRoot: FileStat;
 
@@ -153,6 +157,7 @@ export class FileTreeDialogService extends Tree {
         forceClose: true,
       };
       await this.workbenchEditorService.open(openUri, EDITOR_OPTIONS);
+      this.fileTreeModelService.handleTreeFocus();
     } catch (error) {
       throw new Error(`Failed to open saveAs file: ${error.message}`);
     }

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
@@ -72,6 +72,13 @@ export const FileDialog = ({
     // 如果有文件名的，说明肯定是保存文件的情况
     if (fileName && (options as ISaveDialogOptions).showNameInput && (value?.length === 1 || options.defaultUri)) {
       const filePath = value?.length === 1 ? value[0] : options.defaultUri!.path.toString();
+      if ((options as ISaveDialogOptions & { saveAs?: boolean | undefined })?.saveAs) {
+        fileService.saveAs({
+          oldFilePath: path.join(filePath!, (options as ISaveDialogOptions)?.defaultFileName || ''),
+          newFilePath: path.join(filePath!, fileName),
+        });
+      }
+
       dialogService.hide([path.join(filePath!, fileName)]);
     } else {
       if (value.length > 0) {

--- a/packages/overlay/src/common/index.ts
+++ b/packages/overlay/src/common/index.ts
@@ -92,7 +92,7 @@ export abstract class AbstractMessageService implements IMessageService {
 
 export interface IWindowDialogService {
   showOpenDialog(options?: IOpenDialogOptions): Promise<URI[] | undefined>;
-  showSaveDialog(options?: ISaveDialogOptions): Promise<URI | undefined>;
+  showSaveDialog(options?: ISaveDialogOptions & { saveAs?: boolean }): Promise<URI | undefined>;
 }
 
 export const IWindowDialogService = Symbol('IWindowDialogService');

--- a/packages/types/vscode/typings/vscode.workspace.d.ts
+++ b/packages/types/vscode/typings/vscode.workspace.d.ts
@@ -404,6 +404,29 @@ declare module 'vscode' {
      */
     export function updateWorkspaceFolders(start: number, deleteCount: number | undefined | null, ...workspaceFoldersToAdd: { uri: Uri, name?: string }[]): boolean;
 
+		/**
+		 * Saves the editor identified by the given resource and returns the resulting resource or `undefined`
+		 * if save was not successful or no editor with the given resource was found.
+		 *
+		 * **Note** that an editor with the provided resource must be opened in order to be saved.
+		 *
+		 * @param uri the associated uri for the opened editor to save.
+		 * @returns A thenable that resolves when the save operation has finished.
+		 */
+		export function save(uri: Uri): Thenable<Uri | undefined>;
+
+		/**
+		 * Saves the editor identified by the given resource to a new file name as provided by the user and
+		 * returns the resulting resource or `undefined` if save was not successful or cancelled or no editor
+		 * with the given resource was found.
+		 *
+		 * **Note** that an editor with the provided resource must be opened in order to be saved as.
+		 *
+		 * @param uri the associated uri for the opened editor to save as.
+		 * @returns A thenable that resolves when the save-as operation has finished.
+		 */
+		export function saveAs(uri: Uri): Thenable<Uri | undefined>;
+
     /**
      * Save all dirty files.
      *


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了文件保存功能，包括 `save` 和 `saveAs` 方法，允许用户保存当前编辑器状态或指定新文件名。
  - 文件对话框服务增强，支持用户通过对话框选择文件保存位置和名称。
  - 增加了工作区 API 中的保存方法，提升了文件管理能力。
  - 更新了窗口对话框服务，支持选择是否以新文件名保存。
  - 增加了对文件创建的支持，允许用户在指定路径下创建新文件。

- **文档**
  - 更新了接口和命名空间，增加了与文件保存相关的新方法。

- **修复**
  - 改进了错误处理和日志记录功能，以确保保存操作的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- **演示**

https://github.com/user-attachments/assets/ac4abee1-e8d7-473b-9ff0-9acd3fb60801

