### PR TITLE
feat: support access function for custom fs provider

### DIFF
--- a/packages/file-service/src/browser/file-service-client.ts
+++ b/packages/file-service/src/browser/file-service-client.ts
@@ -511,6 +511,15 @@ export class FileServiceClient implements IFileServiceClient, IDisposable {
     const provider = await this.getProvider(_uri.scheme);
 
     if (!containsExtraFileMethod(provider, 'access')) {
+      if (mode === FileAccess.Constants.F_OK) {
+        // 当 mode 为 F_OK 时，如果 provider 不支持 access 方法，则使用 stat 方法判断文件是否存在
+        try {
+          const stat = await provider.stat(_uri.codeUri);
+          return !!stat;
+        } catch (error) {
+          return false;
+        }
+      }
       throw this.getErrorProvideNotSupport(_uri.scheme, 'access');
     }
 

--- a/packages/file-tree-next/src/browser/file-tree.tsx
+++ b/packages/file-tree-next/src/browser/file-tree.tsx
@@ -146,12 +146,16 @@ export const FileTree = ({ viewState }: PropsWithChildren<{ viewState: ViewState
         if (treeModel) {
           // 确保数据初始化完毕，减少初始化数据过程中多次刷新视图
           await treeModel.ensureReady;
+
+          if (wrapperRef.current) {
+            fileTreeService.initContextKey(wrapperRef.current);
+          }
         }
         setModel(treeModel);
         setIsLoading(false);
       });
     }
-  }, [isReady]);
+  }, [isReady, wrapperRef.current, fileTreeService]);
 
   useEffect(() => {
     const tokenSource = new CancellationTokenSource();


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

当采用插件进程提供的 vscode.FileSystem 时，在 `mode === FileAccess.Constants.F_OK` 情况下使用等价的 stat 判断文件是否存在

### Changelog

support access function for custom fs provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 改进了文件访问检查逻辑：在检测文件存在性时，如果常规方法不可用，将自动采用备用检测方式，从而更可靠地判断文件是否存在，并避免不必要的错误。
  
- **新特性**
  - 增强了文件树组件的响应能力：在组件准备就绪时，初始化文件树服务的上下文键，以改善组件与服务之间的交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->