### PR TITLE
fix: always dispose debug unexpected widget in the end

### DIFF
--- a/packages/core-browser/src/components/ai-native/ai-action/index.tsx
+++ b/packages/core-browser/src/components/ai-native/ai-action/index.tsx
@@ -94,7 +94,7 @@ export const AIAction = (props: AIActionProps) => {
   });
 
   const Logo = useMemo(() => {
-    const InlineChatLogo = aiNativeConfigService.inlineChat.logo;
+    const InlineChatLogo = aiNativeConfigService?.inlineChat.logo;
 
     if (typeof InlineChatLogo === 'string') {
       return <img src={InlineChatLogo} className={styles.ai_action_icon} />;
@@ -105,7 +105,7 @@ export const AIAction = (props: AIActionProps) => {
     }
 
     return null;
-  }, [aiNativeConfigService.inlineChat.logo]);
+  }, [aiNativeConfigService?.inlineChat.logo]);
 
   /**
    * loading 的遮罩

--- a/packages/core-browser/src/react-hooks/injectable-hooks.tsx
+++ b/packages/core-browser/src/react-hooks/injectable-hooks.tsx
@@ -16,7 +16,7 @@ function isDisposable(target: any): target is Disposable {
 export function useInjectable<T = any>(Constructor: Token, args?: any): T {
   const { injector } = useContext(ConfigContext);
 
-  const instance = useMemo(() => injector.get(Constructor, args), [injector, Constructor]);
+  const instance = useMemo(() => injector?.get(Constructor, args), [injector, Constructor]);
 
   useEffect(
     () => () => {

--- a/packages/debug/__tests__/browser/editor/editor-hover-contribution.test.ts
+++ b/packages/debug/__tests__/browser/editor/editor-hover-contribution.test.ts
@@ -3,8 +3,8 @@ import {
   IContextKeyService,
   IFileServiceClient,
   MonacoOverrideServiceRegistry,
+  QuickPickService,
 } from '@opensumi/ide-core-browser';
-import { QuickPickService } from '@opensumi/ide-core-browser';
 import { DebugModelFactory, IDebugModelManager, IDebugServer } from '@opensumi/ide-debug';
 import { DebugPreferences } from '@opensumi/ide-debug/lib/browser/debug-preferences';
 import { DebugEditorContribution } from '@opensumi/ide-debug/lib/browser/editor/debug-editor-contribution';
@@ -63,6 +63,7 @@ describe('Editor Hover Contribution', () => {
         token: IDebugSessionManager,
         useValue: {
           onDidChangeActiveDebugSession: jest.fn(() => Disposable.create(() => {})),
+          onDidDestroyDebugSession: jest.fn(() => Disposable.create(() => {})),
         },
       },
       {

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -1092,20 +1092,13 @@ export class DebugSession implements IDebugSession {
     return this.connection.onDidCustomEvent;
   }
 
-  // REPL
-
   hasSeparateRepl(): boolean {
     return !this.parentSession || this.options.repl !== 'mergeWithParent';
   }
 
-  // REPL end
-
-  // report service
   reportTime(name: string, defaults?: any): (msg: string | undefined, extra?: any) => number {
     return this.sessionManager.reportTime(name, defaults);
   }
-
-  // Cancellation
 
   private getNewCancellationToken(threadId: number, token?: CancellationToken): CancellationToken {
     const tokenSource = new CancellationTokenSource(token);
@@ -1132,8 +1125,6 @@ export class DebugSession implements IDebugSession {
       this.cancelAllRequests();
     }
   }
-
-  // Cancellation end
 
   public getDebugProtocolBreakpoint(breakpointId: string): DebugProtocol.Breakpoint | undefined {
     const data = this.breakpointManager.getBreakpoints().find((bp) => bp.id === breakpointId);
@@ -1164,8 +1155,6 @@ export class DebugSession implements IDebugSession {
     return this.modelManager.model;
   }
 
-  // memory
-
   public async readMemory(
     memoryReference: string,
     offset: number,
@@ -1188,6 +1177,4 @@ export class DebugSession implements IDebugSession {
     }
     return Promise.resolve(undefined);
   }
-
-  // memory end
 }

--- a/packages/debug/src/browser/editor/debug-editor-contribution.ts
+++ b/packages/debug/src/browser/editor/debug-editor-contribution.ts
@@ -275,6 +275,12 @@ export class DebugEditorContribution implements IEditorFeatureContribution {
       }),
     );
 
+    this.disposer.addDispose(
+      this.debugSessionManager.onDidDestroyDebugSession(() => {
+        this.closeExceptionWidget();
+      }),
+    );
+
     this.disposer.addDispose(this.editorDisposer);
 
     this.toggleExceptionWidget();


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🐛 Bug Fixes

### Background or solution

close #4347 

### Changelog

always dispose debug unexpected widget in the end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 当调试会话结束时，异常信息窗口将自动关闭，确保界面状态与调试流程一致。
- **Bug 修复**
	- 为关键组件添加了额外的保护措施，防止因缺少预期数据而引发运行时错误，提高系统稳定性。
- **其他**
	- 清理并移除了一些冗余的调试代码，简化了内部逻辑，便于后续维护。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->