### PR TITLE
fix: add delay for disposing inline edit adapter to prevent rejection

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.language.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.language.ts
@@ -698,7 +698,8 @@ export class ExtHostLanguages implements IExtHostLanguages {
       handle,
       InlineEditAdapter,
       async (adapter) => {
-        adapter.disposeEdit(pid);
+        // 增加延迟释放，避免在 ESC 退出时，InlineEdit 的 Rejected 命令被提前销毁导致异常
+        setTimeout(() => adapter.disposeEdit(pid), 100);
       },
       undefined,
       undefined,


### PR DESCRIPTION
… issues

### Types

- [x] 🐛 Bug Fixes

### Background or solution

当前 freeInlineEdit 的执行时机比 reject 命令执行时机更快，导致命令 dispose 后异常

### Changelog

add delay for disposing inline edit adapter to prevent rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 延迟内联编辑操作结束时资源释放，防止快速退出编辑时产生异常，提高内联编辑稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->