### PR TITLE
fix: adjust default sizes for top slot and menubar height

### DIFF
--- a/packages/ai-native/src/browser/layout/ai-layout.tsx
+++ b/packages/ai-native/src/browser/layout/ai-layout.tsx
@@ -10,11 +10,14 @@ export const AILayout = () => {
   const { layout } = getStorageValue();
   const designLayoutConfig = useInjectable(DesignLayoutConfig);
 
-  const defaultRightSize = useMemo(() => designLayoutConfig.useMergeRightWithLeftPanel ? 0 : 49, [designLayoutConfig.useMergeRightWithLeftPanel]);
+  const defaultRightSize = useMemo(
+    () => (designLayoutConfig.useMergeRightWithLeftPanel ? 0 : 49),
+    [designLayoutConfig.useMergeRightWithLeftPanel],
+  );
 
   return (
     <BoxPanel direction='top-to-bottom'>
-      <SlotRenderer id='top' defaultSize={layout.top?.currentId ? layout.top?.size || 35 : 0} slot='top' />
+      <SlotRenderer id='top' defaultSize={layout.top?.currentId ? layout.top?.size || 32 : 32} slot='top' />
       <SplitPanel
         id='main-horizontal-ai'
         flex={1}

--- a/packages/startup/entry/web/app.tsx
+++ b/packages/startup/entry/web/app.tsx
@@ -12,7 +12,7 @@ renderApp(
     modules: [...AIModules, NotebookModule],
     opts: {
       layoutViewSize: {
-        menubarHeight: 48,
+        menubarHeight: 32,
       },
       layoutConfig: {
         [DESIGN_MENU_BAR_RIGHT]: {


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution

Before:
![image](https://github.com/user-attachments/assets/489150b4-ee4d-4dcf-b7bc-c20a68c3cc59)

After:
![image](https://github.com/user-attachments/assets/9c35a8d9-06de-4bb3-8996-142f994c3c99)

### Changelog

adjust default sizes for top slot and menubar height