### PR TITLE
fix: debug toolbar is disappeared or session paused after debug session started

### DIFF
--- a/packages/ai-native/src/browser/languages/tree-sitter/wasm-manager.ts
+++ b/packages/ai-native/src/browser/languages/tree-sitter/wasm-manager.ts
@@ -2,7 +2,7 @@ import Parser from 'web-tree-sitter';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { EKnownResources, RendererRuntime } from '@opensumi/ide-core-browser/lib/application/runtime/types';
-import { Deferred, URI, path } from '@opensumi/ide-utils';
+import { Deferred } from '@opensumi/ide-utils';
 
 /**
  * Managing and caching the wasm module
@@ -29,10 +29,12 @@ export class WasmModuleManager {
 
   async initParser() {
     const baseUrl = await this.resolvedResourceUriDeferred.promise;
-    const url = new URI(baseUrl);
-    const protocal = url.scheme;
-    const wasmPath = new URI(path.join(url.path.toString(), 'tree-sitter.wasm')).withScheme(protocal);
-
+    let wasmPath;
+    if (baseUrl.endsWith('/')) {
+      wasmPath = `${baseUrl}tree-sitter.wasm`;
+    } else {
+      wasmPath = `${baseUrl}/tree-sitter.wasm`;
+    }
     if (!this.parserInitialized) {
       await Parser.init({
         locateFile: () => wasmPath,
@@ -48,7 +50,12 @@ export class WasmModuleManager {
       const deferred = new Deferred<ArrayBuffer>();
       this.cachedRuntime.set(language, deferred);
       const baseUrl = await this.resolvedResourceUriDeferred.promise;
-      const wasmUrl = path.join(baseUrl, `tree-sitter-${language}.wasm`);
+      let wasmUrl;
+      if (baseUrl.endsWith('/')) {
+        wasmUrl = `${baseUrl}tree-sitter-${language}.wasm`;
+      } else {
+        wasmUrl = `${baseUrl}/tree-sitter-${language}.wasm`;
+      }
       fetch(wasmUrl)
         .then((res) => res.arrayBuffer())
         .then((buffer) => {

--- a/packages/ai-native/src/browser/languages/tree-sitter/wasm-manager.ts
+++ b/packages/ai-native/src/browser/languages/tree-sitter/wasm-manager.ts
@@ -2,7 +2,7 @@ import Parser from 'web-tree-sitter';
 
 import { Autowired, Injectable } from '@opensumi/di';
 import { EKnownResources, RendererRuntime } from '@opensumi/ide-core-browser/lib/application/runtime/types';
-import { Deferred, path } from '@opensumi/ide-utils';
+import { Deferred, URI, path } from '@opensumi/ide-utils';
 
 /**
  * Managing and caching the wasm module
@@ -29,7 +29,10 @@ export class WasmModuleManager {
 
   async initParser() {
     const baseUrl = await this.resolvedResourceUriDeferred.promise;
-    const wasmPath = path.join(baseUrl, 'tree-sitter.wasm');
+    const url = new URI(baseUrl);
+    const protocal = url.scheme;
+    const wasmPath = new URI(path.join(url.path.toString(), 'tree-sitter.wasm')).withScheme(protocal);
+
     if (!this.parserInitialized) {
       await Parser.init({
         locateFile: () => wasmPath,

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -143,7 +143,7 @@ export class DebugBreakpointsService extends WithEventBus {
     this.roots = roots.map((file) => new URI(file.uri));
   }
 
-  toggleBreakpointEnable(data: IDebugBreakpoint | DebugExceptionBreakpoint) {
+  toggleBreakpointEnable = (data: IDebugBreakpoint | DebugExceptionBreakpoint) => {
     if (isDebugBreakpoint(data)) {
       const real = this.breakpoints.getBreakpoint(URI.parse(data.uri), {
         lineNumber: data.raw.line,
@@ -157,7 +157,7 @@ export class DebugBreakpointsService extends WithEventBus {
     if (isDebugExceptionBreakpoint(data)) {
       this.breakpoints.updateExceptionBreakpoints(data.filter, !data.default);
     }
-  }
+  };
 
   extractNodes(item: DebugExceptionBreakpoint | IDebugBreakpoint): BreakpointItem | undefined {
     if (isDebugBreakpoint(item)) {

--- a/packages/debug/src/browser/view/configuration/debug-configuration.module.less
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.module.less
@@ -96,6 +96,8 @@
   justify-content: center;
   z-index: 10;
   user-select: none;
+  top: 0;
+  left: 0;
 
   .debug_action_bar {
     height: 100%;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

1. 调试工具栏有概率性消失，由于 absolute 定位未指定确切位置。

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/681e2c56-e5a6-4c3a-9a3c-07ffb70fdb8a" />

2. Python 调试进程异常暂停问题

### Changelog

fix debug toolbar is disappeared after debug session started


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **样式调整**
	- 调整了调试工具栏的定位，将其固定在容器的左上角。

- **代码重构**
	- 修改了 `toggleBreakpointEnable` 方法的声明方式，确保方法内部的 `this` 上下文保持一致。
	- 改进了 WebAssembly 文件路径的管理，采用更结构化的 URI 表示方式，简化了路径构建逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->