### PR TITLE
fix(file-tree): support copy path keybindings

### DIFF
--- a/packages/core-browser/src/common/common.command.ts
+++ b/packages/core-browser/src/common/common.command.ts
@@ -83,6 +83,7 @@ export namespace FILE_COMMANDS {
   export const COPY_RELATIVE_PATH: Command = {
     id: 'filetree.copy.relativepath',
     category: CATEGORY,
+    label: '%file.copy.relativepath%',
   };
 
   export const COPY_FILE: Command = {

--- a/packages/file-tree-next/__tests__/browser/file-tree-contribution.test.ts
+++ b/packages/file-tree-next/__tests__/browser/file-tree-contribution.test.ts
@@ -2,7 +2,7 @@ import {
   IApplicationService,
   IClipboardService,
   IContextKeyService,
-  OS,
+  OperatingSystem,
   PreferenceService,
   QuickOpenService,
 } from '@opensumi/ide-core-browser';
@@ -15,6 +15,7 @@ import { EXPLORER_CONTAINER_ID } from '@opensumi/ide-explorer/lib/browser/explor
 import { IFileServiceClient } from '@opensumi/ide-file-service';
 import { IFileTreeAPI, IFileTreeService } from '@opensumi/ide-file-tree-next';
 import { FileTreeContribution } from '@opensumi/ide-file-tree-next/lib/browser/file-tree-contribution';
+import { FileTreeModelService } from '@opensumi/ide-file-tree-next/lib/browser/services/file-tree-model.service';
 import { IMainLayoutService, IViewsRegistry } from '@opensumi/ide-main-layout';
 import { ViewsRegistry } from '@opensumi/ide-main-layout/lib/browser/views-registry';
 import { IDialogService, IMessageService, IWindowDialogService } from '@opensumi/ide-overlay';
@@ -26,6 +27,8 @@ import { MockQuickOpenService } from '../../../quick-open/src/common/mocks/quick
 
 describe('FileTreeContribution', () => {
   let mockInjector: MockInjector;
+  let mockClipboardService;
+  let mockFileTreeModelService;
   const tabbarHandlerMap = new Map();
 
   const mockMainLayoutService = {
@@ -38,6 +41,7 @@ describe('FileTreeContribution', () => {
         updateViewTitle: jest.fn(),
         onActivate: jest.fn(),
         onInActivate: jest.fn(),
+        isActivated: jest.fn(() => true),
       };
       tabbarHandlerMap.set(name, handler);
       return handler;
@@ -72,6 +76,22 @@ describe('FileTreeContribution', () => {
 
   beforeEach(() => {
     mockInjector = createBrowserInjector([]);
+    mockClipboardService = {
+      writeText: jest.fn(),
+    };
+    mockFileTreeModelService = {
+      selectedFiles: [],
+      focusedFile: undefined,
+      contextMenuFile: undefined,
+      whenReady: Promise.resolve(),
+      contextKey: {
+        explorerViewletVisibleContext: {
+          set: jest.fn(),
+        },
+      },
+      performLocationOnHandleShow: jest.fn(),
+      handleTreeBlur: jest.fn(),
+    };
 
     mockInjector.overrideProviders(
       {
@@ -112,7 +132,11 @@ describe('FileTreeContribution', () => {
       },
       {
         token: IClipboardService,
-        useValue: {},
+        useValue: mockClipboardService,
+      },
+      {
+        token: FileTreeModelService,
+        useValue: mockFileTreeModelService,
       },
       {
         token: IDialogService,
@@ -137,7 +161,8 @@ describe('FileTreeContribution', () => {
       {
         token: IApplicationService,
         useValue: {
-          getBackendOS: () => Promise.resolve(OS.type()),
+          backendOS: Promise.resolve(OperatingSystem.Linux),
+          getBackendOS: () => Promise.resolve(OperatingSystem.Linux),
         },
       },
     );
@@ -203,6 +228,44 @@ describe('FileTreeContribution', () => {
       const register = jest.fn();
       contribution.registerToolbarItems({ registerItem: register } as any);
       expect(register).toHaveBeenCalled();
+    });
+  });
+
+  describe('copy path commands', () => {
+    const registerCommands = () => {
+      const contribution = mockInjector.get(FileTreeContribution);
+      const commands = new Map<string, any>();
+      contribution.registerCommands({
+        registerCommand: jest.fn((command, handler) => {
+          commands.set(command.id, { command, ...handler });
+        }),
+      } as any);
+      return commands;
+    };
+
+    it('uses the selected explorer file when copy path is triggered from a shortcut', async () => {
+      mockFileTreeModelService.selectedFiles = [{ uri: URI.file('/userhome/test.ts') }];
+      const commands = registerCommands();
+
+      await commands.get('filetree.copy.path').execute();
+
+      expect(mockClipboardService.writeText).toHaveBeenCalledWith('/userhome/test.ts');
+    });
+
+    it('uses the selected explorer file when copy relative path is triggered from a shortcut', async () => {
+      mockFileTreeModelService.selectedFiles = [{ uri: URI.file('/userhome/test.ts') }];
+      const commands = registerCommands();
+
+      await commands.get('filetree.copy.relativepath').execute();
+
+      expect(mockClipboardService.writeText).toHaveBeenCalledWith('test.ts');
+    });
+
+    it('exposes labels for copy path commands so users can configure shortcuts', () => {
+      const commands = registerCommands();
+
+      expect(commands.get('filetree.copy.path').command.label).toBe('%file.copy.path%');
+      expect(commands.get('filetree.copy.relativepath').command.label).toBe('%file.copy.relativepath%');
     });
   });
 });

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -210,6 +210,16 @@ export class FileTreeContribution
     return resourceTitle;
   }
 
+  private getExplorerTargetUri(uri?: URI): URI | undefined {
+    return (
+      uri ||
+      this.fileTreeModelService.activeUri ||
+      this.fileTreeModelService.focusedFile?.uri ||
+      this.fileTreeModelService.selectedFiles?.[0]?.uri ||
+      this.fileTreeModelService.contextMenuFile?.uri
+    );
+  }
+
   private revealFile(locationUri: URI) {
     if (locationUri) {
       if (this.isRendered) {
@@ -749,13 +759,14 @@ export class FileTreeContribution
 
     commands.registerCommand<ExplorerContextCallback>(FILE_COMMANDS.COPY_PATH, {
       execute: async (uri) => {
-        if (!uri) {
+        const targetUri = this.getExplorerTargetUri(uri);
+        if (!targetUri) {
           return;
         }
-        const copyUri: URI = uri;
+        const copyUri: URI = targetUri;
         let uriPath = copyUri.path.toString();
-        if (uri.scheme === DIFF_SCHEME) {
-          const query = uri.getParsedQuery();
+        if (targetUri.scheme === DIFF_SCHEME) {
+          const query = targetUri.getParsedQuery();
           uriPath = new URI(query.modified).path.toString();
         }
         let pathStr: string = decodeURIComponent(uriPath);
@@ -770,14 +781,15 @@ export class FileTreeContribution
 
     commands.registerCommand<ExplorerContextCallback>(FILE_COMMANDS.COPY_RELATIVE_PATH, {
       execute: async (uri) => {
-        if (!uri) {
+        let targetUri = this.getExplorerTargetUri(uri);
+        if (!targetUri) {
           return;
         }
-        if (uri.scheme === DIFF_SCHEME) {
-          const query = uri.getParsedQuery();
-          uri = new URI(query.modified).withScheme('file');
+        if (targetUri.scheme === DIFF_SCHEME) {
+          const query = targetUri.getParsedQuery();
+          targetUri = new URI(query.modified).withScheme('file');
         }
-        const node = this.fileTreeService.getNodeByPathOrUri(uri);
+        const node = this.fileTreeService.getNodeByPathOrUri(targetUri);
         if (node) {
           if (node.filestat.isInSymbolicDirectory) {
             // 软链接文件需要通过直接通过文件树 Path 获取
@@ -789,20 +801,20 @@ export class FileTreeContribution
           // 多工作区额外处理
           for (const root of await this.workspaceService.roots) {
             rootUri = new URI(root.uri);
-            if (rootUri.isEqual(uri)) {
+            if (rootUri.isEqual(targetUri)) {
               return await this.clipboardService.writeText('./');
             }
-            if (rootUri.isEqualOrParent(uri)) {
-              return await this.clipboardService.writeText(decodeURIComponent(rootUri.relative(uri)!.toString()));
+            if (rootUri.isEqualOrParent(targetUri)) {
+              return await this.clipboardService.writeText(decodeURIComponent(rootUri.relative(targetUri)!.toString()));
             }
           }
         } else {
           if (this.workspaceService.workspace) {
             rootUri = new URI(this.workspaceService.workspace.uri);
-            if (rootUri.isEqual(uri)) {
+            if (rootUri.isEqual(targetUri)) {
               return await this.clipboardService.writeText('./');
             }
-            return await this.clipboardService.writeText(decodeURIComponent(rootUri.relative(uri)!.toString()));
+            return await this.clipboardService.writeText(decodeURIComponent(rootUri.relative(targetUri)!.toString()));
           }
         }
       },


### PR DESCRIPTION
### Types

- [ ] 🎉 New Features
- [x] 🐛 Bug Fixes
- [ ] 📚 Documentation Changes
- [ ] 💄 Code Style Changes
- [ ] 💄 Style Changes
- [ ] 🪚 Refactors
- [ ] 🚀 Performance Improvements
- [ ] 🏗️ Build System
- [ ] ⏱ Tests
- [ ] 🧹 Chores
- [ ] Other Changes

 ### Background
The explorer context menu provides `Copy Path` and `Copy Relative Path`, but these commands depend on the menu-provided URI argument. When users configure custom shortcuts for these commands, the keybinding service invokes them without that URI, so nothing is copied.
`Copy Relative Path` also lacked a command label, which prevented it from being exposed properly as a configurable command in the keybindings  UI.

### Solution
  - Add a label for `filetree.copy.relativepath` so users can configure a shortcut for `Copy Relative Path`.
  - Add fallback explorer target resolution for copy path commands when no URI is passed.
  - Resolve the target from the current explorer state: active compressed URI, focused file, selected file, or context menu file.
  - Add regression tests for shortcut-style command execution without menu args.

### Changelog
  - `fix(file-tree)`: support custom shortcuts for `Copy Path`.
  - `fix(file-tree)`: support custom shortcuts for `Copy Relative Path`.
  - `test(file-tree)`: add coverage for shortcut-triggered copy path commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为“复制相对路径”命令添加本地化标签，改进界面显示。
  * 优化路径复制命令执行逻辑，支持从命令参数或资源管理器（活动/聚焦/选中/上下文）识别目标文件，并正确处理多根工作区与已修改差异。

* **测试**
  * 增加/调整路径复制命令测试，覆盖绝对路径与相对路径复制、剪贴板写入及标签显示验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->