### PR TITLE
fix(editor): pass group to side widgets and await open-type reset

### DIFF
--- a/packages/editor/src/browser/editor.view.tsx
+++ b/packages/editor/src/browser/editor.view.tsx
@@ -468,7 +468,9 @@ export const EditorGroupBody = ({ group }: { group: EditorGroup }) => {
           }
         }}
       >
-        {group.currentResource && <EditorSideView side={'top'} resource={group.currentResource}></EditorSideView>}
+        {group.currentResource && (
+          <EditorSideView side={'top'} resource={group.currentResource} group={group}></EditorSideView>
+        )}
         {!editorHasNoTab && <NavigationBar editorGroup={group} />}
         <div className={styles.kt_editor_components}>
           <div
@@ -506,7 +508,9 @@ export const EditorGroupBody = ({ group }: { group: EditorGroup }) => {
             ref={mergeEditorRef}
           />
         </div>
-        {group.currentResource && <EditorSideView side={'bottom'} resource={group.currentResource}></EditorSideView>}
+        {group.currentResource && (
+          <EditorSideView side={'bottom'} resource={group.currentResource} group={group}></EditorSideView>
+        )}
       </div>
     </EditorContext.Provider>
   );
@@ -637,7 +641,7 @@ function removeDecorationDragOverElement(element: HTMLElement) {
   });
 }
 
-const EditorSideView = ({ side, resource }: { side: EditorSide; resource: IResource }) => {
+const EditorSideView = ({ side, resource, group }: { side: EditorSide; resource: IResource; group: EditorGroup }) => {
   const componentRegistry: EditorComponentRegistry = useInjectable(EditorComponentRegistry);
   const eventBus = useInjectable(IEventBus) as IEventBus;
   const widgets = componentRegistry.getSideWidgets(side, resource);
@@ -650,7 +654,7 @@ const EditorSideView = ({ side, resource }: { side: EditorSide; resource: IResou
     <div className={cls(styles['kt_editor_side_widgets'], styles['kt_editor_side_widgets_' + side])}>
       {widgets.map((widget) => {
         const C = widget.component;
-        return <C resource={resource} key={widget.id} {...(widget.initialProps || {})}></C>;
+        return <C resource={resource} group={group} key={widget.id} {...(widget.initialProps || {})}></C>;
       })}
     </div>
   );

--- a/packages/editor/src/browser/types.ts
+++ b/packages/editor/src/browser/types.ts
@@ -34,7 +34,10 @@ import { EditorGroup } from './workbench-editor.service';
 
 export * from '../common';
 
-export type ReactEditorComponent<MetaData = any> = React.ComponentType<{ resource: IResource<MetaData> }>;
+export type ReactEditorComponent<MetaData = any> = React.ComponentType<{
+  resource: IResource<MetaData>;
+  group: EditorGroup;
+}>;
 
 export interface IEditorComponent<MetaData = any> {
   // 唯一id


### PR DESCRIPTION
### Types

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background
  - Side widgets needed access to their owning editor group but weren’t given it.
  - Switching open types (e.g., after large-file interception) didn’t await the reload flow, so loading signals and resource status could be inconsistent.

### Solution

  - Pass the current EditorGroup down to side widgets and their registered components (`packages/editor/src/browser/editor.view.tsx`, `packages/editor/src/browser/types.ts`).
  - Make EditorGroup’s open-type change handler async, reset resource status, and gate tab loading with a short delay while awaiting displayResourceComponent (`packages/editor/src/browser/workbench-editor.service.ts`).
  - Add Jest coverage for delayed/cleared loading during open-type changes (`packages/editor/__tests__/browser/editor-service.test.ts`).

 ### Changelog

  - Editor side widgets now receive group along with resource.
  - Open-type changes await display work and manage loading state for large-file scenarios.
  - Tests ensure loading signals fire (or are skipped) appropriately when reopening with a new type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了资源重新打开时的加载状态处理，确保在类型变更期间正确显示加载指示器

* **Tests**
  * 新增编辑器服务测试，验证资源重新打开及延迟加载状态清理的行为

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->