### PR TITLE
fix(ai-native): use path.join for wasm file paths in WasmModuleManager

### DIFF
--- a/packages/ai-native/src/browser/languages/tree-sitter/wasm-manager.ts
+++ b/packages/ai-native/src/browser/languages/tree-sitter/wasm-manager.ts
@@ -2,7 +2,7 @@ import Parser from 'web-tree-sitter';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { EKnownResources, RendererRuntime } from '@opensumi/ide-core-browser/lib/application/runtime/types';
-import { Deferred } from '@opensumi/ide-utils';
+import { Deferred, path } from '@opensumi/ide-utils';
 
 /**
  * Managing and caching the wasm module
@@ -29,7 +29,7 @@ export class WasmModuleManager {
 
   async initParser() {
     const baseUrl = await this.resolvedResourceUriDeferred.promise;
-    const wasmPath = `${baseUrl}/tree-sitter.wasm`;
+    const wasmPath = path.join(baseUrl, 'tree-sitter.wasm');
     if (!this.parserInitialized) {
       await Parser.init({
         locateFile: () => wasmPath,
@@ -45,7 +45,7 @@ export class WasmModuleManager {
       const deferred = new Deferred<ArrayBuffer>();
       this.cachedRuntime.set(language, deferred);
       const baseUrl = await this.resolvedResourceUriDeferred.promise;
-      const wasmUrl = `${baseUrl}/tree-sitter-${language}.wasm`;
+      const wasmUrl = path.join(baseUrl, `tree-sitter-${language}.wasm`);
       fetch(wasmUrl)
         .then((res) => res.arrayBuffer())
         .then((buffer) => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

解决请求 `tree-sitter-wasm` 资源 404 问题.

opensumi `3.7.0` 版本, AppConfig 配置如下时: 
```js
{
    componentCDNType: 'npmmirror'
}
```
会出现 url path 错误, 导致请求 `https://registry.npmmirror.com/@opensumi/tree-sitter-wasm/0.0.2/files//tree-sitter.wasm` 404.

相关源码:
https://github.com/opensumi/core/blob/v3.7/packages/core-browser/src/react-providers/config-provider.tsx#L390


### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
	- 优化了 WebAssembly (WASM) 文件路径的处理方法
	- 使用 `path.join()` 方法替代字符串拼接，提高路径构建的可靠性和跨平台兼容性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->