### PR TITLE
fix: update default height in search panel container style

### DIFF
--- a/packages/search/src/browser/search.view.tsx
+++ b/packages/search/src/browser/search.view.tsx
@@ -95,7 +95,7 @@ export const Search = memo(({ viewState }: PropsWithChildren<{ viewState: ViewSt
 
   const collapsePanelContainerStyle = {
     width: viewState.width || '100%',
-    height: viewState.height,
+    height: viewState.height || '100%',
   };
 
   const SearchProcess = useMemo(


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

当默认视图为 search 面板时，由于视图渲染问题，会出现搜索内容不展示（高度为 0）问题，增加临时兜底处理
<img width="349" alt="image" src="https://github.com/user-attachments/assets/de8b520e-e8a6-4759-830f-4c711359e83a" />

### Changelog
update default height in search panel container style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修正了面板显示问题：当高度未明确设置时，自动采用默认全高展示，确保页面布局稳定，从而防止因高度不足而引发的显示异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->