### PR TITLE
chore: update default vscode engine version to 1.96.2

### DIFF
--- a/packages/core-common/src/const/application.ts
+++ b/packages/core-common/src/const/application.ts
@@ -4,4 +4,4 @@ export const DEFAULT_APPLICATION_WEB_HOST = 'web';
 export const DEFAULT_URI_SCHEME = 'sumi';
 export const DEFAULT_OPENVSX_REGISTRY = 'https://open-vsx.org'; // Official Registry
 
-export const DEFAULT_VSCODE_ENGINE_VERSION = '1.94.2';
+export const DEFAULT_VSCODE_ENGINE_VERSION = '1.96.2';


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **版本更新**
	- 将默认 VSCode 引擎版本从 1.94.2 更新至 1.96.2。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->