### PR TITLE
feat: show inline input after cmd+K is triggered

### DIFF
--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat.service.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat.service.ts
@@ -8,7 +8,9 @@ export { EInlineChatStatus, EResultKind } from '../../../common';
 export class AIInlineChatService implements IAIInlineChatService {
   private _interactiveInputVisible: boolean = false;
   public get interactiveInputVisible(): boolean {
-    return this._interactiveInputVisible;
+    const visible = this._interactiveInputVisible;
+    this._interactiveInputVisible = false;
+    return visible;
   }
 
   public readonly _onInteractiveInputVisible = new Emitter<boolean>();

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-content-widget.tsx
@@ -44,7 +44,9 @@ const AIInlineChatController = (props: IAIInlineChatControllerProps) => {
   const aiInlineChatService: AIInlineChatService = useInjectable(IAIInlineChatService);
   const inlineChatFeatureRegistry: InlineChatFeatureRegistry = useInjectable(InlineChatFeatureRegistryToken);
   const [status, setStatus] = useState<EInlineChatStatus>(EInlineChatStatus.READY);
-  const [interactiveInputVisible, setInteractiveInputVisible] = useState<boolean>(false);
+  const [interactiveInputVisible, setInteractiveInputVisible] = useState<boolean>(
+    aiInlineChatService.interactiveInputVisible,
+  );
   useEffect(() => {
     const dis = new Disposable();
     dis.addDispose(onChatStatus((s) => setStatus(s)));

--- a/packages/ai-native/src/browser/widget/inline-input/inline-input.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input.controller.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@opensumi/di';
+import { IAIInlineChatService } from '@opensumi/ide-core-browser';
 import {
   CancelResponse,
   Disposable,
@@ -21,7 +22,7 @@ import { LanguageParserService } from '../../languages/service';
 import { ERunStrategy } from '../../types';
 import { InlineChatController } from '../inline-chat/inline-chat-controller';
 import { InlineChatFeatureRegistry } from '../inline-chat/inline-chat.feature.registry';
-import { EInlineChatStatus, EResultKind } from '../inline-chat/inline-chat.service';
+import { AIInlineChatService, EInlineChatStatus, EResultKind } from '../inline-chat/inline-chat.service';
 import { InlineInputPreviewDecorationID } from '../internal.type';
 
 import { InlineInputChatWidget } from './inline-input-widget';
@@ -46,6 +47,10 @@ export class InlineInputController extends BaseAIMonacoEditorController {
 
   private get languageParserService(): LanguageParserService {
     return this.injector.get(LanguageParserService);
+  }
+
+  private get inlineChatService(): AIInlineChatService {
+    return this.injector.get(IAIInlineChatService);
   }
 
   mount(): IDisposable {
@@ -182,6 +187,7 @@ export class InlineInputController extends BaseAIMonacoEditorController {
       const isEmptyLine = !monacoEditor.getModel()?.getLineContent(position.lineNumber).trim();
 
       if (!isEmptyLine) {
+        //
         // 根据光标位置自动检测并选中临近的代码块
         const cursorPosition = monacoEditor.getPosition();
         const editorModel = monacoEditor.getModel();
@@ -202,6 +208,7 @@ export class InlineInputController extends BaseAIMonacoEditorController {
           // 选中当前行
           monacoEditor.setSelection(new monaco.Selection(position.lineNumber, 1, position.lineNumber, Infinity));
         }
+        this.inlineChatService.launchInputVisible(true);
         return;
       }
 

--- a/packages/ai-native/src/browser/widget/inline-input/inline-input.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input.controller.ts
@@ -187,7 +187,6 @@ export class InlineInputController extends BaseAIMonacoEditorController {
       const isEmptyLine = !monacoEditor.getModel()?.getLineContent(position.lineNumber).trim();
 
       if (!isEmptyLine) {
-        //
         // 根据光标位置自动检测并选中临近的代码块
         const cursorPosition = monacoEditor.getPosition();
         const editorModel = monacoEditor.getModel();

--- a/packages/core-browser/src/components/ai-native/ai-action/index.module.less
+++ b/packages/core-browser/src/components/ai-native/ai-action/index.module.less
@@ -89,6 +89,11 @@
   .custom_operation_wrapper {
     padding: 4px 0px;
     box-sizing: content-box;
+    :global {
+      .kt-input {
+        border-radius: 3px;
+      }
+    }
   }
 
   .default_operation_wrapper {

--- a/packages/core-browser/src/components/ai-native/interactive-input/index.module.less
+++ b/packages/core-browser/src/components/ai-native/interactive-input/index.module.less
@@ -1,6 +1,4 @@
 .interactive_input_container {
-  width: 100%;
-  border-radius: 8px;
   padding: 8px 4px 8px 12px;
   font-size: 12px;
   position: relative;

--- a/packages/core-browser/src/components/ai-native/interactive-input/index.tsx
+++ b/packages/core-browser/src/components/ai-native/interactive-input/index.tsx
@@ -237,7 +237,9 @@ export const InteractiveInput = React.forwardRef(
         ref={internalRef}
         placeholder={placeholder}
         wrapperStyle={{ height: wrapperHeight + 'px', width: wrapperWidth }}
-        style={{ height: wrapperHeight - 10 + 'px' }}
+        style={{
+          height: wrapperHeight - 10 + 'px',
+        }}
         value={internalValue}
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

当通过 CMD+K 触发 InlineChat 时，无论是空行还是语法块，默认进入 Input 模式


https://github.com/user-attachments/assets/63dd763a-e15d-4d8e-a131-1d55869af472


鼠标选中情况下仍然展示悬浮组件

### Changelog

show inline input after cmd+K is triggered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 改进了内联聊天服务的可见性管理
	- 优化了交互式输入组件的状态同步

- **样式调整**
	- 修改了某些 UI 组件的样式规则
	- 调整了交互式输入容器的样式属性

- **代码重构**
	- 更新了内联输入控制器的服务集成
	- 优化了聊天服务的状态处理逻辑
<!-- end of auto-generated comment: release notes by coderabbit.ai -->