### PR TITLE
fix: increase timeout duration in RecursiveFileSystemWatcher to 60 se…

### DIFF
--- a/packages/file-service/src/node/hosted/recursive/file-service-watcher.ts
+++ b/packages/file-service/src/node/hosted/recursive/file-service-watcher.ts
@@ -83,8 +83,8 @@ export class RecursiveFileSystemWatcher extends Disposable implements IWatcher {
     return new Promise<void>((resolve, rej) => {
       const timer = setTimeout(() => {
         rej(`Watch ${uri} Timeout`);
-        // FIXME：暂时写死3秒
-      }, 3000);
+        // FIXME：暂时写死60秒
+      }, 60000);
 
       if (options?.excludes) {
         this.updateWatcherFileExcludes(options.excludes);


### PR DESCRIPTION
…conds

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 文件监控功能的超时时间已由原来的3秒延长至60秒，从而改进了错误处理流程，减少了因超时过短引发的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->