### PR TITLE
feat: statusBarService support extends addElement

### DIFF
--- a/packages/core-browser/src/services/status-bar-service.ts
+++ b/packages/core-browser/src/services/status-bar-service.ts
@@ -51,7 +51,7 @@ export interface StatusBarEntry {
    * 可以通过 text 设置图标
    * $(iconClassName) :text
    */
-  text?: string;
+  text?: string | React.ReactNode;
   /**
    * 当前菜单显示名称
    * 标识当前状态栏组件 contextmenu 显示的名称，如果没有使用 text 代替

--- a/packages/status-bar/src/browser/status-bar-item.view.tsx
+++ b/packages/status-bar/src/browser/status-bar-item.view.tsx
@@ -137,22 +137,23 @@ export const StatusBarItem = memo((props: StatusBarEntry) => {
       >
         <div className={styles.popover_item}>
           {iconClass && <span key={-1} className={cls(styles.icon, iconClass)}></span>}
-          {text &&
-            transformLabelWithCodicon(
-              text,
-              {},
-              iconService.fromString.bind(iconService),
-              (text: string, index: number) => (
-                <span
-                  key={`${text}-${index}`}
-                  style={{ height: '22px', lineHeight: '22px' }}
-                  aria-label={ariaLabel}
-                  role={role}
-                >
-                  {replaceLocalizePlaceholder(text)}
-                </span>
-              ),
-            )}
+          {typeof text === 'string'
+            ? transformLabelWithCodicon(
+                text,
+                {},
+                iconService.fromString.bind(iconService),
+                (text: string, index: number) => (
+                  <span
+                    key={`${text}-${index}`}
+                    style={{ height: '22px', lineHeight: '22px' }}
+                    aria-label={ariaLabel}
+                    role={role}
+                  >
+                    {replaceLocalizePlaceholder(text)}
+                  </span>
+                ),
+              )
+            : text}
         </div>
       </Popover>
     </div>

--- a/packages/status-bar/src/browser/status-bar.service.ts
+++ b/packages/status-bar/src/browser/status-bar.service.ts
@@ -27,7 +27,7 @@ export class StatusBarService extends Disposable implements IStatusBarService {
   private background: string | undefined;
   private foreground: string | undefined;
 
-  private entriesObservable = observableValue<Map<string, StatusBarEntry>>(this, new Map());
+  entriesObservable = observableValue<Map<string, StatusBarEntry>>(this, new Map());
 
   @Autowired(CommandService)
   private commandService: CommandService;
@@ -101,14 +101,14 @@ export class StatusBarService extends Disposable implements IStatusBarService {
    * @param id 状态栏 id
    * @returns
    */
-  private getEntriesById(id: string) {
+  getEntriesById(id: string) {
     return this.entriesArray.get().filter((entry) => entry.id === id);
   }
 
   /**
    * 从 storage 中读取 state
    */
-  private getStorageState(id: string) {
+  getStorageState(id: string) {
     return this.layoutState.getState<{ [id: string]: StatusBarState }>(LAYOUT_STATE.STATUSBAR, {})[id];
   }
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [X] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog
feat: statusBarService支持复写addElement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - 更新了状态栏条目接口的 `text` 属性类型，允许其接受更灵活的内容类型（`string | React.ReactNode`），增强了状态栏元素的视觉表现。
  - 修改了 `StatusBarItem` 组件中 `text` 属性的处理逻辑，允许直接渲染非字符串值，提升了灵活性。

- **重构**
  - 优化了部分服务接口的访问级别，将原先私有的方法和属性改为公开，使得其他模块能够更方便地集成和调用，同时保持现有业务逻辑和系统稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->