### PR TITLE
feat: improve python debug stack frames view

### DIFF
--- a/packages/debug/src/browser/model/debug-stack-frame.ts
+++ b/packages/debug/src/browser/model/debug-stack-frame.ts
@@ -43,7 +43,12 @@ export class DebugStackFrame extends DebugStackFrameData {
   }
 
   get canRestart(): boolean {
-    return typeof this.raw.canRestart === 'boolean' ? this.raw.canRestart : true;
+    return (
+      !!this.session.capabilities.supportsRestartFrame &&
+      this.raw.presentationHint !== 'label' &&
+      this.raw.presentationHint !== 'subtle' &&
+      !!this.raw.canRestart
+    );
   }
 
   async open(options?: IResourceOpenOptions) {

--- a/packages/debug/src/browser/view/frames/debug-call-stack-frame.view.tsx
+++ b/packages/debug/src/browser/view/frames/debug-call-stack-frame.view.tsx
@@ -10,9 +10,9 @@ import {
   localize,
   useInjectable,
 } from '@opensumi/ide-core-browser';
-import { isFrameDeemphasized } from '@opensumi/ide-debug/lib/common/debug-frame';
 
 import { IDebugSessionManager } from '../../../common';
+import { isFrameDeemphasized } from '../../../common/debug-frame';
 import { DebugSession } from '../../debug-session';
 import { DebugSessionManager } from '../../debug-session-manager';
 import { DebugStackFrame, ShowMoreDebugStackFrame } from '../../model';

--- a/packages/debug/src/browser/view/frames/debug-call-stack.module.less
+++ b/packages/debug/src/browser/view/frames/debug-call-stack.module.less
@@ -34,6 +34,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  direction: rtl;
 }
 
 .debug_stack_item {

--- a/packages/debug/src/browser/view/frames/debug-call-stack.module.less
+++ b/packages/debug/src/browser/view/frames/debug-call-stack.module.less
@@ -34,7 +34,6 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  direction: rtl;
 }
 
 .debug_stack_item {
@@ -146,6 +145,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  direction: rtl;
 }
 .debug_stack_frames_item_badge {
   display: inline-block;

--- a/packages/debug/src/browser/view/frames/debug-call-stack.module.less
+++ b/packages/debug/src/browser/view/frames/debug-call-stack.module.less
@@ -78,16 +78,20 @@
   width: 100%;
   cursor: pointer;
   box-sizing: border-box;
+  &.debug_stack_frames_can_restart {
+    &:hover {
+      .debug_restart_frame_icon {
+        display: inline-block;
+        pointer-events: all;
+      }
+      .debug_stack_frames_item_badge {
+        display: none;
+      }
+    }
+  }
   &:hover {
     background: var(--list-hoverBackground);
     color: var(--list-hoverForeground);
-    .debug_restart_frame_icon {
-      display: inline-block;
-      pointer-events: all;
-    }
-    .debug_stack_frames_item_badge {
-      display: none;
-    }
   }
   &.selected {
     background: var(--list-activeSelectionBackground);
@@ -132,8 +136,8 @@
     min-width: fit-content;
     opacity: 0.7;
   }
-  &.subtle {
-    opacity: 0.7;
+  &.disabled {
+    opacity: 0.6;
   }
 }
 .debug_stack_frames_item_description {

--- a/packages/debug/src/common/debug-frame.ts
+++ b/packages/debug/src/common/debug-frame.ts
@@ -1,0 +1,6 @@
+import type { DebugProtocol } from '@opensumi/vscode-debugprotocol/lib/debugProtocol';
+
+export function isFrameDeemphasized(frame: DebugProtocol.StackFrame): boolean {
+  const hint = frame.presentationHint ?? frame.source?.presentationHint;
+  return hint === 'deemphasize' || hint === 'subtle';
+}


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

支持更多类型的堆栈信息展开
Before：
![image](https://github.com/user-attachments/assets/f0aedf44-c769-4e70-a574-4808a40c3fe6)

After：
<img width="429" alt="image" src="https://github.com/user-attachments/assets/aea2474b-7123-47db-a32a-f48f0ae550d9" />

### Changelog
improve python debug stack frames view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增了用于判断调试堆栈帧是否应被弱化显示的实用函数，提升了界面一致性。

- **优化与改进**
  - 调整了堆栈帧重启按钮的显示条件，只有在满足多项条件时才可用，提升了交互准确性。
  - 堆栈帧的弱化（deemphasized）显示逻辑被集中管理，视觉表现更统一。
  - 优化了堆栈帧源信息的显示，支持名称或路径的灵活切换。
  - 点击弱化帧不再被阻止，提升了操作流畅性。

- **样式调整**
  - 优化了堆栈帧重启按钮和徽章的悬停显示逻辑，仅在可重启帧悬停时显示。
  - 堆栈帧标签的“subtle”样式更名为“disabled”，并调整了透明度。
  - 堆栈帧描述信息支持从右至左显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->