### PR TITLE
fix: terminal validated link logic

### DIFF
--- a/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
+++ b/packages/terminal-next/__tests__/browser/links/validated-local-link-provider.test.ts
@@ -286,4 +286,79 @@ describe('Workbench - TerminalValidatedLocalLinkProvider', () => {
       },
     ]);
   });
+
+  describe('Special formats', () => {
+    const isWindows = false;
+    test('Python error output format', async () => {
+      await assertLink('  File "/path/to/file.py", line 3, in test_func', isWindows, [
+        {
+          text: '/path/to/file.py", line 3',
+          range: [
+            [9, 1],
+            [33, 1],
+          ],
+        },
+      ]);
+      await assertLink('    File "/absolute/path/script.py", line 123, column 45', isWindows, [
+        {
+          text: '/absolute/path/script.py", line 123, column 45',
+          range: [
+            [11, 1],
+            [56, 1],
+          ],
+        },
+      ]);
+    });
+
+    test('File paths with line and column numbers', async () => {
+      await assertLink('/path/to/file.py:2, column 2', isWindows, [
+        {
+          text: '/path/to/file.py:2',
+          range: [
+            [1, 1],
+            [18, 1],
+          ],
+        },
+      ]);
+
+      await assertLink('/path/to/file.py:2, col 2', isWindows, [
+        {
+          text: '/path/to/file.py:2',
+          range: [
+            [1, 1],
+            [18, 1],
+          ],
+        },
+      ]);
+
+      await assertLink('/path/to/file.py:2:3', isWindows, [
+        {
+          text: '/path/to/file.py:2:3',
+          range: [
+            [1, 1],
+            [20, 1],
+          ],
+        },
+      ]);
+    });
+
+    test('Multiple formats in one line', async () => {
+      await assertLink('Error in /path/to/file.py:2, column 2 and /another/file.js:5:6', isWindows, [
+        {
+          text: '/path/to/file.py:2',
+          range: [
+            [10, 1],
+            [27, 1],
+          ],
+        },
+        {
+          text: '/another/file.js:5:6',
+          range: [
+            [43, 1],
+            [62, 1],
+          ],
+        },
+      ]);
+    });
+  });
 });

