### PR TITLE
feat: improve terminal link provider check logic

### DIFF
--- a/packages/ai-native/src/browser/components/ChatHistory.tsx
+++ b/packages/ai-native/src/browser/components/ChatHistory.tsx
@@ -266,7 +266,7 @@ const ChatHistory: FC<IChatHistoryProps> = memo(
             </div>
           </Popover>
           <Popover
-            id={'ai-chat-header-close'}
+            id={'ai-chat-header-new'}
             position={PopoverPosition.top}
             title={localize('aiNative.operate.newChat.title')}
           >

--- a/packages/ai-native/src/browser/components/chat-history.module.less
+++ b/packages/ai-native/src/browser/components/chat-history.module.less
@@ -32,7 +32,6 @@
     }
 
     .chat_history_header_actions_new {
-      margin-left: 2px;
       cursor: pointer;
     }
 

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -331,6 +331,11 @@ export interface AppConfig {
    * Default value is `nsfw`
    */
   recursiveWatcherBackend?: RecursiveWatcherBackend;
+
+  /**
+   * Open word link with palette on terminal
+   */
+  openWordLinkWithPaletteOnTerminal?: boolean;
 }
 
 export interface ICollaborationClientOpts {

--- a/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
@@ -286,16 +286,4 @@ describe('Workbench - TerminalValidatedLocalLinkProvider', () => {
       },
     ]);
   });
-
-  test('should support single file path', async () => {
-    await assertLink('foo', false, [
-      {
-        range: [
-          [0, 1],
-          [3, 1],
-        ],
-        text: 'foo',
-      },
-    ]);
-  });
 });

--- a/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
+++ b/packages/terminal-next/src/browser/links/external-link-provider-adapter.ts
@@ -76,6 +76,12 @@ export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvide
       );
       const matchingText = lineContent.substr(link.startIndex, link.length) || '';
       const activateLink = this._wrapLinkHandler((_, text) => link.activate(text));
+      const tooltipCallback = (
+        link: TerminalLink,
+        viewportRange: IViewportRange,
+        modifierDownCallback?: () => void,
+        modifierUpCallback?: () => void,
+      ) => this._tooltipCallback(link, viewportRange, modifierDownCallback, modifierUpCallback);
 
       return this.injector.get(TerminalLink, [
         this._xterm,
@@ -83,7 +89,7 @@ export class TerminalExternalLinkProviderAdapter extends TerminalBaseLinkProvide
         matchingText,
         this._xterm.buffer.active.viewportY,
         activateLink,
-        this._tooltipCallback,
+        tooltipCallback,
         true,
         link.label,
       ]);

--- a/packages/terminal-next/src/browser/links/link-manager.ts
+++ b/packages/terminal-next/src/browser/links/link-manager.ts
@@ -186,7 +186,6 @@ export class TerminalLinkManager extends Disposable {
       height: this._xterm.rows,
     };
     const boundingClientRect = core.element.getBoundingClientRect();
