### PR TITLE
feat(chat): add message summary provider to ChatFeatureRegistry

### DIFF
--- a/packages/ai-native/src/browser/chat/chat.feature.registry.ts
+++ b/packages/ai-native/src/browser/chat/chat.feature.registry.ts
@@ -2,7 +2,13 @@ import { Injectable } from '@opensumi/di';
 import { Disposable, Emitter, Event, getDebugLogger } from '@opensumi/ide-core-common';
 
 import { IChatWelcomeMessageContent, ISampleQuestions, SLASH_SYMBOL } from '../../common';
-import { IChatFeatureRegistry, IChatSlashCommandHandler, IChatSlashCommandItem, IImageUploadProvider } from '../types';
+import {
+  IChatFeatureRegistry,
+  IChatSlashCommandHandler,
+  IChatSlashCommandItem,
+  IImageUploadProvider,
+  IMessageSummaryProvider,
+} from '../types';
 
 import { ChatSlashCommandItemModel, ChatWelcomeMessageModel } from './chat-model';
 import { ChatProxyService } from './chat-proxy.service';
@@ -14,12 +20,22 @@ export class ChatFeatureRegistry extends Disposable implements IChatFeatureRegis
   private slashCommandsHandlerMap: Map<string, IChatSlashCommandHandler> = new Map();
   private imageUploadProvider: IImageUploadProvider | undefined;
 
+  private messageSummaryProvider?: IMessageSummaryProvider;
+
   public registerImageUploadProvider(provider: IImageUploadProvider): void {
     this.imageUploadProvider = provider;
   }
 
   public getImageUploadProvider(): IImageUploadProvider | undefined {
     return this.imageUploadProvider;
+  }
+
+  public registerMessageSummaryProvider(provider: IMessageSummaryProvider): void {
+    this.messageSummaryProvider = provider;
+  }
+
+  public getMessageSummaryProvider(): IMessageSummaryProvider | undefined {
+    return this.messageSummaryProvider;
   }
 
   public chatWelcomeMessageModel?: ChatWelcomeMessageModel;

