### PR TITLE
fix: watcher dispose logic

### DIFF
--- a/packages/core-common/src/types/file-watch.ts
+++ b/packages/core-common/src/types/file-watch.ts
@@ -40,7 +40,7 @@ export interface IWatcher {
    * @returns {Promise<void>}
    * @memberof FileSystemWatcherServer
    */
-  unwatchFileChanges(uri: string): Promise<void>;
+  unwatchFileChanges(uri: string): void;
 
   /**
    * Update watcher file excludes

--- a/packages/file-service/src/node/hosted/un-recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/hosted/un-recursive/file-service-watcher.ts
@@ -21,7 +21,7 @@ export class UnRecursiveFileSystemWatcher implements IWatcher {
 
   protected client: FileSystemWatcherClient | undefined;
 
-  constructor(private readonly logger: ILogService) { }
+  constructor(private readonly logger: ILogService) {}
 
   dispose(): void {
     this.toDispose.dispose();
@@ -52,7 +52,9 @@ export class UnRecursiveFileSystemWatcher implements IWatcher {
 
       // 开始走监听流程
       watcher.on('error', (code: number, signal: string) => {
-        this.logger.error(`[Un-Recursive] Failed to watch ${basePath} for changes using fs.watch() (${code}, ${signal})`);
+        this.logger.error(
+          `[Un-Recursive] Failed to watch ${basePath} for changes using fs.watch() (${code}, ${signal})`,
+        );
         watcher.close();
       });
 
@@ -157,7 +159,7 @@ export class UnRecursiveFileSystemWatcher implements IWatcher {
     return disposables;
   }
 
-  async unwatchFileChanges(uri: string): Promise<void> {
+  unwatchFileChanges(uri: string): void {
     const basePath = FileUri.fsPath(uri);
     if (this.watcherCollections.has(basePath)) {
       const watcher = this.watcherCollections.get(basePath);

--- a/packages/file-service/src/node/hosted/watcher.host.service.ts
+++ b/packages/file-service/src/node/hosted/watcher.host.service.ts
@@ -137,7 +137,7 @@ export class WatcherHostServiceImpl implements IWatcherHostService {
 
     disposables.push(
       Disposable.create(async () => {
-        await this.unrecursiveFileSystemWatcher!.unwatchFileChanges(uri.toString());
+        this.unrecursiveFileSystemWatcher!.unwatchFileChanges(uri.toString());
         this.logger.log('dispose unrecursive watcher: ', uri.toString());
         this.watchedDirs.delete(uri.toString());
         this.WATCHER_HANDLERS.delete(watcherId);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - `unwatchFileChanges` 方法的返回类型已更新为 `void`，简化了使用方式。

- **重构**
  - 优化了文件监控管理流程，确保监控路径与实际文件系统更准确匹配，并提升了资源释放与错误处理的稳定性。
  
- **样式**
  - 调整了部分日志和提示信息的格式，提高了问题排查时的信息清晰度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->