### PR TITLE
fix: update diff-manager & apply action btns when need

### DIFF
--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -871,6 +871,7 @@ export const AIChatView = () => {
             {changeList.length > 0 && (
               <FileListDisplay
                 files={changeList}
+                hideActions={loading}
                 onFileClick={(filePath) => {
                   editorService.open(URI.file(path.join(appConfig.workspaceDir, filePath)));
                 }}

--- a/packages/ai-native/src/browser/components/ChangeList.tsx
+++ b/packages/ai-native/src/browser/components/ChangeList.tsx
@@ -19,13 +19,14 @@ export interface FileChange {
 
 interface FileListDisplayProps {
   files: FileChange[];
+  hideActions?: boolean;
   onFileClick: (path: string) => void;
   onRejectAll: () => void;
   onAcceptAll: () => void;
 }
 
 export const FileListDisplay: React.FC<FileListDisplayProps> = (props) => {
-  const { files, onFileClick, onRejectAll, onAcceptAll } = props;
+  const { files, onFileClick, onRejectAll, onAcceptAll, hideActions } = props;
   const [isExpanded, setIsExpanded] = useState(true);
   const editorService = useInjectable<WorkbenchEditorService>(WorkbenchEditorService);
   const labelService = useInjectable<LabelService>(LabelService);
@@ -119,9 +120,9 @@ export const FileListDisplay: React.FC<FileListDisplayProps> = (props) => {
             {isExpanded ? <Icon icon='down' /> : <Icon icon='right' />} Changed Files({totalFiles})
           </button>
           {renderChangeStats(totalChanges.additions, totalChanges.deletions)}
-          {renderViewChanges(files.length)}
+          {!hideActions && renderViewChanges(files.length)}
         </span>
-        {files.some((file) => file.status === 'pending') && (
+        {!hideActions && files.some((file) => file.status === 'pending') && (
           <div className={styles.actions}>
             <Button
               type='link'


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
模型正在输出时需要隐藏 apply accept 相关操作按钮

### Changelog
fix: update diff-manager & apply action btns when need

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 聊天界面在加载处理中会自动隐藏文件操作按钮，提升交互体验。

- **优化**
  - 文件列表组件支持根据状态隐藏“查看变更”、“接受”和“拒绝”等操作按钮，界面更简洁。
  - 内联差异管理器的性能和资源管理得到改进，移除未使用的界面元素。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->