### PR TITLE
fix: monaco caused by the failure of window.addEventListener('compositionstart', () => {})

### DIFF
--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -584,6 +584,8 @@ export class ClientApp implements IClientApp, IDisposable {
     window.removeEventListener('beforeunload', this._handleBeforeUpload);
     window.removeEventListener('unload', this._handleUnload);
     window.removeEventListener('resize', this._handleResize);
+    window.removeEventListener('compositionstart', this.keybindingService?.handleCompositionStart);
+    window.removeEventListener('compositionend', this.keybindingService?.handleCompositionEnd);
     window.removeEventListener('keydown', this._handleKeydown, true);
     if (isOSX) {
       document.body.removeEventListener('wheel', this._handleWheel);

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -487,12 +487,7 @@ export class ClientApp implements IClientApp, IDisposable {
   protected registerEventListeners(): void {
     window.addEventListener('beforeunload', this._handleBeforeUpload);
     window.addEventListener('unload', this._handleUnload);
-
     window.addEventListener('resize', this._handleResize);
-    // 处理中文输入回退时可能出现多个光标问题
-    // https://github.com/eclipse-theia/theia/pull/6673
-    window.addEventListener('compositionstart', this._handleCompositionstart);
-    window.addEventListener('compositionend', this._handleCompositionend);
     window.addEventListener('keydown', this._handleKeydown, true);
     window.addEventListener('keyup', this._handleKeyup, true);
 
@@ -589,8 +584,6 @@ export class ClientApp implements IClientApp, IDisposable {
     window.removeEventListener('beforeunload', this._handleBeforeUpload);
     window.removeEventListener('unload', this._handleUnload);
     window.removeEventListener('resize', this._handleResize);
-    window.removeEventListener('compositionstart', this._handleCompositionstart);
-    window.removeEventListener('compositionend', this._handleCompositionend);
     window.removeEventListener('keydown', this._handleKeydown, true);
     if (isOSX) {
       document.body.removeEventListener('wheel', this._handleWheel);
@@ -660,21 +653,13 @@ export class ClientApp implements IClientApp, IDisposable {
   };
 
   private _handleKeydown = (event: any) => {
-    if (event && event.target!.name !== NO_KEYBINDING_NAME && !this._inComposition) {
+    if (event && event.target!.name !== NO_KEYBINDING_NAME) {
       this.keybindingService.run(event);
     }
   };
 
   private _handleKeyup = (event: any) => {
     this.keybindingService.resolveModifierKey(event);
-  };
-
-  private _handleCompositionstart = () => {
-    this._inComposition = true;
-  };
-
-  private _handleCompositionend = () => {
-    this._inComposition = false;
   };
 
   private _handleWheel = () => {

--- a/packages/core-browser/src/bootstrap/app.ts
+++ b/packages/core-browser/src/bootstrap/app.ts
@@ -488,6 +488,11 @@ export class ClientApp implements IClientApp, IDisposable {
     window.addEventListener('beforeunload', this._handleBeforeUpload);
     window.addEventListener('unload', this._handleUnload);
     window.addEventListener('resize', this._handleResize);
+
+    // 处理中文输入回退时可能出现多个光标问题
+    // https://github.com/eclipse-theia/theia/pull/6673
+    window.addEventListener('compositionstart', this.keybindingService?.handleCompositionStart);
+    window.addEventListener('compositionend', this.keybindingService?.handleCompositionEnd);
     window.addEventListener('keydown', this._handleKeydown, true);
     window.addEventListener('keyup', this._handleKeyup, true);
 

--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -190,6 +190,8 @@ export interface KeybindingService {
    * @param when
    */
   convertMonacoWhen(when: any): string;
+  handleCompositionStart(): void;
+  handleCompositionEnd(): void;
 }
 
 @Injectable()
@@ -230,6 +232,8 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
   @Autowired(IStatusBarService)
   protected readonly statusBar: IStatusBarService;
 
+  private _inComposition = false;
+
   public async initialize(): Promise<void> {
     await this.keyboardLayoutService.initialize();
     this.keyboardLayoutService.onKeyboardLayoutChanged(() => {
@@ -242,6 +246,14 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
   }
 
   protected keybindingsChanged = new Emitter<{ affectsCommands: string[] }>();
+
+  public handleCompositionStart = () => {
+    this._inComposition = true;
+  };
+
+  public handleCompositionEnd = () => {
+    this._inComposition = false;
+  };
 
   /**
    * 由于不同的键盘布局发生更改时触发的事件。
@@ -807,6 +819,9 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
    * @param event 键盘事件
    */
   public run(event: KeyboardEvent): void {
+    if (this._inComposition) {
+      return;
+    }
     if (event.defaultPrevented) {
       return;
     }

--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -235,6 +235,9 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
   private _inComposition = false;
 
   public async initialize(): Promise<void> {
+    window.removeEventListener('compositionstart', this.handleCompositionStart);
+    window.removeEventListener('compositionend', this.handleCompositionEnd);
+
     await this.keyboardLayoutService.initialize();
     this.keyboardLayoutService.onKeyboardLayoutChanged(() => {
       this.clearResolvedKeybindings();

--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -235,9 +235,6 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
   private _inComposition = false;
 
   public async initialize(): Promise<void> {
-    window.removeEventListener('compositionstart', this.handleCompositionStart);
-    window.removeEventListener('compositionend', this.handleCompositionEnd);
-
     await this.keyboardLayoutService.initialize();
     this.keyboardLayoutService.onKeyboardLayoutChanged(() => {
       this.clearResolvedKeybindings();

--- a/packages/monaco/src/browser/monaco.service.ts
+++ b/packages/monaco/src/browser/monaco.service.ts
@@ -3,6 +3,7 @@ import {
   Disposable,
   ILogger,
   KeybindingRegistry,
+  KeybindingService,
   MonacoOverrideServiceRegistry,
   ServiceNames,
 } from '@opensumi/ide-core-browser';
@@ -43,6 +44,9 @@ export default class MonacoServiceImpl extends Disposable implements MonacoServi
 
   @Autowired(KeybindingRegistry)
   private readonly keybindingRegistry: KeybindingRegistry;
+
+  @Autowired(KeybindingService)
+  protected readonly keybindingService: KeybindingService;
 
   @Autowired(ILogger)
   private readonly logger: ILogger;
@@ -105,6 +109,19 @@ export default class MonacoServiceImpl extends Disposable implements MonacoServi
     );
   }
 
+  private doAddCompositionEventListener(editor: ICodeEditor) {
+    this.addDispose(
+      editor.onDidCompositionStart((e) => {
+        this.keybindingService?.handleCompositionStart();
+      }),
+    );
+    this.addDispose(
+      editor.onDidCompositionEnd((e) => {
+        this.keybindingService?.handleCompositionEnd();
+      }),
+    );
+  }
+
   private addClickEventListener(editor: IEditorType) {
     if (isDiffEditor(editor)) {
       const originalEditor = editor.getOriginalEditor();
@@ -114,6 +131,7 @@ export default class MonacoServiceImpl extends Disposable implements MonacoServi
       this.doAddClickEventListener(modifiedEditor);
     } else {
       this.doAddClickEventListener(editor as ICodeEditor);
+      this.doAddCompositionEventListener(editor as ICodeEditor);
     }
   }
 


### PR DESCRIPTION

### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [X] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog
fix: 修复在monaco中删除未写入编辑器的中文会导致代码删除问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新的发布说明

- **新功能**
  - 增加了输入法组合事件支持，确保在文本输入时不会误触快捷键。
  - 编辑器现加入了组合事件监听机制，提升了在中文输入法等复杂输入环境下的交互稳定性和响应准确性。
- **修复**
  - 简化了与组合事件相关的事件处理逻辑，减少了复杂性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->