### PR TITLE
fix: scrollbar in ComponentWrapper  being obscured

### DIFF
--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -571,7 +571,7 @@ export const ComponentWrapper = ({ component, resource, hidden, ...other }) => {
         [styles.kt_hidden]: hidden,
       })}
     >
-      <Scrollbars hiddenHorizontal={true}>
+      <Scrollbars hiddenHorizontal={true} hiddenVertical={true}>
         <ErrorBoundary>
           <div
             ref={(el) => {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution

<img width="3024" height="1132" alt="image" src="https://github.com/user-attachments/assets/55e19d1d-971b-4ffd-bbee-bd5e283a186d" />

ipynb 文件通过 `EditorComponentRegistry` 机制渲染，会被 `ComponentsWrapper` 组件包裹，`ComponentsWrapper` 默认渲染 5px 的纵向滚动条，导致遮挡内部滚动条，notebook 滚动条热区变小，该 PR 隐藏 `ComponentsWrapper` 组件带来的纵向滚动条。

同样经过 `EditorComponentRegistry` 机制的`extension://`，`launch://`，`preferences://` 等经验证也正常。

### Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化编辑器界面,隐藏垂直滚动条显示,保留水平滚动条功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->