### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,17 @@
+name: HOL Skill Validate
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+jobs:
+  validate-skill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate skill package
+        uses: hashgraph-online/skill-publish@8f3c91d7d4cde7b104549e5f0cccdbb4cd7ee58d # v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
This adds a small validate-only CI check for the existing skill metadata in this repo.

It only adds one workflow file, does not publish anything, and does not need secrets.

It runs schema and trust validation for the repository root and leaves runtime code, release flow, and publish credentials alone.
Permissions: read-only. No secrets. No publish. No runtime changes.

If you'd like it folded into an existing workflow or pointed at a different path, I can adjust the branch.