### PR TITLE
feat: improve tool result display

### DIFF
--- a/packages/ai-native/src/browser/components/ChatToolRender.tsx
+++ b/packages/ai-native/src/browser/components/ChatToolRender.tsx
@@ -11,6 +11,7 @@ import { IMCPServerRegistry, TokenMCPServerRegistry } from '../types';
 
 import { CodeEditorWithHighlight } from './ChatEditor';
 import styles from './ChatToolRender.module.less';
+import { ChatToolResult } from './ChatToolResult';
 
 export const ChatToolRender = (props: { value: IChatToolContent['content']; messageId?: string }) => {
   const { value, messageId } = props;
@@ -37,6 +38,7 @@ export const ChatToolRender = (props: { value: IChatToolContent['content']; mess
         return { label: state || 'Unknown', icon: <Icon iconClass='codicon codicon-question' /> };
     }
   };
+
   const getParsedArgs = () => {
     try {
       // TODO: 流式输出中function_call的参数还不完整，需要等待complete状态
@@ -88,7 +90,7 @@ export const ChatToolRender = (props: { value: IChatToolContent['content']; mess
         {value?.result && (
           <div className={styles.tool_result}>
             <div className={styles.section_label}>{localize('ai.native.mcp.tool.results')}:</div>
-            <CodeEditorWithHighlight input={value.result} language={'json'} relationId={uuid(4)} />
+            <ChatToolResult result={value.result} relationId={uuid(4)} />
           </div>
         )}
       </div>

--- a/packages/ai-native/src/browser/components/ChatToolResult.module.less
+++ b/packages/ai-native/src/browser/components/ChatToolResult.module.less
@@ -7,8 +7,6 @@
   margin: 8px 0;
   width: 100%;
   padding: 5px;
-  background-color: var(--editor-background);
-  color: var(--editor-foreground);
 }
 
 .image_content {

--- a/packages/ai-native/src/browser/components/ChatToolResult.module.less
+++ b/packages/ai-native/src/browser/components/ChatToolResult.module.less
@@ -1,0 +1,26 @@
+.result_container {
+  width: 100%;
+  margin: 8px 0;
+}
+
+.text_content {
+  margin: 8px 0;
+  width: 100%;
+  padding: 5px;
+  background-color: var(--editor-background);
+  color: var(--editor-foreground);
+}
+
+.image_content {
+  margin: 8px 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  img {
+    max-width: 100%;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px var(--widget-shadow);
+  }
+}

--- a/packages/ai-native/src/browser/components/ChatToolResult.tsx
+++ b/packages/ai-native/src/browser/components/ChatToolResult.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { localize } from '@opensumi/ide-core-common/lib/localize';
+
+import { CodeEditorWithHighlight } from './ChatEditor';
+import styles from './ChatToolResult.module.less';
+
+interface ResultContent {
+  type: 'text' | 'image';
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+interface ChatToolResultProps {
+  result: string;
+  relationId?: string;
+}
+
+export const ChatToolResult: React.FC<ChatToolResultProps> = ({ result, relationId }) => {
+  const parseResult = React.useCallback((resultStr: string): ResultContent[] => {
+    try {
+      const parsed = JSON.parse(resultStr);
+      return parsed.content || [];
+    } catch (error) {
+      return [{ type: 'text', text: resultStr }];
+    }
+  }, []);
+
+  const renderContent = React.useCallback(
+    (content: ResultContent, index: number) => {
+      switch (content.type) {
+        case 'text':
+          return content.text ? (
+            <div key={`text-${index}`} className={styles.text_content}>
+              <CodeEditorWithHighlight input={content.text} language={'text'} relationId={relationId || ''} />
+            </div>
+          ) : null;
+        case 'image':
+          return content.data ? (
+            <div key={`image-${index}`} className={styles.image_content}>
+              <img
+                src={`data:${content.mimeType || 'image/png'};base64,${content.data}`}
+                alt={localize('aiNative.chat.result.image')}
+              />
+            </div>
+          ) : null;
+        default:
+          return null;
+      }
+    },
+    [relationId],
+  );
+
+  const contents = React.useMemo(() => parseResult(result), [result, parseResult]);
+
+  if (!contents.length) {
+    return null;
+  }
+
+  return (
+    <div className={styles.result_container}>{contents.map((content, index) => renderContent(content, index))}</div>
+  );
+};


### PR DESCRIPTION
### Types

- [x] 🎉 New Features

### Background or solution

支持更好展示 MCP Tool 返回内容，支持图片展示

<img width="660" alt="image" src="https://github.com/user-attachments/assets/acaf6ac3-2ce2-4645-b9bc-36e4c297d27c" />

### Changelog
improve tool result display



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 ChatToolResult 组件，用于更丰富地展示聊天工具的结果内容，支持文本和图片类型的展示。
- **样式**
  - 增加了针对聊天工具结果的样式，优化了文本和图片的显示效果。  
- **优化**
  - 替换聊天工具结果展示方式，提升内容渲染的灵活性和表现力。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->