### PR TITLE
fix: debug variables order

### DIFF
--- a/packages/debug/src/browser/tree/debug-tree-node.define.ts
+++ b/packages/debug/src/browser/tree/debug-tree-node.define.ts
@@ -114,30 +114,12 @@ export class ExpressionTreeService {
   }
 
   sortComparator(a: ITreeNodeOrCompositeTreeNode, b: ITreeNodeOrCompositeTreeNode) {
-    if (a.constructor === b.constructor) {
-      const aName = a.displayName || a.name;
-      const bName = b.displayName || b.name;
-      const isASymbol = !/[a-zA-Z0-9]/.test(aName.charAt(0));
-      const isBSymbol = !/[a-zA-Z0-9]/.test(bName.charAt(0));
-      if (isASymbol && !isBSymbol) {
-        return 1;
-      } else if (!isASymbol && isBSymbol) {
-        return -1;
-      }
-      return aName.localeCompare(bName, 'en', { numeric: true }) as any;
-    }
-    return CompositeTreeNode.is(a) ? -1 : CompositeTreeNode.is(b) ? 1 : 0;
+    return 0;
   }
 }
 
 export class DebugConsoleTreeService extends ExpressionTreeService {
   sortComparator(a: ITreeNodeOrCompositeTreeNode, b: ITreeNodeOrCompositeTreeNode) {
-    if (!a) {
-      return 1;
-    }
-    if (!b) {
-      return -1;
-    }
     return 0;
   }
 }

--- a/packages/debug/src/browser/view/variables/debug-variables.view.tsx
+++ b/packages/debug/src/browser/view/variables/debug-variables.view.tsx
@@ -210,7 +210,7 @@ export const DebugVariableRenderedNode: React.FC<IDebugVariableNodeRenderedProps
       )}
     >
       {node.displayName}
-      {(node as DebugVariable).description ? ':' : ''}
+      {(node as DebugVariable).value ? ':' : ''}
     </div>
   );
 


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution

<img width="252" alt="image" src="https://github.com/user-attachments/assets/54ae5439-052e-4fb1-bf43-dace1199dd2a" />

### Changelog

优化调试变量调试逻辑，不需要额外进行排序


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 变量树节点现在仅在存在值（value）时显示冒号，提升了显示的准确性。

- **优化**
  - 调试表达式和控制台树节点的排序已禁用，节点顺序将保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->