### PR TITLE
style: add color style for codicon keyboard tab icon

### DIFF
--- a/packages/core-browser/src/style/override.less
+++ b/packages/core-browser/src/style/override.less
@@ -90,4 +90,8 @@
   .monaco-icon-label::before {
     box-sizing: content-box;
   }
+
+  .codicon-keyboard-tab {
+    color: var(--vscode-icon-foreground);
+  }
 }


### PR DESCRIPTION
### Types

- [x] 💄 Style Changes

### Background or solution

Before:
<img width="64" alt="image" src="https://github.com/user-attachments/assets/d9519baa-ef37-4198-81e0-1aca4313f84f" />

After:

<img width="108" alt="image" src="https://github.com/user-attachments/assets/eb90f412-86ae-4363-9bd8-80fdcf4c6bf7" />


### Changelog

add color style for codicon keyboard tab icon