### PR TITLE
fix(ide-component): fix the broken closable functionality in the Notification component

### DIFF
--- a/packages/components/src/notification/index.tsx
+++ b/packages/components/src/notification/index.tsx
@@ -76,13 +76,9 @@ export function open<T = string>(
           : null,
         message,
         description,
+        closable,
       };
       cachedArgs.set(key, [type, args]);
-
-      // closable 为 false 时，不展示 closeIcon
-      if (!closable) {
-        args.closeIcon = <span />;
-      }
 
       doOpenNotification(type, args);
     });

--- a/packages/components/src/notification/notification.tsx
+++ b/packages/components/src/notification/notification.tsx
@@ -158,6 +158,7 @@ export interface ArgsProps {
   bottom?: number;
   getContainer?: () => HTMLElement;
   closeIcon?: React.ReactNode;
+  closable?: boolean;
 }
 
 function notice(args: ArgsProps) {
@@ -195,7 +196,7 @@ function notice(args: ArgsProps) {
           </div>
         ),
         duration,
-        closable: true,
+        closable: args.closable ?? true,
         onClose: args.onClose,
         onClick: args.onClick,
         key: args.key,


### PR DESCRIPTION
### Types

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background
if the first Notification was opened with `closable=false`, we injected an empty closeIcon into the shared notification instance. Because that instance is permanent, every subsequent notification kept the empty close icon, so the close affordance stayed broken permanently.

#### example
```tsx
this.messageService.error('失败没有关闭按钮', ['查看'], false, {
  buttons: ['查看'],
});

this.messageService.info('成功应该要有关闭按钮');
```

|Before|After|
|------|-----|
|<img width="864" height="370" alt="notification-before" src="https://github.com/user-attachments/assets/6303253b-c6ac-4a3e-8410-d0e84f6b0894" />|<img width="864" height="380" alt="notifiction-bugfixed" src="https://github.com/user-attachments/assets/46e3d6e0-3147-4336-91c4-7139c94fbf82" />|


### Solution
stop forcing an empty closeIcon when `closable=false` and instead pass the closable flag through to the notification instance; default to true only when unspecified.

### Changelog
open() now forwards closable; ArgsProps includes closable; notice uses `args.closable ?? true` instead of always true, so `closable=false` no longer pollutes the notification instance and close icons work again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **新功能**
  * 通知组件现已支持通过 closable 属性灵活配置是否可关闭，用户可根据需求自定义通知的交互行为。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->