-
     // Don't pass the mouse event as this avoids the modifier check
     return this._showHover(
       {

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -49,7 +49,7 @@ export class TerminalLink extends Disposable implements ILink {
       viewportRange: IViewportRange,
       modifierDownCallback?: () => void,
       modifierUpCallback?: () => void,
-    ) => IDisposable,
+    ) => IDisposable | undefined,
     private readonly _isHighConfidenceLink: boolean,
     readonly label: string | undefined,
   ) {
@@ -106,7 +106,7 @@ export class TerminalLink extends Disposable implements ILink {
     // links). Feedback was that this makes using the terminal overly noisy.
     if (this._isHighConfidenceLink) {
       this._tooltipScheduler = new RunOnceScheduler(() => {
-        this._tooltipDisposable = this._tooltipCallback(
+        this._tooltipDisposable = this._tooltipCallback?.(
           this,
           convertBufferRangeToViewport(this.range, this._viewportY),
           this._isHighConfidenceLink ? () => this._enableDecorations() : undefined,

--- a/packages/terminal-next/src/browser/links/protocol-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/protocol-link-provider.ts
@@ -50,7 +50,12 @@ export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
 
     return links.map((link) => {
       const range = convertLinkRangeToBuffer(lines, this._xterm.cols, link.range, startLine);
-
+      const tooltipCallback = (
+        link: TerminalLink,
+        viewportRange: IViewportRange,
+        modifierDownCallback?: () => void,
+        modifierUpCallback?: () => void,
+      ) => this._tooltipCallback(link, viewportRange, modifierDownCallback, modifierUpCallback);
       // Check if the link if within the mouse position
       return this.injector.get(TerminalLink, [
         this._xterm,
@@ -58,7 +63,7 @@ export class TerminalProtocolLinkProvider extends TerminalBaseLinkProvider {
         link.url?.toString() || '',
         this._xterm.buffer.active.viewportY,
         this._activateCallback,
-        this._tooltipCallback,
+        tooltipCallback,
         true,
         undefined,
       ]);

--- a/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/validated-local-link-provider.ts
@@ -175,13 +175,6 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
       }
     }
 
-    if (result.length === 0) {
-      const validatedLinks = await this.detectLocalLink(text, lines, startLine, stringIndex, 2);
-      if (validatedLinks.length > 0) {
-        result.push(...validatedLinks);
-      }
-    }
-
     return result;
   }
 
@@ -220,6 +213,12 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
             },
             startLine,
           );
+          const tooltipCallback = (
+            link: TerminalLink,
+            viewportRange: IViewportRange,
+            modifierDownCallback?: () => void,
+            modifierUpCallback?: () => void,
+          ) => this._tooltipCallback(link, viewportRange, modifierDownCallback, modifierUpCallback);
           r(
             this.injector.get(TerminalLink, [
               this._xterm,
@@ -227,7 +226,7 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
               text,
               this._xterm.buffer.active.viewportY,
               activateCallback,
-              this._tooltipCallback,
+              tooltipCallback,
               true,
               label,
             ]),

--- a/packages/terminal-next/src/browser/links/word-link-provider.ts
+++ b/packages/terminal-next/src/browser/links/word-link-provider.ts
@@ -4,7 +4,7 @@ import { Autowired, INJECTOR_TOKEN, Injectable, Injector } from '@opensumi/di';
 import { PrefixQuickOpenService } from '@opensumi/ide-core-browser/lib/quick-open';
 import { AppConfig } from '@opensumi/ide-core-browser/lib/react-providers/config-provider';
 import { IWindowService } from '@opensumi/ide-core-browser/lib/window';
-import { URI } from '@opensumi/ide-core-common';
+import { URI, isUndefined } from '@opensumi/ide-core-common';
 import { CommandService } from '@opensumi/ide-core-common/lib/command';
 import { IWorkspaceService } from '@opensumi/ide-workspace/lib/common/workspace.interface';
 
@@ -112,11 +112,13 @@ export class TerminalWordLinkProvider extends TerminalBaseLinkProvider {
               this._activateFileCallback(event, text);
             }
           } else {
-            this.quickOpenService.open(text);
+            const openWordLinkWithPaletteOnTerminal = this.appConfig.openWordLinkWithPaletteOnTerminal;
+            if (isUndefined(openWordLinkWithPaletteOnTerminal) || openWordLinkWithPaletteOnTerminal) {
+              this.quickOpenService.open(text);
+            }
           }
         });
       };
-
       links.push(
         this.injector.get(TerminalLink, [
           this._xterm,


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [x] 🚀 Performance Improvements

### Background or solution

1.  移除冗余的终端路径判断逻辑，减少对 `getFileStat` 调用
2. 修复终端 Tooltip 展示
<img width="394" alt="image" src="https://github.com/user-attachments/assets/183a56a2-135f-448b-86d3-ac207cf12f85" />

3. 优化 Chat 面板样式

### Changelog

improve terminal link provider check logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增加了配置选项，可控制在终端中点击单词链接时是否通过命令面板打开。

- **样式**
  - 优化了聊天历史记录头部按钮的样式，移除了多余的左边距。

- **修复**
  - 改进了终端链接的回调处理，提升了链接悬浮提示的稳定性和兼容性。
  - 调整了终端本地链接检测逻辑，去除了对整行文本的多余回退检测。

- **测试**
  - 移除了终端本地链接提供者中关于单文件路径支持的测试用例。

- **文档**
  - 补充了新配置项的说明文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->