### PR TITLE
fix: tabbar supports React.ReactNode for description

### DIFF
--- a/packages/core-browser/src/layout/layout.interface.ts
+++ b/packages/core-browser/src/layout/layout.interface.ts
@@ -32,7 +32,7 @@ export interface SideStateManager {
 export interface View {
   id: string;
   name?: string;
-  description?: string | React.ComponentType<any>;
+  description?: string | React.ReactNode;
   message?: string;
   weight?: number;
   priority?: number;

--- a/packages/main-layout/src/browser/accordion/accordion.service.ts
+++ b/packages/main-layout/src/browser/accordion/accordion.service.ts
@@ -57,7 +57,7 @@ export interface SectionState {
 interface AccordionViewChangeEvent {
   id: string;
   title?: string;
-  description?: string | React.ComponentType<any>;
+  description?: string | React.ReactNode;
   message?: string;
   badge?: string | ViewBadge | undefined;
 }
@@ -198,7 +198,7 @@ export class AccordionService extends WithEventBus {
     }
   }
 
-  updateViewDesciption(viewId: string, desc: string | React.ComponentType<any>) {
+  updateViewDesciption(viewId: string, desc: string | React.ReactNode) {
     const view = this.views.find((view) => view.id === viewId);
     if (view) {
       view.description = desc;

--- a/packages/main-layout/src/browser/accordion/section.view.tsx
+++ b/packages/main-layout/src/browser/accordion/section.view.tsx
@@ -26,7 +26,7 @@ export interface CollapsePanelProps extends React.PropsWithChildren<any> {
   // Header Title
   header: string;
   // Header Description
-  description?: string | React.ComponentType<any>;
+  description?: string | React.ReactNode;
   // Panel Message
   message?: string;
   // Header Size
@@ -185,11 +185,9 @@ export const AccordionSection = ({
             </div>
             {metadata.description && (
               <div className={styles.section_description} style={{ lineHeight: headerSize + 'px' }}>
-                {typeof metadata.description === 'string' ? (
-                  transformLabelWithCodicon(metadata.description, {}, iconService.fromString.bind(iconService))
-                ) : (
-                  <metadata.description />
-                )}
+                {typeof metadata.description === 'string'
+                  ? transformLabelWithCodicon(metadata.description, {}, iconService.fromString.bind(iconService))
+                  : metadata.description}
               </div>
             )}
             {metadata.badge && (

--- a/packages/main-layout/src/browser/tabbar-handler.ts
+++ b/packages/main-layout/src/browser/tabbar-handler.ts
@@ -156,7 +156,7 @@ export class TabBarHandler {
   /**
    * 更新子视图的描述
    */
-  updateViewDescription(viewId: string, desciption: string | React.ComponentType<any>) {
+  updateViewDescription(viewId: string, desciption: string | React.ReactNode) {
     this.accordionService.updateViewDesciption(viewId, desciption);
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
![image](https://github.com/user-attachments/assets/2b7ec77e-153f-4584-915a-2137316a9fe5)
![image](https://github.com/user-attachments/assets/1111b5df-51f3-47a6-adc0-2d99f9889cab)

### Changelog
fix: Tabbar支持传入ReactNode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了界面描述内容的展示方式，现在支持更丰富的展示元素，使描述内容可以直观渲染更多类型的视觉组件。

- **重构**
	- 优化了描述内容的渲染流程，统一了处理逻辑，从而提升了界面显示的一致性和灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->