### PR TITLE
fix: drop file fail on windows

### DIFF
--- a/packages/addons/src/node/file-drop.service.ts
+++ b/packages/addons/src/node/file-drop.service.ts
@@ -10,13 +10,13 @@ export class FileDropService implements IFileDropBackendService {
   private writeableStreams: Map<string, fs.WriteStream> = new Map();
 
   async $ensureFileExist(fileName: string, targetDir: string): Promise<boolean> {
-    const targetPath = Uri.file(path.join(targetDir, fileName)).path;
+    const targetPath = Uri.file(path.join(targetDir, fileName)).fsPath;
     this.writeableStreams.set(targetPath, fs.createWriteStream(targetPath));
     return true;
   }
 
   $writeStream(chunk: string | ArrayBuffer, fileName: string, targetDir: string, done: boolean): Promise<void> {
-    const targetPath = Uri.file(path.join(targetDir, fileName)).path;
+    const targetPath = Uri.file(path.join(targetDir, fileName)).fsPath;
     const stream = this.writeableStreams.get(targetPath);
     return new Promise((resolve, reject) => {
       stream?.write(chunk, 'binary', (err) => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
fix https://github.com/opensumi/core/issues/3615
<img width="1843" height="794" alt="f04a64cec0c1c8e0a6ac2216e36b19bd" src="https://github.com/user-attachments/assets/0d4bf3f3-88d6-4daa-bea6-4ee3d059749e" />
在 $ensureFileExis方法里的targetPath原来类似于图片上这种，在创建文件写入流会报错，报错原因是路径生成错误。


### Changelog
修复在windows上，拖拽文件到IDE中，文件损坏的问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 修复文件拖放时的目标路径解析问题，解决在 Windows 等平台因路径格式不兼容导致无法创建/写入文件的情况，提升稳定性与跨平台兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->