### PR TITLE
fix: remove prefix of builtin tools

### DIFF
--- a/packages/ai-native/src/common/utils.ts
+++ b/packages/ai-native/src/common/utils.ts
@@ -51,7 +51,8 @@ export const extractCodeBlocks = (content: string): string => {
   return newContents.join('\n');
 };
 
-export const getToolName = (toolName: string, serverName = BUILTIN_MCP_SERVER_NAME) => `mcp_${serverName}_${toolName}`;
+export const getToolName = (toolName: string, serverName: string) =>
+  serverName === BUILTIN_MCP_SERVER_NAME ? toolName : `mcp_${serverName}_${toolName}`;
 
 export const cleanAttachedTextWrapper = (text: string) => {
   const rgAttachedFile = /`<attached_file>(.*)`/g;


### PR DESCRIPTION
### Types

- [x] 🐛 Bug Fixes

### Background or solution
fix: remove prefix of builtin tools

### Changelog
fix: remove prefix of builtin tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 工具名称的显示方式进行了优化，根据不同服务器类型，名称格式将有所区别。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->