### PR TITLE
feat: add styles for dialog content and update file dialog logic

### DIFF
--- a/packages/design/src/browser/style/design.module.less
+++ b/packages/design/src/browser/style/design.module.less
@@ -718,6 +718,17 @@
   }
 }
 
+:global(.kt-dialog-content) {
+  .design-file_tree_node {
+    font-size: 13px;
+  }
+
+  .design-file_tree_node {
+    border-radius: 4px;
+    margin: 0 5px;
+  }
+}
+
 .design-tab_panel {
   &::before {
     content: none !important;

--- a/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
+++ b/packages/file-tree-next/src/browser/dialog/file-dialog.view.tsx
@@ -83,6 +83,8 @@ export const FileDialog = ({
     } else {
       if (value.length > 0) {
         dialogService.hide(value);
+      } else if (selectPath) {
+        dialogService.hide([selectPath]);
       } else if (options.defaultUri) {
         dialogService.hide([options.defaultUri!.path.toString()]);
       } else if (model.treeModel && model.treeModel.root) {
@@ -93,7 +95,7 @@ export const FileDialog = ({
     }
     setIsReady(false);
     fileService.contextKey.fileDialogViewVisibleContext.set(false);
-  }, [isReady, dialogService, model, fileName, options]);
+  }, [isReady, dialogService, model, fileName, options, selectPath]);
 
   const close = useCallback(() => {
     setIsReady(false);
@@ -301,7 +303,7 @@ export const FileDialog = ({
   const DialogButtons = useMemo(
     () => (
       <div className={styles.file_dialog_buttons}>
-        <Button onClick={close} type='secondary' className={styles.button}>
+        <Button onClick={close} type='ghost' className={styles.button}>
           {localize('dialog.file.close')}
         </Button>
         <Button


### PR DESCRIPTION
### Types
- [x] 🎉 New Features

### Background or solution

- 统一样式
- 支持在 Open Dialog 中输入路径后直接打开的交互

### Changelog

add styles for dialog content and update file dialog logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
	- 对话框中的文件树节点视觉效果得到优化，调整了字体大小、圆角和边距，提升呈现精致度。
- **新功能**
	- 改进了文件选择对话框中路径显示与隐藏的逻辑，并更新了关闭按钮的样式，优化用户交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->