--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -952,9 +952,12 @@ export function DefaultChatViewHeader({
       const currentTitle = latestUserMessage
         ? cleanAttachedTextWrapper(latestUserMessage.content).slice(0, MAX_TITLE_LENGTH)
         : '';
-
-      if (summaryProvider && aiChatService.sessionModel.sessionId) {
-        summaryProvider.getMessageSummary(aiChatService.sessionModel.sessionId).then((summary) => {
+      const messages = aiChatService.sessionModel.history.getMessages().map((msg) => ({
+        role: msg.role,
+        content: msg.content,
+      }));
+      if (messages.length > 2 && summaryProvider && aiChatService.sessionModel.sessionId) {
+        summaryProvider.getMessageSummary(messages).then((summary) => {
           if (summary) {
             setCurrentTitle(summary.slice(0, MAX_TITLE_LENGTH));
           } else {

--- a/packages/ai-native/src/browser/chat/chat.view.tsx
+++ b/packages/ai-native/src/browser/chat/chat.view.tsx
@@ -918,6 +918,7 @@ export function DefaultChatViewHeader({
 }) {
   const aiChatService = useInjectable<ChatInternalService>(IChatInternalService);
   const messageService = useInjectable<IMessageService>(IMessageService);
+  const chatFeatureRegistry = useInjectable<ChatFeatureRegistry>(ChatFeatureRegistryToken);
 
   const [historyList, setHistoryList] = React.useState<IChatHistoryItem[]>([]);
   const [currentTitle, setCurrentTitle] = React.useState<string>('');
@@ -947,9 +948,23 @@ export function DefaultChatViewHeader({
     const getHistoryList = () => {
       const currentMessages = aiChatService.sessionModel.history.getMessages();
       const latestUserMessage = currentMessages.findLast((m) => m.role === ChatMessageRole.User);
-      setCurrentTitle(
-        latestUserMessage ? cleanAttachedTextWrapper(latestUserMessage.content).slice(0, MAX_TITLE_LENGTH) : '',
-      );
+      const summaryProvider = chatFeatureRegistry.getMessageSummaryProvider();
+      const currentTitle = latestUserMessage
+        ? cleanAttachedTextWrapper(latestUserMessage.content).slice(0, MAX_TITLE_LENGTH)
+        : '';
+
+      if (summaryProvider && aiChatService.sessionModel.sessionId) {
+        summaryProvider.getMessageSummary(aiChatService.sessionModel.sessionId).then((summary) => {
+          if (summary) {
+            setCurrentTitle(summary.slice(0, MAX_TITLE_LENGTH));
+          } else {
+            setCurrentTitle(currentTitle);
+          }
+        });
+      } else {
+        setCurrentTitle(currentTitle);
+      }
+
       setHistoryList(
         aiChatService.getSessions().map((session) => {
           const history = session.history;

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -134,6 +134,8 @@ export interface IChatFeatureRegistry {
   registerImageUploadProvider(provider: IImageUploadProvider): void;
   registerWelcome(content: IChatWelcomeMessageContent | React.ReactNode, sampleQuestions?: ISampleQuestions[]): void;
   registerSlashCommand(command: IChatSlashCommandItem, handler: IChatSlashCommandHandler): void;
+
+  registerMessageSummaryProvider(provider: IMessageSummaryProvider): void;
 }
 
 export type ChatWelcomeRender = (props: {
@@ -296,6 +298,13 @@ export interface IProblemFixProviderRegistry {
 
 export interface IImageUploadProvider {
   imageUpload(file: File): Promise<DataContent | URL>;
+}
+
+export interface IMessageSummaryProvider {
+  /**
+   * @param sessionId 会话 ID
+   */
+  getMessageSummary(sessionId: string): Promise<string | undefined>;
 }
 
 export const AINativeCoreContribution = Symbol('AINativeCoreContribution');

--- a/packages/ai-native/src/browser/types.ts
+++ b/packages/ai-native/src/browser/types.ts
@@ -5,6 +5,7 @@ import { ZodSchema } from 'zod';
 import { AIActionItem } from '@opensumi/ide-core-browser/lib/components/ai-native/index';
 import {
   CancellationToken,
+  ChatMessageRole,
   ChatResponse,
   Deferred,
   IAICompletionOption,
@@ -301,10 +302,12 @@ export interface IImageUploadProvider {
 }
 
 export interface IMessageSummaryProvider {
-  /**
-   * @param sessionId 会话 ID
-   */
-  getMessageSummary(sessionId: string): Promise<string | undefined>;
+  getMessageSummary(
+    messages: Array<{
+      role: ChatMessageRole;
+      content: string;
+    }>,
+  ): Promise<string | undefined>;
 }
 
 export const AINativeCoreContribution = Symbol('AINativeCoreContribution');

--- a/packages/extension/__tests__/browser/extension-service/extension.service.test.ts
+++ b/packages/extension/__tests__/browser/extension-service/extension.service.test.ts
@@ -99,11 +99,6 @@ describe('Extension service', () => {
       expect(exts).toEqual(MOCK_EXTENSIONS);
     });
 
-    it('should return all mock extensions JSON', async () => {
-      const jsons = await extensionManagementService.getAllExtensionJson();
-      expect(jsons).toEqual(MOCK_EXTENSIONS.map((e) => e.toJSON()));
-    });
-
     it('should return specified extension props', async () => {
       const extensionMetadata = await extensionManagementService.getExtensionProps(MOCK_EXTENSIONS[0].path, {
         readme: './README.md',


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 聊天会话标题现在可通过消息摘要提供者自动生成摘要，提升标题的智能化和简洁性。
  - 新增消息摘要提供者接口及其注册功能，支持基于会话消息自动生成简洁摘要。
  - 引入消息摘要缓存机制，减少频繁摘要请求，提高性能和响应速度。
- **改进**
  - 支持注册和获取自定义消息摘要提供者，为未来扩展和个性化摘要功能打下基础。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->