--- a/packages/terminal-next/src/browser/links/link.ts
+++ b/packages/terminal-next/src/browser/links/link.ts
@@ -43,7 +43,17 @@ export class TerminalLink extends Disposable implements ILink {
     public readonly range: IBufferRange,
     public readonly text: string,
     private readonly _viewportY: number,
-    private readonly _activateCallback: (event: MouseEvent | undefined, uri: string) => void,
+    private readonly _activateCallback: (
+      event: MouseEvent | undefined,
+      uri: string,
+      lineInfo?: {
+        filePath?: string;
+        line?: number;
+        column?: number;
+        endLine?: number;
+        endColumn?: number;
+      },
+    ) => void,
     private readonly _tooltipCallback: (
       link: TerminalLink,
       viewportRange: IViewportRange,
@@ -52,6 +62,13 @@ export class TerminalLink extends Disposable implements ILink {
     ) => IDisposable | undefined,
     private readonly _isHighConfidenceLink: boolean,
     readonly label: string | undefined,
+    private readonly _lineInfo?: {
+      filePath?: string;
+      line?: number;
+      column?: number;
+      endLine?: number;
+      endColumn?: number;
+    },
   ) {
     super();
     this.decorations = {
@@ -71,7 +88,7 @@ export class TerminalLink extends Disposable implements ILink {
   }
 
   activate(event: MouseEvent | undefined, text: string): void {
-    this._activateCallback(event, text);
+    this._activateCallback(event, text, this._lineInfo);
   }
 
   hover(event: MouseEvent, text: string): void {

--- a/packages/terminal-next/src/common/terminal-link.ts
+++ b/packages/terminal-next/src/common/terminal-link.ts
@@ -1,0 +1,183 @@
+/* ---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// 行号和列号的正则生成函数
+class LinkMatchCounters {
+  private ri = 0;
+  private ci = 0;
+  private rei = 0;
+  private cei = 0;
+
+  r(): string {
+    return `(?<row${this.ri++}>\\d+)`;
+  }
+
+  c(): string {
+    return `(?<col${this.ci++}>\\d+)`;
+  }
+
+  re(): string {
+    return `(?<rowEnd${this.rei++}>\\d+)`;
+  }
+
+  ce(): string {
+    return `(?<colEnd${this.cei++}>\\d+)`;
+  }
+}
+
+// 路径相关的正则表达式
+export const pathPrefix = '(\\.\\.?|\\~)';
+export const pathSeparatorClause = '\\/';
+export const excludedPathCharactersClause = '[^\\0\\s!`&*()\\[\\]\'":;\\\\]';
+export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
+export const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
+export const winPathSeparatorClause = '(\\\\|\\/)';
+export const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*()\\[\\]\'":;]';
+
+// Unix 和 Windows 的本地链接正则表达式
+export const unixLocalLinkClause =
+  '((' +
+  pathPrefix +
+  '|(' +
+  excludedPathCharactersClause +
+  ')+)?(' +
+  pathSeparatorClause +
+  '(' +
+  excludedPathCharactersClause +
+  ')+)+)';
+
+export const winLocalLinkClause =
+  '((' +
+  winPathPrefix +
+  '|(' +
+  winExcludedPathCharactersClause +
+  ')+)?(' +
+  winPathSeparatorClause +
+  '(' +
+  winExcludedPathCharactersClause +
+  ')+)+)';
+
+// 行号和列号的匹配正则表达式
+const eolSuffix = '';
+
+/** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
+replacing space with nonBreakningSpace or space ASCII code - 32. */
+export function getLineAndColumnClause(): string {
+  const counters = new LinkMatchCounters();
+
+  return [
+    // foo:339
+    // foo:339:12
+    // foo:339:12-789
+    // foo:339:12-341.789
+    // foo:339.12
+    // foo 339
+    // foo 339:12                              [#140780]
+    // foo 339.12
+    // foo#339
+    // foo#339:12                              [#190288]
+    // foo#339.12
+    // foo, 339                                [#217927]
+    // "foo",339
+    // "foo",339:12
+    // "foo",339.12
+    // "foo",339.12-789
+    // "foo",339.12-341.789
+    `(?::|#| |['"],|, )${counters.r()}([:.]${counters.c()}(?:-(?:${counters.re()}\\.)?${counters.ce()})?)?` + eolSuffix,
+    // The quotes below are optional           [#171652]
+    // "foo", line 339                         [#40468]
+    // "foo", line 339, col 12
+    // "foo", line 339, column 12
+    // "foo":line 339
+    // "foo":line 339, col 12
+    // "foo":line 339, column 12
+    // "foo": line 339
+    // "foo": line 339, col 12
+    // "foo": line 339, column 12
+    // "foo" on line 339
+    // "foo" on line 339, col 12
+    // "foo" on line 339, column 12
+    // "foo" line 339 column 12
+    // "foo", line 339, character 12           [#171880]
+    // "foo", line 339, characters 12-789      [#171880]
+    // "foo", lines 339-341                    [#171880]
+    // "foo", lines 339-341, characters 12-789 [#178287]
+    `['"]?(?:,? |: ?| on )lines? ${counters.r()}(?:-${counters.re()})?(?:,? (?:col(?:umn)?|characters?) ${counters.c()}(?:-${counters.ce()})?)?` +
+      eolSuffix,
+    // () and [] are interchangeable
+    // foo(339)
+    // foo(339,12)
+    // foo(339, 12)
+    // foo (339)
+    // foo (339,12)
+    // foo (339, 12)
+    // foo: (339)
+    // foo: (339,12)
+    // foo: (339, 12)
+    // foo(339:12)                             [#229842]
+    // foo (339:12)                            [#229842]
+    `:? ?[\\[\\(]${counters.r()}(?:(?:, ?|:)${counters.c()})?[\\]\\)]` + eolSuffix,
+  ]
+    .join('|')
+    .replace(/ /g, `[${'\u00A0'} ]`);
+}
+
+// 行号和列号匹配的索引
+export const winLineAndColumnMatchIndex = 12;
+export const unixLineAndColumnMatchIndex = 11;
+
+// 行号和列号子句的组数
+export const lineAndColumnClauseGroupCount = 6;
+
+// 链接信息接口
+export interface ILinkInfo {
+  filePath?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
+// 最大长度限制
+export const MAX_LENGTH = 2000;
+
+/**
+ * 从正则匹配结果中提取行号信息
+ */
+export function extractLineInfoFromMatch(match: RegExpExecArray): ILinkInfo {
+  const result: any = {};
+
+  // 提取文件路径（第一个捕获组）
+  if (match[1]) {
+    result.filePath = match[1];
+  }
+
+  // 提取命名捕获组中的行号信息
+  if (match.groups) {
+    for (const [key, value] of Object.entries(match.groups)) {
+      if (!value) {
+        continue;
+      }
+
+      if (key.startsWith('row')) {
+        const index = key.replace('row', '');
+        if (index === 'End') {
+          result.endLine = parseInt(value, 10);
+        } else {
+          result.line = parseInt(value, 10);
+        }
+      } else if (key.startsWith('col')) {
+        const index = key.replace('col', '');
+        if (index === 'End') {
+          result.endColumn = parseInt(value, 10);
+        } else {
+          result.column = parseInt(value, 10);
+        }
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 终端链接支持更丰富的行号和列号格式，点击链接可直接定位到指定的行列范围。
- **优化**
  - 统一并集中管理终端链接中行列信息的正则表达式和解析逻辑，提升链接识别的准确性和一致性。
  - 链接激活时增加焦点聚焦，改善用户体验。
  - 增强对特殊格式文件路径和行列信息的识别能力，支持更多终端输出样式。
- **修复**
  - 修正了链接解析和路径解析顺序，提升了本地文件链接的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->