### PR TITLE
fix IconTabView hook usage by providing a fallback observable

### DIFF
--- a/packages/main-layout/package.json
+++ b/packages/main-layout/package.json
@@ -21,10 +21,10 @@
     "@opensumi/ide-components": "workspace:*",
     "@opensumi/ide-core-browser": "workspace:*",
     "@opensumi/ide-core-common": "workspace:*",
-    "@opensumi/ide-theme": "workspace:*"
+    "@opensumi/ide-theme": "workspace:*",
+    "@opensumi/ide-monaco": "workspace:*"
   },
   "devDependencies": {
-    "@opensumi/ide-dev-tool": "workspace:*",
-    "@opensumi/ide-monaco": "workspace:*"
+    "@opensumi/ide-dev-tool": "workspace:*"
   }
 }

--- a/packages/main-layout/src/browser/tabbar/bar.view.tsx
+++ b/packages/main-layout/src/browser/tabbar/bar.view.tsx
@@ -18,6 +18,7 @@ import { InlineMenuBar } from '@opensumi/ide-core-browser/lib/components/actions
 import { Layout } from '@opensumi/ide-core-browser/lib/components/layout/layout';
 import { VIEW_CONTAINERS } from '@opensumi/ide-core-browser/lib/layout/view-id';
 import { IProgressService } from '@opensumi/ide-core-browser/lib/progress';
+import { observableValue } from '@opensumi/ide-monaco/lib/common/observable';
 
 import { IMainLayoutService } from '../../common';
 
@@ -242,8 +243,8 @@ export const IconTabView: FC<{ component: ComponentRegistryProvider }> = ({ comp
   const styles_icon_tab = useDesignStyles(styles.icon_tab, 'icon_tab');
   const [component, setComponent] = useState<ComponentRegistryProvider>(defaultComponent);
   const indicator = progressService.getIndicator(component.options?.containerId || '');
-
-  const inProgress = indicator ? useAutorun(indicator.progressModel.show) : false;
+  const fallbackShowObservable = useMemo(() => observableValue('IconTabView.fallbackShow', false), []);
+  const inProgress = useAutorun(indicator?.progressModel.show ?? fallbackShowObservable);
 
   const title = useMemo(() => {
     const options = component.options;


### PR DESCRIPTION
### Types

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
- the previous `useAutorun` hook is inside a conditional caused the subsequent `useMemo` to crash because React detected broken hook ordering
<img width="2850" height="2652" alt="CleanShot 2025-10-24 at 15 52 31@2x" src="https://github.com/user-attachments/assets/87e4946f-05f1-43be-ad16-c8917f955753" />



### Changelog
- fix IconTabView so `useAutorun` is no longer invoked inside a conditional; 
- create a memoized fallback observable when no progress indicator exists, ensuring hooks execute deterministically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了标签栏进度指示器的可靠性，优化了进度显示的回退逻辑，确保即使在指示器不可用的情况下也能正确显示进度状态。

* **依赖调整**
  * 调整了内部依赖范围配置，优化项目结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->