### PR TITLE
fix: mcp stdio should run in workspace & support mcp tool enable/disable

### DIFF
--- a/packages/ai-native/__test__/node/mcp-server.stdio.test.ts
+++ b/packages/ai-native/__test__/node/mcp-server.stdio.test.ts
@@ -24,7 +24,14 @@ describe('StdioMCPServer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    server = new StdioMCPServer('test-server', 'test-command', ['arg1', 'arg2'], { ENV: 'test' }, mockLogger);
+    server = new StdioMCPServer(
+      'test-server',
+      'test-command',
+      ['arg1', 'arg2'],
+      { ENV: 'test' },
+      undefined,
+      mockLogger,
+    );
   });
 
   describe('constructor', () => {

--- a/packages/ai-native/src/browser/chat/apply.service.ts
+++ b/packages/ai-native/src/browser/chat/apply.service.ts
@@ -102,7 +102,7 @@ export class ApplyService extends BaseApplyService {
     Provide the complete updated code.
 `,
       {
-        ...this.chatProxyService.getRequestOptions(),
+        ...(await this.chatProxyService.getRequestOptions()),
         trimTexts: ['<updated-code>', '</updated-code>'],
         system:
           'You are a coding assistant that helps merge code updates, ensuring every modification is fully integrated.',

--- a/packages/ai-native/src/browser/mcp/config/components/mcp-config.module.less
+++ b/packages/ai-native/src/browser/mcp/config/components/mcp-config.module.less
@@ -222,4 +222,16 @@
   font-weight: 500;
   transition: all 0.2s ease;
   cursor: pointer;
+
+  &.disabledTool {
+    opacity: 0.5;
+    background-color: var(--notification-warning-background);
+    color: var(--notification-warning-foreground);
+    text-decoration: line-through;
+  }
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
 }

--- a/packages/ai-native/src/browser/mcp/config/mcp-config.service.ts
+++ b/packages/ai-native/src/browser/mcp/config/mcp-config.service.ts
@@ -1,5 +1,5 @@
 import { Autowired, Injectable } from '@opensumi/di';
-import { ILogger } from '@opensumi/ide-core-browser';
+import { AppConfig, ILogger } from '@opensumi/ide-core-browser';
 import { PreferenceService } from '@opensumi/ide-core-browser/lib/preferences';
 import {
   Deferred,
@@ -45,6 +45,9 @@ export class MCPConfigService extends Disposable {
 
   @Autowired(WorkbenchEditorService)
   private readonly workbenchEditorService: WorkbenchEditorService;
+
+  @Autowired(AppConfig)
+  private readonly appConfig: AppConfig;
 
   @Autowired(ILogger)
   private readonly logger: ILogger;
@@ -259,7 +262,7 @@ export class MCPConfigService extends Disposable {
           type: MCP_SERVER_TYPE.STDIO,
           command: server.command,
           args: server.args,
-          env: server.env,
+          env: Object.assign({ cwd: this.appConfig.workspaceDir }, server.env),
           enabled: !disabledMCPServers.includes(serverName),
         };
       }

--- a/packages/ai-native/src/node/base-language-model.ts
+++ b/packages/ai-native/src/node/base-language-model.ts
@@ -38,6 +38,12 @@ export abstract class BaseLanguageModel {
     if (clientId) {
       const registry = this.toolInvocationRegistryManager.getRegistry(clientId);
       allFunctions = options.noTool ? [] : registry.getAllFunctions();
+
+      // 过滤禁用的工具
+      if (options.disabledTools && options.disabledTools.length > 0) {
+        const disabledToolsSet = new Set(options.disabledTools);
+        allFunctions = allFunctions.filter((tool) => !disabledToolsSet.has(tool.name));
+      }
     }
 
     return this.handleStreamingRequest(

--- a/packages/ai-native/src/node/mcp-server-manager-impl.ts
+++ b/packages/ai-native/src/node/mcp-server-manager-impl.ts
@@ -161,14 +161,15 @@ export class MCPServerManagerImpl implements MCPServerManager {
     const existingServer = this.servers.get(description.name);
     if (description.type === MCP_SERVER_TYPE.STDIO) {
       const { name, command, args, env } = description;
-      const envs = {
+      const envs: any = {
         ...env,
         PATH: this.shellPath || process.env.PATH || '',
       };
       if (existingServer) {
         existingServer.update(command, args, envs);
       } else {
-        const newServer = new StdioMCPServer(name, command, args, envs, this.logger);
+        // cwd 默认从前端透传过来
+        const newServer = new StdioMCPServer(name, command, args, envs, envs.cwd, this.logger);
         this.servers.set(name, newServer);
       }
     } else if (description.type === MCP_SERVER_TYPE.SSE) {

--- a/packages/core-common/src/storage.ts
+++ b/packages/core-common/src/storage.ts
@@ -54,6 +54,7 @@ export const STORAGE_NAMESPACE = {
   DEBUG: new URI('debug').withScheme(STORAGE_SCHEMA.SCOPE),
   OUTLINE: new URI('outline').withScheme(STORAGE_SCHEMA.SCOPE),
   CHAT: new URI('chat').withScheme(STORAGE_SCHEMA.SCOPE),
+  MCP: new URI('mcp').withScheme(STORAGE_SCHEMA.SCOPE),
   // global database
   GLOBAL_LAYOUT: new URI('layout-global').withScheme(STORAGE_SCHEMA.GLOBAL),
   GLOBAL_EXTENSIONS: new URI('extensions').withScheme(STORAGE_SCHEMA.GLOBAL),

--- a/packages/core-common/src/types/ai-native/index.ts
+++ b/packages/core-common/src/types/ai-native/index.ts
@@ -187,6 +187,7 @@ export interface IAIBackServiceOption {
   noTool?: boolean;
   /** 响应首尾是否有需要trim的内容 */
   trimTexts?: [string, string];
+  disabledTools?: string[];
 }
 
 /**
@@ -440,7 +441,7 @@ export const CoreMessgaeRoleMap = {
 export interface IHistoryChatMessage extends IChatMessage {
   id: string;
   order: number;
-  isSummarized?: boolean;  // 添加这个属性，表示消息是否已被总结
+  isSummarized?: boolean; // 添加这个属性，表示消息是否已被总结
 
   type?: 'string' | 'component';
   images?: string[];


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
fix: mcp stdio should run in workspace

### Changelog
fix: mcp stdio should run in workspace
feat: support mcp tool enable/disable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 现在在启动 STDIO 类型的服务器时，会自动设置当前工作目录（cwd），以提升服务器的环境配置灵活性。
  * MCP 配置界面新增工具启用/禁用切换功能，支持用户直接在界面中管理工具状态。
  * 聊天请求中集成了禁用工具列表配置，提升对工具状态的动态控制能力。

* **优化**
  * 日志中新增了当前工作目录（cwd）的显示，便于调试和定位问题。
  * 请求参数获取改为异步，确保配置数据完整加载后再发起请求。
  * 工具禁用状态在界面以视觉样式区分，提升用户交互体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->