### PR TITLE
fix: check command `enablement` when keybinding is triggered

### DIFF
--- a/packages/core-browser/package.json
+++ b/packages/core-browser/package.json
@@ -21,6 +21,7 @@
     "@opensumi/ide-components": "workspace:*",
     "@opensumi/ide-connection": "workspace:*",
     "@opensumi/ide-core-common": "workspace:*",
+    "@opensumi/monaco-editor-core": "0.54.0-patch.2",
     "@opensumi/vscode-debugprotocol": "1.49.0-beta.1",
     "@vscode/codicons": "0.0.35",
     "ajv": "^6.10.0",

--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -10,6 +10,7 @@ import {
   ILogger,
   formatLocalize,
   isOSX,
+  isString,
   isUndefined,
 } from '@opensumi/ide-core-common';
 import {
@@ -761,7 +762,7 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
   public isEnabled(binding: Keybinding, event?: KeyboardEvent, enablement?: string): boolean {
     let { when } = binding;
 
-    const whenExpr = typeof when === 'string' ? ContextKeyExpr.deserialize(when) : when;
+    const whenExpr = isString(when) ? ContextKeyExpr.deserialize(when) : when;
     const enablementExpr = ContextKeyExpr.deserialize(enablement);
 
     if (enablementExpr) {

--- a/packages/core-browser/src/keybinding/keybinding.ts
+++ b/packages/core-browser/src/keybinding/keybinding.ts
@@ -12,7 +12,10 @@ import {
   isOSX,
   isUndefined,
 } from '@opensumi/ide-core-common';
-import { ContextKeyExpression } from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
+import {
+  ContextKeyExpr,
+  ContextKeyExpression,
+} from '@opensumi/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 
 import { IContextKeyService } from '../context-key';
 import { KeyboardLayoutService } from '../keyboard/keyboard-layout-service';
@@ -753,9 +756,19 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
    * 只有在没有上下文（全局上下文）或者我们处于该上下文中时才执行
    * @param binding
    * @param event
+   * @param enablement
    */
-  public isEnabled(binding: Keybinding, event?: KeyboardEvent): boolean {
-    if (binding.when && !this.whenContextService.match(binding.when, event && (event.target as HTMLElement))) {
+  public isEnabled(binding: Keybinding, event?: KeyboardEvent, enablement?: string): boolean {
+    let { when } = binding;
+
+    const whenExpr = typeof when === 'string' ? ContextKeyExpr.deserialize(when) : when;
+    const enablementExpr = ContextKeyExpr.deserialize(enablement);
+
+    if (enablementExpr) {
+      when = ContextKeyExpr.and(enablementExpr, whenExpr)?.serialize();
+    }
+
+    if (when && !this.whenContextService.match(when, event && (event.target as HTMLElement))) {
       return false;
     }
     return true;
@@ -905,6 +918,10 @@ export class KeybindingRegistryImpl implements KeybindingRegistry, KeybindingSer
         } else {
           const command = this.commandRegistry.getCommand(binding.command);
           if (command) {
+            if (!this.isEnabled(binding, event, command.enablement)) {
+              continue;
+            }
+
             this.commandService
               .executeCommand(command.id, binding.args)
               .catch((err) => this.logger.error('Failed to execute command:', err, binding.command));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,6 +3529,7 @@ __metadata:
     "@opensumi/ide-components": "workspace:*"
     "@opensumi/ide-connection": "workspace:*"
     "@opensumi/ide-core-common": "workspace:*"
+    "@opensumi/monaco-editor-core": "npm:0.54.0-patch.2"
     "@opensumi/vscode-debugprotocol": "npm:1.49.0-beta.1"
     "@vscode/codicons": "npm:0.0.35"
     ajv: "npm:^6.10.0"


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

Closes #4559 

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 增强了按键绑定的可用性判断，现支持结合命令的 enablement 表达式进行更精确的启用条件判定。

- **修复**
  - 修正了部分情况下按键绑定未正确判断启用状态的问题，提升了按键操作的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->