### PR TITLE
feat: support recreate watcher process after reconnected

### DIFF
--- a/packages/ai-native/src/browser/components/ChatMentionInput.tsx
+++ b/packages/ai-native/src/browser/components/ChatMentionInput.tsx
@@ -6,6 +6,7 @@ import { LabelService, RecentFilesManager, useInjectable } from '@opensumi/ide-c
 import { Icon, getIcon } from '@opensumi/ide-core-browser/lib/components';
 import { ChatFeatureRegistryToken, URI, localize } from '@opensumi/ide-core-common';
 import { CommandService } from '@opensumi/ide-core-common/lib/command';
+import { defaultFilesWatcherExcludes } from '@opensumi/ide-core-common/lib/preferences/file-watch';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileSearchServicePath, IFileSearchService } from '@opensumi/ide-file-search';
 import { IMessageService } from '@opensumi/ide-overlay';
@@ -216,7 +217,7 @@ export const ChatMentionInput = (props: IChatMentionInputProps) => {
             useGitIgnore: true,
             noIgnoreParent: true,
             fuzzyMatch: true,
-            excludePatterns: ['**/node_modules/**/*', '**/.git/**/*'],
+            excludePatterns: Object.keys(defaultFilesWatcherExcludes),
             limit: 10,
           });
           const folders = Array.from(

--- a/packages/ai-native/src/browser/mcp/tools/fileSearch.ts
+++ b/packages/ai-native/src/browser/mcp/tools/fileSearch.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { Autowired } from '@opensumi/di';
 import { getValidateInput } from '@opensumi/ide-addons/lib/browser/file-search.contribution';
 import { Domain, URI } from '@opensumi/ide-core-common';
+import { defaultFilesWatcherExcludes } from '@opensumi/ide-core-common/lib/preferences/file-watch';
 import { FileSearchServicePath, IFileSearchService } from '@opensumi/ide-file-search/lib/common';
 import { IWorkspaceService } from '@opensumi/ide-workspace';
 
@@ -63,8 +64,7 @@ export class FileSearchTool implements MCPServerContribution {
     const searchPattern = this.normalizeQuery(args.query);
     const searchResults = await this.fileSearchService.find(searchPattern, {
       rootUris: [new URI(workspaceRoots[0].uri).codeUri.fsPath],
-      // TODO: 忽略配置
-      excludePatterns: ['**/node_modules/**'],
+      excludePatterns: Object.keys(defaultFilesWatcherExcludes),
       limit: 100,
       useGitIgnore: true,
       noIgnoreParent: true,

--- a/packages/file-service/src/browser/file-service-contribution.ts
+++ b/packages/file-service/src/browser/file-service-contribution.ts
@@ -6,6 +6,7 @@ import {
   Domain,
   FsProviderContribution,
   IDisposable,
+  ILogger,
   Schemes,
 } from '@opensumi/ide-core-browser';
 
@@ -26,6 +27,12 @@ export class FileServiceContribution implements ClientAppContribution, IDisposab
 
   @Autowired(FsProviderContribution)
   contributionProvider: ContributionProvider<FsProviderContribution>;
+
+  @Autowired(IFileServiceClient)
+  protected readonly fileServiceClient: IFileServiceClient;
+
+  @Autowired(ILogger)
+  protected readonly logger: ILogger;
 
   constructor() {
     // 初始化资源读取逻辑，需要在最早初始化时注册
@@ -51,6 +58,10 @@ export class FileServiceContribution implements ClientAppContribution, IDisposab
     if (this.fileSystem.initialize) {
       await this.fileSystem.initialize();
     }
+  }
+
+  onReconnect() {
+    this.fileServiceClient.reconnect().catch((err) => this.logger.error('Failed to reconnect watchers:', err));
   }
 
   dispose() {

--- a/packages/file-service/src/common/file-service-client.ts
+++ b/packages/file-service/src/common/file-service-client.ts
@@ -88,6 +88,10 @@ export interface IFileServiceClient {
 
   unwatchFileChanges(watchId: number): Promise<void>;
 
+  reconnect(): Promise<void>;
+
+  dispose(): void;
+
   setWatchFileExcludes(excludes: string[]): Promise<void>;
 
   getWatchFileExcludes(): Promise<string[]>;

--- a/packages/file-service/src/node/watcher-process-manager.ts
+++ b/packages/file-service/src/node/watcher-process-manager.ts
@@ -142,10 +142,16 @@ export class WatcherProcessManagerImpl implements IWatcherProcessManager {
   }
 
   async createProcess(clientId: string, backend?: RecursiveWatcherBackend) {
+    this._whenReadyDeferred = new Deferred();
     this.logger.log('create watcher process for client: ', clientId);
     this.logger.log('appconfig watcherHost: ', this.watcherHost);
 
     const ipcHandlerPath = await this.getIPCHandlerPath('watcher_process');
+    // 如果存在连接，则关闭连接, 避免重复创建
+    const connection = this.clientWatcherConnectionServer.get(clientId);
+    if (connection) {
+      connection.close();
+    }
     await this.createWatcherServer(clientId, ipcHandlerPath);
 
     const pid = await this.createWatcherProcess(clientId, ipcHandlerPath, backend);

--- a/packages/file-tree-next/__tests__/browser/file-tree-contribution.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree-contribution.test.ts
@@ -177,12 +177,6 @@ describe('FileTreeContribution', () => {
       expect(title).toBe('userhome');
     });
 
-    it('should onReconnect be work', async () => {
-      const contribution = mockInjector.get(FileTreeContribution);
-      contribution.onReconnect();
-      expect(mockFileTreeService.reWatch).toHaveBeenCalledTimes(1);
-    });
-
     it('should registerCommands be work', async () => {
       const contribution = mockInjector.get(FileTreeContribution);
       const register = jest.fn();

--- a/packages/file-tree-next/__tests__/browser/file-tree.service.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree.service.test.ts
@@ -225,15 +225,6 @@ describe('FileTree Service should be work alone', () => {
     await fileTreeService.flushEventQueue();
   });
 
-  it('Re-watch should be work while re-connect', async () => {
-    const fileTreeContribution = injector.get(FileTreeContribution);
-    const testUri = new URI('file://userhome/test.js');
-    fileTreeService.startWatchFileEvent();
-    await fileTreeService.watchFilesChange(testUri);
-    await fileTreeContribution.onReconnect();
-    expect(fileChangeWatcher.onFilesChanged).toHaveBeenCalledTimes(2);
-  });
-
   it('Commands should be work', () => {
     const testUri = new URI('file://userhome/test.js');
     // openAndFixedFile

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -210,10 +210,6 @@ export class FileTreeContribution
     return resourceTitle;
   }
 
-  onReconnect() {
-    this.fileTreeService.reWatch();
-  }
-
   private revealFile(locationUri: URI) {
     if (locationUri) {
       if (this.isRendered) {

--- a/packages/file-tree-next/src/browser/file-tree.service.ts
+++ b/packages/file-tree-next/src/browser/file-tree.service.ts
@@ -680,14 +680,6 @@ export class FileTreeService extends Tree implements IFileTreeService {
     }
   }
 
-  public reWatch() {
-    // 重连时重新监听文件变化
-    for (const [uri, watcher] of this._fileServiceWatchers) {
-      watcher.dispose();
-      this.watchFilesChange(new URI(uri));
-    }
-  }
-
   get isMultipleWorkspace(): boolean {
     return !!this.workspaceService.workspace && !this.workspaceService.workspace.isDirectory;
   }


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

### Changelog

支持 Watcher Process 的重连逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 文件服务客户端新增了重连和资源释放功能，提升了断线后的自动恢复能力。
- **优化**
  - 文件搜索和文件监视的排除规则现在将动态适配默认配置，提升了搜索和监控的准确性与灵活性。
  - 文件监视器在重建时会自动释放旧连接，避免重复实例和资源浪费。
- **修复**
  - 修正了文件监视器可能因未正确释放导致的重复监听问题。
- **移除**
  - 文件树相关的重连和重新监听功能被移除，简化了文件树服务逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->