### PR TITLE
feat: support auto scroll code block on chat

### DIFF
--- a/packages/ai-native/src/browser/components/ChatEditor.tsx
+++ b/packages/ai-native/src/browser/components/ChatEditor.tsx
@@ -77,6 +77,16 @@ export const CodeEditorWithHighlight = (props: Props) => {
     return () => dispose.dispose();
   }, []);
 
+  useEffect(() => {
+    if (ref.current) {
+      const highlightElement = ref.current;
+      const preElement = highlightElement.querySelector('pre');
+      if (preElement) {
+        preElement.scrollTop = preElement.scrollHeight;
+      }
+    }
+  }, [input]);
+
   const handleCopy = useCallback(async () => {
     setIsCoping(true);
     await clipboardService.writeText(input);
@@ -140,7 +150,7 @@ export const CodeEditorWithHighlight = (props: Props) => {
           />
         </Popover>
       </div>
-      <Highlight language={language} ref={ref} className={styles.editor}>
+      <Highlight language={language} ref={ref} className={styles.highlight_editor}>
         {input}
       </Highlight>
     </div>
@@ -313,8 +323,8 @@ export const CodeBlockWrapper = ({
   workspaceService,
 }: {
   text?: string;
-  relationId: string;
   renderText?: (t: string) => React.ReactNode;
+  relationId: string;
   agentId?: string;
   labelService?: LabelService;
   commandService?: CommandService;

--- a/packages/ai-native/src/browser/components/ChatEditor.tsx
+++ b/packages/ai-native/src/browser/components/ChatEditor.tsx
@@ -80,7 +80,7 @@ export const CodeEditorWithHighlight = (props: Props) => {
   useEffect(() => {
     if (ref.current) {
       const highlightElement = ref.current;
-      const preElement = highlightElement.querySelector('pre');
+      const preElement = highlightElement?.querySelector?.('pre');
       if (preElement) {
         preElement.scrollTop = preElement.scrollHeight;
       }

--- a/packages/ai-native/src/browser/components/ChatMarkdown.tsx
+++ b/packages/ai-native/src/browser/components/ChatMarkdown.tsx
@@ -60,8 +60,14 @@ export const ChatMarkdown = (props: MarkdownProps) => {
     renderer.codespan = (code) => <code className={styles.code_inline}>{code}</code>;
 
     const reactParser = new MarkdownReactParser({ renderer });
-    const markedOptions = props.markedOptions ?? {};
-    markedOptions.renderer = reactParser;
+    const markedOptions = {
+      ...marked.defaults,
+      ...props.markedOptions,
+      renderer: reactParser,
+      mangle: false,
+      headerIds: false,
+      smartypants: false,
+    };
 
     let value = markdown.value ?? '';
     if (value.length > 100_000) {
@@ -72,7 +78,6 @@ export const ChatMarkdown = (props: MarkdownProps) => {
     let tokensList: marked.TokensList;
     if (props.fillInIncompleteTokens) {
       const opts = {
-        ...marked.defaults,
         ...markedOptions,
       };
       const tokens = marked.lexer(value, opts);
@@ -80,7 +85,7 @@ export const ChatMarkdown = (props: MarkdownProps) => {
       renderedMarkdown = marked.parser(newTokens, opts);
       tokensList = newTokens;
     } else {
-      const tokens = marked.lexer(value, marked.defaults);
+      const tokens = marked.lexer(value, markedOptions);
       renderedMarkdown = marked.parser(tokens, markedOptions);
       tokensList = tokens;
     }

--- a/packages/ai-native/src/browser/components/components.module.less
+++ b/packages/ai-native/src/browser/components/components.module.less
@@ -1,4 +1,3 @@
-// 进度条
 .thinking_container {
   position: relative;
   height: 100%;
@@ -251,7 +250,7 @@
   > pre {
     margin-bottom: 10px;
   }
-  .editor {
+  .highlight_editor {
     border-radius: 8px;
     font-size: 12px;
     padding: 28px 8px 8px 8px;

--- a/packages/ai-native/src/browser/components/utils.ts
+++ b/packages/ai-native/src/browser/components/utils.ts
@@ -3,7 +3,7 @@ import { ITextMessageProps } from 'react-chat-elements';
 import { CODICON_OWNER, getExternalIcon } from '@opensumi/ide-core-browser';
 import { ChatMessageRole } from '@opensumi/ide-core-common/lib/types/ai-native';
 
-import { IChatReplyFollowup, ISampleQuestions } from '../../common/index';
+import { ISampleQuestions } from '../../common/index';
 
 export interface MessageData extends Pick<ITextMessageProps, 'id' | 'position' | 'className' | 'title'> {
   role: ChatMessageRole;

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -31,6 +31,7 @@ interface MoreActionProps {
   moreVisible?: boolean;
   placement?: Placement;
   onVisibleChange?: (visible: boolean) => void;
+  showLoadingIcon?: boolean;
 }
 
 export type ButtonProps<T> = {
@@ -101,6 +102,7 @@ export const Button = React.memo(
     moreVisible,
     placement,
     title,
+    showLoadingIcon = true,
     onVisibleChange,
     ...otherProps
   }: ButtonProps<T>): React.ReactElement<ButtonProps<T>> => {
@@ -149,7 +151,7 @@ export const Button = React.memo(
             type={htmlType}
             onClick={loading || disabled ? noop : onClick}
           >
-            {loading && type !== 'link' && <LoadingCircle />}
+            {loading && type !== 'link' && showLoadingIcon && <LoadingCircle />}
             {iconNode && iconNode}
             {children}
             {more && (
@@ -167,7 +169,7 @@ export const Button = React.memo(
         type={htmlType}
         onClick={loading || disabled ? noop : onClick}
       >
-        {loading && type !== 'link' && <LoadingCircle />}
+        {loading && type !== 'link' && showLoadingIcon && <LoadingCircle />}
         {iconNode && iconNode}
         {children}
       </button>

--- a/packages/core-browser/src/components/actions/index.tsx
+++ b/packages/core-browser/src/components/actions/index.tsx
@@ -305,6 +305,7 @@ export const InlineActionWidget: React.FC<
   return (
     <Button
       loading={loading}
+      showLoadingIcon={false}
       className={cls(className, styles_btnAction)}
       disabled={data.disabled}
       onClick={handleClick}

--- a/packages/debug/src/browser/tree/debug-tree-node.define.ts
+++ b/packages/debug/src/browser/tree/debug-tree-node.define.ts
@@ -20,6 +20,7 @@ export class ExpressionTreeService {
     if (DebugVariableRoot.is(parent) && !parent.variablesReference && !parent.presetChildren) {
       return (await this.session?.getScopes(parent)) || [];
     }
+    const data = 'test';
     return await this.doResolve(parent);
   }
 

--- a/packages/debug/src/browser/tree/debug-tree-node.define.ts
+++ b/packages/debug/src/browser/tree/debug-tree-node.define.ts
@@ -20,7 +20,6 @@ export class ExpressionTreeService {
     if (DebugVariableRoot.is(parent) && !parent.variablesReference && !parent.presetChildren) {
       return (await this.session?.getScopes(parent)) || [];
     }
-    const data = 'test';
     return await this.doResolve(parent);
   }
 

--- a/packages/scm/src/browser/scm.module.less
+++ b/packages/scm/src/browser/scm.module.less
@@ -8,6 +8,14 @@
 
 .scm {
   display: block;
+  :global(.kt-primary-button-loading) {
+    & ~ :global(.secondary-button) {
+      background-color: var(--kt-button-disableBackground) !important;
+      box-shadow: var(--kt-button-disableBorder) 0 0 0 1px inset;
+      color: var(--kt-button-disableForeground) !important;
+      cursor: not-allowed;
+    }
+  }
 }
 
 .noop {


### PR DESCRIPTION
### Types

- [x] 🎉 New Features
- [x] 💄 Style Changes

### Background or solution

1. 当 chat 代码块输出时，自动吸底
2. 优化 SCM 面板提交按钮样式
Before：
![image](https://github.com/user-attachments/assets/f2a31c92-00c5-4b4e-a726-93a637580c3f)
After：
<img width="252" alt="image" src="https://github.com/user-attachments/assets/48ba76a7-5637-4e36-b2a8-f7e005fa73b7" />
<img width="307" alt="image" src="https://github.com/user-attachments/assets/94b0dd0c-3e2e-4a18-b298-3528f0a3cbd5" />

解决 Markdown 文本被 HTML 转义的问题
<img width="348" alt="image" src="https://github.com/user-attachments/assets/50083556-48ef-4c35-b010-c66fe00e070b" />

### Changelog
support auto scroll code block on chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 按钮组件新增可选属性，支持控制加载动画的显示与否。

- **样式**
  - 优化代码编辑器高亮区域的滚动体验，自动滚动至最新内容。
  - 按钮加载中时，相关的次级按钮将被禁用并有相应视觉提示。
  - 代码高亮样式类名调整，提升样式一致性。

- **其他**
  - 移除无用的代码导入，提升代码整洁度。
  - 统一和优化了聊天组件中Markdown解析的默认选项配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->