### PR TITLE
chore: revert incorrect prop name in Modal component

### DIFF
--- a/packages/components/src/modal/Modal.tsx
+++ b/packages/components/src/modal/Modal.tsx
@@ -233,7 +233,7 @@ export default class Modal extends React.Component<PropsWithChildren<ModalProps>
         animation={this.props.animation}
         getContainer={getContainer}
         prefixCls={prefixCls}
-        className={cls({ [`${prefixCls}-centered`]: !!centered }, wrapClassName)}
+        wrapClassName={cls({ [`${prefixCls}-centered`]: !!centered }, wrapClassName)}
         footer={footer === undefined ? defaultFooter : footer}
         visible={visible}
         mousePosition={mousePosition}


### PR DESCRIPTION
### Types

- [x] 🧹 Chores

### Background or solution

### Changelog

revert incorrect prop name in Modal component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式调整**
	- 修改了模态框组件的类名传递方式，可能会影响模态框的视觉呈现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->