### PR TITLE
fix: getModelInfo with providerOptions, pass args only when need

### DIFF
--- a/packages/ai-native/src/browser/components/components.module.less
+++ b/packages/ai-native/src/browser/components/components.module.less
@@ -649,4 +649,6 @@
 
 .image_wrapper {
   display: inline-block;
+  border-radius: 3px;
+  overflow: hidden;
 }

--- a/packages/ai-native/src/node/base-language-model.ts
+++ b/packages/ai-native/src/node/base-language-model.ts
@@ -74,7 +74,7 @@ export abstract class BaseLanguageModel {
 
   protected abstract getModelIdentifier(provider: any, modelId?: string): any;
 
-  protected abstract getModelInfo(modelId: string): ModelInfo | undefined;
+  protected abstract getModelInfo(modelId: string, providerOptions?: Record<string, any>): ModelInfo | undefined;
 
   protected async handleStreamingRequest(
     provider: any,
@@ -112,7 +112,7 @@ export abstract class BaseLanguageModel {
             : request,
         },
       ];
-      const modelInfo = modelId ? this.getModelInfo(modelId) : undefined;
+      const modelInfo = modelId ? this.getModelInfo(modelId, providerOptions) : undefined;
       const stream = streamText({
         model: this.getModelIdentifier(provider, modelId),
         tools: aiTools,
@@ -121,11 +121,11 @@ export abstract class BaseLanguageModel {
         experimental_toolCallStreaming: true,
         maxSteps: 12,
         maxTokens,
-        temperature: modelInfo?.temperature || 0,
-        topP: modelInfo?.topP || 0.8,
         system: systemPrompt,
         providerOptions,
-        ...(!images?.length && { topK: modelInfo?.topK || 1 }),
+        ...(modelInfo?.temperature !== undefined && { temperature: modelInfo.temperature }),
+        ...(modelInfo?.topP !== undefined && { topP: modelInfo.topP }),
+        ...(modelInfo?.topK !== undefined && { topK: modelInfo.topK }),
       });
 
       // 状态跟踪变量

--- a/packages/ai-native/src/node/openai-compatible/openai-compatible-language-model.ts
+++ b/packages/ai-native/src/node/openai-compatible/openai-compatible-language-model.ts
@@ -24,7 +24,7 @@ export class OpenAICompatibleModel extends BaseLanguageModel {
     return provider(modelId);
   }
 
-  protected getModelInfo() {
+  protected getModelInfo(_modelId: string, _providerOptions?: Record<string, any>) {
     return undefined;
   }
 }

--- a/packages/ai-native/src/node/openai-compatible/openai-compatible-language-model.ts
+++ b/packages/ai-native/src/node/openai-compatible/openai-compatible-language-model.ts
@@ -4,6 +4,7 @@ import { LanguageModelV1 } from 'ai';
 import { Injectable } from '@opensumi/di';
 import { AINativeSettingSectionsId, IAIBackServiceOption } from '@opensumi/ide-core-common';
 
+import { ModelInfo } from '../../common';
 import { BaseLanguageModel } from '../base-language-model';
 
 @Injectable()
@@ -24,7 +25,7 @@ export class OpenAICompatibleModel extends BaseLanguageModel {
     return provider(modelId);
   }
 
-  protected getModelInfo(_modelId: string, _providerOptions?: Record<string, any>) {
+  protected getModelInfo(_modelId: string, _providerOptions?: Record<string, any>): ModelInfo | undefined {
     return undefined;
   }
 }


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
fix: getModelInfo with providerOptions, pass args only when need
claude_3.7 同一个 modelID 支持不同的模式（Thinking），获取 modelInfo 时需要区分开来

### Changelog
fix: getModelInfo with providerOptions, pass args only when need

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **样式**
  - 更新了图片展示效果，图片元素现在采用圆角设计并隐藏超出部分，带来更现代和整洁的界面外观。
- **重构**
  - 优化了后台模型配置的处理，提升了参数管理的灵活性和流式响应的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->