### PR TITLE
feat: support NES render in code edits

### DIFF
--- a/packages/ai-native/src/browser/ai-core.contribution.ts
+++ b/packages/ai-native/src/browser/ai-core.contribution.ts
@@ -425,6 +425,10 @@ export class AINativeBrowserContribution
             localized: 'preference.ai.native.codeEdits.typing',
           },
           {
+            id: AINativeSettingSectionsId.CodeEditsRenderType,
+            localized: 'preference.ai.native.codeEdits.renderType',
+          },
+          {
             id: AINativeSettingSectionsId.SystemPrompt,
             localized: 'preference.ai.native.chat.system.prompt',
           },

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/index.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/index.ts
@@ -12,12 +12,10 @@ import { ITriggerData } from './source/trigger.source';
 import type { ILineChangeData } from './source/line-change.source';
 import type { ILinterErrorData } from './source/lint-error.source';
 
-export const CodeEditsRenderType = {
-  legacy: 'legacy',
-  default: 'default',
-} as const;
-
-export type CodeEditsRenderType = (typeof CodeEditsRenderType)[keyof typeof CodeEditsRenderType];
+export enum CodeEditsRenderType {
+  Legacy = 'legacy',
+  Default = 'default',
+}
 
 /**
  * 有效弃用时间（毫秒）
@@ -66,9 +64,9 @@ export class CodeEditsResultValue<T extends ICodeEdit = ICodeEdit> extends Dispo
 
   public get items(): T[] {
     return this.raw.items.map((item) => ({
-        ...item,
-        isInlineEdit: true,
-      }));
+      ...item,
+      isInlineEdit: true,
+    }));
   }
 
   public get range(): IRange {

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/view/base.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/view/base.ts
@@ -1,0 +1,31 @@
+import { Injector } from '@opensumi/di';
+import { Disposable } from '@opensumi/ide-core-common';
+import { ICodeEditor } from '@opensumi/ide-monaco';
+import {
+  ObservableCodeEditor,
+  observableCodeEditor,
+} from '@opensumi/monaco-editor-core/esm/vs/editor/browser/observableCodeEditor';
+
+import { CodeEditsResultValue } from '../index';
+
+export abstract class BaseCodeEditsView extends Disposable {
+  protected editorObs: ObservableCodeEditor;
+
+  public modelId: string;
+
+  constructor(protected readonly monacoEditor: ICodeEditor, protected readonly injector: Injector) {
+    super();
+
+    this.editorObs = observableCodeEditor(this.monacoEditor);
+    this.mount();
+
+    this.addDispose({ dispose: () => this.hide() });
+  }
+
+  protected mount(): void {}
+
+  abstract render(completionModel: CodeEditsResultValue): void;
+  abstract hide(): void;
+  abstract accept(): void;
+  abstract discard(): void;
+}

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/view/code-edits-previewer.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/view/code-edits-previewer.ts
@@ -29,7 +29,7 @@ export class CodeEditsPreviewer extends Disposable {
     super();
 
     this.renderTypeObs = observableFromEvent(this, this.preferenceService.onPreferenceChanged, () =>
-      this.preferenceService.getValid(AINativeSettingSectionsId.CodeEditsRenderType, CodeEditsRenderType.default),
+      this.preferenceService.getValid(AINativeSettingSectionsId.CodeEditsRenderType, CodeEditsRenderType.Default),
     );
 
     this.addDispose(
@@ -40,7 +40,7 @@ export class CodeEditsPreviewer extends Disposable {
           this.view = undefined;
         }
 
-        if (renderType === CodeEditsRenderType.default) {
+        if (renderType === CodeEditsRenderType.Default) {
           this.view = new DefaultCodeEditsView(this.monacoEditor, this.injector);
         } else {
           this.view = new LegacyCodeEditsView(this.monacoEditor, this.injector);

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/view/code-edits-previewer.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/view/code-edits-previewer.ts
@@ -1,0 +1,69 @@
+import { Autowired, INJECTOR_TOKEN, Injectable, Injector, Optional } from '@opensumi/di';
+import { PreferenceService } from '@opensumi/ide-core-browser';
+import { AINativeSettingSectionsId, Disposable } from '@opensumi/ide-core-common';
+import { ICodeEditor } from '@opensumi/ide-monaco';
+import { IObservable, IReader, autorun, observableFromEvent } from '@opensumi/ide-monaco/lib/common/observable';
+
+import { AINativeContextKey } from '../../../ai-core.contextkeys';
+import { CodeEditsRenderType, CodeEditsResultValue } from '../index';
+
+import { BaseCodeEditsView } from './base';
+import { DefaultCodeEditsView } from './default';
+import { LegacyCodeEditsView } from './legacy';
+
+@Injectable()
+export class CodeEditsPreviewer extends Disposable {
+  @Autowired(INJECTOR_TOKEN)
+  protected readonly injector: Injector;
+
+  @Autowired(PreferenceService)
+  private readonly preferenceService: PreferenceService;
+
+  private readonly renderTypeObs: IObservable<CodeEditsRenderType>;
+  private view: BaseCodeEditsView | undefined;
+
+  constructor(
+    @Optional() protected readonly monacoEditor: ICodeEditor,
+    @Optional() protected readonly aiNativeContextKey: AINativeContextKey,
+  ) {
+    super();
+
+    this.renderTypeObs = observableFromEvent(this, this.preferenceService.onPreferenceChanged, () =>
+      this.preferenceService.getValid(AINativeSettingSectionsId.CodeEditsRenderType, CodeEditsRenderType.default),
+    );
+
+    this.addDispose(
+      autorun((reader: IReader) => {
+        const renderType = this.renderTypeObs.read(reader);
+        if (this.view) {
+          this.view.dispose();
+          this.view = undefined;
+        }
+
+        if (renderType === CodeEditsRenderType.default) {
+          this.view = new DefaultCodeEditsView(this.monacoEditor, this.injector);
+        } else {
+          this.view = new LegacyCodeEditsView(this.monacoEditor, this.injector);
+        }
+      }),
+    );
+  }
+
+  public render(completionModel: CodeEditsResultValue) {
+    this.view?.render(completionModel);
+    this.aiNativeContextKey.multiLineEditsIsVisible.set(true);
+  }
+
+  public hide() {
+    this.view?.hide();
+    this.aiNativeContextKey.multiLineEditsIsVisible.set(false);
+  }
+
+  public accept() {
+    this.view?.accept();
+  }
+
+  public discard() {
+    this.view?.discard();
+  }
+}

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/view/default.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/view/default.ts
@@ -1,0 +1,146 @@
+import {
+  InlineCompletionContext,
+  InlineCompletionTriggerKind,
+  InlineCompletionsProvider,
+  Position,
+  Range,
+} from '@opensumi/ide-monaco';
+import {
+  IObservable,
+  asyncTransaction,
+  constObservable,
+  derived,
+  transaction,
+} from '@opensumi/ide-monaco/lib/common/observable';
+import { equalsIfDefined, itemEquals } from '@opensumi/monaco-editor-core/esm/vs/base/common/equals';
+import { LanguageFeatureRegistry } from '@opensumi/monaco-editor-core/esm/vs/editor/common/languageFeatureRegistry';
+import { InlineCompletionsController } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController';
+import { InlineCompletionsModel } from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel';
+import {
+  InlineCompletionsSource,
+  UpToDateInlineCompletions,
+} from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource';
+import {
+  InlineCompletionProviderResult,
+  provideInlineCompletions,
+} from '@opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions';
+
+import { CodeEditsResultValue, ICodeEdit, ICodeEditsResult } from '../index';
+
+import { BaseCodeEditsView } from './base';
+
+/**
+ * copy from @opensumi/monaco-editor-core/esm/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions
+ */
+class UpdateRequest {
+  constructor(
+    public readonly position: Position,
+    public readonly context: InlineCompletionContext,
+    public readonly versionId: number,
+  ) {}
+
+  public satisfies(other: UpdateRequest): boolean {
+    return (
+      this.position.equals(other.position) &&
+      equalsIfDefined(this.context.selectedSuggestionInfo, other.context.selectedSuggestionInfo, itemEquals()) &&
+      (other.context.triggerKind === InlineCompletionTriggerKind.Automatic ||
+        this.context.triggerKind === InlineCompletionTriggerKind.Explicit) &&
+      this.versionId === other.versionId
+    );
+  }
+
+  public get isExplicitRequest() {
+    return this.context.triggerKind === InlineCompletionTriggerKind.Explicit;
+  }
+}
+
+export class DefaultCodeEditsView extends BaseCodeEditsView {
+  private monacoCompletionsModel: IObservable<InlineCompletionsModel | undefined> = derived(this, (reader) => {
+    const inlineCompletionsController = InlineCompletionsController.get(this.monacoEditor);
+    if (!inlineCompletionsController) {
+      return;
+    }
+
+    return inlineCompletionsController.model.read(reader);
+  });
+
+  private monacoCompletionsSource: IObservable<InlineCompletionsSource | undefined> = derived(this, (reader) => {
+    const model = this.monacoCompletionsModel.read(reader);
+    if (!model) {
+      return;
+    }
+
+    const source = model['_source'] as InlineCompletionsSource;
+    return source;
+  });
+
+  public render(completionModel: CodeEditsResultValue): void {
+    const source = this.monacoCompletionsSource.get();
+    if (!source) {
+      return;
+    }
+
+    asyncTransaction(async (tx) => {
+      const position = this.editorObs.positions.get()?.[0];
+      if (!position) {
+        return;
+      }
+
+      const model = this.editorObs.model.get();
+      if (!model) {
+        return;
+      }
+
+      const versionId = this.editorObs.versionId.get();
+      const context: InlineCompletionContext = {
+        triggerKind: InlineCompletionTriggerKind.Automatic,
+        selectedSuggestionInfo: undefined,
+        includeInlineCompletions: false,
+        includeInlineEdits: true,
+      };
+
+      const request = new UpdateRequest(position, context, versionId!);
+      const inlineEdits: InlineCompletionProviderResult = await provideInlineCompletions(
+        {
+          all: () => [
+              {
+                provideInlineCompletions: () => {},
+                provideInlineEditsForRange(model, range, context, token) {
+                  return completionModel;
+                },
+                freeInlineCompletions: () => [],
+              } as InlineCompletionsProvider<ICodeEditsResult<ICodeEdit>>,
+            ],
+        } as unknown as LanguageFeatureRegistry<InlineCompletionsProvider>,
+        Range.lift(completionModel.range),
+        model,
+        context,
+      );
+
+      const completions = new UpToDateInlineCompletions(
+        inlineEdits,
+        request,
+        model,
+        this.editorObs.versionId,
+        constObservable(1000),
+      );
+      source.inlineCompletions.set(completions, tx);
+    });
+  }
+
+  public accept(): void {
+    const model = this.monacoCompletionsModel.get();
+    model?.accept();
+  }
+
+  public discard(): void {
+    const model = this.monacoCompletionsModel.get();
+    transaction((tx) => {
+      model?.stop('explicitCancel', tx);
+    });
+  }
+
+  public hide(): void {
+    this.monacoCompletionsSource.get()?.inlineCompletions?.set(undefined, undefined);
+  }
+}

