### PR TITLE
feat: support TerminalWordLink can be override

### DIFF
--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -139,9 +139,7 @@ export class TerminalLinkManager extends Disposable {
       async (link, cb) => cb(await this._resolvePath(link)),
     ]);
     this._standardLinkProviders.push(validatedProvider);
-
-    this.enableTerminalWordLinkProvider();
-
+    this.addTerminalWordLinkProvider();
     this._registerStandardLinkProviders();
   }
 
@@ -149,7 +147,7 @@ export class TerminalLinkManager extends Disposable {
     this._processCwd = processCwd;
   }
 
-  public enableTerminalWordLinkProvider() {
+  public addTerminalWordLinkProvider() {
     const wordLinkProvider = this.injector.get(TerminalWordLinkProvider, [
       this._xterm,
       async (link, cb) => cb(await this._resolvePath(link)),

--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -113,6 +113,8 @@ export class TerminalLinkManager extends Disposable {
 
   private _getHomeDirPromise: Promise<string>;
 
+  private _wrappedTextLinkActivateCallback: XtermLinkMatcherHandler;
+
   constructor(private _xterm: Terminal, private _client: TerminalClient) {
     super();
 
@@ -127,6 +129,7 @@ export class TerminalLinkManager extends Disposable {
 
     // Validated local links
     const wrappedTextLinkActivateCallback = this._wrapLinkHandler((_, link) => this._handleLocalLink(link));
+    this._wrappedTextLinkActivateCallback = wrappedTextLinkActivateCallback;
     const validatedProvider = this.injector.get(TerminalValidatedLocalLinkProvider, [
       this._xterm,
       this._client,
@@ -137,18 +140,22 @@ export class TerminalLinkManager extends Disposable {
     ]);
     this._standardLinkProviders.push(validatedProvider);
 
-    const wordLinkProvider = this.injector.get(TerminalWordLinkProvider, [
-      this._xterm,
-      async (link, cb) => cb(await this._resolvePath(link)),
-      wrappedTextLinkActivateCallback,
-    ]);
-    this._standardLinkProviders.push(wordLinkProvider);
+    this.enableTerminalWordLinkProvider();
 
     this._registerStandardLinkProviders();
   }
 
   public set processCwd(processCwd: string) {
     this._processCwd = processCwd;
+  }
+
+  public enableTerminalWordLinkProvider() {
+    const wordLinkProvider = this.injector.get(TerminalWordLinkProvider, [
+      this._xterm,
+      async (link, cb) => cb(await this._resolvePath(link)),
+      this._wrappedTextLinkActivateCallback,
+    ]);
+    this._standardLinkProviders.push(wordLinkProvider);
   }
 
   // user may change the terminal cwd, so we need to get it from the service


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [X] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
终端的文字被错误识别成链接，在点击时会触发唤起命令面板
![image](https://github.com/user-attachments/assets/ed4698d6-a328-4c03-bf47-d7c39383fd00)

### Changelog
feat： TerminalWordLink能够按需开启

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了终端链接处理流程，实现了更及时和一致的链接交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->