### PR TITLE
fix: delete files on multiple workspace

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -628,7 +628,11 @@ export class FileTreeService extends Tree implements IFileTreeService {
         if (rootUri.isEqualOrParent(pathURI)) {
           const relativePath = rootUri.relative(pathURI);
           if (relativePath) {
-            path = new Path(this.root.path).join(relativePath.toString()).toString();
+            if (this.isMultipleWorkspace) {
+              path = new Path(this.root.path).join(rootUri.displayName).join(relativePath.toString()).toString();
+            } else {
+              path = new Path(this.root.path).join(relativePath.toString()).toString();
+            }
           }
         }
       }
@@ -726,8 +730,8 @@ export class FileTreeService extends Tree implements IFileTreeService {
   /**
    * 将文件排序并删除多余文件（指已有父文件夹将被删除）
    */
-  public sortPaths(_paths: (string | URI)[]) {
-    const paths = _paths.slice();
+  public sortPaths(pathOrUri: (string | URI)[]) {
+    const paths = pathOrUri.slice();
     const nodes = paths
       .map((path) => ({
         node: this.getNodeByPathOrUri(path),
@@ -735,7 +739,7 @@ export class FileTreeService extends Tree implements IFileTreeService {
       }))
       .filter((node) => node && !!node.node) as ISortNode[];
 
-    if (_paths.length > 1) {
+    if (pathOrUri.length > 1) {
       nodes.sort((pathA, pathB) => {
         // 直接获取节点深度比通过path取深度更可靠
         const pathADepth = pathA.node?.depth || 0;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

close #4415.

### Changelog

delete files on multiple workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在多工作区环境下优化了文件路径显示逻辑，现在文件路径会包含工作区标识，以提升文件导航的清晰性。
- **重构**
  - 优化了排序流程中的参数命名，提升了代码的一致性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->