### PR TITLE
fix(debug-variables): try to fix incorrect undefined type checking

### DIFF
--- a/packages/debug/src/browser/view/variables/debug-variables.view.tsx
+++ b/packages/debug/src/browser/view/variables/debug-variables.view.tsx
@@ -217,9 +217,8 @@ export const DebugVariableRenderedNode: React.FC<IDebugVariableNodeRenderedProps
   const renderDescription = (node: ExpressionContainer | ExpressionNode) => {
     const booleanRegex = /^true|false$/i;
     const stringRegex = /^(['"]).*\1$/;
-    const description = (node as DebugVariableContainer).description
-      ? (node as DebugVariableContainer).description.replace('function', 'ƒ ')
-      : '';
+    const { description: desc = '' } = node as DebugVariableContainer;
+    const description = desc !== 'undefined' ? desc.replace('function', 'ƒ ') : '';
     const addonClass = [styles.debug_variables_variable];
     if (item.variableType === 'number' || item.variableType === 'boolean' || item.variableType === 'string') {
       addonClass.push(styles[item.variableType]);


### PR DESCRIPTION
### Types

- [ ] 🐛 Bug Fixes

### Background or solution
#### Background
debug过程中，variables模块中的Globals部分出现预期外的undefined标识，与vscode不对齐：
1. opensumi：
![bug1](https://github.com/user-attachments/assets/9a23eeca-560b-4c19-bfa8-3bccea499e6c)
![bug2](https://github.com/user-attachments/assets/b92b9f8d-7a29-462d-84b4-8194477c1998)
2. vscode：
![vscode](https://github.com/user-attachments/assets/81aa4ae5-2134-4808-9c87-c884009ac85a)

经过检查，发现debug-variables.view.tsx中对renderDescription方法对description是否为undefined判断有误，node.description始终为string类型，而这里预期是通过?:三元运算符进行undefined的兜底转换逻辑（转换成空字符串），二者有冲突
#### solution
+ 使用字符串比较判断description是否为undefined
+ 通过解构赋值和明确的字符串比较优化了代码，减少了重复的类型转换，同时增加了默认值以防止潜在的空值错误
### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
	- 优化了调试视图中变量描述的处理逻辑，确保当描述值为空或显示为“undefined”时，不再进行不必要的替换操作，从而提升了调试信息显示的准确性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
