### PR TITLE
fix: disable model selector when session start

### DIFF
--- a/packages/ai-native/src/browser/chat/chat-model.ts
+++ b/packages/ai-native/src/browser/chat/chat-model.ts
@@ -295,10 +295,11 @@ export class ChatRequestModel implements IChatRequestModel {
 export class ChatModel extends Disposable implements IChatModel {
   private requestIdPool = 0;
 
-  constructor(initParams?: { sessionId?: string; history?: MsgHistoryManager }) {
+  constructor(initParams?: { sessionId?: string; history?: MsgHistoryManager; modelId?: string }) {
     super();
     this.#sessionId = initParams?.sessionId ?? uuid();
     this.history = initParams?.history ?? new MsgHistoryManager();
+    this.#modelId = initParams?.modelId;
   }
 
   #sessionId: string;
@@ -322,6 +323,16 @@ export class ChatModel extends Disposable implements IChatModel {
 
   public get slicedMessageCount() {
     return this.#slicedMessageCount;
+  }
+
+  #modelId?: string;
+
+  public get modelId(): string | undefined {
+    return this.#modelId;
+  }
+
+  set modelId(modelId: string | undefined) {
+    this.#modelId = modelId;
   }
 
   getMessageHistory(contextWindow?: number) {
@@ -434,6 +445,7 @@ export class ChatModel extends Disposable implements IChatModel {
   toJSON() {
     return {
       sessionId: this.sessionId,
+      modelId: this.modelId,
       history: this.history,
       requests: this.requests,
     };

--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -875,6 +875,7 @@ export const AIChatView = () => {
               command={command}
               setCommand={setCommand}
               ref={chatInputRef}
+              disableModelSelector={msgHistoryManager.size > 0}
             />
           </div>
         </div>

--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -131,7 +131,7 @@ export const AIChatView = () => {
   const workspaceService = useInjectable<IWorkspaceService>(IWorkspaceService);
   const commandService = useInjectable<CommandService>(CommandService);
   const [shortcutCommands, setShortcutCommands] = React.useState<ChatSlashCommandItemModel[]>([]);
-  const [disableModelSelector, setDisableModelSelector] = React.useState(msgHistoryManager.size > 0);
+  const [sessionModelId, setSessionModelId] = React.useState<string | undefined>(aiChatService.sessionModel.modelId);
 
   const [changeList, setChangeList] = React.useState<FileChange[]>(getFileChanges(applyService.getSessionCodeBlocks()));
 
@@ -153,16 +153,10 @@ export const AIChatView = () => {
   const [defaultAgentId, setDefaultAgentId] = React.useState<string>('');
   const [command, setCommand] = React.useState('');
   const [theme, setTheme] = React.useState<string | null>(null);
-
+  // 切换session或Agent输出状态变化时
   React.useEffect(() => {
-    setDisableModelSelector(msgHistoryManager.size > 0);
-    const toDispose = msgHistoryManager.onMessageChange(() => {
-      setDisableModelSelector(msgHistoryManager.size > 0);
-    });
-    return () => {
-      toDispose.dispose();
-    };
-  }, [msgHistoryManager]);
+    setSessionModelId(aiChatService.sessionModel.modelId);
+  }, [loading, aiChatService.sessionModel]);
 
   React.useEffect(() => {
     const disposer = new Disposable();
@@ -886,7 +880,8 @@ export const AIChatView = () => {
               command={command}
               setCommand={setCommand}
               ref={chatInputRef}
-              disableModelSelector={disableModelSelector}
+              disableModelSelector={sessionModelId !== undefined || loading}
+              sessionModelId={sessionModelId}
             />
           </div>
         </div>

--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -131,6 +131,7 @@ export const AIChatView = () => {
   const workspaceService = useInjectable<IWorkspaceService>(IWorkspaceService);
   const commandService = useInjectable<CommandService>(CommandService);
   const [shortcutCommands, setShortcutCommands] = React.useState<ChatSlashCommandItemModel[]>([]);
+  const [disableModelSelector, setDisableModelSelector] = React.useState(msgHistoryManager.size > 0);
 
   const [changeList, setChangeList] = React.useState<FileChange[]>(getFileChanges(applyService.getSessionCodeBlocks()));
 
@@ -152,6 +153,16 @@ export const AIChatView = () => {
   const [defaultAgentId, setDefaultAgentId] = React.useState<string>('');
   const [command, setCommand] = React.useState('');
   const [theme, setTheme] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setDisableModelSelector(msgHistoryManager.size > 0);
+    const toDispose = msgHistoryManager.onMessageChange(() => {
+      setDisableModelSelector(msgHistoryManager.size > 0);
+    });
+    return () => {
+      toDispose.dispose();
+    };
+  }, [msgHistoryManager]);
 
   React.useEffect(() => {
     const disposer = new Disposable();
@@ -875,7 +886,7 @@ export const AIChatView = () => {
               command={command}
               setCommand={setCommand}
               ref={chatInputRef}
-              disableModelSelector={msgHistoryManager.size > 0}
+              disableModelSelector={disableModelSelector}
             />
           </div>
         </div>

--- a/packages/ai-native/src/browser/components/ChatMentionInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatMentionInput.tsx
@@ -46,6 +46,7 @@ export interface IChatMentionInputProps {
   command: string;
   setCommand: (command: string) => void;
   disableModelSelector?: boolean;
+  sessionModelId?: string;
 }
 
 // 指令命令激活组件
@@ -251,7 +252,7 @@ export const ChatMentionInput = (props: IChatMentionInputProps) => {
         { label: 'QWQ 32B', value: 'qwq-32b' },
         { label: 'DeepSeek R1', value: 'deepseek-r1' },
       ],
-      defaultModel: 'deepseek-r1',
+      defaultModel: props.sessionModelId || 'deepseek-r1',
       buttons: [
         {
           id: 'mcp-server',
@@ -282,7 +283,7 @@ export const ChatMentionInput = (props: IChatMentionInputProps) => {
       showModelSelector: true,
       disableModelSelector: props.disableModelSelector,
     }),
-    [handleShowMCPConfig, props.disableModelSelector],
+    [handleShowMCPConfig, props.disableModelSelector, props.sessionModelId],
   );
 
   const handleStop = useCallback(() => {

--- a/packages/ai-native/src/browser/components/ChatMentionInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatMentionInput.tsx
@@ -281,7 +281,7 @@ export const ChatMentionInput = (props: IChatMentionInputProps) => {
       ],
       showModelSelector: props.disableModelSelector ? false : true,
     }),
-    [handleShowMCPConfig],
+    [handleShowMCPConfig, props.disableModelSelector],
   );
 
   const handleStop = useCallback(() => {

--- a/packages/ai-native/src/browser/components/ChatMentionInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatMentionInput.tsx
@@ -45,6 +45,7 @@ export interface IChatMentionInputProps {
   defaultAgentId?: string;
   command: string;
   setCommand: (command: string) => void;
+  disableModelSelector?: boolean;
 }
 
 // 指令命令激活组件
@@ -278,7 +279,7 @@ export const ChatMentionInput = (props: IChatMentionInputProps) => {
           position: FooterButtonPosition.LEFT,
         },
       ],
-      showModelSelector: true,
+      showModelSelector: props.disableModelSelector ? false : true,
     }),
     [handleShowMCPConfig],
   );

--- a/packages/ai-native/src/browser/components/ChatMentionInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatMentionInput.tsx
@@ -279,7 +279,8 @@ export const ChatMentionInput = (props: IChatMentionInputProps) => {
           position: FooterButtonPosition.LEFT,
         },
       ],
-      showModelSelector: props.disableModelSelector ? false : true,
+      showModelSelector: true,
+      disableModelSelector: props.disableModelSelector,
     }),
     [handleShowMCPConfig, props.disableModelSelector],
   );

--- a/packages/ai-native/src/browser/components/mention-input/mention-input.tsx
+++ b/packages/ai-native/src/browser/components/mention-input/mention-input.tsx
@@ -90,6 +90,10 @@ export const MentionInput: React.FC<MentionInputProps> = ({
   // 使用防抖处理搜索文本
   const debouncedSecondLevelFilter = useDebounce(mentionState.secondLevelFilter, 300);
 
+  React.useEffect(() => {
+    setSelectedModel(footerConfig.defaultModel || '');
+  }, [footerConfig.defaultModel]);
+
   // 监听搜索文本变化，实时更新二级菜单
   React.useEffect(() => {
     if (mentionState.level === 1 && mentionState.parentType && debouncedSecondLevelFilter !== undefined) {

--- a/packages/ai-native/src/browser/components/mention-input/mention-input.tsx
+++ b/packages/ai-native/src/browser/components/mention-input/mention-input.tsx
@@ -994,6 +994,7 @@ export const MentionInput: React.FC<MentionInputProps> = ({
               onChange={handleModelChange}
               className={styles.model_selector}
               size='small'
+              disabled={footerConfig.disableModelSelector}
             />
           )}
           {renderButtons(FooterButtonPosition.LEFT)}

--- a/packages/ai-native/src/browser/components/mention-input/types.ts
+++ b/packages/ai-native/src/browser/components/mention-input/types.ts
@@ -67,6 +67,7 @@ export interface FooterConfig {
   defaultModel?: string;
   buttons?: FooterButton[];
   showModelSelector?: boolean;
+  disableModelSelector?: boolean;
 }
 
 export interface MentionInputProps {

--- a/packages/ai-native/src/browser/model/msg-history-manager.ts
+++ b/packages/ai-native/src/browser/model/msg-history-manager.ts
@@ -26,6 +26,10 @@ export class MsgHistoryManager extends Disposable {
     super.dispose();
   }
 
+  public get size(): number {
+    return this.messageMap.size;
+  }
+
   public clearMessages() {
     this.messageMap.clear();
     this.messageAdditionalMap.clear();

--- a/packages/components/src/select/style.less
+++ b/packages/components/src/select/style.less
@@ -66,8 +66,13 @@
 
     &.kt-select-disabled {
       pointer-events: none;
+      cursor: not-allowed;
       background-color: var(--kt-select-disableBackground);
       color: var(--kt-select-disableForeground);
+      .kt-select-option,
+      .kt-icon {
+        color: inherit;
+      }
     }
     &.kt-select-warning {
       border-color: var(--kt-select-warningForeground);


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
fix: disable model selector when session start
当会话已经开启时，禁用模型选择（为此新增加了会话模型记忆能力），避免模型格式和能力不对齐

<img width="456" alt="image" src="https://github.com/user-attachments/assets/0a2d8f4a-da6f-4828-9a6a-846413e5e34b" />


### Changelog
feat: save chat session model to memory
fix: disable model selector when session start


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 聊天界面在有消息历史时自动禁用模型选择器，提升交互体验。
  - 会话模型ID管理功能增强，确保模型一致性，防止切换模型时出现异常。
- **优化**
  - 聊天输入区根据实际消息历史动态禁用模型选择器。
  - 模型选择器禁用状态在相关输入组件中得到统一支持和视觉反馈。
  - 禁用状态下的模型选择器增加“禁止操作”光标样式，提升视觉提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->