### PR TITLE
refactor(terminal): decouple terminal input from JSON RPC path

### DIFF
--- a/packages/extension/__tests__/hosted/api/vscode/ext.host.terminal.test.ts
+++ b/packages/extension/__tests__/hosted/api/vscode/ext.host.terminal.test.ts
@@ -78,6 +78,12 @@ describe('ext host terminal test', () => {
         detectAvailableProfiles() {
           return [];
         },
+        input() {
+          // no-op for tests
+        },
+        resize() {
+          // no-op for tests
+        },
       },
     },
     {

--- a/packages/terminal-next/__tests__/browser/inject.ts
+++ b/packages/terminal-next/__tests__/browser/inject.ts
@@ -194,6 +194,12 @@ export const injector = new MockInjector([
         pid: 0,
         name: '123',
       }),
+      input() {
+        // no-op for tests
+      },
+      resize() {
+        // no-op for tests
+      },
       $resolveUnixShellPath(p) {
         return p;
       },

--- a/packages/terminal-next/__tests__/browser/terminal.service.test.ts
+++ b/packages/terminal-next/__tests__/browser/terminal.service.test.ts
@@ -90,6 +90,12 @@ describe('terminal service test cases', () => {
             (terminalService as any)?.$processChange(sessionId, 'zsh');
           });
         },
+        input() {
+          // no-op for tests
+        },
+        resize() {
+          // no-op for tests
+        },
         $resolveUnixShellPath(p) {
           return p;
         },

--- a/packages/terminal-next/__tests__/node/terminal.reconnect.test.ts
+++ b/packages/terminal-next/__tests__/node/terminal.reconnect.test.ts
@@ -92,6 +92,7 @@ class MockTerminalClient implements ITerminalServiceClient {
   reconnectedIds: string[] = [];
   disconnectedIds: string[] = [];
   setConnectionClientId(): void {}
+  input(): void {}
   onMessage(): void {}
   resize(): void {}
   disposeById(): void {}

--- a/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
+++ b/packages/terminal-next/__tests__/node/terminal.service.client.test.ts
@@ -62,7 +62,7 @@ describe('TerminalServiceClientImpl', () => {
       receiveData = receiveData + data;
     });
 
-    terminalServiceClient.onMessage(mockId, JSON.stringify({ data: 'message test' }));
+    terminalServiceClient.input(mockId, 'message test');
     terminalServiceClient.resize(mockId, 400, 400);
 
     await new Promise<void>((resolve) => {

--- a/packages/terminal-next/src/browser/terminal.service.ts
+++ b/packages/terminal-next/src/browser/terminal.service.ts
@@ -27,8 +27,6 @@ export interface EventMessage {
 }
 @Injectable()
 export class NodePtyTerminalService extends Disposable implements ITerminalService {
-  static countId = 1;
-
   private backendOs: OperatingSystem | undefined;
 
   @Autowired(INJECTOR_TOKEN)
@@ -117,29 +115,12 @@ export class NodePtyTerminalService extends Disposable implements ITerminalServi
     this.logger.error(`${sessionId} cannot create ptyInstance`, ptyInstance);
   }
 
-  private _sendMessage(sessionId: string, json: any, requestId?: number) {
-    const id = requestId || NodePtyTerminalService.countId++;
-
-    this.serviceClientRPC.onMessage(
-      sessionId,
-      JSON.stringify({
-        id,
-        ...json,
-      }),
-    );
-  }
-
   async sendText(sessionId: string, message: string) {
-    this._sendMessage(sessionId, {
-      data: message,
-    });
+    this.serviceClientRPC.input(sessionId, message);
   }
 
   async resize(sessionId: string, cols: number, rows: number) {
-    this._sendMessage(sessionId, {
-      method: 'resize',
-      params: { cols, rows },
-    });
+    this.serviceClientRPC.resize(sessionId, rows, cols);
   }
 
   async getCodePlatformKey(): Promise<'osx' | 'windows' | 'linux'> {

--- a/packages/terminal-next/src/common/pty.ts
+++ b/packages/terminal-next/src/common/pty.ts
@@ -328,6 +328,7 @@ export interface ITerminalServiceClient {
     rows: number,
     launchConfig: IShellLaunchConfig,
   ): Promise<INodePtyInstance | undefined>;
+  input(id: string, data: string): void;
   onMessage(id: string, msg: string): void;
   resize(id: string, rows: number, cols: number): void;
   disposeById(id: string): void;

--- a/packages/terminal-next/src/node/terminal.service.client.ts
+++ b/packages/terminal-next/src/node/terminal.service.client.ts
@@ -155,13 +155,22 @@ export class TerminalServiceClientImpl extends RPCService<IRPCTerminalService> i
   }
 
   onMessage(id: string, msg: string): void {
-    const { data, params, method } = JSON.parse(msg);
+    try {
+      const { data, params, method } = JSON.parse(msg);
 
-    if (method === 'resize') {
-      this.resize(id, params.rows, params.cols);
-    } else {
-      this.terminalService.onMessage(id, data);
+      if (method === 'resize') {
+        this.resize(id, params.rows, params.cols);
+      } else {
+        this.terminalService.onMessage(id, data);
+      }
+    } catch {
+      // Fallback for legacy/raw messages.
+      this.terminalService.onMessage(id, msg);
     }
+  }
+
+  input(id: string, data: string): void {
+    this.terminalService.onMessage(id, data);
   }
 
   resize(id: string, rows: number, cols: number) {


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [ ] 🎉 New Features
- [ ] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [x] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

### Background
Terminal input was flowing through the same JSON RPC path as resize/other messages, causing per‑keystroke JSON.stringify/parse overhead and coupling input with output handling under high output load.

### Solution
Introduce a dedicated raw input RPC method for terminal input. The browser now sends input via input(id, data) and resize via its own method, avoiding JSON serialization on every keystroke. The node side handles raw input directly and keeps a backward‑compatible fallback for legacy JSON messages.

### Changelog
- Added input(id, data) to ITerminalServiceClient for raw terminal input.
- Browser terminal service now uses raw input RPC and direct resize calls.
- Node terminal service client handles raw input and keeps legacy JSON handling in onMessage.
- Updated related tests and mocks to support the new input method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  - 简化了终端输入和大小调整的内部实现机制，采用更直接的远程调用方式，提升代码效率。

* **测试**
  - 更新所有终端相关测试中的mock实现，确保与新的操作接口兼容。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->