--- a/packages/ai-native/src/browser/contrib/intelligent-completions/view/legacy.ts
+++ b/packages/ai-native/src/browser/contrib/intelligent-completions/view/legacy.ts
@@ -1,0 +1,182 @@
+import { IRange, ITextModel, Range } from '@opensumi/ide-monaco';
+import { Event } from '@opensumi/ide-utils';
+import { empty } from '@opensumi/ide-utils/lib/strings';
+
+import { REWRITE_DECORATION_INLINE_ADD, RewriteWidget } from '../../../widget/rewrite/rewrite-widget';
+import { AdditionsDeletionsDecorationModel } from '../decoration/additions-deletions.decoration';
+import { MultiLineDecorationModel } from '../decoration/multi-line.decoration';
+import {
+  IMultiLineDiffChangeResult,
+  computeMultiLineDiffChanges,
+  mergeMultiLineDiffChanges,
+  wordChangesToLineChangesMap,
+} from '../diff-computer';
+import { CodeEditsResultValue } from '../index';
+
+import { BaseCodeEditsView } from './base';
+
+export class LegacyCodeEditsView extends BaseCodeEditsView {
+  private get model() {
+    return this.monacoEditor.getModel()!;
+  }
+
+  private multiLineDecorationModel: MultiLineDecorationModel = new MultiLineDecorationModel(this.monacoEditor);
+  private additionsDeletionsDecorationModel: AdditionsDeletionsDecorationModel = new AdditionsDeletionsDecorationModel(
+    this.monacoEditor,
+  );
+  private rewriteWidget: RewriteWidget | null;
+
+  protected mount(): void {
+    this.addDispose(
+      Event.any<any>(
+        this.monacoEditor.onDidChangeCursorPosition,
+        this.monacoEditor.onDidChangeModelContent,
+        this.monacoEditor.onDidBlurEditorWidget,
+      )(() => {
+        this.additionsDeletionsDecorationModel.clearAdditionsDecorations();
+      }),
+    );
+  }
+
+  private destroyRewriteWidget() {
+    if (this.rewriteWidget) {
+      this.rewriteWidget.dispose();
+      this.rewriteWidget = null;
+    }
+  }
+
+  private async renderRewriteWidget(
+    wordChanges: IMultiLineDiffChangeResult[],
+    model: ITextModel | null,
+    range: IRange,
+    insertTextString: string,
+  ) {
+    this.destroyRewriteWidget();
+
+    const cursorPosition = this.monacoEditor.getPosition();
+    if (!cursorPosition) {
+      return;
+    }
+
+    this.rewriteWidget = this.injector.get(RewriteWidget, [this.monacoEditor]);
+
+    const startOffset = this.model.getOffsetAt({ lineNumber: range.startLineNumber, column: range.startColumn });
+    const endOffset = this.model.getOffsetAt({ lineNumber: range.endLineNumber, column: range.endColumn });
+    const allText = this.model.getValue();
+    // 这里是为了能在 rewrite widget 的 editor 当中完整的复用代码高亮与语法检测的能力
+    const newVirtualContent = allText.substring(0, startOffset) + insertTextString + allText.substring(endOffset);
+
+    const lineChangesMap = wordChangesToLineChangesMap(wordChanges, range, model);
+
+    await this.rewriteWidget.defered.promise;
+
+    const allLineChanges = Object.values(lineChangesMap).map((lineChanges) => ({
+      changes: lineChanges
+        .map((change) => change.filter((item) => item.value.trim() !== empty))
+        .filter((change) => change.length > 0),
+    }));
+
+    this.rewriteWidget.setInsertText(insertTextString);
+    this.rewriteWidget.show({ position: cursorPosition });
+    this.rewriteWidget.setEditArea(range);
+
+    if (allLineChanges.every(({ changes }) => changes.every((change) => change.every(({ removed }) => removed)))) {
+      // 处理全是删除的情况
+      this.rewriteWidget.renderTextLineThrough(allLineChanges);
+    } else {
+      this.rewriteWidget.renderVirtualEditor(newVirtualContent, wordChanges);
+    }
+  }
+
+  public render(completionModel: CodeEditsResultValue): void {
+    const { items } = completionModel;
+    const { range, insertText } = items[0];
+
+    // code edits 必须提供 range
+    if (!range) {
+      return;
+    }
+
+    const position = this.monacoEditor.getPosition()!;
+    const model = this.monacoEditor.getModel();
+    const insertTextString = insertText.toString();
+    const originalContent = model?.getValueInRange(range);
+    const eol = this.model.getEOL();
+
+    const changes = computeMultiLineDiffChanges(
+      originalContent!,
+      insertTextString,
+      this.monacoEditor,
+      range.startLineNumber,
+      eol,
+    );
+
+    if (!changes) {
+      return;
+    }
+
+    const { singleLineCharChanges, charChanges, wordChanges, isOnlyAddingToEachWord } = changes;
+
+    // 限制 changes 数量，超过这个数量直接显示智能重写
+    const maxCharChanges = 20;
+    const maxWordChanges = 20;
+
+    if (
+      range &&
+      isOnlyAddingToEachWord &&
+      charChanges.length <= maxCharChanges &&
+      wordChanges.length <= maxWordChanges
+    ) {
+      const modificationsResult = this.multiLineDecorationModel.applyInlineDecorations(
+        this.monacoEditor,
+        mergeMultiLineDiffChanges(singleLineCharChanges, eol),
+        range.startLineNumber,
+        position,
+      );
+
+      this.multiLineDecorationModel.clearDecorations();
+
+      if (!modificationsResult) {
+        this.renderRewriteWidget(wordChanges, model, range, insertTextString);
+      } else if (modificationsResult && modificationsResult.inlineMods) {
+        this.multiLineDecorationModel.updateLineModificationDecorations(modificationsResult.inlineMods);
+      }
+    } else {
+      this.additionsDeletionsDecorationModel.updateDeletionsDecoration(wordChanges, range, eol);
+      this.renderRewriteWidget(wordChanges, model, range, insertTextString);
+    }
+  }
+
+  public accept(): void {
+    this.multiLineDecorationModel.accept();
+
+    if (this.rewriteWidget) {
+      this.rewriteWidget.accept();
+
+      const virtualEditor = this.rewriteWidget.getVirtualEditor();
+      // 采纳完之后将 virtualEditor 的 decorations 重新映射在 editor 上
+      if (virtualEditor) {
+        const editArea = this.rewriteWidget.getEditArea();
+        const decorations = virtualEditor.getDecorationsInRange(Range.lift(editArea));
+        const preAddedDecorations = decorations?.filter(
+          (decoration) => decoration.options.description === REWRITE_DECORATION_INLINE_ADD,
+        );
+        if (preAddedDecorations) {
+          this.additionsDeletionsDecorationModel.updateAdditionsDecoration(
+            preAddedDecorations.map((decoration) => decoration.range),
+          );
+        }
+      }
+    }
+  }
+
+  public discard(): void {
+    this.hide();
+  }
+
+  public hide(): void {
+    this.multiLineDecorationModel.clearDecorations();
+    this.additionsDeletionsDecorationModel.clearDeletionsDecorations();
+    this.destroyRewriteWidget();
+  }
+}

