### PR TITLE
fix: display debug hover view with correct size config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: tools/playwright/test-results

--- a/packages/debug/src/browser/editor/debug-hover.view.tsx
+++ b/packages/debug/src/browser/editor/debug-hover.view.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { INodeRendererWrapProps, IRecycleTreeHandle, RecycleTree, TreeNodeEvent } from '@opensumi/ide-components';
 import { useInjectable } from '@opensumi/ide-core-browser';
+import { LayoutViewSizeConfig } from '@opensumi/ide-core-browser/lib/layout/constants';
 import { IDisposable } from '@opensumi/ide-core-common';
 
 import {
@@ -19,8 +20,11 @@ import styles from './debug-hover.module.less';
 
 export const DebugHoverView = () => {
   const debugHoverTreeModelService: DebugHoverTreeModelService = useInjectable(DebugHoverTreeModelService);
+  const layoutViewSize = useInjectable<LayoutViewSizeConfig>(LayoutViewSizeConfig);
 
   const DEFAULT_LAYOUT_HEIGHT = 250;
+  const DEFAULT_MAX_HEIGHT = 500;
+  const DEFAULT_HOVER_WEIGET_MARGIN_BOTTOM = 4;
   const [model, setModel] = React.useState<{ treeModel?: DebugHoverModel; variable?: DebugVariable }>({});
   const [treeLayoutHeight, setTreeLayoutHeight] = React.useState<number>(DEFAULT_LAYOUT_HEIGHT);
   const wrapperRef = React.useRef<HTMLDivElement | null>(null);
@@ -44,9 +48,17 @@ export const DebugHoverView = () => {
     setTreeLayoutHeight(DEFAULT_LAYOUT_HEIGHT);
 
     if (model.treeModel) {
-      disposable = model.treeModel.root.watcher.on(TreeNodeEvent.DidChangeExpansionState, (data) => {
-        const treeHeight = Math.max(DEFAULT_LAYOUT_HEIGHT, ~~model.treeModel?.root.branchSize! * 22);
-        setTreeLayoutHeight(Math.min(500, treeHeight));
+      disposable = model.treeModel.root.watcher.on(TreeNodeEvent.DidChangeExpansionState, () => {
+        const treeHeight = Math.max(DEFAULT_LAYOUT_HEIGHT, (model.treeModel?.root.branchSize || 0) * 22);
+        const rect = wrapperRef.current?.getBoundingClientRect();
+        if (rect) {
+          const top = rect.top;
+          const maxHeight =
+            window.innerHeight - top - layoutViewSize.statusBarHeight - DEFAULT_HOVER_WEIGET_MARGIN_BOTTOM;
+          setTreeLayoutHeight(Math.min(maxHeight, treeHeight));
+        } else {
+          setTreeLayoutHeight(Math.min(DEFAULT_MAX_HEIGHT, treeHeight));
+        }
       });
     }
     return () => {

--- a/packages/debug/src/browser/editor/debug-hover.view.tsx
+++ b/packages/debug/src/browser/editor/debug-hover.view.tsx
@@ -23,7 +23,7 @@ export const DebugHoverView = () => {
   const layoutViewSize = useInjectable<LayoutViewSizeConfig>(LayoutViewSizeConfig);
 
   const DEFAULT_LAYOUT_HEIGHT = 250;
-  const DEFAULT_MAX_HEIGHT = 500;
+  const DEFAULT_MAX_HEIGHT = 420;
   const DEFAULT_HOVER_WEIGET_MARGIN_BOTTOM = 4;
   const [model, setModel] = React.useState<{ treeModel?: DebugHoverModel; variable?: DebugVariable }>({});
   const [treeLayoutHeight, setTreeLayoutHeight] = React.useState<number>(DEFAULT_LAYOUT_HEIGHT);
@@ -55,7 +55,7 @@ export const DebugHoverView = () => {
           const top = rect.top;
           const maxHeight =
             window.innerHeight - top - layoutViewSize.statusBarHeight - DEFAULT_HOVER_WEIGET_MARGIN_BOTTOM;
-          setTreeLayoutHeight(Math.min(maxHeight, treeHeight));
+          setTreeLayoutHeight(Math.min(maxHeight, treeHeight, DEFAULT_MAX_HEIGHT));
         } else {
           setTreeLayoutHeight(Math.min(DEFAULT_MAX_HEIGHT, treeHeight));
         }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
Before:
![image](https://github.com/user-attachments/assets/4cc98150-e79d-40d1-8453-3d9c4fe29fc7)
After:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/5e37cfd7-6492-4eb5-af5e-acbbe6a068c3" />

### Changelog

display debug hover view with correct size config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 调试悬停视图现可根据当前屏幕空间和状态栏位置自动调整高度，确保布局更加灵活和响应迅速，从而提升用户体验。
- **其他变更**
	- 更新了E2E测试的GitHub Actions工作流，升级了`actions/upload-artifact`的版本，从`v3`更新至`v4`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->