### PR TITLE
fix: sumi extension restart logic

### DIFF
--- a/packages/extension/src/browser/extension-instance-management.ts
+++ b/packages/extension/src/browser/extension-instance-management.ts
@@ -75,9 +75,7 @@ export class ExtInstanceManagementService extends Disposable implements Abstract
 
   public disposeExtensionInstancesByPath(paths: string[]) {
     paths.forEach((path) => {
-      if (this.extensionMap.has(path)) {
-        this.extensionMap.get(path)!.dispose();
-      }
+      this.extensionMap.get(path)?.dispose();
     });
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

1. 修复插件贡献点重复注册逻辑，解决菜单重复注册问题
<img width="507" alt="image" src="https://github.com/user-attachments/assets/68680575-7682-41e2-be6c-7677987ca4f9" />

2. 优化 `ExtensionHost Restart` 时序，移除并发状态下的 cancel 逻辑（会导致 Extension 的 activate 方法重复调用多次问题）
### Changelog

优化 Sumi Extension 重启流程


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了扩展实例清理流程，使操作逻辑更简洁高效，保障扩展正常关闭。
  
- **修复**
  - 改进了扩展重启时加载状态的管理，避免重复显示进度指示，提升了重启体验的流畅性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->