### PR TITLE
fix: trim mcp command and url

### DIFF
--- a/packages/ai-native/src/browser/mcp/config/components/mcp-server-form.tsx
+++ b/packages/ai-native/src/browser/mcp/config/components/mcp-server-form.tsx
@@ -109,6 +109,9 @@ export const MCPServerForm: FC<Props> = ({ visible, initialData, onSave, onCance
       if (form.command) {
         form.command = form.command.trim();
       }
+      if (form.url) {
+        form.url = form.url.trim();
+      }
       if (formData.type === MCP_SERVER_TYPE.SSE) {
         form.url = form.url?.trim();
       } else {

--- a/packages/ai-native/src/browser/mcp/config/components/mcp-server-form.tsx
+++ b/packages/ai-native/src/browser/mcp/config/components/mcp-server-form.tsx
@@ -106,6 +106,9 @@ export const MCPServerForm: FC<Props> = ({ visible, initialData, onSave, onCance
       const form = {
         ...formData,
       };
+      if (form.command) {
+        form.command = form.command.trim();
+      }
       if (formData.type === MCP_SERVER_TYPE.SSE) {
         form.url = form.url?.trim();
       } else {


### PR DESCRIPTION
### Types
- [x] 🐛 Bug Fixes

### Background or solution

部分场景下，空格可能导致异常

### Changelog

trim mcp command and url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 提交表单时，自动去除命令和 URL 字段的首尾空格，提升数据准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->