### PR TITLE
feat: support fetching preference file after editor is saved

### DIFF
--- a/packages/ai-native/src/browser/contrib/terminal/component/terminal-command-suggest-controller.tsx
+++ b/packages/ai-native/src/browser/contrib/terminal/component/terminal-command-suggest-controller.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Emitter, localize } from '@opensumi/ide-core-browser';

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -101,7 +101,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
     watcher.onFilesChanged((e: FileChange[]) => {
       const effected = e.find((file) => file.uri.startsWith(uri.parent.toString()));
       if (effected) {
-        // return this.debouncedReadPreferences();
+        return this.debouncedReadPreferences();
       }
     });
     this.toDispose.push(Disposable.create(() => this.reset()));


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

文件配置支持从编辑器事件中同步配置内容，解决部分环境下文件监听服务异常问题。

### Changelog

support fetching preference file after editor is saved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 调整了防抖功能的引入方式，提升了内部代码的一致性。

- **Refactor**
  - 优化了偏好配置更新机制，通过引入延迟处理策略，在文档保存后减少重复读取操作，从而提高整体响应性能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->