### PR TITLE
refactor: inline diff data layer & render layer

### DIFF
--- a/packages/ai-native/src/browser/model/styles.module.less
+++ b/packages/ai-native/src/browser/model/styles.module.less
@@ -1,7 +1,0 @@
-.hidden {
-  visibility: hidden;
-}
-
-.visible {
-  visibility: visible;
-}

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat-editor.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat-editor.controller.ts
@@ -446,7 +446,7 @@ export class InlineChatEditorController extends BaseAIMonacoEditorController {
     }
 
     const diffPreviewer = this.inlineDiffController.showPreviewerByStream(monacoEditor, options);
-    diffPreviewer.mount(this.aiInlineContentWidget);
+    diffPreviewer.mountWidget(this.aiInlineContentWidget);
   }
 
   private ensureInlineChatVisible(monacoEditor: monaco.ICodeEditor, crossSelection: monaco.Selection) {
@@ -472,7 +472,6 @@ export class InlineChatEditorController extends BaseAIMonacoEditorController {
     const { monacoEditor, strategy, crossSelection, relationId, isRetry, actionType, actionSource } = params;
     const model = monacoEditor.getModel();
 
-    this.inlineDiffController.destroyPreviewer(model!.uri.toString());
     this.aiInlineChatOperationDisposable.dispose();
 
     this.ensureInlineChatVisible(monacoEditor, crossSelection);

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff-previewer.ts
@@ -44,12 +44,12 @@ export abstract class BaseInlineDiffPreviewer<N extends IInlineDiffPreviewerNode
   protected inlineContentWidget: AIInlineContentWidget | null = null;
   protected selection: Selection;
   protected model: ITextModel;
-  public id: string;
+  public modelId: string;
 
   constructor(protected readonly monacoEditor: ICodeEditor) {
     super();
     this.model = this.monacoEditor.getModel()!;
-    this.id = this.model.id;
+    this.modelId = this.model.id;
 
     this.addDispose(
       Disposable.create(() => {

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
@@ -80,16 +80,14 @@ export class InlineDiffController extends BaseAIMonacoEditorController {
         }
 
         const storedPreview = this.previewerStore.get(model.id);
-        if (storedPreview && storedPreview.id === id) {
-          transaction((tx) => {
+        transaction((tx) => {
+          if (storedPreview && storedPreview.id === id) {
             this.currentPreviewer.set(storedPreview, tx);
             storedPreview.resume();
-          });
-        } else {
-          transaction((tx) => {
+          } else {
             this.currentPreviewer.set(undefined, tx);
-          });
-        }
+          }
+        });
       }),
     );
 
@@ -227,19 +225,6 @@ export class InlineDiffController extends BaseAIMonacoEditorController {
     }
 
     return previewer.getOriginValue();
-  }
-
-  destroyPreviewer() {
-    const previewer = this.getPreviewer();
-    if (!previewer) {
-      return;
-    }
-
-    previewer.dispose();
-    transaction((tx) => {
-      this.currentPreviewer.set(undefined, tx);
-      this.previewerStore.delete(previewer.id);
-    });
   }
 
   revealFirstDiff() {

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/inline-stream-diff.handler.tsx
@@ -3,6 +3,7 @@ import { Disposable, Emitter, Event, FRAME_THREE, Schemes, Uri, randomString, sl
 import { ISingleEditOperation } from '@opensumi/ide-editor';
 import { ICodeEditor, ITextModel, Range, Selection } from '@opensumi/ide-monaco';
 import { StandaloneServices } from '@opensumi/ide-monaco/lib/browser/monaco-api/services';
+import { ISettableObservable, observableValue, transaction } from '@opensumi/ide-monaco/lib/common/observable';
 import { LineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/lineRange';
 import { linesDiffComputers } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/linesDiffComputers';
 import { DetailedLineRangeMapping } from '@opensumi/monaco-editor-core/esm/vs/editor/common/diff/rangeMapping';
@@ -15,7 +16,7 @@ import { IDiffPreviewerOptions, IInlineDiffPreviewerNode } from '../inline-diff/
 
 import { InlineStreamDiffComputer } from './inline-stream-diff-computer';
 import { IRemovedWidgetState } from './live-preview.component';
-import { ILivePreviewDiffDecorationSnapshotData, LivePreviewDiffDecorationModel } from './live-preview.decoration';
+import { LivePreviewDiffDecorationModel } from './live-preview.decoration';
 
 interface IRangeChangeData {
   removedTextLines: string[];
@@ -29,7 +30,7 @@ interface IRangeChangeData {
     | undefined;
 }
 
-interface IComputeDiffData {
+export interface IComputeDiffData {
   newFullRangeTextLines: string[];
   changes: IRangeChangeData[];
   activeLine: number;
@@ -39,14 +40,6 @@ interface IComputeDiffData {
 export enum EComputerMode {
   legacy = 'legacy',
   default = 'default',
-}
-
-export interface IInlineStreamDiffSnapshotData {
-  rawOriginalTextLines: string[];
-  rawOriginalTextLinesTokens: LineTokens[];
-  undoRedoGroup: UndoRedoGroup;
-  decorationSnapshotData: ILivePreviewDiffDecorationSnapshotData;
-  previewerOptions: IDiffPreviewerOptions;
 }
 
 const inlineStreamDiffComputer = new InlineStreamDiffComputer();
@@ -64,17 +57,20 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
   private originalModel: ITextModel;
   private virtualModel: ITextModel;
 
-  // Parts that require snapshots
   private rawOriginalTextLines: string[];
   private rawOriginalTextLinesTokens: LineTokens[] = [];
-  private undoRedoGroup: UndoRedoGroup;
+  private undoRedoGroup: UndoRedoGroup = new UndoRedoGroup();
+
+  private readonly diffModel: ISettableObservable<IComputeDiffData | undefined> = observableValue(this, undefined);
+  private readonly finallyDiffModel: ISettableObservable<IComputeDiffData | undefined> = observableValue(
+    this,
+    undefined,
+  );
 
   public livePreviewDiffDecorationModel: LivePreviewDiffDecorationModel;
 
   constructor(private readonly monacoEditor: ICodeEditor) {
     super();
-
-    this.undoRedoGroup = new UndoRedoGroup();
 
     const modelService = StandaloneServices.get(IModelService);
     this.virtualModel = modelService.createModel(
@@ -134,44 +130,6 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
     );
 
     this.livePreviewDiffDecorationModel.initialize(zone);
-  }
-
-  private _snapshotStore: IInlineStreamDiffSnapshotData | undefined;
-  restoreSnapshot(snapshot: IInlineStreamDiffSnapshotData): void {
-    this._snapshotStore = snapshot;
-    const {
-      rawOriginalTextLines,
-      rawOriginalTextLinesTokens,
-      undoRedoGroup,
-      decorationSnapshotData,
-      previewerOptions,
-    } = snapshot;
-
-    this.setPreviewerOptions(previewerOptions);
-
-    this.rawOriginalTextLines = rawOriginalTextLines;
-    this.rawOriginalTextLinesTokens = rawOriginalTextLinesTokens;
-    this.undoRedoGroup = undoRedoGroup;
-
-    this.livePreviewDiffDecorationModel.initialize(decorationSnapshotData.zone);
-  }
-
-  get currentSnapshotStore(): IInlineStreamDiffSnapshotData | undefined {
-    return this._snapshotStore;
-  }
-
-  restoreDecorationSnapshot(decorationSnapshotData: ILivePreviewDiffDecorationSnapshotData): void {
-    this.livePreviewDiffDecorationModel.restoreSnapshot(decorationSnapshotData);
-  }
-
-  createSnapshot(): IInlineStreamDiffSnapshotData {
-    return {
-      rawOriginalTextLines: this.rawOriginalTextLines,
-      rawOriginalTextLinesTokens: this.rawOriginalTextLinesTokens,
-      undoRedoGroup: this.undoRedoGroup,
-      decorationSnapshotData: this.livePreviewDiffDecorationModel.createSnapshot(),
-      previewerOptions: this.previewerOptions,
-    };
   }
 
   getVirtualModelValue() {
@@ -345,7 +303,7 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
     });
   }
 
-  private handleEdits(diffModel: IComputeDiffData): void {
+  private renderDiffEdits(diffModel: IComputeDiffData): void {
     const { activeLine, newFullRangeTextLines, pendingRange } = diffModel;
     const eol = this.originalModel.getEOL();
     const zone = this.getZone();
@@ -466,9 +424,8 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
   }
 
   private currentEditLine = 0;
-  private finallyDiffModel: IComputeDiffData | null = null;
   private isEditing = false;
-  private async rateEditController(): Promise<void> {
+  public async rateRenderEditController(): Promise<void> {
     if (this.isEditing === false) {
       this.isEditing = true;
 
@@ -480,15 +437,16 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
         const virtualTextLines = this.virtualModel.getLinesContent();
         const currentText = virtualTextLines.slice(0, this.currentEditLine);
         const currentDiffModel = this.computeDiff(this.rawOriginalTextLines, currentText);
-        this.handleEdits(currentDiffModel);
+        this.renderDiffEdits(currentDiffModel);
 
         this.currentEditLine += 1;
 
         await sleep(FRAME_THREE);
       }
 
-      if (this.finallyDiffModel) {
-        this.finallyRender(this.finallyDiffModel);
+      const finallyDiffModel = this.finallyDiffModel.get();
+      if (finallyDiffModel) {
+        this.finallyRender(finallyDiffModel);
       }
 
       this.isEditing = false;
@@ -496,25 +454,39 @@ export class InlineStreamDiffHandler extends Disposable implements IInlineDiffPr
   }
 
   public addLinesToDiff(newText: string, computerMode: EComputerMode = EComputerMode.default): void {
-    this.recompute(computerMode, newText);
-    this.rateEditController();
+    const diffModel = this.recompute(computerMode, newText);
+    transaction((tx) => {
+      this.diffModel.set(diffModel, tx);
+    });
   }
 
   public pushRateFinallyDiffStack(diffModel: IComputeDiffData): void {
-    this.finallyDiffModel = diffModel;
-
-    // 可能存在 rate editr controller 处理完之后接口层流式才结束
-    if (this.isEditing === false) {
-      this.finallyRender(this.finallyDiffModel);
-    }
+    transaction((tx) => {
+      this.finallyDiffModel.set(diffModel, tx);
+      // 可能存在 rate editor controller 处理完之后接口层流式才结束
+      if (this.isEditing === false) {
+        this.finallyRender(diffModel);
+      }
+    });
   }
 
   public finallyRender(diffModel: IComputeDiffData): void {
+    transaction((tx) => {
+      this.diffModel.set(diffModel, tx);
+    });
     // 流式结束后才会确定所有的 added range，再渲染 partial edit widgets
     this.renderPartialEditWidgets(diffModel);
-    this.handleEdits(diffModel);
+    this.renderDiffEdits(diffModel);
     this.pushStackElement();
     this.monacoEditor.focus();
+  }
+
+  public hide(): void {
+    this.livePreviewDiffDecorationModel.hide();
+  }
+
+  public resume(): void {
+    this.livePreviewDiffDecorationModel.resume();
   }
 
   acceptAll(): void {

--- a/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
+++ b/packages/ai-native/src/browser/widget/inline-stream-diff/live-preview.decoration.tsx
@@ -15,18 +15,10 @@ import { StandaloneServices } from '@opensumi/ide-monaco/lib/browser/monaco-api/
 import { EditOperation } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/editOperation';
 import { LineRange } from '@opensumi/monaco-editor-core/esm/vs/editor/common/core/lineRange';
 import { ModelDecorationOptions } from '@opensumi/monaco-editor-core/esm/vs/editor/common/model/textModel';
-import {
-  IUndoRedoService,
-  ResourceEditStackSnapshot,
-  UndoRedoGroup,
-} from '@opensumi/monaco-editor-core/esm/vs/platform/undoRedo/common/undoRedo';
+import { IUndoRedoService, UndoRedoGroup } from '@opensumi/monaco-editor-core/esm/vs/platform/undoRedo/common/undoRedo';
 
 import { AINativeContextKey } from '../../ai-core.contextkeys';
-import {
-  EnhanceDecorationsCollection,
-  IDecorationSerializableState,
-  IEnhanceModelDeltaDecoration,
-} from '../../model/enhanceDecorationsCollection';
+import { IDecorationSerializableState, IEnhanceModelDeltaDecoration } from '../../model/enhanceDecorationsCollection';
 import { InlineDiffService } from '../inline-diff';
 
 import styles from './inline-stream-diff.module.less';
@@ -36,6 +28,7 @@ import {
   AcceptPartialEditWidget,
   ActiveLineDecoration,
   AddedRangeDecoration,
+  AddedRangeDecorationsCollection,
   EPartialEdit,
   IPartialEditEvent,
   IPartialEditWidgetOptions,
@@ -45,14 +38,6 @@ import {
   PendingRangeDecoration,
   RemovedZoneWidget,
 } from './live-preview.component';
-
-export interface ILivePreviewDiffDecorationSnapshotData {
-  addedDecList: IEnhanceModelDeltaDecoration[];
-  partialEditWidgetList: AcceptPartialEditWidget[];
-  removedWidgetList: RemovedZoneWidget[];
-  editStackSnapshot: ResourceEditStackSnapshot;
-  zone: LineRange;
-}
 
 export interface ITotalCodeInfo {
   totalAddedLinesCount: number;
@@ -97,8 +82,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
 
   protected model: ITextModel;
 
-  // Parts that require snapshots
-  private addedRangeDec: EnhanceDecorationsCollection;
+  private addedRangeDec: AddedRangeDecorationsCollection;
   private partialEditWidgetList: AcceptPartialEditWidget[] = [];
   private removedZoneWidgets: RemovedZoneWidget[] = [];
   private zone: LineRange;
@@ -108,11 +92,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     this.model = this.monacoEditor.getModel()!;
 
     this.undoRedoService = StandaloneServices.get(IUndoRedoService);
+    this.aiNativeContextKey = this.injector.get(AINativeContextKey, [this.monacoEditor.contextKeyService]);
 
     this.activeLineDec = this.monacoEditor.createDecorationsCollection();
     this.pendingRangeDec = this.monacoEditor.createDecorationsCollection();
-
-    this.aiNativeContextKey = this.injector.get(AINativeContextKey, [this.monacoEditor.contextKeyService]);
 
     this.addDispose(
       this.inlineStreamDiffService.onAcceptDiscardPartialEdit((isAccept) => {
@@ -139,13 +122,13 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       }),
     );
 
-    this.addedRangeDec = new EnhanceDecorationsCollection(this.monacoEditor);
+    this.addedRangeDec = new AddedRangeDecorationsCollection(this.monacoEditor);
     this.addDispose(
       this.addedRangeDec.onDidDecorationsChange((newAddedRangeDec) => {
         const inlineDiffPartialEditsIsVisible = this.aiNativeContextKey.inlineDiffPartialEditsIsVisible.get();
         if (inlineDiffPartialEditsIsVisible) {
           this.partialEditWidgetList.forEach((widget) => {
-            const addedWidget = newAddedRangeDec.find((a) => widget.getDecorationId() === a.id);
+            const addedWidget = newAddedRangeDec.find((a) => widget.getAddedRangeId() === a.id);
             if (addedWidget) {
               const range = addedWidget.getRange();
               /**
@@ -159,11 +142,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       }),
     );
 
-    this.addDispose(
-      Disposable.create(() => {
-        this.clear();
-      }),
-    );
+    this.addDispose(Disposable.create(() => this.clear()));
   }
 
   clear() {
@@ -174,82 +153,30 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     this.clearPartialEditWidgetList();
   }
 
+  hide() {
+    this.addedRangeDec.getDecorations().forEach((dec) => dec.hide());
+    this.partialEditWidgetList.forEach((widget) => widget.hide());
+    this.removedZoneWidgets.forEach((widget) => widget.hide());
+
+    this.activeLineDec.clear();
+    this.pendingRangeDec.clear();
+  }
+
+  /**
+   * 仅恢复渲染 status 为 pending 的部件
+   */
+  resume() {
+    this.addedRangeDec.getDecorations().forEach((dec) => dec.status === 'pending' && dec.resume());
+    this.partialEditWidgetList.forEach((widget) => widget.status === 'pending' && widget.resume());
+    this.removedZoneWidgets.forEach((widget) => widget.status === 'pending' && widget.resume());
+  }
+
   initialize(zone: LineRange): void {
     this.updateZone(zone);
   }
 
   getRemovedWidgets(): RemovedZoneWidget[] {
     return this.removedZoneWidgets;
-  }
-
-  restoreSnapshot(snapshot: ILivePreviewDiffDecorationSnapshotData): void {
-    const {
-      addedDecList,
-      removedWidgetList,
-      zone,
-      editStackSnapshot,
-      partialEditWidgetList: snapshotPartialEditWidgetList,
-    } = snapshot;
-
-    // restore zone
-    this.updateZone(zone);
-
-    // restore added
-    this.addedRangeDec.set(addedDecList);
-
-    // restore removed
-    this.clearRemovedWidgets();
-    removedWidgetList.forEach((widget) => {
-      const position = widget.getLastPosition();
-      if (position) {
-        this.showRemovedWidgetByLineNumber(position.lineNumber, widget.textLines, {
-          isHidden: widget.isHidden,
-          recordPosition: widget.getLastPosition(),
-          undoRedoGroup: widget.group,
-        });
-      }
-    });
-
-    // restore partial edit widget
-    this.clearPartialEditWidgetList();
-    snapshotPartialEditWidgetList.forEach((snapshotWidget) => {
-      const lineNumber = snapshotWidget.getPosition()?.position?.lineNumber;
-      if (lineNumber) {
-        const newPartialEditWidget = this.createPartialEditWidget(lineNumber);
-
-        if (snapshotWidget.status === 'accept') {
-          newPartialEditWidget.accept(snapshotWidget.addedLinesCount, snapshotWidget.deletedLinesCount);
-        } else if (snapshotWidget.status === 'discard') {
-          newPartialEditWidget.discard(snapshotWidget.addedLinesCount, snapshotWidget.deletedLinesCount);
-        }
-
-        newPartialEditWidget.setGroup(snapshotWidget.group);
-        this.partialEditWidgetList.push(newPartialEditWidget);
-      }
-    });
-    this.firePartialEditWidgetList();
-    this.recordPartialEditWidgetWithAddedDec();
-
-    // restore undo/redo stack
-    const uri = this.model.uri;
-    this.undoRedoService.restoreSnapshot(editStackSnapshot);
-    const elements = this.undoRedoService.getElements(uri);
-    elements.future.concat(elements.past).forEach((node) => {
-      if (node instanceof LivePreviewUndoRedoStackElement) {
-        // 在每次 restore 的时候需要将当前的类重新指向到 undo/redo 的 stack 中
-        node.attachModel(this);
-      }
-    });
-  }
-
-  createSnapshot(): ILivePreviewDiffDecorationSnapshotData {
-    return {
-      addedDecList: this.addedRangeDec.getDecorations(),
-      partialEditWidgetList: this.partialEditWidgetList,
-      removedWidgetList: this.removedZoneWidgets,
-      editStackSnapshot: this.undoRedoService.createSnapshot(this.model.uri),
-      zone: this.zone,
-    };
   }
 
   public showRemovedWidgetByLineNumber(
@@ -388,7 +315,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     const findAddedRangeDecByGroup = (model: LivePreviewDiffDecorationModel) =>
       model.addedRangeDec.getDecorationByGroup(group);
 
-    let modifyContent;
+    let modifyContent: string;
     const removeContent = removedWidget?.getRemovedTextLines().join('\n') || '';
     const range = addedDec?.getRange();
     if (range) {
@@ -411,10 +338,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
         });
       }
       const removedWidget = findRemovedWidgetByGroup(decorationModel);
-      removedWidget?.hide();
+      removedWidget?.discard();
 
       const addedDec = findAddedRangeDecByGroup(decorationModel);
-      addedDec?.hide();
+      addedDec?.discard();
 
       const partialEditWidget = findPartialWidgetByGroup(decorationModel);
       const operation = this.doDiscardPartialWidget(partialEditWidget!, addedDec, removedWidget);
@@ -422,7 +349,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       return operation;
     };
 
-    const accpet = (decorationModel: LivePreviewDiffDecorationModel) => {
+    const accept = (decorationModel: LivePreviewDiffDecorationModel) => {
       // 只有点击行采纳时才会上报
       if (isReport) {
         this.aiReporter.end(relationId, {
@@ -439,10 +366,10 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       partialEditWidget?.accept(addedLinesCount, deletedLinesCount);
 
       const removedWidget = findRemovedWidgetByGroup(decorationModel);
-      removedWidget?.hide();
+      removedWidget?.accept();
 
       const addedDec = findAddedRangeDecByGroup(decorationModel);
-      addedDec?.hide();
+      addedDec?.accept();
     };
 
     const resume = (decorationModel: LivePreviewDiffDecorationModel) => {
@@ -458,7 +385,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
 
     switch (type) {
       case EPartialEdit.accept:
-        accpet(this);
+        accept(this);
         if (isPushStack) {
           const stack = this.createEditStackElement(group);
           stack.attachModel(this);
@@ -466,7 +393,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
             resume(model);
           });
           stack.registerRedo((model: LivePreviewDiffDecorationModel) => {
-            accpet(model);
+            accept(model);
           });
         }
         break;
@@ -515,8 +442,8 @@ export class LivePreviewDiffDecorationModel extends Disposable {
 
   private firePartialEditWidgetList(): void {
     this._onPartialEditWidgetListChange.fire(this.partialEditWidgetList);
-    const visiableLists = this.partialEditWidgetList.filter((widget) => !widget.isHidden);
-    this.aiNativeContextKey.inlineDiffPartialEditsIsVisible.set(visiableLists.length !== 0);
+    const visibleLists = this.partialEditWidgetList.filter((widget) => !widget.isHidden);
+    this.aiNativeContextKey.inlineDiffPartialEditsIsVisible.set(visibleLists.length !== 0);
   }
 
   public createEditStackElement(group: UndoRedoGroup): LivePreviewUndoRedoStackElement {
@@ -535,7 +462,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
     // 2. 删除 N 行 => N
     // 3. 新增 M 行，删除 N 行 => max(M, N)
     // 综上所述，变更行数 = sum(list.map(item => max(新增行数, 删除行数)))
-    const resolvedStatus = caculate(partialEditWidgetList);
+    const resolvedStatus = calculate(partialEditWidgetList);
     const unresolvedStatus = { added: 0, deleted: 0, changed: 0 };
     partialEditWidgetList.forEach((v, idx) => {
       if (v.status === 'pending') {
@@ -558,7 +485,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       unresolvedChangedLinesCount: unresolvedStatus.changed,
     };
 
-    function caculate(list: AcceptPartialEditWidget[]) {
+    function calculate(list: AcceptPartialEditWidget[]) {
       const result = { added: 0, deleted: 0, changed: 0 };
       list.forEach((widget) => {
         const addedLinesCount = widget.addedLinesCount;
@@ -593,7 +520,7 @@ export class LivePreviewDiffDecorationModel extends Disposable {
       if (lineNumber) {
         const addedWidget = this.addedRangeDec.getDecorationByLineNumber(lineNumber);
         if (addedWidget) {
-          widget.recordDecorationId(addedWidget.id);
+          widget.recordAddedRangeId(addedWidget.id);
         }
       }
     });

--- a/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
+++ b/packages/monaco/src/browser/ai-native/BaseInlineContentWidget.tsx
@@ -71,7 +71,7 @@ export abstract class ReactInlineContentWidget extends Disposable implements IIn
     this.options = options;
   }
 
-  show(options?: ShowAIContentOptions | undefined): void {
+  show(options: ShowAIContentOptions | undefined = this.options): void {
     if (!options) {
       return;
     }


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

- [x] 重构 inline diff 的恢复逻辑
- [x] 支持数据层和渲染层分离

之前在切换文件时是通过临时存储一份 snapshot 快照数据然后销毁原有实例，在每次恢复 inline diff 的时候又重新创建一个实例然后 attach 这个 snapshot，这种思路不好，容易遗漏一些数据层面的存储。

现重构成，切换文件时不销毁实例（除非主动销毁），仅销毁渲染层，然后每次在恢复的时候由于数据层不变，只需要恢复渲染层即可，而且这样也能实现在流式的过程当中切换文件不会导致中断。


https://github.com/user-attachments/assets/b7981a23-e78c-4a0e-9948-ac5928bb12f9


### Changelog
切换文件时不中断 inline diff 的流式数据
