### PR TITLE
refactor(ai-native): enable mcp server by default

### DIFF
--- a/packages/ai-native/src/common/mcp-server-manager.ts
+++ b/packages/ai-native/src/common/mcp-server-manager.ts
@@ -100,4 +100,4 @@ export type MCPServerDescription =
 export const MCPServerManager = Symbol('MCPServerManager');
 export const MCPServerManagerPath = 'ServicesMCPServerManager';
 
-export const MCPServersEnabledKey = 'mcp_servers_enabled';
+export const MCPServersDisabledKey = 'mcp_servers_disabled';


### PR DESCRIPTION
### Types

- [x] 🪚 Refactors

### Background or solution
目前的设计将 enable mcp 配置存在 storage 下，在 OpenSumi 常用的 WebIDE 场景下，每一次新建空间都需要启用
### Changelog
refactor(ai-native): enable mcp server by default