### PR TITLE
chore: remove reasoning_content from history

### DIFF
--- a/packages/ai-native/src/browser/chat/chat-model.ts
+++ b/packages/ai-native/src/browser/chat/chat-model.ts
@@ -352,7 +352,9 @@ export class ChatModel extends Disposable implements IChatModel {
           : request.message.prompt,
       });
       for (const part of request.response.responseParts) {
-        if (part.kind === 'treeData' || part.kind === 'component') {
+        // Remove reasoning_content from history
+        // https://api-docs.deepseek.com/zh-cn/guides/reasoning_model#%E4%B8%8A%E4%B8%8B%E6%96%87%E6%8B%BC%E6%8E%A5
+        if (part.kind === 'treeData' || part.kind === 'component' || part.kind === 'reasoning') {
           continue;
         }
         if (part.kind !== 'toolCall') {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 聊天历史记录中将不再包含类型为“reasoning”的回复内容，提升消息展示的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->