### PR TITLE
feat: improve inlineChat and inlineEditInput UX

### DIFF
--- a/packages/ai-native/src/browser/languages/parser.ts
+++ b/packages/ai-native/src/browser/languages/parser.ts
@@ -4,7 +4,7 @@ import { Autowired, Injectable } from '@opensumi/di';
 import * as monaco from '@opensumi/ide-monaco/lib/common';
 import { Deferred, IDisposable, LRUCache } from '@opensumi/ide-utils';
 
-import { INearestCodeBlock } from '../../common/types';
+import { INearestCodeBlock, NearestCodeBlockType } from '../../common/types';
 
 import { toMonacoRange } from './tree-sitter/common';
 import { SupportedTreeSitterLanguages, TreeSitterLanguageFacts } from './tree-sitter/language-facts';
@@ -462,7 +462,10 @@ export class LanguageParser implements IDisposable {
           },
         },
         offset,
-        type: selectedNode.type,
+        type:
+          selectedNode.startPosition.row === selectedNode.endPosition.row
+            ? NearestCodeBlockType.Line
+            : NearestCodeBlockType.Block,
       };
     }
     return null;

--- a/packages/ai-native/src/browser/languages/parser.ts
+++ b/packages/ai-native/src/browser/languages/parser.ts
@@ -408,14 +408,28 @@ export class LanguageParser implements IDisposable {
     }
 
     let errorCount = 0;
-    const cursor = rootNode.walk();
 
-    do {
-      const node = cursor.currentNode;
-      if (node.hasError || node.isMissing || node.type === 'ERROR') {
+    const countErrors = (node: Parser.SyntaxNode) => {
+      // 仅检查特定类型的节点，例如函数声明
+      const isLargeSyntaxBlock =
+        node.type === 'function_declaration' ||
+        node.type === 'class_declaration' ||
+        node.type === 'variable_declarator' ||
+        node.type === 'statement_block' ||
+        node.type === 'expression_statement';
+      if (isLargeSyntaxBlock && (node.hasError || node.isMissing || node.type === 'ERROR')) {
         errorCount++;
       }
-    } while (cursor.gotoNextSibling());
+      // 递归检查子节点
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child) {
+          countErrors(child);
+        }
+      }
+    };
+
+    countErrors(rootNode); // 从根节点开始检查错误
 
     return errorCount;
   }

