### PR TITLE
fix: passthrough icon and color for extension terminal

### DIFF
--- a/packages/extension/src/hosted/api/vscode/ext.host.terminal.ts
+++ b/packages/extension/src/hosted/api/vscode/ext.host.terminal.ts
@@ -223,7 +223,7 @@ export class ExtHostTerminal implements IExtHostTerminal {
     const shortId = uuid();
     const terminal = new Terminal(options.name, options, this.proxy);
     const p = new ExtHostPseudoterminal(options.pty);
-    terminal.createExtensionTerminal(shortId);
+    terminal.createExtensionTerminal(shortId, options.iconPath, options.color);
     this.terminalsMap.set(shortId, terminal);
     this._terminalStartDeferreds.set(shortId, new Deferred());
     const disposable = this._setupExtHostProcessListeners(shortId, p);
@@ -773,8 +773,11 @@ export class Terminal implements vscode.Terminal {
     this.proxy.$dispose(this.id);
   }
 
-  async createExtensionTerminal(id: string): Promise<void> {
-    await this.proxy.$createTerminal({ name: this.name, isExtensionTerminal: true }, id);
+  async createExtensionTerminal(id: string, iconPath?: vscode.IconPath, color?: vscode.ThemeColor): Promise<void> {
+    await this.proxy.$createTerminal(
+      { name: this.name, isExtensionTerminal: true, iconPath, color, isTransient: true },
+      id,
+    );
     this.created(id);
   }
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
fix: passthrough icon and color for extension terminal
<img width="744" alt="image" src="https://github.com/user-attachments/assets/1dbc048e-d2a9-4768-8eac-1595ba3977c8" />


### Changelog
fix: passthrough icon and color for extension terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 终端现在支持为扩展终端指定图标和颜色，并可设置为临时终端。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->