### PR TITLE
fix: not displayed when widget.disposed

### DIFF
--- a/packages/comments/src/browser/comments-thread.ts
+++ b/packages/comments/src/browser/comments-thread.ts
@@ -253,7 +253,9 @@ export class CommentsThread extends Disposable implements ICommentsThread {
       // 如果标记之前是已经展示的 widget，则调用 show 方法
       if (editor.currentUri?.isEqual(this.uri)) {
         setTimeout(() => {
-          widget?.show();
+          if (!widget.disposed) {
+            widget?.show();
+          }
         }, 0);
       }
     }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [X] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog
fix: 修复widget为disposed后不展示


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 优化了组件展示逻辑，在确保组件仍然有效后再进行显示，从而避免因展示已失效组件而引发的错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->