--- a/packages/ai-native/src/browser/languages/service.ts
+++ b/packages/ai-native/src/browser/languages/service.ts
@@ -6,7 +6,7 @@ import { SupportedTreeSitterLanguages, parserNameMap } from './tree-sitter/langu
 @Injectable()
 export class LanguageParserService {
   @Autowired(INJECTOR_TOKEN)
-  injector: Injector;
+  private injector: Injector;
 
   private pool = new Map<SupportedTreeSitterLanguages, LanguageParser>();
 

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
@@ -44,9 +44,7 @@ const AIInlineChatController = (props: IAIInlineChatControllerProps) => {
   const aiInlineChatService: AIInlineChatService = useInjectable(IAIInlineChatService);
   const inlineChatFeatureRegistry: InlineChatFeatureRegistry = useInjectable(InlineChatFeatureRegistryToken);
   const [status, setStatus] = useState<EInlineChatStatus>(EInlineChatStatus.READY);
-  const [inputValue, setInputValue] = useState<string>('');
   const [interactiveInputVisible, setInteractiveInputVisible] = useState<boolean>(false);
-
   useEffect(() => {
     const dis = new Disposable();
     dis.addDispose(onChatStatus((s) => setStatus(s)));
@@ -107,10 +105,6 @@ const AIInlineChatController = (props: IAIInlineChatControllerProps) => {
     [inlineChatFeatureRegistry],
   );
 
-  const handleValueChange = useCallback((value) => {
-    setInputValue(value);
-  }, []);
-
   const customOperationRender = useMemo(() => {
     if (!interactiveInputVisible) {
       return null;
@@ -124,12 +118,10 @@ const AIInlineChatController = (props: IAIInlineChatControllerProps) => {
         placeholder={localize('aiNative.inline.chat.input.placeholder.default')}
         width={320}
         disabled={isLoading}
-        value={inputValue}
-        onValueChange={handleValueChange}
         onSend={handleInteractiveInputSend}
       />
     );
-  }, [isLoading, interactiveInputVisible, inputValue]);
+  }, [isLoading, interactiveInputVisible]);
 
   const renderContent = useCallback(() => {
     if (operationList.length === 0 && moreOperation.length === 0) {
@@ -403,8 +395,8 @@ export class AIInlineContentWidget extends ReactInlineContentWidget {
    * 3. 显示的区域方向在右侧，左侧不考虑
    */
   protected computePosition(selection: monaco.Selection): monaco.editor.IContentWidgetPosition {
-    let startPosition = selection.getStartPosition();
-    let endPosition = selection.getEndPosition();
+    const startPosition = selection.getStartPosition();
+    const endPosition = selection.getEndPosition();
     let cursorPosition = selection.getPosition();
 
     const model = this.editor.getModel()!;

--- a/packages/ai-native/src/browser/widget/inline-hint/inline-hint-line-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-hint/inline-hint-line-widget.tsx
@@ -35,17 +35,17 @@ export class InlineHintLineDecoration extends Disposable {
     );
   }
 
-  private getSequenceKeyString() {
+  private getSequenceKeyString(separator = '+') {
     const keybindings = this.keybindingRegistry.getKeybindingsForCommand(AI_INLINE_CHAT_INTERACTIVE_INPUT_VISIBLE.id);
     const resolved = keybindings[0]?.resolved;
     if (!resolved) {
       return '';
     }
-    return this.keybindingRegistry.acceleratorForSequence(resolved, '+');
+    return this.keybindingRegistry.acceleratorForSequence(resolved, separator);
   }
 
   public async show(position: IPosition) {
-    const content = formatLocalize('aiNative.inline.hint.widget.placeholder', this.getSequenceKeyString());
+    const content = formatLocalize('aiNative.inline.hint.widget.placeholder', this.getSequenceKeyString(''));
 
     const theme = await this.themeService.getCurrentTheme();
     const color = this.colorRegister.resolveDefaultColor(inputPlaceholderForeground, theme);
@@ -60,6 +60,7 @@ export class InlineHintLineDecoration extends Disposable {
             color: color?.toString() ?? '',
             padding: '0 0 0 12px',
             width: 'max-content',
+            fontFamily: '-apple-system,BlinkMacSystemFont,PingFang SC,Hiragino Sans GB,sans-serif',
           },
         },
       },

--- a/packages/ai-native/src/browser/widget/inline-hint/inline-hint.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-hint/inline-hint.controller.ts
@@ -1,8 +1,6 @@
-import { IDisposable } from '@opensumi/ide-core-common';
-import { Disposable } from '@opensumi/ide-core-common';
+import { Disposable, IDisposable } from '@opensumi/ide-core-common';
 import { ICodeEditor } from '@opensumi/ide-monaco';
 import * as monaco from '@opensumi/ide-monaco';
-import { empty } from '@opensumi/ide-utils/lib/strings';
 
 import { AINativeContextKey } from '../../ai-core.contextkeys';
 import { BaseAIMonacoEditorController } from '../../contrib/base';
@@ -49,18 +47,17 @@ export class InlineHintController extends BaseAIMonacoEditorController {
         return;
       }
 
-      const content = model.getLineContent(position.lineNumber);
       const decorations = model.getLineDecorations(position.lineNumber);
-
-      const isEmpty = content?.trim() === empty;
-      const isEmptySelection = monacoEditor.getSelection()?.isEmpty();
       const hasPreviewDecoration = decorations.some(
         (dec) => dec.options.description === InlineInputPreviewDecorationID,
       );
 
-      if (isEmpty && isEmptySelection && !hasPreviewDecoration) {
+      if (!hasPreviewDecoration) {
         const inlineHintLineDecoration = this.injector.get(InlineHintLineDecoration, [monacoEditor]);
-        inlineHintLineDecoration.show(position);
+        const lineContent = monacoEditor.getModel()?.getLineContent(position.lineNumber);
+        if (!lineContent?.trim()) {
+          inlineHintLineDecoration.show(position);
+        }
         this.inlineInputChatService.setCurrentVisiblePosition(position);
 
         aiNativeContextKey.inlineHintWidgetIsVisible.set(true);

--- a/packages/ai-native/src/browser/widget/inline-input/inline-input-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input-widget.tsx
@@ -23,7 +23,6 @@ interface IInlineInputWidgetRenderProps {
 const InlineInputWidgetRender = (props: IInlineInputWidgetRenderProps) => {
   const { onClose, onInteractiveInputSend, onLayoutChange, onChatStatus, onResultClick } = props;
   const [status, setStatus] = useState<EInlineChatStatus>(EInlineChatStatus.READY);
-  const [inputValue, setInputValue] = useState<string>('');
 
   useEffect(() => {
     const dis = new Disposable();
@@ -49,10 +48,6 @@ const InlineInputWidgetRender = (props: IInlineInputWidgetRenderProps) => {
     [onInteractiveInputSend],
   );
 
-  const handleValueChange = useCallback((value) => {
-    setInputValue(value);
-  }, []);
-
   if (isError) {
     return null;
   }
@@ -73,8 +68,6 @@ const InlineInputWidgetRender = (props: IInlineInputWidgetRenderProps) => {
           size='small'
           placeholder={localize('aiNative.inline.chat.input.placeholder.default')}
           width={320}
-          value={inputValue}
-          onValueChange={handleValueChange}
           disabled={isLoading}
           onSend={handleInteractiveInputSend}
         />

--- a/packages/ai-native/src/common/types.ts
+++ b/packages/ai-native/src/common/types.ts
@@ -1,0 +1,15 @@
+export interface INearestCodeBlock {
+  range: {
+    start: {
+      line: number;
+      character: number;
+    };
+    end: {
+      line: number;
+      character: number;
+    };
+  };
+  codeBlock: string;
+  offset: number;
+  type?: string;
+}

--- a/packages/ai-native/src/common/types.ts
+++ b/packages/ai-native/src/common/types.ts
@@ -1,3 +1,8 @@
+export enum NearestCodeBlockType {
+  Block = 'block',
+  Line = 'line',
+}
+
 export interface INearestCodeBlock {
   range: {
     start: {
@@ -11,5 +16,5 @@ export interface INearestCodeBlock {
   };
   codeBlock: string;
   offset: number;
-  type?: string;
+  type?: NearestCodeBlockType;
 }

--- a/packages/core-browser/src/application/runtime/constants.ts
+++ b/packages/core-browser/src/application/runtime/constants.ts
@@ -4,4 +4,3 @@ export enum ESupportRuntime {
 }
 
 export const onigWasmCDNUri = 'https://g.alicdn.com/kaitian/vscode-oniguruma-wasm/1.5.1/onig.wasm';
-export const treeSitterWasmCDNUri = 'https://gw.alipayobjects.com/os/lib/opensumi/tree-sitter-wasm/0.0.2';

--- a/packages/core-browser/src/application/runtime/electron-renderer/index.ts
+++ b/packages/core-browser/src/application/runtime/electron-renderer/index.ts
@@ -3,7 +3,7 @@ import { Injectable, Injector } from '@opensumi/di';
 import { BrowserModule } from '../../../browser-module';
 import { AppConfig } from '../../../react-providers';
 import { electronEnv } from '../../../utils/electron';
-import { ESupportRuntime, onigWasmCDNUri, treeSitterWasmCDNUri } from '../constants';
+import { ESupportRuntime, onigWasmCDNUri } from '../constants';
 import { EKnownResources, RendererRuntime } from '../types';
 
 import { injectElectronInnerProviders } from './inner-providers-electron';
@@ -29,7 +29,9 @@ export class ElectronRendererRuntime extends RendererRuntime {
         return electronEnv.onigWasmUri || this.appConfig.onigWasmUri || onigWasmCDNUri;
       case EKnownResources.TreeSitterWasmDirectory:
         return (
-          electronEnv.treeSitterWasmDirectoryUri || this.appConfig.treeSitterWasmDirectoryUri || treeSitterWasmCDNUri
+          electronEnv.treeSitterWasmDirectoryUri ||
+          this.appConfig.treeSitterWasmDirectoryUri ||
+          getTreeSitterWasmCDNUri(this.appConfig.componentCDNType)
         );
       default:
         throw new Error(`Unknown resource: ${resource}`);

--- a/packages/core-browser/src/application/runtime/types.ts
+++ b/packages/core-browser/src/application/runtime/types.ts
@@ -1,8 +1,8 @@
 import { Autowired, Injectable } from '@opensumi/di';
 
-import { AppConfig } from '../../react-providers/config-provider';
+import { AppConfig, getTreeSitterWasmCDNUri } from '../../react-providers/config-provider';
 
-import { type ESupportRuntime, onigWasmCDNUri, treeSitterWasmCDNUri } from './constants';
+import { type ESupportRuntime, onigWasmCDNUri } from './constants';
 
 import type { BrowserModule } from '../../browser-module';
 import type { Injector } from '@opensumi/di';
@@ -31,7 +31,7 @@ export abstract class RendererRuntime {
       case EKnownResources.OnigWasm:
         return this.appConfig.onigWasmUri || onigWasmCDNUri;
       case EKnownResources.TreeSitterWasmDirectory:
-        return this.appConfig.treeSitterWasmDirectoryUri || treeSitterWasmCDNUri;
+        return this.appConfig.treeSitterWasmDirectoryUri || getTreeSitterWasmCDNUri(this.appConfig.componentCDNType);
       default:
         throw new Error(`Unknown resource: ${resource}`);
     }

--- a/packages/core-browser/src/components/ai-native/interactive-input/index.tsx
+++ b/packages/core-browser/src/components/ai-native/interactive-input/index.tsx
@@ -4,6 +4,9 @@ import React, { MutableRefObject, useCallback, useEffect, useImperativeHandle, u
 import { IInputBaseProps, Popover, PopoverPosition, TextArea, getIcon } from '@opensumi/ide-components';
 import { isUndefined, localize, uuid } from '@opensumi/ide-core-common';
 
+import { Key } from '../../../keyboard';
+import { useInjectable } from '../../../react-hooks';
+import { GlobalBrowserStorageService } from '../../../services/storage-service';
 import { EnhanceIcon } from '../index';
 
 import styles from './index.module.less';
@@ -21,6 +24,8 @@ export interface IInteractiveInputProps extends IInputBaseProps<HTMLTextAreaElem
   sendBtnClassName?: string;
   popoverPosition?: PopoverPosition;
 }
+
+const GLOBAL_AI_NATIVE_CHAT_INPUT_HISTORY_KEY = 'ai-native-chat-input-history';
 
 export const InteractiveInput = React.forwardRef(
   (props: IInteractiveInputProps, ref: MutableRefObject<HTMLTextAreaElement>) => {
@@ -42,12 +47,22 @@ export const InteractiveInput = React.forwardRef(
     } = props;
 
     const internalRef = useRef<HTMLTextAreaElement>(null);
-
+    const globalStroageService = useInjectable<GlobalBrowserStorageService>(GlobalBrowserStorageService);
+    const history = useRef<string[]>();
+    const historyIndex = useRef<number>(0);
     const [internalValue, setInternalValue] = useState(props.value || '');
     const [wrapperHeight, setWrapperHeight] = useState(height || DEFAULT_HEIGHT);
     const [focus, setFocus] = useState(false);
+    const isDirtyInput = React.useRef<boolean>(false);
 
     useImperativeHandle(ref, () => internalRef.current as HTMLTextAreaElement);
+
+    useEffect(() => {
+      const historyStore = globalStroageService.getData<string[]>(GLOBAL_AI_NATIVE_CHAT_INPUT_HISTORY_KEY);
+      if (historyStore) {
+        history.current = historyStore;
+      }
+    }, []);
 
     useEffect(() => {
       if (internalRef && internalRef.current && autoFocus) {
@@ -97,6 +112,7 @@ export const InteractiveInput = React.forwardRef(
 
     const handleInputChange = useCallback(
       (value: string) => {
+        isDirtyInput.current = true;
         setInternalValue(value);
         onValueChange?.(value);
       },
@@ -127,13 +143,18 @@ export const InteractiveInput = React.forwardRef(
       if (!internalValue.trim()) {
         return;
       }
+      history.current = history.current || [];
+      history.current.push(internalValue);
+      historyIndex.current = 0;
+      globalStroageService.setData(GLOBAL_AI_NATIVE_CHAT_INPUT_HISTORY_KEY, history.current);
+      isDirtyInput.current = false;
 
       onSend?.(internalValue);
     }, [onSend, internalValue, disabled]);
 
     const handleKeyDown = useCallback(
       (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+        if (event.key === Key.ENTER.code && !event.nativeEvent.isComposing) {
           if (event.shiftKey) {
             return;
           }
@@ -141,11 +162,29 @@ export const InteractiveInput = React.forwardRef(
           event.preventDefault();
           handleSend();
           return;
+        } else if (
+          (event.key === Key.ARROW_UP.code || event.key === Key.ARROW_DOWN.code) &&
+          (!internalValue || !isDirtyInput.current)
+        ) {
+          event.preventDefault();
+          if (event.key === Key.ARROW_UP.code) {
+            const value = history.current?.[history.current.length - 1 - historyIndex.current];
+            if (value) {
+              setInternalValue(value);
+            }
+            historyIndex.current = Math.min(historyIndex.current + 1, history.current?.length || 0);
+          } else if (event.key === Key.ARROW_DOWN.code) {
+            event.preventDefault();
+            const value = history.current?.[history.current.length - 1 - historyIndex.current];
+            if (value) {
+              setInternalValue(value);
+            }
+            historyIndex.current = Math.max(historyIndex.current - 1, 0);
+          }
         }
-
         onKeyDown?.(event);
       },
-      [onKeyDown, handleSend],
+      [onKeyDown, handleSend, internalValue],
     );
 
     const renderAddonAfter = useMemo(

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -372,7 +372,7 @@ const CDN_TYPE_MAP: IComponentCDNTypeMap = {
   jsdelivr: 'https://cdn.jsdelivr.net/npm',
 };
 
-export function getCdnHref(
+export function getCDNHref(
   packageName: string,
   filePath: string,
   version: string,
@@ -385,4 +385,8 @@ export function getCdnHref(
   } else {
     return `${CDN_TYPE_MAP[cdnType]}/${packageName}@${version}/${filePath}`;
   }
+}
+
+export function getTreeSitterWasmCDNUri(CDNType: string = 'alipay') {
+  return getCDNHref('@opensumi/tree-sitter-wasm', '', '0.0.2', CDNType as TComponentCDNType);
 }

--- a/packages/editor/src/browser/tab.view.tsx
+++ b/packages/editor/src/browser/tab.view.tsx
@@ -3,7 +3,6 @@ import React, {
   DragEvent,
   HTMLAttributes,
   MouseEvent,
-  Ref,
   forwardRef,
   useCallback,
   useContext,

--- a/packages/extension/src/browser/shadowRoot.tsx
+++ b/packages/extension/src/browser/shadowRoot.tsx
@@ -7,7 +7,7 @@ import {
   DisposableCollection,
   LabelService,
   TComponentCDNType,
-  getCdnHref as getCdnHrefRaw,
+  getCDNHref as getCDNHrefRaw,
   useInjectable,
 } from '@opensumi/ide-core-browser';
 import { ExtensionBrowserStyleSheet, URI, localize } from '@opensumi/ide-core-common';
@@ -72,8 +72,8 @@ function useMutationObserver(from: HTMLHeadElement, target: HTMLHeadElement) {
 
 const packageName = '@opensumi/ide-components';
 
-function getCdnHref(filePath: string, version: string, cdnType: TComponentCDNType = 'alipay') {
-  return getCdnHrefRaw(packageName, filePath, version, cdnType);
+function getCDNHref(filePath: string, version: string, cdnType: TComponentCDNType = 'alipay') {
+  return getCDNHrefRaw(packageName, filePath, version, cdnType);
 }
 
 function getStyleSheet(href: string) {
@@ -115,9 +115,9 @@ const ShadowRoot = ({
           proxiedHead.appendChild(getStyleSheet(styleSheet.componentUri));
           proxiedHead.appendChild(getStyleSheet(styleSheet.iconfontUri));
         } else {
-          proxiedHead.appendChild(getStyleSheet(getCdnHref('dist/index.css', pkgJson.version, cdnType)));
+          proxiedHead.appendChild(getStyleSheet(getCDNHref('dist/index.css', pkgJson.version, cdnType)));
           proxiedHead.appendChild(
-            getStyleSheet(getCdnHref('lib/icon/iconfont/iconfont.css', pkgJson.version, cdnType)),
+            getStyleSheet(getCDNHref('lib/icon/iconfont/iconfont.css', pkgJson.version, cdnType)),
           );
         }
 

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1461,7 +1461,7 @@ export const localizationBundle = {
     'aiNative.inline.chat.operate.thumbsup.title': 'Thumbs up',
     'aiNative.inline.chat.operate.thumbsdown.title': 'Thumbs down',
     'aiNative.inline.chat.operate.loading.cancel': 'Esc to cancel',
-    'aiNative.inline.chat.input.placeholder.default': 'Ask Copilot（shift + enter newline）',
+    'aiNative.inline.chat.input.placeholder.default': 'New code instructions...(↑↓ for history)',
     'aiNative.inline.hint.widget.placeholder': '{0} to inline chat',
     'aiNative.inline.problem.fix.title': 'Fix with AI',
     'aiNative.inline.diff.accept': 'Accept',

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1229,7 +1229,7 @@ export const localizationBundle = {
     'aiNative.inline.chat.operate.thumbsup.title': '赞',
     'aiNative.inline.chat.operate.thumbsdown.title': '踩',
     'aiNative.inline.chat.operate.loading.cancel': '按 ESC 取消',
-    'aiNative.inline.chat.input.placeholder.default': '可以问我任何问题，支持 shift + 回车换行',
+    'aiNative.inline.chat.input.placeholder.default': '请输入你的意图...(↑↓ 切换历史)',
     'aiNative.inline.hint.widget.placeholder': '按 {0} 唤起 Inline Chat',
     'aiNative.inline.problem.fix.title': 'AI 修复',
     'aiNative.inline.diff.accept': '采纳',

--- a/packages/monaco/src/browser/monaco.contribution.ts
+++ b/packages/monaco/src/browser/monaco.contribution.ts
@@ -24,7 +24,7 @@ import {
   ServiceNames,
   StaticResourceContribution,
   StaticResourceService,
-  getCdnHref,
+  getCDNHref,
   getWorkerBootstrapUrl,
 } from '@opensumi/ide-core-browser';
 import {
@@ -643,7 +643,7 @@ export class MonacoClientContribution
               const { moduleId } = JSON.parse(query);
               if (moduleId === 'workerMain.js') {
                 return URI.parse(
-                  getCdnHref(
+                  getCDNHref(
                     packageName,
                     'worker/editor.worker.bundle.js',
                     packageVersion,


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
改动点如下：
1. 调整了 WASM 文件的引入结构
2. 空行触发 InlineChat 时，ESC 或 CMD+K 退出后支持编辑器光标恢复
3. 任意文本行触发 InlineChat 时（CMD+K），自动获取最近的语法块触发 Inline 浮动组件展示，支持进一步 CMD+K 触发 Input
4. LanguageParserService 支持更多语法检测方法

效果如下：

https://github.com/user-attachments/assets/f5e921d7-18a2-4732-86ef-7198cc9f2417


### Changelog

improve inlineChat and inlineEditInput UX