### PR TITLE
fix: ai layout right tabbar render

### DIFF
--- a/packages/ai-native/src/browser/layout/ai-layout.tsx
+++ b/packages/ai-native/src/browser/layout/ai-layout.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import { SlotRenderer } from '@opensumi/ide-core-browser';
+import { SlotRenderer, useInjectable } from '@opensumi/ide-core-browser';
 import { BoxPanel, SplitPanel, getStorageValue } from '@opensumi/ide-core-browser/lib/components';
+import { DesignLayoutConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
 
 import { AI_CHAT_VIEW_ID } from '../../common';
 
 export const AILayout = () => {
   const { layout } = getStorageValue();
+  const designLayoutConfig = useInjectable(DesignLayoutConfig);
+
+  const defaultRightSize = useMemo(() => designLayoutConfig.useMergeRightWithLeftPanel ? 0 : 49, [designLayoutConfig.useMergeRightWithLeftPanel]);
 
   return (
     <BoxPanel direction='top-to-bottom'>
@@ -44,9 +48,9 @@ export const AILayout = () => {
           <SlotRenderer
             slot='right'
             isTabbar={true}
-            defaultSize={layout.right?.currentId ? layout.right?.size || 360 : 49}
+            defaultSize={layout.right?.currentId ? layout.right?.size || 360 : defaultRightSize}
             minResize={280}
-            minSize={49}
+            minSize={defaultRightSize}
           />
         </SplitPanel>
         <SlotRenderer

--- a/packages/ai-native/src/browser/layout/ai-layout.tsx
+++ b/packages/ai-native/src/browser/layout/ai-layout.tsx
@@ -44,10 +44,9 @@ export const AILayout = () => {
           <SlotRenderer
             slot='right'
             isTabbar={true}
-            defaultSize={layout.right?.currentId ? layout.right?.size || 360 : 0}
-            maxResize={360}
+            defaultSize={layout.right?.currentId ? layout.right?.size || 360 : 49}
             minResize={280}
-            minSize={0}
+            minSize={49}
           />
         </SplitPanel>
         <SlotRenderer


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

### Changelog
修复 right tabbar 不显示的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **布局调整**
	- 修改了右侧插槽和AI聊天插槽的默认尺寸和最小尺寸
	- 将某些布局组件的最小尺寸从0调整为49
	- 优化了布局的响应性和可用性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->