### PR TITLE
fix: hide debug hover widget when esc pressed

### DIFF
--- a/packages/debug/src/browser/editor/debug-model.ts
+++ b/packages/debug/src/browser/editor/debug-model.ts
@@ -138,7 +138,13 @@ export class DebugModel implements IDebugModel {
 
     this.toDispose.pushAll([
       this.breakpointWidget,
-      this.editor.onKeyDown(() => this.debugHoverWidget.hide({ immediate: false })),
+      this.editor.onKeyDown((e) => {
+        if (e.code === 'Escape' && !e.altKey && !e.shiftKey && !e.metaKey) {
+          this.debugHoverWidget.hide({ immediate: true });
+        } else {
+          this.debugHoverWidget.hide({ immediate: false });
+        }
+      }),
       this.editor.onDidChangeModelContent(() => this.renderFrames()),
       this.debugSessionManager.onDidChange(() => this.renderFrames()),
       this.debugBreakpointsService.onDidFocusedBreakpoints(({ range }) => {


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes


### Background or solution

支持 ESC 快速退出调试视图显示

### Changelog

hide debug hover widget when esc is pressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 提升了调试界面的键盘交互体验：当按下不带修饰键的 Escape 键时，调试提示会立即关闭；其他键操作仍保持原有的延迟关闭行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->