### PR TITLE
feat: tabbar supports React.ReactNode for description

### DIFF
--- a/packages/core-browser/src/layout/layout.interface.ts
+++ b/packages/core-browser/src/layout/layout.interface.ts
@@ -32,7 +32,7 @@ export interface SideStateManager {
 export interface View {
   id: string;
   name?: string;
-  description?: string;
+  description?: string | React.ComponentType<any>;
   message?: string;
   weight?: number;
   priority?: number;

--- a/packages/main-layout/src/browser/accordion/accordion.service.ts
+++ b/packages/main-layout/src/browser/accordion/accordion.service.ts
@@ -57,7 +57,7 @@ export interface SectionState {
 interface AccordionViewChangeEvent {
   id: string;
   title?: string;
-  description?: string;
+  description?: string | React.ComponentType<any>;
   message?: string;
   badge?: string | ViewBadge | undefined;
 }
@@ -198,7 +198,7 @@ export class AccordionService extends WithEventBus {
     }
   }
 
-  updateViewDesciption(viewId: string, desc: string) {
+  updateViewDesciption(viewId: string, desc: string | React.ComponentType<any>) {
     const view = this.views.find((view) => view.id === viewId);
     if (view) {
       view.description = desc;

--- a/packages/main-layout/src/browser/accordion/section.view.tsx
+++ b/packages/main-layout/src/browser/accordion/section.view.tsx
@@ -26,7 +26,7 @@ export interface CollapsePanelProps extends React.PropsWithChildren<any> {
   // Header Title
   header: string;
   // Header Description
-  description?: string;
+  description?: string | React.ComponentType<any>;
   // Panel Message
   message?: string;
   // Header Size
@@ -185,7 +185,11 @@ export const AccordionSection = ({
             </div>
             {metadata.description && (
               <div className={styles.section_description} style={{ lineHeight: headerSize + 'px' }}>
-                {transformLabelWithCodicon(metadata.description, {}, iconService.fromString.bind(iconService))}
+                {typeof metadata.description === 'string' ? (
+                  transformLabelWithCodicon(metadata.description, {}, iconService.fromString.bind(iconService))
+                ) : (
+                  <metadata.description />
+                )}
               </div>
             )}
             {metadata.badge && (

--- a/packages/main-layout/src/browser/tabbar-handler.ts
+++ b/packages/main-layout/src/browser/tabbar-handler.ts
@@ -156,7 +156,7 @@ export class TabBarHandler {
   /**
    * 更新子视图的描述
    */
-  updateViewDescription(viewId: string, desciption: string) {
+  updateViewDescription(viewId: string, desciption: string | React.ComponentType<any>) {
     this.accordionService.updateViewDesciption(viewId, desciption);
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
![image](https://github.com/user-attachments/assets/96d4bc63-ca70-4498-8f84-e40911adca2f)

https://github.com/opensumi/core/issues/4322
### Changelog
feat: tabbar的描述支持传入React.ReactNode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
  - 多个界面组件的描述属性现支持文本以及动态组件，提供更灵活丰富的内容呈现体验。  
  - 更新后的展示逻辑确保在适配不同描述类型时，内容能够直观、有效地展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->