--- a/packages/ai-native/src/browser/preferences/schema.ts
+++ b/packages/ai-native/src/browser/preferences/schema.ts
@@ -1,6 +1,8 @@
 import { AINativeSettingSectionsId, PreferenceSchema } from '@opensumi/ide-core-browser';
 import { localize } from '@opensumi/ide-core-common';
 
+import { CodeEditsRenderType } from '../contrib/intelligent-completions';
+
 export enum EInlineDiffPreviewMode {
   inlineLive = 'inlineLive',
   sideBySide = 'sideBySide',
@@ -57,6 +59,12 @@ export const aiNativePreferenceSchema: PreferenceSchema = {
     [AINativeSettingSectionsId.CodeEditsLineChange]: {
       type: 'boolean',
       default: false,
+    },
+    [AINativeSettingSectionsId.CodeEditsRenderType]: {
+      type: 'string',
+      default: CodeEditsRenderType.default,
+      enum: [CodeEditsRenderType.legacy, CodeEditsRenderType.default],
+      description: localize('preference.ai.native.codeEdits.renderType'),
     },
     [AINativeSettingSectionsId.LLMModelSelection]: {
       type: 'string',

--- a/packages/ai-native/src/browser/preferences/schema.ts
+++ b/packages/ai-native/src/browser/preferences/schema.ts
@@ -62,8 +62,8 @@ export const aiNativePreferenceSchema: PreferenceSchema = {
     },
     [AINativeSettingSectionsId.CodeEditsRenderType]: {
       type: 'string',
-      default: CodeEditsRenderType.default,
-      enum: [CodeEditsRenderType.legacy, CodeEditsRenderType.default],
+      default: CodeEditsRenderType.Default,
+      enum: [CodeEditsRenderType.Legacy, CodeEditsRenderType.Default],
       description: localize('preference.ai.native.codeEdits.renderType'),
     },
     [AINativeSettingSectionsId.LLMModelSelection]: {

--- a/packages/ai-native/src/browser/widget/inline-hint/inline-hint.controller.ts
+++ b/packages/ai-native/src/browser/widget/inline-hint/inline-hint.controller.ts
@@ -40,6 +40,10 @@ export class InlineHintController extends BaseAIMonacoEditorController {
         return;
       }
 
+      if (position.lineNumber > model.getLineCount()) {
+        return;
+      }
+
       if (this.inlineCompletionsService.isVisibleCompletion) {
         return;
       }
@@ -50,7 +54,7 @@ export class InlineHintController extends BaseAIMonacoEditorController {
       );
       if (!hasPreviewDecoration) {
         const inlineHintLineDecoration = this.injector.get(InlineHintLineDecoration, [monacoEditor]);
-        const lineContent = monacoEditor.getModel()?.getLineContent(position.lineNumber);
+        const lineContent = model.getLineContent(position.lineNumber);
         if (!lineContent?.trim()) {
           inlineHintLineDecoration.show(position);
         }

--- a/packages/core-common/src/settings/ai-native.ts
+++ b/packages/core-common/src/settings/ai-native.ts
@@ -22,6 +22,8 @@ export enum AINativeSettingSectionsId {
    */
   CodeEditsLintErrors = 'ai.native.codeEdits.lintErrors',
   CodeEditsLineChange = 'ai.native.codeEdits.lineChange',
+  CodeEditsTyping = 'ai.native.codeEdits.typing',
+  CodeEditsRenderType = 'ai.native.codeEdits.renderType',
 
   /**
    * Language model API keys
@@ -36,7 +38,6 @@ export enum AINativeSettingSectionsId {
    * MCP Server configurations
    */
   MCPServers = 'ai.native.mcp.servers',
-  CodeEditsTyping = 'ai.native.codeEdits.typing',
 
   /**
    * System prompt

--- a/packages/i18n/src/common/en-US.lang.ts
+++ b/packages/i18n/src/common/en-US.lang.ts
@@ -1521,6 +1521,8 @@ export const localizationBundle = {
     'preference.ai.native.codeEdits.lineChange':
       'Whether to trigger intelligent rewriting when the cursor line number changes',
     'preference.ai.native.codeEdits.typing': 'Whether to trigger intelligent rewriting when the content changes',
+    'preference.ai.native.codeEdits.renderType': 'Code Edits Render Type',
+
     'preference.ai.native.chat.system.prompt': 'Default Chat System Prompt',
     // #endregion AI Native
 

--- a/packages/i18n/src/common/zh-CN.lang.ts
+++ b/packages/i18n/src/common/zh-CN.lang.ts
@@ -1287,6 +1287,8 @@ export const localizationBundle = {
     'preference.ai.native.codeEdits.lintErrors': '是否在发生 Lint Error 时触发智能改写',
     'preference.ai.native.codeEdits.lineChange': '是否在光标行号发生变化时触发智能改写',
     'preference.ai.native.codeEdits.typing': '是否在内容发生变化时触发智能改写',
+    'preference.ai.native.codeEdits.renderType': '智能改写渲染方式',
+
     'preference.ai.native.chat.system.prompt': '默认聊天系统提示词',
     // #endregion AI Native
 

--- a/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
+++ b/packages/startup/entry/sample-modules/ai-native/ai-native.contribution.ts
@@ -422,7 +422,7 @@ export class AINativeContribution implements AINativeCoreContribution {
 
     registry.registerCodeEditsProvider(async (editor, position, bean, token) => {
       const model = editor.getModel();
-      const maxLine = Math.max(position.lineNumber + 3, model?.getLineCount() ?? 0);
+      const maxLine = Math.min(position.lineNumber + 3, model?.getLineCount() ?? 0);
       const lineMaxColumn = model!.getLineMaxColumn(maxLine) ?? 1;
 
       const value = model!.getValueInRange({


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

![image](https://github.com/user-attachments/assets/945ea3af-c3cb-4c4d-9345-1cb640ac6ff5)
并支持配置项渲染

default: 类 vscode 的 NES 渲染
legacy: 类 cursor 的渲染方式

### Changelog
code edits 支持 NES 的渲染方式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增“代码编辑渲染方式”设置，允许用户在传统与默认模式间切换，提升代码编辑提示的自定义体验。
- **Bug 修复**
	- 优化内联提示逻辑，有效防止因行号超出范围而引发的问题，增强提示功能的稳定性。
- **重构**
	- 重构并整合内联编辑建议和预览机制，实现更高效、统一的代码编辑体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->