### PR TITLE
fix(file-service): improve recursive watcher backend handling

### DIFF
--- a/packages/file-service/__tests__/browser/file-service-client.test.ts
+++ b/packages/file-service/__tests__/browser/file-service-client.test.ts
@@ -50,7 +50,7 @@ describe('FileServiceClient should be work', () => {
 
   beforeAll(() => {
     // @ts-ignore
-    injector.mock(RecursiveFileSystemWatcher, 'isEnableNSFW', () => false);
+    injector.mock(RecursiveFileSystemWatcher, 'shouldUseNSFW', () => Promise.resolve(false));
     fileServiceClient = injector.get(IFileServiceClient);
     toDispose.push(fileServiceClient.registerProvider('file', injector.get(IDiskFileProvider)));
   });

--- a/packages/file-service/__tests__/node/file-service-watcher.test.ts
+++ b/packages/file-service/__tests__/node/file-service-watcher.test.ts
@@ -160,7 +160,7 @@ const sleepTime = 1000;
     const injector = createNodeInjector([]);
     const root = FileUri.create(fse.realpathSync(await temp.mkdir('nfsw-test')));
     const watcherServer = new RecursiveFileSystemWatcher([], injector.get(ILogServiceManager).getLogger());
-    watcherServer['isEnableNSFW'] = () => false;
+    watcherServer['shouldUseNSFW'] = () => Promise.resolve(false);
 
     fse.mkdirpSync(FileUri.fsPath(root.resolve('for_rename_folder')));
     fse.writeFileSync(FileUri.fsPath(root.resolve('for_rename')), 'rename');

--- a/packages/file-service/__tests__/node/index.test.ts
+++ b/packages/file-service/__tests__/node/index.test.ts
@@ -34,7 +34,7 @@ describe('FileService', () => {
 
     injector = createNodeInjector([FileServiceModule]);
     // @ts-ignore
-    injector.mock(RecursiveFileSystemWatcher, 'isEnableNSFW', () => false);
+    injector.mock(RecursiveFileSystemWatcher, 'shouldUseNSFW', () => Promise.resolve(false));
     fileService = injector.get(IFileService);
   });
 

--- a/packages/file-service/__tests__/node/recursive-watcher-backend-selection.test.ts
+++ b/packages/file-service/__tests__/node/recursive-watcher-backend-selection.test.ts
@@ -1,0 +1,98 @@
+jest.mock('@opensumi/ide-core-common/lib/utils', () => {
+  const actual = jest.requireActual('@opensumi/ide-core-common/lib/utils');
+  return {
+    ...actual,
+    isLinux: true,
+    isWindows: false,
+  };
+});
+
+jest.mock('fs-extra', () => {
+  const actual = jest.requireActual('fs-extra');
+  return {
+    ...actual,
+    mkdtemp: jest.fn(),
+    remove: jest.fn(),
+  };
+});
+
+jest.mock('@parcel/watcher', () => {
+  const mock: any = {
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    getEventsSince: jest.fn(),
+    writeSnapshot: jest.fn(),
+  };
+  mock.default = mock;
+  return mock;
+});
+
+import ParcelWatcher from '@parcel/watcher';
+import fs from 'fs-extra';
+
+import { RecursiveWatcherBackend } from '../../src/common';
+import { RecursiveFileSystemWatcher } from '../../src/node/hosted/recursive/file-service-watcher';
+
+const mkdtempMock = fs.mkdtemp as unknown as jest.Mock;
+const removeMock = fs.remove as unknown as jest.Mock;
+const writeSnapshotMock = ParcelWatcher.writeSnapshot as unknown as jest.Mock;
+
+const createLogger = () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('RecursiveFileSystemWatcher backend selection on linux', () => {
+  beforeEach(() => {
+    mkdtempMock.mockReset();
+    removeMock.mockReset();
+    writeSnapshotMock.mockReset();
+  });
+
+  it('prefers parcel watcher when linux backend probe succeeds', async () => {
+    mkdtempMock.mockResolvedValue('/tmp/sumi-parcel-1');
+    removeMock.mockResolvedValue(undefined);
+    writeSnapshotMock.mockResolvedValue('/tmp/sumi-parcel-1/snapshot');
+
+    const watcher = new RecursiveFileSystemWatcher([], createLogger() as any, RecursiveWatcherBackend.NSFW);
+
+    const shouldFallback = await watcher['shouldUseNSFW']();
+    expect(shouldFallback).toBe(false);
+    expect(writeSnapshotMock).toHaveBeenCalledTimes(1);
+
+    // Cached result avoids re-running the probe.
+    await watcher['shouldUseNSFW']();
+    expect(writeSnapshotMock).toHaveBeenCalledTimes(1);
+
+    watcher.dispose();
+  });
+
+  it('falls back to nsfw when parcel watcher probe fails', async () => {
+    mkdtempMock.mockResolvedValue('/tmp/sumi-parcel-2');
+    removeMock.mockResolvedValue(undefined);
+    writeSnapshotMock.mockRejectedValue(new Error('fail to init parcel'));
+
+    const logger = createLogger();
+    const watcher = new RecursiveFileSystemWatcher([], logger as any, RecursiveWatcherBackend.NSFW);
+
+    const shouldFallback = await watcher['shouldUseNSFW']();
+
+    expect(shouldFallback).toBe(true);
+    expect(logger.warn).toHaveBeenCalled();
+    expect(removeMock).toHaveBeenCalledTimes(1);
+
+    watcher.dispose();
+  });
+
+  it('skips linux probe when backend is not nsfw', async () => {
+    const watcher = new RecursiveFileSystemWatcher([], createLogger() as any, RecursiveWatcherBackend.PARCEL);
+
+    const shouldFallback = await watcher['shouldUseNSFW']();
+    expect(shouldFallback).toBe(false);
+    expect(writeSnapshotMock).not.toHaveBeenCalled();
+
+    watcher.dispose();
+  });
+});

--- a/packages/file-service/package.json
+++ b/packages/file-service/package.json
@@ -23,9 +23,9 @@
     "@opensumi/ide-core-node": "workspace:*",
     "@opensumi/ide-logs": "workspace:*",
     "@opensumi/ide-utils": "workspace:*",
-    "@parcel/watcher": "2.1.0",
+    "@parcel/watcher": "2.5.1",
     "file-type": "16.5.4",
-    "nsfw": "2.2.0",
+    "nsfw": "2.2.5",
     "trash": "^5.2.0",
     "vscode-languageserver-types": "^3.16.0",
     "write-file-atomic": "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,9 +3897,9 @@ __metadata:
     "@opensumi/ide-dev-tool": "workspace:*"
     "@opensumi/ide-logs": "workspace:*"
     "@opensumi/ide-utils": "workspace:*"
-    "@parcel/watcher": "npm:2.1.0"
+    "@parcel/watcher": "npm:2.5.1"
     file-type: "npm:16.5.4"
-    nsfw: "npm:2.2.0"
+    nsfw: "npm:2.2.5"
     trash: "npm:^5.2.0"
     vscode-languageserver-types: "npm:^3.16.0"
     write-file-atomic: "npm:^5.0.1"
@@ -4629,16 +4629,147 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/watcher@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@parcel/watcher@npm:2.1.0"
+"@parcel/watcher-android-arm64@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-android-arm64@npm:2.5.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-darwin-arm64@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-darwin-arm64@npm:2.5.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-darwin-x64@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-darwin-x64@npm:2.5.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-freebsd-x64@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-freebsd-x64@npm:2.5.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm-glibc@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-linux-arm-glibc@npm:2.5.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm-musl@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-linux-arm-musl@npm:2.5.1"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm64-glibc@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-linux-arm64-glibc@npm:2.5.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-arm64-musl@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-linux-arm64-musl@npm:2.5.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-x64-glibc@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-linux-x64-glibc@npm:2.5.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-linux-x64-musl@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-linux-x64-musl@npm:2.5.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-win32-arm64@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-win32-arm64@npm:2.5.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-win32-ia32@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-win32-ia32@npm:2.5.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher-win32-x64@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher-win32-x64@npm:2.5.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@parcel/watcher@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@parcel/watcher@npm:2.5.1"
   dependencies:
+    "@parcel/watcher-android-arm64": "npm:2.5.1"
+    "@parcel/watcher-darwin-arm64": "npm:2.5.1"
+    "@parcel/watcher-darwin-x64": "npm:2.5.1"
+    "@parcel/watcher-freebsd-x64": "npm:2.5.1"
+    "@parcel/watcher-linux-arm-glibc": "npm:2.5.1"
+    "@parcel/watcher-linux-arm-musl": "npm:2.5.1"
+    "@parcel/watcher-linux-arm64-glibc": "npm:2.5.1"
+    "@parcel/watcher-linux-arm64-musl": "npm:2.5.1"
+    "@parcel/watcher-linux-x64-glibc": "npm:2.5.1"
+    "@parcel/watcher-linux-x64-musl": "npm:2.5.1"
+    "@parcel/watcher-win32-arm64": "npm:2.5.1"
+    "@parcel/watcher-win32-ia32": "npm:2.5.1"
+    "@parcel/watcher-win32-x64": "npm:2.5.1"
+    detect-libc: "npm:^1.0.3"
     is-glob: "npm:^4.0.3"
     micromatch: "npm:^4.0.5"
-    node-addon-api: "npm:^3.2.1"
+    node-addon-api: "npm:^7.0.0"
     node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.3.0"
-  checksum: 10/33d68a0f42bee67e1ec371040dac149fdf7cf862dc4800b18584d54531e01ebea091a94d3c5b061050b96aabb3c3d4e38c16c2899762df1b3392d02f1cca9282
+  dependenciesMeta:
+    "@parcel/watcher-android-arm64":
+      optional: true
+    "@parcel/watcher-darwin-arm64":
+      optional: true
+    "@parcel/watcher-darwin-x64":
+      optional: true
+    "@parcel/watcher-freebsd-x64":
+      optional: true
+    "@parcel/watcher-linux-arm-glibc":
+      optional: true
+    "@parcel/watcher-linux-arm-musl":
+      optional: true
+    "@parcel/watcher-linux-arm64-glibc":
+      optional: true
+    "@parcel/watcher-linux-arm64-musl":
+      optional: true
+    "@parcel/watcher-linux-x64-glibc":
+      optional: true
+    "@parcel/watcher-linux-x64-musl":
+      optional: true
+    "@parcel/watcher-win32-arm64":
+      optional: true
+    "@parcel/watcher-win32-ia32":
+      optional: true
+    "@parcel/watcher-win32-x64":
+      optional: true
+  checksum: 10/2cc1405166fb3016b34508661902ab08b6dec59513708165c633c84a4696fff64f9b99ea116e747c121215e09619f1decab6f0350d1cb26c9210b98eb28a6a56
   languageName: node
   linkType: hard
 
@@ -10363,6 +10494,15 @@ __metadata:
   version: 2.1.2
   resolution: "detect-kerning@npm:2.1.2"
   checksum: 10/3d71a9a28cfb1cd7a81017dec270e6434ce1a3c6e1b807ac7da1d09738d2e5b9f515278ec07a1c975bdfb394e5bcf63b6be81ceeb946ce07112d590272b1543c
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "detect-libc@npm:1.0.3"
+  bin:
+    detect-libc: ./bin/detect-libc.js
+  checksum: 10/3849fe7720feb153e4ac9407086956e073f1ce1704488290ef0ca8aab9430a8d48c8a9f8351889e7cdc64e5b1128589501e4fef48f3a4a49ba92cd6d112d0757
   languageName: node
   linkType: hard
 
@@ -17808,21 +17948,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "node-addon-api@npm:3.2.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/681b52dfa3e15b0a8e5cf283cc0d8cd5fd2a57c559ae670fcfd20544cbb32f75de7648674110defcd17ab2c76ebef630aa7d2d2f930bc7a8cc439b20fe233518
-  languageName: node
-  linkType: hard
-
 "node-addon-api@npm:^4.3.0":
   version: 4.3.0
   resolution: "node-addon-api@npm:4.3.0"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10/d3b38d16cb9ad0714d965331d0e38cef1c27750c2c3343cd3464a9ed8158501a2910ccbf2fd9fdc476e806a19dbc9e0524ff9d66a7c779d42a9752a63ba30b80
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^7.0.0":
+  version: 7.1.1
+  resolution: "node-addon-api@npm:7.1.1"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/ee1e1ed6284a2f8cd1d59ac6175ecbabf8978dcf570345e9a8095a9d0a2b9ced591074ae77f9009287b00c402352b38aa9322a34f2199cdc9f567b842a636b94
   languageName: node
   linkType: hard
 
@@ -17858,17 +17998,6 @@ __metadata:
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
   checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:^4.3.0":
-  version: 4.8.0
-  resolution: "node-gyp-build@npm:4.8.0"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10/80f410ab412df38e84171d3634a5716b6c6f14ecfa4eb971424d289381fb76f8bcbe1b666419ceb2c81060e558fd7c6d70cc0f60832bcca6a1559098925d9657
   languageName: node
   linkType: hard
 
@@ -18368,13 +18497,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nsfw@npm:2.2.0":
-  version: 2.2.0
-  resolution: "nsfw@npm:2.2.0"
+"nsfw@npm:2.2.5":
+  version: 2.2.5
+  resolution: "nsfw@npm:2.2.5"
   dependencies:
     node-addon-api: "npm:*"
     node-gyp: "npm:latest"
-  checksum: 10/536ef494161877c833760a4a496b59b8d87e0e46b498e6a6e03c7d0d623f1388780b98ce9adb4592feb770eb1cf7b41984bf4eede257f609eab48e4897f76922
+  checksum: 10/038ac44ff1f210e164b1f3534d139ce21ad3dbaa2e742a1708c4bbca6b7b34979f34e0b0a91b4b2bd28bc11cd34d0aa91746fecfd01fe2ccbc94a81dcb0565ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [x] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background

  - Recursive watcher backend on Linux could crash due to parcel/watcher SIGSEGV; switching to NSFW
    blindly left no graceful fallback or detection.
  - Watcher host service didn’t guard async start/dispose flows, making it hard to know which
    watchers were active and potentially leaking handlers.
  - Tests lacked coverage for the Linux backend-selection logic, and dependency versions were
    outdated relative to the fixes.

### Solution

  - Added parcel-watcher probing on Linux to prefer parcel when safe and fall back to NSFW
    otherwise, plus cleaned up watch-path bookkeeping so dispose targets the actual watch root.
  - Updated WatcherHostServiceImpl to start unrecursive/recursive watchers concurrently, track which
    ones started, and dispose them deterministically with clearer logging.
  - Bumped @parcel/watcher and nsfw, updated lockfile, and introduced a focused Jest suite that
    mocks OS/filesystem probes to cover backend selection.

### Changelog

  - packages/file-service/src/node/hosted/recursive/file-service-watcher.ts: map request paths to
    real watch roots, add Linux parcel probe with temp-dir snapshot test, cache detection result,
    tighten cleanup.
  - packages/file-service/src/node/hosted/watcher.host.service.ts: safer watcher spin-up/tear-down
    flow, shared URI strings, better logging.
  - packages/file-service/__tests__/node/recursive-watcher-backend-selection.test.ts: new tests
    covering parcel probe success/failure and non-NSFW backends.
  - packages/file-service/__tests__ adjustments: minor assertions/log tweaks to accommodate new
    behavior.
  - packages/file-service/package.json, yarn.lock: bump @parcel/watcher to 2.5.1 and nsfw to 2.2.5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化文件监听器在 Linux 系统上的后端选择逻辑，实现 Parcel 监听器与 NSFW 监听器的智能切换。

* **依赖项**
  * 更新 @parcel/watcher 至 2.5.1 版本。
  * 更新 nsfw 至 2.2.5 版本。

* **测试**
  * 新增文件监听器后端选择的测试用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->