### PR TITLE
refactor: upgrade monaco to 0.54.0 and support vscode.languages.registerInlineEditProvider API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache directory path
-        id: yarn_cache_dir_path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      # - name: Get yarn cache directory path
+      #   id: yarn_cache_dir_path
+      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4
-        id: yarn_cache
-        with:
-          path: ${{ steps.yarn_cache_dir_path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      # - uses: actions/cache@v4
+      #   id: yarn_cache
+      #   with:
+      #     path: ${{ steps.yarn_cache_dir_path.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      # - name: Get yarn cache directory path
-      #   id: yarn_cache_dir_path
-      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Get yarn cache directory path
+        id: yarn_cache_dir_path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      # - uses: actions/cache@v4
-      #   id: yarn_cache
-      #   with:
-      #     path: ${{ steps.yarn_cache_dir_path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
+      - uses: actions/cache@v4
+        id: yarn_cache
+        with:
+          path: ${{ steps.yarn_cache_dir_path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install
         run: |

--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -89,3 +89,10 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 });
+
+Object.defineProperty(window, 'crypto', {
+  writable: true,
+  value: {
+    randomUUID: () => 'mocked-uuid',
+  },
+});

--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -90,10 +90,19 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+// Mock window.crypto
 Object.defineProperty(window, 'crypto', {
   writable: true,
   value: {
     randomUUID: () => 'mocked-uuid',
     getRandomValues: () => 'mocked-uuid',
+  },
+});
+
+// Mock window.CSS
+Object.defineProperty(window, 'CSS', {
+  writable: true,
+  value: {
+    escape: jest.fn((str) => str),
   },
 });

--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -94,8 +94,23 @@ Object.defineProperty(window, 'matchMedia', {
 Object.defineProperty(window, 'crypto', {
   writable: true,
   value: {
-    randomUUID: () => 'mocked-uuid',
-    getRandomValues: () => 'mocked-uuid',
+    randomUUID: () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    }),
+    getRandomValues: (array) => {
+      if (!(array instanceof Int8Array || array instanceof Uint8Array ||
+            array instanceof Int16Array || array instanceof Uint16Array ||
+            array instanceof Int32Array || array instanceof Uint32Array ||
+            array instanceof Uint8ClampedArray)) {
+        throw new TypeError('Expected a TypedArray');
+      }
+      for (let i = 0; i < array.length; i++) {
+        array[i] = Math.floor(Math.random() * 256);
+      }
+      return array;
+    },
   },
 });
 

--- a/jest.setup.jsdom.js
+++ b/jest.setup.jsdom.js
@@ -94,5 +94,6 @@ Object.defineProperty(window, 'crypto', {
   writable: true,
   value: {
     randomUUID: () => 'mocked-uuid',
+    getRandomValues: () => 'mocked-uuid',
   },
 });

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.controller.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.controller.ts
@@ -28,7 +28,7 @@ import { InlineCompletionsController } from '@opensumi/monaco-editor-core/esm/vs
 import {
   SuggestItemInfo,
   SuggestWidgetAdaptor,
-} from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdaptor';
+} from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter';
 import { ContextKeyExpr } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 
 import { AINativeContextKey } from '../../ai-core.contextkeys';
@@ -144,8 +144,7 @@ export class IntelligentCompletionsController extends BaseAIMonacoEditorControll
             model?.inlineCompletionState.read(reader);
 
             const suggestWidgetSelectedItem = inlineCompletionsController['_suggestWidgetSelectedItem'] as IObservable<
-              SuggestItemInfo | undefined,
-              unknown
+              SuggestItemInfo | undefined
             >;
             const selectedItem = suggestWidgetSelectedItem.get();
             if (selectedItem) {

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.feature.registry.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/intelligent-completions.feature.registry.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@opensumi/di';
 import { Disposable } from '@opensumi/ide-core-common';
+import { InlineEditProvider } from '@opensumi/ide-monaco';
 
 import { ICodeEditsProvider, IIntelligentCompletionProvider, IIntelligentCompletionsRegistry } from '../../types';
 
@@ -7,6 +8,7 @@ import { ICodeEditsProvider, IIntelligentCompletionProvider, IIntelligentComplet
 export class IntelligentCompletionsRegistry extends Disposable implements IIntelligentCompletionsRegistry {
   private inlineCompletionsProvider: IIntelligentCompletionProvider | undefined;
   private codeEditsProvider: ICodeEditsProvider | undefined;
+  private inlineEditProvider: InlineEditProvider | undefined;
 
   registerIntelligentCompletionProvider(provider: IIntelligentCompletionProvider): void {
     this.inlineCompletionsProvider = provider;
@@ -14,6 +16,10 @@ export class IntelligentCompletionsRegistry extends Disposable implements IIntel
 
   registerInlineCompletionsProvider(provider: IIntelligentCompletionProvider): void {
     this.inlineCompletionsProvider = provider;
+  }
+
+  registerInlineEditProvider(provider: InlineEditProvider): void {
+    this.inlineEditProvider = provider;
   }
 
   registerCodeEditsProvider(provider: ICodeEditsProvider): void {
@@ -26,5 +32,10 @@ export class IntelligentCompletionsRegistry extends Disposable implements IIntel
 
   getCodeEditsProvider(): ICodeEditsProvider | undefined {
     return this.codeEditsProvider;
+  }
+
+  getInlineEditProvider(): InlineEditProvider | undefined {
+    // TODO: 支持模块内调用
+    return this.inlineEditProvider;
   }
 }

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -13,7 +13,15 @@ import {
   MaybePromise,
   MergeConflictEditorMode,
 } from '@opensumi/ide-core-common';
-import { ICodeEditor, IRange, ISelection, ITextModel, NewSymbolNamesProvider, Position } from '@opensumi/ide-monaco';
+import {
+  ICodeEditor,
+  IRange,
+  ISelection,
+  ITextModel,
+  InlineEditProvider,
+  NewSymbolNamesProvider,
+  Position,
+} from '@opensumi/ide-monaco';
 import { SumiReadableStream } from '@opensumi/ide-utils/lib/stream';
 import { IMarker } from '@opensumi/monaco-editor-core/esm/vs/platform/markers/common/markers';
 
@@ -224,14 +232,39 @@ export type ICodeEditsProvider = (
   token: CancellationToken,
 ) => MaybePromise<ICodeEditsResult | undefined>;
 
+export type IIntelligentInlineEditProvider = (
+  editor: ICodeEditor,
+  position: IPosition,
+  contextBean: IAICompletionOption,
+  token: CancellationToken,
+) => MaybePromise<IIntelligentCompletionsResult>;
+
+/**
+ * Interface for registering intelligent completion providers and code edits providers.
+ */
 export interface IIntelligentCompletionsRegistry {
   /**
-   *  @deprecated use registerInlineCompletionProvider API
+   * Registers an intelligent completion provider.
+   * @deprecated Use the `registerInlineCompletionsProvider` method instead.
+   * @param provider - The intelligent completion provider to register.
    */
   registerIntelligentCompletionProvider(provider: IIntelligentCompletionProvider): void;
-  registerInlineCompletionsProvider(provider: IIntelligentCompletionProvider): void;
+
   /**
-   * 注册 code edits 功能
+   * Registers an inline completions provider.
+   * @param provider - The intelligent completion provider to register.
+   */
+  registerInlineCompletionsProvider(provider: IIntelligentCompletionProvider): void;
+
+  /**
+   * Registers an inline edit provider.
+   * @param provider The inline edit provider to register.
+   */
+  registerInlineEditProvider(provider: InlineEditProvider): void;
+
+  /**
+   * Registers a code edits provider.
+   * @param provider - The code edits provider to register.
    */
   registerCodeEditsProvider(provider: ICodeEditsProvider): void;
 }

--- a/packages/ai-native/src/browser/widget/inline-chat/inline-chat-editor.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-chat/inline-chat-editor.controller.ts
@@ -222,7 +222,7 @@ export class InlineChatEditorController extends BaseAIMonacoEditorController {
 
   protected async showInlineChat(monacoEditor: monaco.ICodeEditor): Promise<void> {
     // 调试状态下禁用 inline chat。影响调试体验
-    const inDebugMode = this.contextKeyService.getContextValue(CONTEXT_IN_DEBUG_MODE_KEY);
+    const inDebugMode = this.contextKeyService.getContextKeyValue(CONTEXT_IN_DEBUG_MODE_KEY);
     if (inDebugMode) {
       return;
     }

--- a/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-diff/inline-diff.controller.ts
@@ -51,7 +51,7 @@ export class InlineDiffController extends BaseAIMonacoEditorController {
 
   private previewerStore: Map<string, IInlineDiffPreviewer>;
   private currentPreviewer: ISettableObservable<IInlineDiffPreviewer | undefined>;
-  private modelChangeObs: IObservable<monaco.editor.ITextModel, unknown>;
+  private modelChangeObs: IObservable<monaco.editor.ITextModel>;
 
   mount(): IDisposable {
     this.previewerStore = new Map();

--- a/packages/ai-native/src/browser/widget/inline-input/inline-input.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-input/inline-input.controller.ts
@@ -67,7 +67,7 @@ export class InlineInputController extends BaseAIMonacoEditorController {
   private aiNativeContextKey: AINativeContextKey;
 
   private inputValue: ISettableObservable<string>;
-  private modelChangeObs: IObservable<monaco.editor.ITextModel, unknown>;
+  private modelChangeObs: IObservable<monaco.editor.ITextModel>;
   private inlineInputWidgetStore: Map<
     string,
     InlineInputWidgetStoreInEmptyLine | InlineInputWidgetStoreInSelection | null

--- a/packages/comments/__test__/browser/comment-thread.test.ts
+++ b/packages/comments/__test__/browser/comment-thread.test.ts
@@ -1,14 +1,14 @@
 import { Injector } from '@opensumi/di';
 import { IContextKeyService } from '@opensumi/ide-core-browser';
 import { URI } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { positionToRange } from '@opensumi/ide-monaco';
+import { createMockedMonaco } from '@opensumi/ide-monaco/__mocks__/monaco';
+import { MockContextKeyService } from '@opensumi/ide-monaco/__mocks__/monaco.context-key.service';
 import { IIconService } from '@opensumi/ide-theme';
 import { IconService } from '@opensumi/ide-theme/lib/browser';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
-import { createMockedMonaco } from '../../../monaco/__mocks__/monaco';
-import { MockContextKeyService } from '../../../monaco/__mocks__/monaco.context-key.service';
 import { CommentsModule } from '../../src/browser';
 import { CommentMode, ICommentsService } from '../../src/common';
 
@@ -134,10 +134,10 @@ describe('comment service test', () => {
     const thread = commentsService.createThread(uri, positionToRange(1), {
       contextValue,
     });
-    expect(thread.contextKeyService.getContextValue('thread')).toBe(contextValue);
-    expect(thread.contextKeyService.getContextValue('threadsLength')).toBe(1);
+    expect(thread.contextKeyService.getContextKeyValue('thread')).toBe(contextValue);
+    expect(thread.contextKeyService.getContextKeyValue('threadsLength')).toBe(1);
     commentsService.createThread(uri, positionToRange(2));
     // 同一个 uri 的 threadsLength 会变为 2
-    expect(thread.contextKeyService.getContextValue('threadsLength')).toBe(2);
+    expect(thread.contextKeyService.getContextKeyValue('threadsLength')).toBe(2);
   });
 });

--- a/packages/comments/src/browser/comments-thread.ts
+++ b/packages/comments/src/browser/comments-thread.ts
@@ -46,7 +46,7 @@ export class CommentsThread extends Disposable implements ICommentsThread {
   }
 
   get contextValue() {
-    return this._contextKeyService.getContextValue('thread');
+    return this._contextKeyService.getContextKeyValue('thread');
   }
 
   get onDidChangeCollapsibleState() {

--- a/packages/components/src/input/HistoryInputBox.tsx
+++ b/packages/components/src/input/HistoryInputBox.tsx
@@ -32,7 +32,7 @@ export class HistoryInputBox extends React.Component<HistoryInputBoxProp> {
   public componentDidMount() {
     const { history, onReady } = this.props;
 
-    this.history = new HistoryNavigator(history, 100);
+    this.history = new HistoryNavigator(history || new Set([]), 100);
     this.inputProps = { ...this.props };
     delete this.inputProps.onReady;
 

--- a/packages/components/src/input/HistoryInputBox.tsx
+++ b/packages/components/src/input/HistoryInputBox.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { HistoryNavigator } from '@opensumi/monaco-editor-core/esm/vs/base/common/history';
+import { HistoryNavigator, IHistory } from '@opensumi/monaco-editor-core/esm/vs/base/common/history';
 
 import { IInputBaseProps, Input } from './Input';
 
 export interface HistoryInputBoxProp extends IInputBaseProps {
   // 上层自己持久化历史记录
-  history?: string[];
+  history?: IHistory<string>;
   onReady?: (api: IHistoryInputBoxHandler) => void;
 }
 
@@ -32,7 +32,7 @@ export class HistoryInputBox extends React.Component<HistoryInputBoxProp> {
   public componentDidMount() {
     const { history, onReady } = this.props;
 
-    this.history = new HistoryNavigator(history || [], 100);
+    this.history = new HistoryNavigator(history, 100);
     this.inputProps = { ...this.props };
     delete this.inputProps.onReady;
 

--- a/packages/core-browser/src/context-key.ts
+++ b/packages/core-browser/src/context-key.ts
@@ -24,7 +24,7 @@ export interface IContextKeyService {
   createKey<T extends ContextKeyValue = any>(key: string, defaultValue: T | undefined): IContextKey<T>;
   match(expression: string | ContextKeyExpr | undefined, context?: HTMLElement | null): boolean;
   getKeysInWhen(when: string | ContextKeyExpr | undefined): string[];
-  getContextValue<T>(key: string): T | undefined;
+  getContextKeyValue<T>(key: string): T | undefined;
   contextKeyService: IMonacoContextKeyService;
 
   createScoped(target?: IContextKeyServiceTarget | ContextKeyService): IScopedContextKeyService;

--- a/packages/core-browser/src/progress/progress-bar.tsx
+++ b/packages/core-browser/src/progress/progress-bar.tsx
@@ -11,17 +11,16 @@ export const ProgressBar: React.FC<{ progressModel: IProgressModel; className?: 
   progressModel,
   className,
 }) => {
-  const worked = useAutorun(progressModel.worked);
-  const total = useAutorun(progressModel.total);
-  const show = useAutorun(progressModel.show);
-  const fade = useAutorun(progressModel.fade);
+  const worked = useAutorun<number>(progressModel.worked);
+  const total = useAutorun<number | undefined>(progressModel.total);
+  const show = useAutorun<boolean>(progressModel.show);
+  const fade = useAutorun<boolean>(progressModel.fade);
+
+  const progressWidth = total ? (worked / total || 0.02) * 100 + '%' : '2%';
 
   return (
     <div className={cls(className, styles.progressBar, { [styles.hide]: !show }, { [styles.fade]: fade })}>
-      <div
-        className={cls(styles.progress, { [styles.infinite]: !total })}
-        style={total ? { width: (worked / total || 0.02) * 100 + '%' } : { width: '2%' }}
-      ></div>
+      <div className={cls(styles.progress, { [styles.infinite]: !total })} style={{ width: progressWidth }}></div>
     </div>
   );
 };

--- a/packages/core-browser/src/raw-context-key.ts
+++ b/packages/core-browser/src/raw-context-key.ts
@@ -71,7 +71,7 @@ export class RawContextKey<T extends ContextKeyValue> implements IRawContextKey<
   }
 
   public getValue(target: IContextKeyService): T | undefined {
-    return target.getContextValue<T>(this.key);
+    return target.getContextKeyValue<T>(this.key);
   }
 
   /**

--- a/packages/core-browser/src/utils/react-hooks.ts
+++ b/packages/core-browser/src/utils/react-hooks.ts
@@ -138,7 +138,7 @@ export const useLatest = <T>(value: T): { readonly current: T } => {
   return ref;
 };
 
-export const useAutorun = <T, TChange = unknown>(observable: IObservable<T, TChange>): T => {
+export const useAutorun = <T>(observable: IObservable<T>): T => {
   const [value, setValue] = useState<T>(observable.get());
 
   useDisposable(

--- a/packages/debug/__tests__/browser/editor/debug-breakpoint-widget.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-breakpoint-widget.test.ts
@@ -90,7 +90,7 @@ describe('Debug Breakpoint Widget', () => {
       token: IContextKeyService,
       useValue: {
         createKey: jest.fn(),
-        getContextValue: jest.fn(),
+        getContextKeyValue: jest.fn(),
         onDidChangeContext: new Emitter().event,
       },
     });

--- a/packages/debug/__tests__/browser/editor/debug-model.test.ts
+++ b/packages/debug/__tests__/browser/editor/debug-model.test.ts
@@ -9,11 +9,11 @@ import { EditorDocumentModelServiceImpl } from '@opensumi/ide-editor/lib/browser
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { FileServiceClient } from '@opensumi/ide-file-service/lib/browser/file-service-client';
 import * as monaco from '@opensumi/ide-monaco';
+import { createMockedMonaco } from '@opensumi/ide-monaco/__mocks__/monaco';
 import { monacoBrowser } from '@opensumi/ide-monaco/lib/browser';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { WorkspaceService } from '@opensumi/ide-workspace/lib/browser/workspace-service';
 
-import { createMockedMonaco } from '../../../../monaco/__mocks__/monaco';
 import { DebugBreakpointWidget, DebugHoverWidget, DebugModel } from '../../../src/browser/editor';
 
 describe('Debug Model', () => {
@@ -117,7 +117,7 @@ describe('Debug Model', () => {
     mockInjector.overrideProviders({
       token: IContextKeyService,
       useValue: {
-        getContextValue: jest.fn(),
+        getContextKeyValue: jest.fn(),
       },
     });
 

--- a/packages/debug/__tests__/browser/view/breakpoint/debug-breakpoints.service.test.ts
+++ b/packages/debug/__tests__/browser/view/breakpoint/debug-breakpoints.service.test.ts
@@ -49,7 +49,7 @@ describe('Debug Breakpoints Service', () => {
 
   const mockContextKeyService = {
     onDidChangeContext: jest.fn(),
-    getContextValue: () => true,
+    getContextKeyValue: () => true,
   };
 
   const mockDebugViewModel = {

--- a/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
+++ b/packages/debug/src/browser/view/breakpoints/debug-breakpoints.service.ts
@@ -109,7 +109,7 @@ export class DebugBreakpointsService extends WithEventBus {
     this.contextKeyService.onDidChangeContext((e) => {
       if (e.payload.affectsSome(new Set([CONTEXT_IN_DEBUG_MODE_KEY]))) {
         transaction((tx) => {
-          this.inDebugMode.set(this.contextKeyService.getContextValue(CONTEXT_IN_DEBUG_MODE_KEY) || false, tx);
+          this.inDebugMode.set(this.contextKeyService.getContextKeyValue(CONTEXT_IN_DEBUG_MODE_KEY) || false, tx);
         });
       }
     });
@@ -137,7 +137,7 @@ export class DebugBreakpointsService extends WithEventBus {
   async updateRoots() {
     transaction((tx) => {
       this.enable.set(this.breakpoints.breakpointsEnabled, tx);
-      this.inDebugMode.set(this.contextKeyService.getContextValue(CONTEXT_IN_DEBUG_MODE_KEY) || false, tx);
+      this.inDebugMode.set(this.contextKeyService.getContextKeyValue(CONTEXT_IN_DEBUG_MODE_KEY) || false, tx);
     });
     const roots = await this.workspaceService.roots;
     this.roots = roots.map((file) => new URI(file.uri));

--- a/packages/debug/src/browser/view/console/debug-console.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console.service.ts
@@ -139,7 +139,7 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
     }
 
     const storage = await this.storageProvider(STORAGE_NAMESPACE.DEBUG);
-    this.history = new HistoryNavigator(storage.get(HISTORY_STORAGE_KEY, []), 50);
+    this.history = new HistoryNavigator(new Set(storage.get(HISTORY_STORAGE_KEY, [])), 50);
 
     if (this.inputEditor?.monacoEditor) {
       return;

--- a/packages/debug/src/browser/view/console/debug-console.service.ts
+++ b/packages/debug/src/browser/view/console/debug-console.service.ts
@@ -148,7 +148,7 @@ export class DebugConsoleService implements IHistoryNavigationWidget {
     this._consoleInputElement = e;
     this.inputEditor = this.editorService.createCodeEditor(this._consoleInputElement!, {
       ...consoleInputMonacoOptions,
-      readOnly: !this.contextKeyService.getContextValue(CONTEXT_IN_DEBUG_MODE_KEY),
+      readOnly: !this.contextKeyService.getContextKeyValue(CONTEXT_IN_DEBUG_MODE_KEY),
     });
 
     this.debugContextKey = this.injector.get(DebugContextKey, [this.inputEditor.monacoEditor.contextKeyService]);

--- a/packages/extension/src/browser/vscode/api/main.thread.language.ts
+++ b/packages/extension/src/browser/vscode/api/main.thread.language.ts
@@ -50,13 +50,13 @@ import {
   ISuggestResultDtoField,
   IdentifiableInlineCompletion,
   IdentifiableInlineCompletions,
+  IdentifiableInlineEdit,
   MonacoModelIdentifier,
-  RangeSuggestDataDto,
   testGlob,
 } from '../../../common/vscode';
 import { IDocumentFilterDto, fromLanguageSelector } from '../../../common/vscode/converter';
 import { CancellationError, UriComponents } from '../../../common/vscode/ext-types';
-import { IExtensionDescription } from '../../../common/vscode/extension';
+import { ExtensionIdentifier, IExtensionDescription } from '../../../common/vscode/extension';
 import {
   CallHierarchyItem,
   FoldingRangeProvider,
@@ -401,6 +401,30 @@ export class MainThreadLanguages implements IMainThreadLanguages {
     this.disposables.set(
       handle,
       monacoApi.languages.registerInlineCompletionsProvider(fromLanguageSelector(selector)!, provider),
+    );
+  }
+
+  $registerInlineEditProvider(
+    handle: number,
+    selector: IDocumentFilterDto[],
+    extensionId: ExtensionIdentifier,
+    displayName: string,
+  ): void {
+    const provider: monaco.languages.InlineEditProvider<IdentifiableInlineEdit> = {
+      displayName,
+      provideInlineEdit: async (
+        model: ITextModel,
+        context: monaco.languages.IInlineEditContext,
+        token: CancellationToken,
+      ): Promise<IdentifiableInlineEdit | undefined> =>
+        this.proxy.$provideInlineEdit(handle, model.uri, context, token),
+      freeInlineEdit: (edit: IdentifiableInlineEdit): void => {
+        this.proxy.$freeInlineEdit(handle, edit.pid);
+      },
+    };
+    this.disposables.set(
+      handle,
+      monacoApi.languages.registerInlineEditProvider(fromLanguageSelector(selector)!, provider),
     );
   }
 

--- a/packages/extension/src/common/vscode/ext-types.ts
+++ b/packages/extension/src/common/vscode/ext-types.ts
@@ -3997,4 +3997,15 @@ export enum NotebookVariablesRequestKind {
   Named = 1,
   Indexed = 2,
 }
+
+// #region InlineEdit
+export class InlineEdit implements vscode.InlineEdit {
+  constructor(public readonly text: string, public readonly range: Range) {}
+}
+
+export enum InlineEditTriggerKind {
+  Invoke = 0,
+  Automatic = 1,
+}
+
 // #endregion

--- a/packages/extension/src/common/vscode/languages.ts
+++ b/packages/extension/src/common/vscode/languages.ts
@@ -11,7 +11,7 @@ import { ILanguageStatus, ISingleEditOperation } from '@opensumi/ide-editor';
 
 import { IDocumentFilterDto } from './converter';
 import { Disposable } from './ext-types';
-import { IExtensionDescription } from './extension';
+import { ExtensionIdentifier, IExtensionDescription } from './extension';
 import {
   CacheId,
   ChainedCacheId,
@@ -105,6 +105,12 @@ export interface IMainThreadLanguages {
     supportsHandleDidShowCompletionItem: boolean,
     extensionId: string,
     yieldsToExtensionIds: string[],
+  ): void;
+  $registerInlineEditProvider(
+    handle: number,
+    selector: IDocumentFilterDto[],
+    extensionId: ExtensionIdentifier,
+    displayName: string,
   ): void;
   $registerDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
   $registerTypeDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
@@ -545,6 +551,13 @@ export interface IExtHostLanguages {
   ): Promise<IInlayHintsDto | undefined>;
   $resolveInlayHint(handle: number, id: ChainedCacheId, token: CancellationToken): Promise<IInlayHintDto | undefined>;
   $releaseInlayHints(handle: number, id: number): void;
+  $provideInlineEdit(
+    handle: number,
+    document: UriComponents,
+    context: languages.IInlineEditContext,
+    token: CancellationToken,
+  ): Promise<IdentifiableInlineEdit | undefined>;
+  $freeInlineEdit(handle: number, pid: number): void;
 }
 
 export interface ILinkedEditingRangesDto {
@@ -695,8 +708,11 @@ export interface ICodeActionProviderMetadataDto {
   readonly documentation?: ReadonlyArray<{ readonly kind: string; readonly command: Command }>;
 }
 
-// inline completion begin
 export interface IdentifiableInlineCompletions extends languages.InlineCompletions<IdentifiableInlineCompletion> {
+  pid: number;
+}
+
+export interface IdentifiableInlineEdit extends languages.IInlineEdit {
   pid: number;
 }
 

--- a/packages/extension/src/hosted/api/vscode/language/inlineEdit.ts
+++ b/packages/extension/src/hosted/api/vscode/language/inlineEdit.ts
@@ -1,0 +1,127 @@
+import vscode, { CancellationToken } from 'vscode';
+
+import { DisposableStore, Uri as URI } from '@opensumi/ide-core-common';
+
+import { ExtensionDocumentDataManager, IExtensionDescription, IdentifiableInlineEdit } from '../../../../common/vscode';
+import * as typeConvert from '../../../../common/vscode/converter';
+import { InlineEditTriggerKind } from '../../../../common/vscode/ext-types';
+import * as languages from '../../../../common/vscode/languages';
+import { CommandsConverter } from '../ext.host.command';
+
+export class InlineEditAdapter {
+  private readonly _references = new ReferenceMap<{
+    dispose(): void;
+    item: vscode.InlineEdit;
+  }>();
+
+  private languageTriggerKindToVSCodeTriggerKind: Record<InlineEditTriggerKind, InlineEditTriggerKind> = {
+    [InlineEditTriggerKind.Automatic]: InlineEditTriggerKind.Automatic,
+    [InlineEditTriggerKind.Invoke]: InlineEditTriggerKind.Invoke,
+  };
+
+  async provideInlineEdits(
+    uri: URI,
+    context: vscode.InlineEditContext,
+    token: CancellationToken,
+  ): Promise<IdentifiableInlineEdit | undefined> {
+    const doc = this._documents.getDocument(uri);
+    const result = await this._provider.provideInlineEdit(
+      doc,
+      {
+        triggerKind: this.languageTriggerKindToVSCodeTriggerKind[context.triggerKind],
+        requestUuid: context.requestUuid,
+      },
+      token,
+    );
+
+    if (!result) {
+      // undefined and null are valid results
+      return undefined;
+    }
+
+    if (token.isCancellationRequested) {
+      // cancelled -> return without further ado, esp no caching
+      // of results as they will leak
+      return undefined;
+    }
+    let disposableStore: DisposableStore | undefined;
+    const pid = this._references.createReferenceId({
+      dispose() {
+        disposableStore?.dispose();
+      },
+      item: result,
+    });
+
+    let acceptCommand: languages.Command | undefined;
+    if (result.accepted) {
+      if (!disposableStore) {
+        disposableStore = new DisposableStore();
+      }
+      acceptCommand = this._commands.toInternal(result.accepted, disposableStore);
+    }
+    let rejectCommand: languages.Command | undefined;
+    if (result.rejected) {
+      if (!disposableStore) {
+        disposableStore = new DisposableStore();
+      }
+      rejectCommand = this._commands.toInternal(result.rejected, disposableStore);
+    }
+
+    let shownCommand: languages.Command | undefined;
+    if (result.shown) {
+      if (!disposableStore) {
+        disposableStore = new DisposableStore();
+      }
+      shownCommand = this._commands.toInternal(result.shown, disposableStore);
+    }
+
+    if (!disposableStore) {
+      disposableStore = new DisposableStore();
+    }
+    const langResult: IdentifiableInlineEdit = {
+      pid,
+      text: result.text,
+      range: typeConvert.Range.from(result.range),
+      showRange: typeConvert.Range.from(result.showRange),
+      accepted: acceptCommand,
+      rejected: rejectCommand,
+      shown: shownCommand,
+      commands: result.commands?.map((c) => this._commands.toInternal(c, disposableStore)) as languages.Command[],
+    };
+
+    return langResult;
+  }
+
+  disposeEdit(pid: number) {
+    const data = this._references.disposeReferenceId(pid);
+    data?.dispose();
+  }
+
+  constructor(
+    _extension: IExtensionDescription,
+    private readonly _documents: ExtensionDocumentDataManager,
+    private readonly _provider: vscode.InlineEditProvider,
+    private readonly _commands: CommandsConverter,
+  ) {}
+}
+
+class ReferenceMap<T> {
+  private readonly _references = new Map<number, T>();
+  private _idPool = 1;
+
+  createReferenceId(value: T): number {
+    const id = this._idPool++;
+    this._references.set(id, value);
+    return id;
+  }
+
+  disposeReferenceId(referenceId: number): T | undefined {
+    const value = this._references.get(referenceId);
+    this._references.delete(referenceId);
+    return value;
+  }
+
+  get(referenceId: number): T | undefined {
+    return this._references.get(referenceId);
+  }
+}

--- a/packages/file-tree-next/__tests__/browser/file-tree.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.test.ts
@@ -229,7 +229,7 @@ describe('FileTree should be work while on single workspace model', () => {
       useValue: rawFileTreeApi,
     });
 
-    injector.mock(IContextKeyService, 'getContextValue', mockGetContextValue);
+    injector.mock(IContextKeyService, 'getContextKeyValue', mockGetContextValue);
     const fileService = injector.get(FileService, [FileSystemNodeOptions.DEFAULT]);
     injector.overrideProviders({
       token: FileServicePath,

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -3,10 +3,7 @@ import { IdGenerator } from '@opensumi/ide-core-common/lib/id-generator';
 import * as monaco from '@opensumi/ide-monaco';
 import { Color, RGBA } from '@opensumi/ide-theme';
 // @ts-ignore
-import {
-  createCSSRule,
-  removeCSSRulesContainingSelector,
-} from '@opensumi/monaco-editor-core/esm/vs/base/browser/domStyleSheets';
+import { createCSSRule, removeCSSRulesContainingSelector } from '@opensumi/monaco-editor-core/esm/vs/base/browser/domStyleSheets';
 import {
   IHorizontalSashLayoutProvider,
   ISashEvent,

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -2,6 +2,7 @@ import { Disposable, DomListener, Emitter, Event, IDisposable, IRange, uuid } fr
 import { IdGenerator } from '@opensumi/ide-core-common/lib/id-generator';
 import * as monaco from '@opensumi/ide-monaco';
 import { Color, RGBA } from '@opensumi/ide-theme';
+// @ts-ignore
 import {
   createCSSRule,
   removeCSSRulesContainingSelector,

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -2,7 +2,10 @@ import { Disposable, DomListener, Emitter, Event, IDisposable, IRange, uuid } fr
 import { IdGenerator } from '@opensumi/ide-core-common/lib/id-generator';
 import * as monaco from '@opensumi/ide-monaco';
 import { Color, RGBA } from '@opensumi/ide-theme';
-import { createCSSRule, removeCSSRulesContainingSelector } from '@opensumi/monaco-editor-core/esm/vs/base/browser/dom';
+import {
+  createCSSRule,
+  removeCSSRulesContainingSelector,
+} from '@opensumi/monaco-editor-core/esm/vs/base/browser/domStyleSheets';
 import {
   IHorizontalSashLayoutProvider,
   ISashEvent,

--- a/packages/monaco-enhance/src/browser/zone-widget.ts
+++ b/packages/monaco-enhance/src/browser/zone-widget.ts
@@ -2,8 +2,10 @@ import { Disposable, DomListener, Emitter, Event, IDisposable, IRange, uuid } fr
 import { IdGenerator } from '@opensumi/ide-core-common/lib/id-generator';
 import * as monaco from '@opensumi/ide-monaco';
 import { Color, RGBA } from '@opensumi/ide-theme';
-// @ts-ignore
-import { createCSSRule, removeCSSRulesContainingSelector } from '@opensumi/monaco-editor-core/esm/vs/base/browser/domStyleSheets';
+import {
+  createCSSRule,
+  removeCSSRulesContainingSelector,
+} from '@opensumi/monaco-editor-core/esm/vs/base/browser/domStylesheets';
 import {
   IHorizontalSashLayoutProvider,
   ISashEvent,

--- a/packages/monaco/__mocks__/monaco.context-key.service.ts
+++ b/packages/monaco/__mocks__/monaco.context-key.service.ts
@@ -158,7 +158,7 @@ export class MockContextKeyService implements IScopedContextKeyService {
   }
 
   getValue<T>(key: string): T | undefined {
-    return this.getContextValue(key);
+    return this.getContextKeyValue(key);
   }
 
   match(expression: string | ContextKeyExpression | undefined, context?: HTMLElement | null | undefined): boolean {
@@ -171,7 +171,7 @@ export class MockContextKeyService implements IScopedContextKeyService {
 
   private getData() {
     return Array.from(this._keys.keys()).reduce((prev, key) => {
-      prev[key] = this.getContextValue(key);
+      prev[key] = this.getContextKeyValue(key);
       return prev;
     }, {});
   }
@@ -184,7 +184,7 @@ export class MockContextKeyService implements IScopedContextKeyService {
     return expr ? expr.keys() : [];
   }
 
-  getContextValue<T>(key: string): T | undefined {
+  getContextKeyValue<T>(key: string): T | undefined {
     const value = this._keys.get(key);
     if (value) {
       return value.get();

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -21,7 +21,7 @@
     "@opensumi/ide-overlay": "workspace:*",
     "@opensumi/ide-theme": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
-    "@opensumi/monaco-editor-core": "0.53.0-patch.2"
+    "@opensumi/monaco-editor-core": "0.54.0-patch.0"
   },
   "devDependencies": {
     "@opensumi/ide-dev-tool": "workspace:*",

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -21,7 +21,7 @@
     "@opensumi/ide-overlay": "workspace:*",
     "@opensumi/ide-theme": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
-    "@opensumi/monaco-editor-core": "0.54.0-patch.0"
+    "@opensumi/monaco-editor-core": "0.54.0-patch.1"
   },
   "devDependencies": {
     "@opensumi/ide-dev-tool": "workspace:*",

--- a/packages/monaco/src/browser/monaco.context-key.service.ts
+++ b/packages/monaco/src/browser/monaco.context-key.service.ts
@@ -334,7 +334,7 @@ abstract class BaseContextKeyService extends Disposable implements IContextKeySe
     return expr ? expr.keys() : [];
   }
 
-  getContextValue<T>(key: string): T | undefined {
+  getContextKeyValue<T>(key: string): T | undefined {
     return this.contextKeyService.getContextKeyValue(key);
   }
 

--- a/packages/monaco/src/common/observable.ts
+++ b/packages/monaco/src/common/observable.ts
@@ -9,7 +9,6 @@ export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInterna
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/debugName';
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/derived';
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/logging';
-// export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/promise';
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/utils';
 
 export function autorunDelta<T>(

--- a/packages/monaco/src/common/observable.ts
+++ b/packages/monaco/src/common/observable.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { autorun, autorunOpts } from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/autorun';
 import { IObservable } from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/base';
 import { IDisposable } from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/commonFacade/deps';

--- a/packages/monaco/src/common/observable.ts
+++ b/packages/monaco/src/common/observable.ts
@@ -8,7 +8,7 @@ export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInterna
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/debugName';
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/derived';
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/logging';
-export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/promise';
+// export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/promise';
 export * from '@opensumi/monaco-editor-core/esm/vs/base/common/observableInternal/utils';
 
 export function autorunDelta<T>(

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -427,9 +427,9 @@ export class AINativeContribution implements AINativeCoreContribution {
   }
 
   registerIntelligentCompletionFeature(registry: IIntelligentCompletionsRegistry): void {
-    registry.registerInlineCompletionsProvider(async (editor, position, bean, token) => ({
-      items: [{ insertText: 'Hello OpenSumi' }],
-    }));
+    // registry.registerInlineCompletionsProvider(async (editor, position, bean, token) => ({
+    //   items: [{ insertText: 'Hello OpenSumi' }],
+    // }));
 
     registry.registerCodeEditsProvider(async (editor, position, bean, token) => {
       const model = editor.getModel();

--- a/packages/types/vscode.d.ts
+++ b/packages/types/vscode.d.ts
@@ -52,3 +52,4 @@
 /// <reference path='./vscode/typings/vscode.proposed.terminalDataWriteEvent.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.documentPaste.d.ts' />
 /// <reference path='./vscode/typings/vscode.proposed.dropMetadata.d.ts' />
+/// <reference path='./vscode/typings/vscode.proposed.inlineEdit.d.ts' />

--- a/packages/types/vscode/typings/vscode.proposed.inlineEdit.d.ts
+++ b/packages/types/vscode/typings/vscode.proposed.inlineEdit.d.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	export class InlineEdit {
+
+
+		/**
+		 * The new text for this edit.
+		 */
+		readonly text: string;
+
+		/**
+		 * A range that will be replaced by the text of the inline edit.
+		 * If the change is only additive, this can be empty (same start and end position).
+		 */
+		readonly range: Range;
+
+		/**
+		 * A range specifying when the edit can be shown based on the cursor position.
+		 * If the cursor is within this range, the inline edit can be displayed.
+		 */
+		readonly showRange?: Range;
+
+		/**
+		 * An optional command that will be executed after applying the inline edit.
+		 */
+		accepted?: Command;
+
+		/**
+		 * An optional command that will be executed after rejecting the inline edit.
+		 */
+		rejected?: Command;
+
+		shown?: Command;
+
+		commands?: Command[];
+
+		/**
+		 * Creates a new inline edit.
+		 *
+		 * @param text The new text for this edit.
+		 * @param range A range that will be replaced by the text of the inline edit.
+		 */
+		constructor(text: string, range: Range);
+	}
+
+	export interface InlineEditContext {
+		/**
+		 * Describes how the inline edit was triggered.
+		 */
+		triggerKind: InlineEditTriggerKind;
+
+		readonly requestUuid?: string;
+	}
+
+	export enum InlineEditTriggerKind {
+		/**
+		 * Completion was triggered explicitly by a user gesture.
+		 * Return multiple completion items to enable cycling through them.
+		 */
+		Invoke = 0,
+
+		/**
+		 * Completion was triggered automatically while editing.
+		 * It is sufficient to return a single completion item in this case.
+		 */
+		Automatic = 1,
+	}
+
+	export interface InlineEditProvider {
+
+		readonly displayName?: string;
+
+		/**
+		 * Provide inline edit for the given document.
+		 *
+		 * @param document The document for which the inline edit are computed.
+		 * @param context Additional context information about the request.
+		 * @param token A cancellation token.
+		 * @return An inline edit or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideInlineEdit(document: TextDocument, context: InlineEditContext, token: CancellationToken): ProviderResult<InlineEdit>;
+	}
+
+	export namespace languages {
+
+		/**
+		 * Register a provider that can handle inline edits.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A provider that can handle inline edits.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerInlineEditProvider(selector: DocumentSelector, provider: InlineEditProvider): Disposable;
+
+	}
+}

--- a/packages/workspace/__tests__/browser/workspace-storage-service.test.ts
+++ b/packages/workspace/__tests__/browser/workspace-storage-service.test.ts
@@ -1,10 +1,10 @@
 import { CommandService, IContextKeyService } from '@opensumi/ide-core-browser';
 import { URI } from '@opensumi/ide-core-common';
+import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
+import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 import { WorkspaceVariableContribution } from '@opensumi/ide-workspace/lib/browser/workspace-variable-contribution';
 
-import { createBrowserInjector } from '../../../../tools/dev-tool/src/injector-helper';
-import { MockInjector } from '../../../../tools/dev-tool/src/mock-injector';
 import { WorkspaceModule } from '../../src/browser';
 
 describe('WorkspaceContribution should be work', () => {
@@ -14,7 +14,7 @@ describe('WorkspaceContribution should be work', () => {
     getWorkspaceRootUri: jest.fn(),
   };
   const mockContextKeyService = {
-    getContextValue: jest.fn(),
+    getContextKeyValue: jest.fn(),
   };
   const mockCommandService = {
     executeCommand: jest.fn(),
@@ -40,7 +40,7 @@ describe('WorkspaceContribution should be work', () => {
   afterEach(async () => {
     await injector.disposeAll();
     mockWorkspaceService.getWorkspaceRootUri.mockReset();
-    mockContextKeyService.getContextValue.mockReset();
+    mockContextKeyService.getContextKeyValue.mockReset();
   });
 
   it('registerVariables contribution point should be work', async () => {

--- a/tools/playwright/src/text-editor.ts
+++ b/tools/playwright/src/text-editor.ts
@@ -306,7 +306,7 @@ export class OpenSumiTextEditor extends OpenSumiEditor {
     await this.placeCursorInLine(existingLine);
     await this.page.keyboard.press('End');
     await this.page.keyboard.press('Enter');
-    await this.page.keyboard.type(newText);
+    await this.page.keyboard.type(newText, { delay: 100 });
   }
 
   async pasteContentAfterLineByLineNumber(lineNumber: number): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,7 +3854,7 @@ __metadata:
     "@opensumi/ide-theme": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
-    "@opensumi/monaco-editor-core": "npm:0.53.0-patch.2"
+    "@opensumi/monaco-editor-core": "npm:0.54.0-patch.0"
   languageName: unknown
   linkType: soft
 
@@ -4323,10 +4323,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opensumi/monaco-editor-core@npm:0.53.0-patch.2":
-  version: 0.53.0-patch.2
-  resolution: "@opensumi/monaco-editor-core@npm:0.53.0-patch.2"
-  checksum: 10/e5ebd5c3bb8fada9341cf9c023283ed5cd3e9b1bc01e1bf74a7d12e688947994572292e6ffcd352126be37a738a435650b289270dc71abcd42b0363176245d2f
+"@opensumi/monaco-editor-core@npm:0.54.0-patch.0":
+  version: 0.54.0-patch.0
+  resolution: "@opensumi/monaco-editor-core@npm:0.54.0-patch.0"
+  checksum: 10/352507670e866ab9df2557d43388888ea003f49b6800185966d2d580c57a35330d4b6256c4cf4bcc00b5b23e35b749d30ce714ce864a6d5e201287ec3f7ce5ad
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,7 +3854,7 @@ __metadata:
     "@opensumi/ide-theme": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
-    "@opensumi/monaco-editor-core": "npm:0.54.0-patch.0"
+    "@opensumi/monaco-editor-core": "npm:0.54.0-patch.1"
   languageName: unknown
   linkType: soft
 
@@ -4323,10 +4323,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opensumi/monaco-editor-core@npm:0.54.0-patch.0":
-  version: 0.54.0-patch.0
-  resolution: "@opensumi/monaco-editor-core@npm:0.54.0-patch.0"
-  checksum: 10/352507670e866ab9df2557d43388888ea003f49b6800185966d2d580c57a35330d4b6256c4cf4bcc00b5b23e35b749d30ce714ce864a6d5e201287ec3f7ce5ad
+"@opensumi/monaco-editor-core@npm:0.54.0-patch.1":
+  version: 0.54.0-patch.1
+  resolution: "@opensumi/monaco-editor-core@npm:0.54.0-patch.1"
+  checksum: 10/36f7b3fad00136d42ac27d1063f95043b241ea0005315f1154e3cfa128653e85028e6d82e5119e4d776e82d481c1d1f3fb9d7a626d2763ef32abba1eb2904623
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

Upgrade `@opensumi/monaco-editor-core` to latest version https://github.com/opensumi/monaco-editor-core/tree/feat/0.54.0-dev [vscode@1.97]

Support `vscode.languages.registerInlineEditProvider` API

https://github.com/user-attachments/assets/48d315b6-a31f-441d-b5c8-edd3ee9f72f7


### Changelog

support provideInlineEdit API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 增强内联编辑体验：统一和扩展了内联编辑支持，为更智能、互动的文本编辑提供了全新功能。
  - 优化历史记录管理：调整了历史记录的数据结构，确保记录和补全建议更加精准。
  - 改进进度条显示：重构了宽度计算逻辑，使加载提示更平滑、准确。
  - 移除预设静态补全：取消了固定提示项，进一步聚焦智能补全体验。
  - 新增内联编辑提供者注册功能，支持更复杂的编辑场景。
  - 引入新的类型和接口，扩展了 VS Code API 的内联编辑能力。
  - 更新了上下文键服务的调用方式，提升了上下文值的管理一致性。
  - 更新了上下文值的获取方式，确保上下文键的访问更加一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->