### PR TITLE
feat: support copy relative path from link files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,8 +17,9 @@ const baseConfig = {
     // 部分contribution文件为-contribution结尾
     '!packages/**/*-contribution.ts',
     '!packages/startup/**/*.ts',
-    // Test 功能暂未完成
+    // Test, Notebook 模块暂不覆盖
     '!packages/testing/**/*.ts',
+    '!packages/notebook/**/*.ts',
     // CLI 不需要测试
     '!packages/remote-cli/**/*.ts',
     '!packages/core-electron-main/**/*.ts',

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -236,9 +236,11 @@ export class TreeNode implements ITreeNode {
   get path(): string {
     if (!this._path) {
       if (!this.parent) {
-        this._path = `${Path.separator}${this.name}`;
+        this._path = this.name.startsWith(Path.separator) ? this.name : `${Path.separator}${this.name}`;
       } else {
-        this._path = `${this.parent.path}${Path.separator}${this.name}`;
+        this._path = this.name.startsWith(Path.separator)
+          ? `${this.parent.path}${this.name}`
+          : `${this.parent.path}${Path.separator}${this.name}`;
       }
     }
     return this._path;

--- a/packages/components/src/recycle-tree/tree/TreeNode.ts
+++ b/packages/components/src/recycle-tree/tree/TreeNode.ts
@@ -236,9 +236,9 @@ export class TreeNode implements ITreeNode {
   get path(): string {
     if (!this._path) {
       if (!this.parent) {
-        this._path = new Path(`${Path.separator}${this.name}`).toString();
+        this._path = `${Path.separator}${this.name}`;
       } else {
-        this._path = new Path(this.parent.path).join(this.name).toString();
+        this._path = `${this.parent.path}${Path.separator}${this.name}`;
       }
     }
     return this._path;

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -24,7 +24,6 @@
     "@opensumi/ide-components": "workspace:*",
     "@opensumi/ide-core-browser": "workspace:*",
     "@opensumi/ide-core-common": "workspace:*",
-    "@opensumi/ide-utils": "workspace:*",
     "@opensumi/ide-decoration": "workspace:*",
     "@opensumi/ide-dev-tool": "workspace:*",
     "@opensumi/ide-editor": "workspace:*",
@@ -33,6 +32,7 @@
     "@opensumi/ide-overlay": "workspace:*",
     "@opensumi/ide-terminal-next": "workspace:*",
     "@opensumi/ide-theme": "workspace:*",
+    "@opensumi/ide-utils": "workspace:*",
     "@opensumi/ide-workspace": "workspace:*",
     "@opensumi/ide-workspace-edit": "workspace:*"
   }

--- a/packages/file-tree-next/package.json
+++ b/packages/file-tree-next/package.json
@@ -24,6 +24,7 @@
     "@opensumi/ide-components": "workspace:*",
     "@opensumi/ide-core-browser": "workspace:*",
     "@opensumi/ide-core-common": "workspace:*",
+    "@opensumi/ide-utils": "workspace:*",
     "@opensumi/ide-decoration": "workspace:*",
     "@opensumi/ide-dev-tool": "workspace:*",
     "@opensumi/ide-editor": "workspace:*",

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -50,6 +50,7 @@ import { EXPLORER_CONTAINER_ID } from '@opensumi/ide-explorer/lib/browser/explor
 import { IMainLayoutService, IViewsRegistry, MainLayoutContribution } from '@opensumi/ide-main-layout';
 import { ViewContentGroups } from '@opensumi/ide-main-layout/lib/browser/views-registry';
 import { IOpenDialogOptions, ISaveDialogOptions, IWindowDialogService } from '@opensumi/ide-overlay';
+import { Path } from '@opensumi/ide-utils/lib/path';
 import { IWorkspaceService, UNTITLED_WORKSPACE } from '@opensumi/ide-workspace';
 
 import { IFileTreeService, PasteTypes, RESOURCE_VIEW_ID } from '../common';
@@ -778,8 +779,14 @@ export class FileTreeContribution
         }
         if (uri.scheme === DIFF_SCHEME) {
           const query = uri.getParsedQuery();
-          // 需要file scheme才能与工作区计算相对路径
           uri = new URI(query.modified).withScheme('file');
+        }
+        const node = this.fileTreeService.getNodeByPathOrUri(uri);
+        if (node) {
+          if (node.filestat.isInSymbolicDirectory) {
+            // 软链接文件需要通过直接通过文件树 Path 获取
+            return await this.clipboardService.writeText(node.path.split(Path.separator).slice(2).join(Path.separator));
+          }
         }
         let rootUri: URI;
         if (this.fileTreeService.isMultipleWorkspace) {

--- a/packages/opened-editor/src/browser/opened-editor-node.define.ts
+++ b/packages/opened-editor/src/browser/opened-editor-node.define.ts
@@ -70,7 +70,7 @@ export class EditorFile extends TreeNode {
     public dirty: boolean = false,
     parent: EditorFileGroup | undefined,
   ) {
-    super(tree as ITree, parent, undefined, { name: `${resource.uri.toString()}` });
+    super(tree as ITree, parent, undefined, { name: `${resource.uri.codeUri.fsPath.toString()}` });
   }
 
   get displayName() {

--- a/packages/opened-editor/src/browser/services/opened-editor-tree.service.ts
+++ b/packages/opened-editor/src/browser/services/opened-editor-tree.service.ts
@@ -127,16 +127,16 @@ export class OpenedEditorService extends Tree {
           .join(groupName)
           .join(
             resource && (resource as IResource).uri
-              ? (resource as IResource).uri.toString()
-              : (resource as URI).toString(),
+              ? (resource as IResource).uri.codeUri.fsPath
+              : (resource as URI).codeUri.fsPath,
           )
           .toString();
       } else {
         path = new Path(path)
           .join(
             resource && (resource as IResource).uri
-              ? (resource as IResource).uri.toString()
-              : (resource as URI).toString(),
+              ? (resource as IResource).uri.codeUri.fsPath
+              : (resource as URI).codeUri.fsPath,
           )
           .toString();
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,6 +3731,7 @@ __metadata:
     "@opensumi/ide-overlay": "workspace:*"
     "@opensumi/ide-terminal-next": "workspace:*"
     "@opensumi/ide-theme": "workspace:*"
+    "@opensumi/ide-utils": "workspace:*"
     "@opensumi/ide-workspace": "workspace:*"
     "@opensumi/ide-workspace-edit": "workspace:*"
   languageName: unknown


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

软链接路径不能直接通过 URI 进行相对路径解析，增加兜底方案

### Changelog

support copy relative path from link files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
	- 简化了节点路径构建逻辑，采用直接字符串拼接代替了原有复杂的方式。
	- 修改了 `EditorFile` 类构造函数中的名称属性获取方式，从通用 URI 表示改为更具体的文件系统路径表示。
	- 更新了 `OpenedEditorService` 中的 URI 处理逻辑，确保使用文件系统路径的一致性。
- **新功能**
	- 在复制相对路径的操作中加入了对符号链接的支持，确保在符号目录下能正确生成目标路径。
- **依赖更新**
	- 在 `devDependencies` 中新增了 `@opensumi/ide-utils` 依赖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->