### PR TITLE
feat: improve terminal local link parser

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Install libsecret-1
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Install
         run: |
           yarn install --immutable

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,9 +38,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install libsecret-1
-        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
-
       - name: Install
         run: |
           yarn install --immutable

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install libsecret-1
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Use Node.js "20.x"
         uses: actions/setup-node@v4
         with:

--- a/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
@@ -286,4 +286,16 @@ describe('Workbench - TerminalValidatedLocalLinkProvider', () => {
       },
     ]);
   });
+
+  test('should support single file path', async () => {
+    await assertLink('foo', false, [
+      {
+        range: [
+          [0, 1],
+          [3, 1],
+        ],
+        text: 'foo',
+      },
+    ]);
+  });
 });

--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -375,13 +375,8 @@ export class TerminalLinkManager extends Disposable {
       return undefined;
     }
 
-    const linkUrl = this.extractLinkUrl(preprocessedLink);
-    if (!linkUrl) {
-      return undefined;
-    }
-
     try {
-      const uri = URI.file(linkUrl);
+      const uri = URI.file(preprocessedLink);
       const stat = await this._fileService.getFileStat(uri.toString());
       if (stat) {
         return { uri, isDirectory: stat.isDirectory };

--- a/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
@@ -184,7 +184,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
         stringIndex += 2;
       }
 
-      const validatedLinks = await this.detectedLocalLinks(link, lines, startLine, stringIndex);
+      const validatedLinks = await this.detectLocalLink(link, lines, startLine, stringIndex);
 
       if (validatedLinks.length > 0) {
         result.push(...validatedLinks);
@@ -192,7 +192,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
     }
 
     if (result.length === 0) {
-      const validatedLinks = await this.detectedLocalLinks(text, lines, startLine, stringIndex);
+      const validatedLinks = await this.detectLocalLink(text, lines, startLine, stringIndex);
       if (validatedLinks.length > 0) {
         result.push(...validatedLinks);
       }
@@ -201,7 +201,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
     return result;
   }
 
-  private async detectedLocalLinks(text: string, bufferLines: IBufferLine[], startLine: number, stringIndex: number) {
+  private async detectLocalLink(text: string, bufferLines: IBufferLine[], startLine: number, stringIndex: number) {
     const result: TerminalLink[] = [];
     const validatedLink = await new Promise<TerminalLink | undefined>((r) => {
       this._validationCallback(text, async (result) => {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

https://github.com/user-attachments/assets/91c936d1-576f-4f33-9b63-088820da05f6

support terminal local link parser for:

1. single file name
2. path in the current workspace

### Changelog

improve terminal local link parser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
	- 终端链接管理器中的路径解析逻辑得到简化
	- 本地链接验证提供程序的路径匹配和验证机制进行了优化

- **改进**
	- 改进了链接处理的代码结构
	- 增强了对本地链接的检测和验证能力

- **技术更新**
	- 增加了GitHub Actions工作流中的E2E测试步骤
	- 新增了对单文件路径的支持测试用例
	- 在CI工作流中为macOS和Windows添加了库安装步骤
<!-- end of auto-generated comment: release notes by coderabbit.ai -->