### PR TITLE
fix: 修复插件注入的 bottomView 在启动时会高度为 0 的问题

### DIFF
--- a/packages/main-layout/src/browser/tabbar/tabbar.service.ts
+++ b/packages/main-layout/src/browser/tabbar/tabbar.service.ts
@@ -828,7 +828,7 @@ export class TabbarService extends WithEventBus {
 
   protected onResize() {
     fastdom.measureAtNextFrame(() => {
-      if (!this.currentContainerId || !this.resizeHandle) {
+      if (!this.currentContainerId.get() || !this.resizeHandle) {
         // 折叠时不监听变化
         return;
       }


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
当退出 IDE 时选择了一个插件注入的 tabbar/bottomBar，重新进入恢复时，由于插件启动时机晚，会导致其高度为 0 。
问题原因为 currentContainerId Observable 改造漏了 onResize 中的为空判断条件，导致它在启动时会被错误调用

### Changelog
*  修复插件注入的 bottomView 在启动时会高度为 0 的问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * 修复当不存在活动容器时的尺寸变更处理，避免无效计算与不必要的更新触发，降低异常概率。
  * 改善选项卡栏在窗口/容器调整大小时的稳定性与一致性，带来更平滑的交互体验。
  * 优化尺寸监听的早期返回条件，在边界场景下行为更可预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->