### PR TITLE
WIP: split single websocket channel into multiple websocket connections

### DIFF
--- a/packages/connection/src/node/common-channel-handler.ts
+++ b/packages/connection/src/node/common-channel-handler.ts
@@ -26,7 +26,9 @@ export class CommonChannelHandler extends BaseCommonChannelHandler implements We
     logger: ILogger = console,
     private options: CommonChannelHandlerOptions = {},
   ) {
-    super('node-channel-handler', commonChannelPathHandler, logger);
+    // 根据routePath创建多个CommonChannelHandler
+    const handlerId = 'node-channel-handler' + routePath;
+    super(handlerId, commonChannelPathHandler, logger);
     this.handlerRoute = match(routePath, options.pathMatchOptions);
     this.initWSServer();
   }

--- a/packages/core-browser/src/bootstrap/app.interface.ts
+++ b/packages/core-browser/src/bootstrap/app.interface.ts
@@ -41,6 +41,19 @@ export interface IClientAppOpts extends Partial<AppConfig> {
   useCdnIcon?: boolean;
   // 插件开发模式下指定的插件路径
   extensionDevelopmentPath?: string | string[];
+  /**
+   * WebSocket路径和模块的映射配置，用于根据连接路径动态选择加载的模块,没有指定的模块就会走/service
+   * 仅支持全匹配
+   * 例如：
+   * {
+   *   "/terminal": ["TerminalModule"],
+   * }
+   */
+  wsPathModuleMapping?: Record<string, ModuleConstructor[]>;
+  /**
+   * 自定义多个前后端通信路径，用于支持多个WebSocket连接
+   */
+  connectionPaths?: string[];
 }
 
 export interface LayoutConfig {

--- a/packages/core-browser/src/react-providers/config-provider.tsx
+++ b/packages/core-browser/src/react-providers/config-provider.tsx
@@ -287,6 +287,10 @@ export interface AppConfig {
    */
   connectionPath?: UrlProvider;
   /**
+   * 自定义多个前后端通信路径，用于支持多个WebSocket连接
+   */
+  connectionPaths?: UrlProvider[];
+  /**
    * 支持的通信协议类型
    */
   connectionProtocols?: string[];

--- a/packages/core-node/src/types.ts
+++ b/packages/core-node/src/types.ts
@@ -133,6 +133,7 @@ export interface IServerAppOpts extends Partial<Config> {
   modulesInstances?: NodeModule[];
   webSocketHandler?: WebSocketHandler[];
   wsServerOptions?: ws.ServerOptions;
+  connectionPaths?: string[];
   pathMatchOptions?: {
     // When true the regexp will match to the end of the string.
     end?: boolean;


### PR DESCRIPTION
### Types
<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background or solution
支持多个websocket 连接
<img width="1636" height="326" alt="image" src="https://github.com/user-attachments/assets/7bcfc467-a7fc-4455-bc8b-e780ffcf7b59" />

#### Example
packages/startup/entry/web/app.tsx
```
....
    AINativeConfig: {
        capabilities: {
          supportsMCP: true,
          supportsCustomLLMSettings: true,
        },
      },
      notebookServerHost: 'localhost:8888',
      connectionPaths: ['/terminal'],
      wsPathModuleMapping: {
        '/terminal': [TerminalNextModule],
      },
...
```
tools/dev-tool/src/server.ts
```
...
  let opts: IServerAppOpts = {
    connectionPaths: ['/terminal'],
```

### Changelog
