### PR TITLE
fix: fixed the error  when clicking "No configuration"

### DIFF
--- a/packages/debug/src/browser/view/configuration/debug-configuration.view.tsx
+++ b/packages/debug/src/browser/view/configuration/debug-configuration.view.tsx
@@ -313,7 +313,7 @@ export const DebugControllerView = (props: DebugControllerViewProps) => {
     } else {
       value = event;
     }
-    if (value.startsWith(DEFAULT_ADD_CONFIGURATION_KEY)) {
+    if (value.startsWith(DEFAULT_ADD_CONFIGURATION_KEY) || value === DEFAULT_NO_CONFIGURATION_KEY) {
       const index = value.slice(DEFAULT_ADD_CONFIGURATION_KEY.length);
       if (index) {
         addConfiguration(workspaceRoots[index]);


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->


- [x] 🐛 Bug Fixes

### Background or solution
<img width="726" height="468" alt="image" src="https://github.com/user-attachments/assets/4dfd03e1-0e82-4dd8-9075-7ee0489f1b95" />
<img width="1124" height="310" alt="image" src="https://github.com/user-attachments/assets/4541287f-a066-417d-940b-9664acf512fa" />

「没有配置」和「默认配置」运行一样的逻辑

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复问题**
  * 修复了在选择“无配置”选项时无法正确添加调试配置的问题，现在选择“添加配置”或“无配置”选项均会触发添加调试配置流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->