### PR TITLE
fix: showing all mcp server in the list

### DIFF
--- a/packages/ai-native/src/browser/mcp/config/components/mcp-config.view.tsx
+++ b/packages/ai-native/src/browser/mcp/config/components/mcp-config.view.tsx
@@ -28,6 +28,7 @@ export const MCPConfigView: React.FC = () => {
   const loadServers = useCallback(async () => {
     const userServers = preferenceService.get<MCPServerDescription[]>(AINativeSettingSectionsId.MCPServers, []);
     const runningServers = await mcpServerProxyService.$getServers();
+    const builtinServer = runningServers.find((server) => server.name === BUILTIN_MCP_SERVER_NAME);
     const allServers = userServers.map((server) => {
       const runningServer = runningServers.find((s) => s.name === server.name);
       return {
@@ -37,6 +38,7 @@ export const MCPConfigView: React.FC = () => {
         tools: runningServer?.tools,
       };
     });
+    allServers.unshift(builtinServer as any);
     setServers(allServers);
   }, [mcpServerProxyService]);
 

--- a/packages/ai-native/src/browser/mcp/config/components/mcp-config.view.tsx
+++ b/packages/ai-native/src/browser/mcp/config/components/mcp-config.view.tsx
@@ -37,8 +37,10 @@ export const MCPConfigView: React.FC = () => {
         isStarted: !!runningServer,
         tools: runningServer?.tools,
       };
-    });
-    allServers.unshift(builtinServer as any);
+    }) as MCPServer[];
+    if (builtinServer) {
+      allServers.unshift(builtinServer);
+    }
     setServers(allServers);
   }, [mcpServerProxyService]);
 

--- a/packages/ai-native/src/browser/mcp/config/components/mcp-config.view.tsx
+++ b/packages/ai-native/src/browser/mcp/config/components/mcp-config.view.tsx
@@ -26,7 +26,17 @@ export const MCPConfigView: React.FC = () => {
   const [editingServer, setEditingServer] = React.useState<MCPServerFormData | undefined>();
   const [loadingServer, setLoadingServer] = React.useState<string | undefined>();
   const loadServers = useCallback(async () => {
-    const allServers = await mcpServerProxyService.$getServers();
+    const userServers = preferenceService.get<MCPServerDescription[]>(AINativeSettingSectionsId.MCPServers, []);
+    const runningServers = await mcpServerProxyService.$getServers();
+    const allServers = userServers.map((server) => {
+      const runningServer = runningServers.find((s) => s.name === server.name);
+      return {
+        ...server,
+        name: server.name,
+        isStarted: !!runningServer,
+        tools: runningServer?.tools,
+      };
+    });
     setServers(allServers);
   }, [mcpServerProxyService]);
 

--- a/packages/ai-native/src/common/index.ts
+++ b/packages/ai-native/src/common/index.ts
@@ -134,7 +134,14 @@ export interface ISumiMCPServerBackend {
   initBuiltinMCPServer(enabled: boolean): void;
   initExternalMCPServers(servers: MCPServerDescription[]): void;
   getAllMCPTools(): Promise<MCPTool[]>;
-  getServers(): Promise<Array<{ name: string; isStarted: boolean; tools: MCPTool[] }>>;
+  getServers(): Promise<
+    Array<{
+      name: string;
+      isStarted: boolean;
+      type: string;
+      tools: MCPTool[];
+    }>
+  >;
   startServer(serverName: string): Promise<void>;
   stopServer(serverName: string): Promise<void>;
   addOrUpdateServer(description: MCPServerDescription): void;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

原有实现会导致用户存储的非启动配置丢失

### Changelog

showing all mcp server in the list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 优化了服务器信息加载逻辑，现在整合了用户自定义设置与实时运行状态，展示更精准的服务器状态。
  - 扩充了服务器数据内容，新增服务器类型信息，让用户获取更全面的服务详情。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->