### PR TITLE
feat: support builtin mcp tool order

### DIFF
--- a/packages/ai-native/src/browser/mcp/mcp-server.feature.registry.ts
+++ b/packages/ai-native/src/browser/mcp/mcp-server.feature.registry.ts
@@ -60,7 +60,7 @@ export class MCPServerRegistry implements IMCPServerRegistry {
   }
 
   getMCPTools(): MCPToolDefinition[] {
-    return this.tools;
+    return this.tools.sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
   }
 
   async callMCPTool(

--- a/packages/ai-native/src/browser/mcp/tools/createNewFileWithText.ts
+++ b/packages/ai-native/src/browser/mcp/tools/createNewFileWithText.ts
@@ -35,6 +35,7 @@ export class CreateNewFileWithTextTool implements MCPServerContribution {
     return {
       name: 'create_new_file_with_text',
       label: 'Create File',
+      order: 7,
       description:
         'Creates a new file at the specified path within the project directory and populates it with the provided text. ' +
         'Use this tool to generate new files in your project structure. ' +

--- a/packages/ai-native/src/browser/mcp/tools/editFile.ts
+++ b/packages/ai-native/src/browser/mcp/tools/editFile.ts
@@ -46,6 +46,7 @@ export class EditFileTool implements MCPServerContribution {
     return {
       name: 'edit_file',
       label: 'Edit File',
+      order: 5,
       description: `Use this tool to propose an edit to an existing file.
 This will be read by a less intelligent model, which will quickly apply the edit. You should make it clear what the edit is, while also minimizing the unchanged code you write.
 When writing the edit, you should specify each edit in sequence, with the special comment \`// ... existing code ...\` to represent unchanged code in between edited lines.

--- a/packages/ai-native/src/browser/mcp/tools/fileSearch.ts
+++ b/packages/ai-native/src/browser/mcp/tools/fileSearch.ts
@@ -41,6 +41,7 @@ export class FileSearchTool implements MCPServerContribution {
     return {
       name: 'file_search',
       label: 'Search Files',
+      order: 6,
       description:
         "Fast file search based on fuzzy matching against file path. Use if you know part of the file path but don't know where it's located exactly. Response will be capped to 10 results. Make your query more specific if need to filter results further.",
       inputSchema,

--- a/packages/ai-native/src/browser/mcp/tools/getDiagnosticsByPath.ts
+++ b/packages/ai-native/src/browser/mcp/tools/getDiagnosticsByPath.ts
@@ -29,7 +29,8 @@ export class GetDiagnosticsByPathTool implements MCPServerContribution {
   getToolDefinition(): MCPToolDefinition {
     return {
       name: 'get_diagnostics_by_path',
-      label: 'Get Diagnostics',
+      label: 'Get Diagnostics By Path',
+      order: 9,
       description:
         'Retrieves diagnostic information (errors, warnings, etc.) from a specific file in the project. ' +
         'Use this tool to get information about problems in any project file. ' +

--- a/packages/ai-native/src/browser/mcp/tools/getOpenEditorFileDiagnostics.ts
+++ b/packages/ai-native/src/browser/mcp/tools/getOpenEditorFileDiagnostics.ts
@@ -31,6 +31,8 @@ export class GetOpenEditorFileDiagnosticsTool implements MCPServerContribution {
   getToolDefinition(): MCPToolDefinition {
     return {
       name: 'get_open_in_editor_file_diagnostics',
+      label: 'Get Current Editor Diagnostics',
+      order: 8,
       description:
         'Retrieves diagnostic information (errors, warnings, etc.) from the currently active file in VS Code editor. ' +
         'Use this tool to get information about problems in your current file. ' +

--- a/packages/ai-native/src/browser/mcp/tools/grepSearch.ts
+++ b/packages/ai-native/src/browser/mcp/tools/grepSearch.ts
@@ -48,6 +48,7 @@ export class GrepSearchTool implements MCPServerContribution {
     return {
       name: 'grep_search',
       label: 'Search Contents',
+      order: 4,
       description:
         // TODO: 支持语义化搜索后需要描述清楚优劣势
         'Fast text-based regex search that finds exact pattern matches within files or directories, utilizing the ripgrep command for efficient searching.\nResults will be formatted in the style of ripgrep and can be configured to include line numbers and content.\nTo avoid overwhelming output, the results are capped at 50 matches.\nUse the include or exclude patterns to filter the search scope by file type or specific paths.\n\nThis is best for finding exact text matches or regex patterns.',

--- a/packages/ai-native/src/browser/mcp/tools/listDir.ts
+++ b/packages/ai-native/src/browser/mcp/tools/listDir.ts
@@ -41,6 +41,7 @@ export class ListDirTool implements MCPServerContribution {
     return {
       name: 'list_dir',
       label: 'List Directory',
+      order: 3,
       description:
         'List the contents of a directory. The quick tool to use for discovery, before using more targeted tools like semantic search or file reading. Useful to try to understand the file structure before diving deeper into specific files. Can be used to explore the codebase.',
       inputSchema,

--- a/packages/ai-native/src/browser/mcp/tools/readFile.ts
+++ b/packages/ai-native/src/browser/mcp/tools/readFile.ts
@@ -38,6 +38,7 @@ export class ReadFileTool implements MCPServerContribution {
     return {
       name: 'read_file',
       label: 'Read File',
+      order: 1,
       description: `Read the contents of a file (and the outline).
 
 When using this tool to gather information, it's your responsibility to ensure you have the COMPLETE context. Each time you call this command you should:

--- a/packages/ai-native/src/browser/mcp/tools/runTerminalCmd.ts
+++ b/packages/ai-native/src/browser/mcp/tools/runTerminalCmd.ts
@@ -33,6 +33,7 @@ export class RunTerminalCommandTool implements MCPServerContribution {
     return {
       name: 'run_terminal_cmd',
       label: 'Run Command',
+      order: 2,
       description:
         "PROPOSE a command to run on behalf of the user.\nIf you have this tool, note that you DO have the ability to run commands directly on the USER's system.\n\nAdhere to these rules:\n1. Based on the contents of the conversation, you will be told if you are in the same shell as a previous step or a new shell.\n2. If in a new shell, you should `cd` to the right directory and do necessary setup in addition to running the command.\n3. If in the same shell, the state will persist, no need to do things like `cd` to the same directory.\n4. For ANY commands that would use a pager, you should append ` | cat` to the command (or whatever is appropriate). You MUST do this for: git, less, head, tail, more, etc.\n5. For commands that are long running/expected to run indefinitely until interruption, please run them in the background. To run jobs in the background, set `is_background` to true rather than changing the details of the command.\n6. Dont include any newlines in the command.",
       inputSchema,

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -350,6 +350,7 @@ export interface MCPLogger {
 export interface MCPToolDefinition {
   name: string;
   label?: string;
+  order?: number;
   description: string;
   inputSchema: ZodSchema<any>; // JSON Schema
   handler: (


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution
feat: support builtin mcp tool order

内置工具顺序按照 Cursor 来实现：
1. codebase_search
1. read_file
1. run_terminal_cmd
1. list_dir
1. grep_search
1. edit_file
1. file_search

### Changelog
feat: support builtin mcp tool order